### PR TITLE
Work around an apparent namespace-in-template scoping bug in MSVC on Windows

### DIFF
--- a/src/bin/align-text.cc
+++ b/src/bin/align-text.cc
@@ -26,10 +26,9 @@ bool IsNotToken(const std::string &token) {
   return ! kaldi::IsToken(token);
 }
 
-int main(int argc, char *argv[]) {
-  using namespace kaldi;
-  typedef kaldi::int32 int32;
+namespace kaldi {
 
+int main(int argc, char *argv[]) {
   try {
     const char *usage =
         "Computes alignment between two sentences with the same key in the\n"
@@ -132,4 +131,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/bin/extract-ctx.cc
+++ b/src/bin/extract-ctx.cc
@@ -29,7 +29,7 @@
 #include "tree/build-tree-questions.h"
 #include "fst/fstlib.h"
 
-using namespace kaldi;
+namespace kaldi {
 
 using std::vector;
 
@@ -212,4 +212,9 @@ int main(int argc, char *argv[]) {
   }
 }
 
+}  //namespace kaldi
 
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
+}

--- a/src/bin/phones-to-prons.cc
+++ b/src/bin/phones-to-prons.cc
@@ -26,6 +26,8 @@
 #include "fst/fstlib.h"
 #include "fstext/fstext-lib.h"
 
+namespace kaldi {
+
 // Create FST that accepts the phone sequence, with any number
 // of word-start and word-end symbol in between each phone. 
 void CreatePhonesAltFst(const std::vector<int32> &phones,
@@ -60,10 +62,8 @@ void CreatePhonesAltFst(const std::vector<int32> &phones,
 }
 
 int main(int argc, char *argv[]) {
-  using namespace kaldi;
   using fst::VectorFst;
   using fst::StdArc;
-  typedef kaldi::int32 int32;
   try {
     const char *usage =
         "Convert pairs of (phone-level, word-level) transcriptions to\n"
@@ -220,4 +220,9 @@ int main(int argc, char *argv[]) {
   }
 }
 
+}  //namespace kaldi
 
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
+}

--- a/src/bin/post-to-phone-post.cc
+++ b/src/bin/post-to-phone-post.cc
@@ -23,11 +23,10 @@
 #include "hmm/transition-model.h"
 #include "hmm/posterior.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;  
-
     const char *usage =
         "Convert posteriors to phone-level posteriors\n"
         "See also: post-to-pdf-post, post-to-weights, get-post-on-ali\n"
@@ -75,3 +74,9 @@ int main(int argc, char *argv[]) {
   }
 }
 
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
+}

--- a/src/gmmbin/gmm-decode-nbest.cc
+++ b/src/gmmbin/gmm-decode-nbest.cc
@@ -30,7 +30,7 @@
 #include "lat/kaldi-lattice.h" // for CompactLatticeArc
 #include "fstext/lattice-utils.h" // for ConvertLattice
 
-using namespace kaldi;
+namespace kaldi {
 
 fst::Fst<fst::StdArc> *ReadNetwork(std::string filename) {
   // read decoding network FST
@@ -67,8 +67,6 @@ fst::Fst<fst::StdArc> *ReadNetwork(std::string filename) {
 
 int main(int argc, char *argv[]) {
   try {
-    typedef kaldi::int32 int32;
-
     const char *usage =
       "Decode features using GMM-based model, producing N-best lattice output.\n"
       "Note: this program was mainly intended to validate the lattice generation\n"
@@ -245,4 +243,9 @@ int main(int argc, char *argv[]) {
   }
 }
 
+}  //namespace kaldi
 
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
+}

--- a/src/kwsbin/generate-proxy-keywords.cc
+++ b/src/kwsbin/generate-proxy-keywords.cc
@@ -17,7 +17,6 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "fstext/fstext-utils.h"
@@ -53,15 +52,16 @@ bool PrintProxyFstPath(const VectorFst<StdArc> &proxy,
 }
 }
 
+using namespace fst;
+using kaldi::int32;
+using kaldi::uint64;
+using kaldi::BasicVectorHolder;
+using kaldi::ParseOptions;
+using kaldi::SequentialInt32VectorReader;
+using kaldi::TableWriter;
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    using namespace fst;
-    typedef kaldi::int32 int32;
-    typedef kaldi::uint64 uint64;
-    typedef StdArc::StateId StateId;
-    typedef StdArc::Weight Weight;
-
     const char *usage =
         "Convert the keywords into in-vocabulary words using the given phone\n"
         "level edit distance fst (E.fst). The large lexicon (L2.fst) and\n"

--- a/src/kwsbin/kws-index-union.cc
+++ b/src/kwsbin/kws-index-union.cc
@@ -24,13 +24,17 @@
 #include "lat/kaldi-kws.h"
 #include "lat/kws-functions.h"
 
+using namespace fst;
+using kaldi::int32;
+using kaldi::uint64;
+using kaldi::KwsLexicographicArc;
+using kaldi::KwsLexicographicFst;
+using kaldi::ParseOptions;
+using kaldi::SequentialTableReader;
+using kaldi::TableWriter;
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    using namespace fst;
-    typedef kaldi::int32 int32;
-    typedef kaldi::uint64 uint64;
-
     const char *usage =
         "Take a union of the indexed lattices. The input index is in the T*T*T semiring and\n"
         "the output index is also in the T*T*T semiring. At the end of this program, encoded\n"

--- a/src/kwsbin/kws-search.cc
+++ b/src/kwsbin/kws-search.cc
@@ -70,17 +70,25 @@ class VectorFstToKwsLexicographicFstMapper {
 
 }
 
-int main(int argc, char *argv[]) {
-  try {
-    using namespace kaldi;
-    using namespace fst;
-    typedef kaldi::int32 int32;
-    typedef kaldi::uint32 uint32;
-    typedef kaldi::uint64 uint64;
-    typedef KwsLexicographicArc Arc;
-    typedef Arc::Weight Weight;
-    typedef Arc::StateId StateId;
+using namespace fst;
+using kaldi::int32;
+using kaldi::uint64;
+using kaldi::BasicVectorHolder;
+using kaldi::DecodeLabelUid;
+using kaldi::EncodeLabel;
+using kaldi::KwsLexicographicArc;
+using kaldi::KwsLexicographicFst;
+using kaldi::ParseOptions;
+using kaldi::RandomAccessTableReader;
+using kaldi::SequentialTableReader;
+using kaldi::TableWriter;
+using kaldi::VectorFstToKwsLexicographicFstMapper;
 
+int main(int argc, char *argv[]) {
+  typedef KwsLexicographicArc Arc;
+  typedef Arc::Weight Weight;
+  typedef Arc::StateId StateId;
+  try {
     const char *usage =
         "Search the keywords over the index. This program can be executed parallely, either\n"
         "on the index side or the keywords side; we use a script to combine the final search\n"

--- a/src/kwsbin/lattice-to-kws-index.cc
+++ b/src/kwsbin/lattice-to-kws-index.cc
@@ -28,13 +28,32 @@
 #include "lat/kws-functions.h"
 #include "fstext/epsilon-property.h"
 
+using fst::VectorFst;
+using kaldi::int32;
+using kaldi::uint64;
+using kaldi::BaseFloat;
+using kaldi::ClusterLattice;
+using kaldi::CompactLattice;
+using kaldi::CompactLatticeStateTimes;
+using kaldi::CompactLatticeStateTimes;
+using kaldi::CreateFactorTransducer;
+using kaldi::DoFactorDisambiguation;
+using kaldi::DoFactorMerging;
+using kaldi::KwsLexicographicArc;
+using kaldi::KwsLexicographicFst;
+using kaldi::KwsProductFst;
+using kaldi::MaybeDoSanityCheck;
+using kaldi::OptimizeFactorTransducer;
+using kaldi::ParseOptions;
+using kaldi::RandomAccessInt32Reader;
+using kaldi::RandomAccessTableReader;
+using kaldi::RemoveLongSilences;
+using kaldi::SequentialCompactLatticeReader;
+using kaldi::SequentialTableReader;
+using kaldi::TableWriter;
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    using fst::VectorFst;
-    typedef kaldi::int32 int32;
-    typedef kaldi::uint64 uint64;
-
     const char *usage =
         "Create an inverted index of the given lattices. The output index is in the T*T*T\n"
         "semiring. For details for the semiring, please refer to Dogan Can and Muran Saraclar's"

--- a/src/latbin/lattice-add-trans-probs.cc
+++ b/src/latbin/lattice-add-trans-probs.cc
@@ -26,11 +26,10 @@
 #include "hmm/transition-model.h"
 #include "hmm/hmm-utils.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -89,4 +88,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-arcgraph.cc
+++ b/src/latbin/lattice-arcgraph.cc
@@ -24,6 +24,8 @@
 #include "lat/kaldi-lattice.h"
 #include "hmm/transition-model.h"
 
+namespace kaldi {
+
 typedef fst::StdArc::StateId StateId;
 typedef fst::StdArc::Weight Weight;
 typedef fst::StdArc::Label Label;
@@ -135,9 +137,6 @@ void MapTransitionIdsToTransitionStates(kaldi::CompactLattice *lat,
 
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -262,4 +261,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-compose.cc
+++ b/src/latbin/lattice-compose.cc
@@ -23,11 +23,10 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -163,4 +162,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-determinize-pruned.cc
+++ b/src/latbin/lattice-determinize-pruned.cc
@@ -24,11 +24,10 @@
 #include "lat/push-lattice.h"
 #include "lat/minimize-lattice.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    
     const char *usage =
         "Determinize lattices, keeping only the best path (sequence of acoustic states)\n"
         "for each input-symbol sequence.  This version does pruning as part of the\n"
@@ -116,4 +115,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-interp.cc
+++ b/src/latbin/lattice-interp.cc
@@ -23,11 +23,10 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -110,4 +109,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-lmrescore-const-arpa.cc
+++ b/src/latbin/lattice-lmrescore-const-arpa.cc
@@ -25,12 +25,10 @@
 #include "lm/const-arpa-lm.h"
 #include "util/common-utils.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
-
     const char *usage =
         "Rescores lattice with the ConstArpaLm format language model. The LM\n"
         "will be wrapped into the DeterministicOnDemandFst interface and the\n"
@@ -120,4 +118,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-lmrescore.cc
+++ b/src/latbin/lattice-lmrescore.cc
@@ -24,11 +24,10 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -149,4 +148,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-oracle.cc
+++ b/src/latbin/lattice-oracle.cc
@@ -218,13 +218,8 @@ bool GetOracleLattice(Lattice *oracle_lat,
   return status;
 }
 
-}
-
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -432,4 +427,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-rescore-mapped.cc
+++ b/src/latbin/lattice-rescore-mapped.cc
@@ -69,13 +69,8 @@ void LatticeAcousticRescore(const TransitionModel &trans_model,
   }
 }
 
-}  // namespace kaldi
-
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -171,4 +166,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-reverse.cc
+++ b/src/latbin/lattice-reverse.cc
@@ -24,11 +24,10 @@
 #include "lat/kaldi-lattice.h"
 //#include "lat/lattice-functions.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::VectorFst;
     using fst::StdArc;
 
@@ -79,4 +78,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-to-nbest.cc
+++ b/src/latbin/lattice-to-nbest.cc
@@ -23,11 +23,10 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -129,4 +128,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/lattice-to-phone-lattice.cc
+++ b/src/latbin/lattice-to-phone-lattice.cc
@@ -25,11 +25,10 @@
 #include "lat/lattice-functions.h"
 #include "hmm/transition-model.h"
 
+namespace kaldi {
+
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -96,4 +95,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/latbin/linear-to-nbest.cc
+++ b/src/latbin/linear-to-nbest.cc
@@ -24,6 +24,7 @@
 #include "lat/kaldi-lattice.h"
 
 namespace kaldi {
+
 void MakeLatticeFromLinear(const std::vector<int32> &ali,
                            const std::vector<int32> &words,
                            BaseFloat lm_cost,
@@ -45,13 +46,9 @@ void MakeLatticeFromLinear(const std::vector<int32> &ali,
   }
   lat_out->SetFinal(cur_state, Weight(lm_cost, ac_cost));
 }
-}
 
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
     using fst::SymbolTable;
     using fst::VectorFst;
     using fst::StdArc;
@@ -133,4 +130,11 @@ int main(int argc, char *argv[]) {
     std::cerr << e.what();
     return -1;
   }
+}
+
+}  //namespace kaldi
+
+
+int main(int argc, char *argv[]) {
+  return kaldi::main(argc, argv);
 }

--- a/src/sgmm/estimate-am-sgmm-multi-test.cc
+++ b/src/sgmm/estimate-am-sgmm-multi-test.cc
@@ -23,18 +23,12 @@
 #include "sgmm/estimate-am-sgmm-multi.h"
 #include "util/kaldi-io.h"
 
-using kaldi::AmSgmm;
-using kaldi::MleAmSgmmAccs;
-using kaldi::BaseFloat;
-namespace ut = kaldi::unittest;
+namespace kaldi {
 
 // Tests the MleAmSgmmUpdaterMulti (and MleAmSgmmGlobalAccs) classes.
 void TestMultiSgmmEst(const std::vector<AmSgmm*> &models,
                       const std::vector< kaldi::Matrix<BaseFloat> > &feats,
                       kaldi::SgmmUpdateFlagsType flags) {
-  using namespace kaldi;
-  typedef kaldi::int32 int32;
-
   int32 num_gauss = models[0]->NumGauss(),
       feat_dim = models[0]->FeatureDim(),
       phn_dim = models[0]->PhoneSpaceDim(),
@@ -101,7 +95,7 @@ void UnitTestEstimateSgmm() {
   int32 dim = 2 + kaldi::RandInt(0, 9);  // random dimension of the gmm
   int32 num_comp = 2 + kaldi::RandInt(0, 9);  // random mixture size
   kaldi::FullGmm full_gmm;
-  ut::InitRandFullGmm(dim, num_comp, &full_gmm);
+  unittest::InitRandFullGmm(dim, num_comp, &full_gmm);
 
   int32 num_states = 1;
   int32 num_models = kaldi::RandInt(2, 9);
@@ -129,7 +123,7 @@ void UnitTestEstimateSgmm() {
     feats[i].Resize(num_feat_comp * 200, dim);
     for (int32 m = 0; m < num_feat_comp; ++m) {
       kaldi::SubMatrix<BaseFloat> tmp(feats[i], m*200, 200, 0, dim);
-      ut::RandDiagGaussFeatures(200, means.Row(m), vars.Row(m), &tmp);
+      unittest::RandDiagGaussFeatures(200, means.Row(m), vars.Row(m), &tmp);
     }
   }
   kaldi::SgmmUpdateFlagsType flags = kaldi::kSgmmAll;
@@ -143,9 +137,12 @@ void UnitTestEstimateSgmm() {
   kaldi::DeletePointers(&models);
 }
 
+}  // namespace kaldi
+
+
 int main() {
   for (int i = 0; i < 10; ++i)
-    UnitTestEstimateSgmm();
+    kaldi::UnitTestEstimateSgmm();
   std::cout << "Test OK.\n";
   return 0;
 }

--- a/src/sgmm/estimate-am-sgmm-test.cc
+++ b/src/sgmm/estimate-am-sgmm-test.cc
@@ -23,18 +23,12 @@
 #include "sgmm/estimate-am-sgmm.h"
 #include "util/kaldi-io.h"
 
-using kaldi::AmSgmm;
-using kaldi::MleAmSgmmAccs;
-using kaldi::BaseFloat;
-namespace ut = kaldi::unittest;
+namespace kaldi {
 
 // Tests the Read() and Write() methods for the accumulators, in both binary
 // and ASCII mode, as well as Check().
 void TestUpdateAndAccsIO(const AmSgmm &sgmm,
                          const kaldi::Matrix<BaseFloat> &feats) {
-  using namespace kaldi;
-  typedef kaldi::int32 int32;
-
   kaldi::SgmmUpdateFlagsType flags = kaldi::kSgmmAll;
   kaldi::SgmmPerFrameDerivedVars frame_vars;
   kaldi::SgmmPerSpkDerivedVars empty;
@@ -120,7 +114,7 @@ void UnitTestEstimateSgmm() {
   int32 dim = 1 + kaldi::RandInt(0, 9);  // random dimension of the gmm
   int32 num_comp = 2 + kaldi::RandInt(0, 9);  // random mixture size
   kaldi::FullGmm full_gmm;
-  ut::InitRandFullGmm(dim, num_comp, &full_gmm);
+  unittest::InitRandFullGmm(dim, num_comp, &full_gmm);
 
   int32 num_states = 1;
   AmSgmm sgmm;
@@ -144,15 +138,18 @@ void UnitTestEstimateSgmm() {
     feats.Resize(num_feat_comp * 200, dim);
     for (int32 m = 0; m < num_feat_comp; m++) {
       kaldi::SubMatrix<BaseFloat> tmp(feats, m*200, 200, 0, dim);
-      ut::RandDiagGaussFeatures(200, means.Row(m), vars.Row(m), &tmp);
+      unittest::RandDiagGaussFeatures(200, means.Row(m), vars.Row(m), &tmp);
     }
   }
   TestUpdateAndAccsIO(sgmm, feats);
 }
 
+}  // namespace kaldi
+
+
 int main() {
   for (int i = 0; i < 10; i++)
-    UnitTestEstimateSgmm();
+    kaldi::UnitTestEstimateSgmm();
   std::cout << "Test OK.\n";
   return 0;
 }


### PR DESCRIPTION
Work around an apparent namespace-in-template scoping bug in MSVC on Windows