### PR TITLE
Modified ResizeOutputLayer method in nnet-nnet.cc 

### DIFF
--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -1407,6 +1407,20 @@ Component *AffineComponent::CollapseWithNext(
   return ans;
 }
 
+Component *AffineComponent::CollapseWithNext(
+    const FixedScaleComponent &next_component) const {
+  KALDI_ASSERT(this->OutputDim() == next_component.InputDim());
+  AffineComponent *ans =
+      dynamic_cast<AffineComponent*>(this->Copy());
+  KALDI_ASSERT(ans != NULL);
+  ans->linear_params_.MulRowsVec(next_component.scales_);
+  ans->bias_params_.MulElements(next_component.scales_);
+
+  return ans;
+}
+
+
+
 Component *AffineComponent::CollapseWithPrevious(
     const FixedAffineComponent &prev_component) const {
   // If at least one was non-updatable, make the whole non-updatable.

--- a/src/nnet2/nnet-component.h
+++ b/src/nnet2/nnet-component.h
@@ -709,6 +709,7 @@ class ScaleComponent: public Component {
 
 class SumGroupComponent; // Forward declaration.
 class AffineComponent; // Forward declaration.
+class FixedScaleComponent; // Forward declaration.
 
 class SoftmaxComponent: public NonlinearComponent {
  public:
@@ -803,6 +804,7 @@ class AffineComponent: public UpdatableComponent {
   // FixedLinearComponent yet.
   Component *CollapseWithNext(const AffineComponent &next) const ;
   Component *CollapseWithNext(const FixedAffineComponent &next) const;
+  Component *CollapseWithNext(const FixedScaleComponent &next) const;
   Component *CollapseWithPrevious(const FixedAffineComponent &prev) const;
 
   virtual std::string Info() const;
@@ -1473,6 +1475,7 @@ class FixedScaleComponent: public Component {
   virtual void Write(std::ostream &os, bool binary) const;
 
  protected:
+  friend class AffineComponent; // necessary for collapse
   CuVector<BaseFloat> scales_;  
   KALDI_DISALLOW_COPY_AND_ASSIGN(FixedScaleComponent);
 };


### PR DESCRIPTION
  Modified ResizeOutputLayer method in nnet-nnet.cc to accommodate networks with FixedScaleComponents