### PR TITLE
Cosmetic change: OptionsItf *po -> OptionsItf *opts

### DIFF
--- a/src/decoder/decoder-wrappers.h
+++ b/src/decoder/decoder-wrappers.h
@@ -38,7 +38,7 @@ struct AlignConfig {
 
   AlignConfig(): beam(200.0), retry_beam(0.0), careful(false) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("beam", &beam, "Decoding beam used in alignment");
     po->Register("retry-beam", &retry_beam,
                  "Decoding beam for second try at alignment");

--- a/src/decoder/faster-decoder.h
+++ b/src/decoder/faster-decoder.h
@@ -42,7 +42,7 @@ struct FasterDecoderOptions {
                                           // alignment, use small default.
                           beam_delta(0.5),
                           hash_ratio(2.0) { }
-  void Register(OptionsItf *po, bool full) {  /// if "full", use obscure
+  void Register(OptionsItf *opts, bool full) {  /// if "full", use obscure
     /// options too.
     /// Depends on program.
     po->Register("beam", &beam, "Decoder beam");

--- a/src/decoder/lattice-faster-decoder.h
+++ b/src/decoder/lattice-faster-decoder.h
@@ -64,7 +64,7 @@ struct LatticeFasterDecoderConfig {
                                 beam_delta(0.5),
                                 hash_ratio(2.0),
                                 prune_scale(0.1) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     det_opts.Register(po);
     po->Register("beam", &beam, "Decoding beam.");
     po->Register("max-active", &max_active, "Decoder max active states.");

--- a/src/decoder/lattice-simple-decoder.h
+++ b/src/decoder/lattice-simple-decoder.h
@@ -53,7 +53,7 @@ struct LatticeSimpleDecoderConfig {
                                 determinize_lattice(true),
                                 beam_ratio(0.9),
                                 prune_scale(0.1) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     det_opts.Register(po);
     po->Register("beam", &beam, "Decoding beam.");
     po->Register("lattice-beam", &lattice_beam, "Lattice generation beam");

--- a/src/decoder/lattice-tracking-decoder.h
+++ b/src/decoder/lattice-tracking-decoder.h
@@ -54,7 +54,7 @@ struct LatticeTrackingDecoderConfig {
                                 hash_ratio(2.0),
                                 extra_beam(4.0),
                                 max_beam(40.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     det_opts.Register(po);
     po->Register("beam", &beam, "Decoding beam.");
     po->Register("max-active", &max_active, "Decoder max active states.");

--- a/src/decoder/nbest-decoder.h
+++ b/src/decoder/nbest-decoder.h
@@ -41,7 +41,7 @@ struct NBestDecoderOptions {
                          max_active(std::numeric_limits<int32>::max()),
                          n_best(1),
                          beam_delta(0.5), hash_ratio(2.0) { }
-  void Register(OptionsItf *po, bool full) {  /// if "full", use obscure
+  void Register(OptionsItf *opts, bool full) {  /// if "full", use obscure
     /// options too.
     /// Depends on program.
     po->Register("beam", &beam, "Decoder beam");

--- a/src/decoder/training-graph-compiler.h
+++ b/src/decoder/training-graph-compiler.h
@@ -42,7 +42,7 @@ struct TrainingGraphCompilerOptions {
       rm_eps(false),
       reorder(b) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("transition-scale", &transition_scale, "Scale of transition "
                  "probabilities (excluding self-loops)");
     po->Register("self-loop-scale", &self_loop_scale, "Scale of self-loop vs. "

--- a/src/feat/feature-fbank.h
+++ b/src/feat/feature-fbank.h
@@ -53,7 +53,7 @@ struct FbankOptions {
                  htk_compat(false),
                  use_log_fbank(true) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     frame_opts.Register(po);
     mel_opts.Register(po);
     po->Register("use-energy", &use_energy,

--- a/src/feat/feature-functions.h
+++ b/src/feat/feature-functions.h
@@ -52,7 +52,7 @@ struct MelBanksOptions {
       : num_bins(num_bins), low_freq(20), high_freq(0), vtln_low(100),
         vtln_high(-500), debug_mel(false), htk_mode(false) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-mel-bins", &num_bins,
                  "Number of triangular mel-frequency bins");
     po->Register("low-freq", &low_freq,
@@ -95,7 +95,7 @@ struct FrameExtractionOptions {
       round_to_power_of_two(true),
       snip_edges(true){ }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("sample-frequency", &samp_freq,
                  "Waveform data sample frequency (must match the waveform file, "
                  "if specified there)");
@@ -197,7 +197,7 @@ struct DeltaFeaturesOptions {
 
   DeltaFeaturesOptions(int32 order = 2, int32 window = 2):
       order(order), window(window) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("delta-order", &order, "Order of delta computation");
     po->Register("delta-window", &window,
                  "Parameter controlling window for delta computation (actual window"
@@ -233,7 +233,7 @@ struct ShiftedDeltaFeaturesOptions {
 
   ShiftedDeltaFeaturesOptions():
       window(1), num_blocks(7), block_shift(3) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("delta-window", &window, "Size of delta advance and delay.");
     po->Register("num-blocks", &num_blocks, "Number of delta blocks in advance"
                  " of each frame to be concatenated");
@@ -320,7 +320,7 @@ struct SlidingWindowCmnOptions {
       normalize_variance(false),
       center(false) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("cmn-window", &cmn_window, "Window in frames for running "
                  "average CMN computation");
     po->Register("min-cmn-window", &min_window, "Minimum CMN window "

--- a/src/feat/feature-mfcc.h
+++ b/src/feat/feature-mfcc.h
@@ -57,7 +57,7 @@ struct MfccOptions {
                   cepstral_lifter(22.0),
                   htk_compat(false) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     frame_opts.Register(po);
     mel_opts.Register(po);
     po->Register("num-ceps", &num_ceps,

--- a/src/feat/feature-plp.h
+++ b/src/feat/feature-plp.h
@@ -66,7 +66,7 @@ struct PlpOptions {
                  cepstral_scale(1.0),
                  htk_compat(false) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     frame_opts.Register(po);
     mel_opts.Register(po);
     po->Register("lpc-order", &lpc_order,

--- a/src/feat/feature-spectrogram.h
+++ b/src/feat/feature-spectrogram.h
@@ -44,7 +44,7 @@ struct SpectrogramOptions {
     energy_floor(0.0),  // not in log scale: a small value e.g. 1.0e-10
     raw_energy(true) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     frame_opts.Register(po);
     po->Register("energy-floor", &energy_floor,
                  "Floor on energy (absolute, not relative) in Spectrogram computation");

--- a/src/feat/pitch-functions.h
+++ b/src/feat/pitch-functions.h
@@ -130,7 +130,7 @@ struct PitchExtractionOptions {
       nccf_ballast_online(false),
       snip_edges(true) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("sample-frequency", &samp_freq,
                  "Waveform data sample frequency (must match the waveform "
                  "file, if specified there)");

--- a/src/feat/sinusoid-detection.h
+++ b/src/feat/sinusoid-detection.h
@@ -269,7 +269,7 @@ struct MultiSinusoidDetectorConfig {
       max_freq(1800.0), subsample_freq(4000),
       subsample_filter_cutoff(1900.0), subsample_filter_zeros(5) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("frame-length", &frame_length_ms,
                  "Frame length in milliseconds");
     po->Register("frame-shift", &frame_shift_ms,

--- a/src/featbin/interpolate-pitch.cc
+++ b/src/featbin/interpolate-pitch.cc
@@ -35,7 +35,7 @@ struct PitchInterpolatorOptions {
                               interpolator_factor(1.0e-05),
                               max_voicing_prob(0.9),
                               max_pitch_change_per_frame(10.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("pitch-interval", &pitch_interval, "Frequency interval in Hz, used "
                  "for the pitch interpolation and smoothing algorithm.");
     po->Register("interpolator-factor", &interpolator_factor, "Factor affecting the "

--- a/src/gmm/am-diag-gmm.h
+++ b/src/gmm/am-diag-gmm.h
@@ -173,7 +173,7 @@ struct UbmClusteringOptions {
         : ubm_num_gauss(ncomp), reduce_state_factor(red),
           intermediate_num_gauss(interm_gauss), cluster_varfloor(vfloor),
           max_am_gauss(max_am_gauss) {}
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "UbmClusteringOptions: ";
     po->Register("max-am-gauss", &max_am_gauss, module+
                  "We first reduce acoustic model to this max #Gauss before clustering.");

--- a/src/gmm/ebw-diag-gmm.h
+++ b/src/gmm/ebw-diag-gmm.h
@@ -36,7 +36,7 @@ struct EbwOptions {
   BaseFloat tau; // This is only useful for smoothing "to the model":
   // if you want to smooth to ML stats, you need to use gmm-ismooth-stats
   EbwOptions(): E(2.0), tau(0.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwOptions: ";
     po->Register("E", &E, module+"Constant E for Extended Baum-Welch (EBW) update");
     po->Register("tau", &tau, module+"Tau value for smoothing to the model "
@@ -52,7 +52,7 @@ struct EbwWeightOptions {
   EbwWeightOptions(): min_num_count_weight_update(10.0),
                       min_gaussian_weight(1.0e-05),
                       tau(0.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwWeightOptions: ";
     po->Register("min-num-count-weight-update", &min_num_count_weight_update,
                  module+"Minimum numerator count required at "

--- a/src/gmm/mle-diag-gmm.h
+++ b/src/gmm/mle-diag-gmm.h
@@ -56,7 +56,7 @@ struct MleDiagGmmOptions {
     min_variance            = 0.001;
     remove_low_count_gaussians = true;
   }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleDiagGmmOptions: ";
     po->Register("min-gaussian-weight", &min_gaussian_weight,
                  module+"Min Gaussian weight before we remove it.");
@@ -90,7 +90,7 @@ struct MapDiagGmmOptions {
                              variance_tau(50.0),
                              weight_tau(10.0) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("mean-tau", &mean_tau,
                  "Tau value for updating means.");
     po->Register("variance-tau", &mean_tau,

--- a/src/gmm/mle-full-gmm.h
+++ b/src/gmm/mle-full-gmm.h
@@ -53,7 +53,7 @@ struct MleFullGmmOptions {
     max_condition          = 1.0e+04;
     remove_low_count_gaussians = true;
   }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleFullGmmOptions: ";
     po->Register("min-gaussian-weight", &min_gaussian_weight,
                  module+"Min Gaussian weight before we remove it.");

--- a/src/hmm/hmm-utils.h
+++ b/src/hmm/hmm-utils.h
@@ -63,7 +63,7 @@ struct HTransducerConfig {
   // Note-- this Register registers the easy-to-register options
   // but not the "sym_type" which is an enum and should be handled
   // separately in main().
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("transition-scale", &transition_scale,
                  "Scale of transition probs (relative to LM)");
     po->Register("reverse", &reverse,

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -93,7 +93,7 @@ struct MleTransitionUpdateConfig {
                             bool share_for_pdfs = false):
       floor(floor), mincount(mincount), share_for_pdfs(share_for_pdfs) {}
   
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("transition-floor", &floor,
                  "Floor for transition probabilities");
     po->Register("transition-min-count", &mincount,
@@ -109,7 +109,7 @@ struct MapTransitionUpdateConfig {
   bool share_for_pdfs; // If true, share all transition parameters that have the same pdf.
   MapTransitionUpdateConfig(): tau(5.0), share_for_pdfs(false) { }
 
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("transition-tau", &tau, "Tau value for MAP estimation of transition "
                  "probabilities.");
     po->Register("share-for-pdfs", &share_for_pdfs,

--- a/src/ivector/ivector-extractor.h
+++ b/src/ivector/ivector-extractor.h
@@ -51,7 +51,7 @@ struct IvectorEstimationOptions {
   double acoustic_weight;
   double max_count;
   IvectorEstimationOptions(): acoustic_weight(1.0), max_count(0.0) {}
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("acoustic-weight", &acoustic_weight,
                  "Weight on part of auxf that involves the data (e.g. 0.2); "
                  "if this weight is small, the prior will have more effect.");
@@ -108,7 +108,7 @@ struct IvectorExtractorOptions {
   bool use_weights;
   IvectorExtractorOptions(): ivector_dim(400), num_iters(2),
                              use_weights(true) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-iters", &num_iters, "Number of iterations in "
                  "iVector estimation (>1 needed due to weights)");
     po->Register("ivector-dim", &ivector_dim, "Dimension of iVector");
@@ -426,7 +426,7 @@ struct IvectorExtractorStatsOptions {
                          compute_auxf(true),
                          num_samples_for_weights(10),
                          cache_size(100) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("update-variances", &update_variances, "If true, update the "
                  "Gaussian variances");
     po->Register("compute-auxf", &compute_auxf, "If true, compute the "
@@ -450,7 +450,7 @@ struct IvectorExtractorEstimationOptions {
   IvectorExtractorEstimationOptions(): variance_floor_factor(0.1),
                                        gaussian_min_count(100.0),
                                        diagonalize(true) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("variance-floor-factor", &variance_floor_factor,
                  "Factor that determines variance flooring (we floor each covar "
                  "to this times global average covariance");

--- a/src/ivector/logistic-regression.h
+++ b/src/ivector/logistic-regression.h
@@ -35,7 +35,7 @@ struct LogisticRegressionConfig {
          power;
   LogisticRegressionConfig(): max_steps(20), mix_up(0), 
                               normalizer(0.0025), power(0.15){ }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("max-steps", &max_steps,
                  "Maximum steps in L-BFGS.");
     po->Register("normalizer", &normalizer,

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -51,7 +51,7 @@ struct PldaConfig {
   // prior to dot-product scoring.
   bool normalize_length;
   PldaConfig(): normalize_length(true) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("normalize-length", &normalize_length,
                  "If true, do length normalization as part of PLDA.  This "
                  "normalizes the length of the iVectors to be equal to the "
@@ -186,7 +186,7 @@ class PldaStats {
 struct PldaEstimationConfig {
   int32 num_em_iters;
   PldaEstimationConfig(): num_em_iters(10){ }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-em-iters", &num_em_iters,
                  "Number of iterations of E-M used for PLDA estimation");
   }
@@ -258,7 +258,7 @@ struct PldaUnsupervisedAdaptorConfig {
       within_covar_scale(0.3),
       between_covar_scale(0.7) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("mean-diff-scale", &mean_diff_scale,
                  "Scale with which to add to the total data variance, the outer "
                  "product of the difference between the original mean and the "

--- a/src/ivector/voice-activity-detection.h
+++ b/src/ivector/voice-activity-detection.h
@@ -49,7 +49,7 @@ struct VadEnergyOptions {
                       vad_energy_mean_scale(0.5),
                       vad_frames_context(5),
                       vad_proportion_threshold(0.6) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("vad-energy-threshold", &vad_energy_threshold,
                  "Constant term in energy threshold for MFCC0 for VAD (also see "
                  "--vad-energy-mean-scale)");

--- a/src/kws/kws-scoring.cc
+++ b/src/kws/kws-scoring.cc
@@ -110,7 +110,7 @@ typedef unordered_map <std::string, SweepThresholdStats> PerKwSweepStats;
 }  // namespace kws_internal
 
 
-void KwsTermsAlignerOptions::Register(OptionsItf *po) {
+void KwsTermsAlignerOptions::Register(OptionsItf *opts) {
   po->Register("max_distance", &max_distance,
                "Max distance on the ref and hyp centers "
                "to be considered as a potential match");
@@ -294,7 +294,7 @@ TwvMetricsOptions::TwvMetricsOptions(): cost_fa(0.1f),
                                         sweep_step(0.05f),
                                         audio_duration(0.0f) {}
 
-void TwvMetricsOptions::Register(OptionsItf *po) {
+void TwvMetricsOptions::Register(OptionsItf *opts) {
   po->Register("cost-fa", &cost_fa,
               "The cost of an incorrect detection");
   po->Register("value-corr", &value_corr,

--- a/src/kws/kws-scoring.h
+++ b/src/kws/kws-scoring.h
@@ -130,7 +130,7 @@ struct KwsTermsAlignerOptions {
                      // Default: 50 frames (usually 0.5 seconds)
 
   inline KwsTermsAlignerOptions(): max_distance(50) {}
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
 class KwsTermsAligner {
@@ -213,7 +213,7 @@ struct TwvMetricsOptions {
     return (cost_fa/value_corr) * (1.0/prior_probability - 1);
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
 class TwvMetricsStats;

--- a/src/lat/determinize-lattice-pruned.h
+++ b/src/lat/determinize-lattice-pruned.h
@@ -124,7 +124,7 @@ struct DeterminizeLatticePrunedOptions {
                                      max_states(-1),
                                      max_arcs(-1),
                                      retry_cutoff(0.5) { }
-  void Register (kaldi::OptionsItf *po) {
+  void Register (kaldi::OptionsItf *opts) {
     po->Register("delta", &delta, "Tolerance used in determinization");
     po->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
                 "determinization (real usage might be many times this)");
@@ -160,7 +160,7 @@ struct DeterminizeLatticePhonePrunedOptions {
                                           phone_determinize(true),
                                           word_determinize(true),
                                           minimize(false) {}
-  void Register (kaldi::OptionsItf *po) {
+  void Register (kaldi::OptionsItf *opts) {
     po->Register("delta", &delta, "Tolerance used in determinization");
     po->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
                 "determinization (real usage might be many times this).");

--- a/src/lat/phone-align-lattice.h
+++ b/src/lat/phone-align-lattice.h
@@ -38,7 +38,7 @@ struct PhoneAlignLatticeOptions {
   PhoneAlignLatticeOptions(): reorder(true),
                               remove_epsilon(true),
                               replace_output_symbols(false) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("reorder", &reorder, "True if lattice was created from HCLG with "
                  "--reorder=true option.");
     po->Register("remove-epsilon", &remove_epsilon, "If true, removes epsilons from "

--- a/src/lat/word-align-lattice-lexicon.h
+++ b/src/lat/word-align-lattice-lexicon.h
@@ -126,7 +126,7 @@ struct WordAlignLatticeLexiconOpts {
   WordAlignLatticeLexiconOpts(): partial_word_label(0), reorder(true),
                                  test(false), max_expand(-1.0) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("partial-word-label", &partial_word_label, "Numeric id of "
                  "word symbol that is to be used for arcs in the word-aligned "
                  "lattice corresponding to partial words at the end of "

--- a/src/lat/word-align-lattice.h
+++ b/src/lat/word-align-lattice.h
@@ -59,7 +59,7 @@ struct WordBoundaryInfoOpts {
                           reorder(true), silence_may_be_word_internal(false),
                           silence_has_olabels(false) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("wbegin-phones", &wbegin_phones, "Colon-separated list of "
                  "numeric ids of phones that begin a word");
     po->Register("wend-phones", &wend_phones, "Colon-separated list of "
@@ -101,7 +101,7 @@ struct WordBoundaryInfoNewOpts {
   WordBoundaryInfoNewOpts(): silence_label(0), partial_word_label(0),
                              reorder(true) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("silence-label", &silence_label, "Numeric id of word symbol "
                  "that is to be used for silence arcs in the word-aligned "
                  "lattice (zero is OK)");

--- a/src/matrix/kaldi-gpsr.h
+++ b/src/matrix/kaldi-gpsr.h
@@ -93,10 +93,10 @@ struct GpsrConfig {
     max_iters_debias = 50;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void GpsrConfig::Register(OptionsItf *po) {
+inline void GpsrConfig::Register(OptionsItf *opts) {
   std::string module = "GpsrConfig: ";
   po->Register("use-gpsr-bb", &use_gpsr_bb, module+
                "Use the Barzilai-Borwein gradient projection method.");

--- a/src/nnet/nnet-pdf-prior.h
+++ b/src/nnet/nnet-pdf-prior.h
@@ -41,7 +41,7 @@ struct PdfPriorOptions {
                       prior_scale(1.0),
                       prior_floor(1e-10) {}
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("class-frame-counts", &class_frame_counts,
                  "Vector with frame-counts of pdfs to compute log-priors."
                  " (priors are typically subtracted from log-posteriors"

--- a/src/nnet/nnet-randomizer.h
+++ b/src/nnet/nnet-randomizer.h
@@ -39,7 +39,7 @@ struct NnetDataRandomizerOptions {
    : randomizer_size(32768), randomizer_seed(777), minibatch_size(256) 
   { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("randomizer-size", &randomizer_size, "Capacity of randomizer, length of concatenated utterances which are used for frame-level shuffling (in frames, affects memory consumption, max 8000000).");
     po->Register("randomizer-seed", &randomizer_seed, "Seed value for srand, sets fixed order of frame-level shuffling");
     po->Register("minibatch-size", &minibatch_size, "Size of a minibatch.");

--- a/src/nnet/nnet-trnopts.h
+++ b/src/nnet/nnet-trnopts.h
@@ -40,7 +40,7 @@ struct NnetTrainOptions {
                        l1_penalty(0.0) 
                        { }
   // register options
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("learn-rate", &learn_rate, "Learning rate");
     po->Register("momentum", &momentum, "Momentum");
     po->Register("l2-penalty", &l2_penalty, "L2 penalty (weight decay)");
@@ -76,7 +76,7 @@ struct RbmTrainOptions {
                       l2_penalty(0.0002)
                       { }
   // register options
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("learn-rate", &learn_rate, "Learning rate");
 
     po->Register("momentum", &momentum, "Initial momentum for linear scheduling");

--- a/src/nnet2/combine-nnet-a.h
+++ b/src/nnet2/combine-nnet-a.h
@@ -49,7 +49,7 @@ struct NnetCombineAconfig {
                         max_learning_rate_factor(2.0),
                         min_learning_rate(0.0001) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
                  "evaluations for BFGS to use when optimizing combination weights");
     po->Register("initial-step", &initial_step, "Parameter in the optimization, "

--- a/src/nnet2/combine-nnet-fast.h
+++ b/src/nnet2/combine-nnet-fast.h
@@ -70,7 +70,7 @@ struct NnetCombineFastConfig {
                            alpha(0.01), fisher_minibatch_size(64), minibatch_size(1024),
                            max_lbfgs_dim(10), regularizer(0.0) {}
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("initial-model", &initial_model, "Specifies where to start the "
                  "optimization from.  If 0 ... #models-1, then specifies the model; "
                  "if >= #models, then the average of all inputs; if <0, chosen "

--- a/src/nnet2/combine-nnet.h
+++ b/src/nnet2/combine-nnet.h
@@ -47,7 +47,7 @@ struct NnetCombineConfig {
                        initial_impr(0.01),
                        test_gradient(false) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("initial-model", &initial_model, "Specifies where to start the "
                  "optimization from.  If 0 ... #models-1, then specifies the model; "
                  "if #models, then the average of all inputs; otherwise, chosen "

--- a/src/nnet2/get-feature-transform.h
+++ b/src/nnet2/get-feature-transform.h
@@ -44,7 +44,7 @@ struct FeatureTransformEstimateOptions {
   FeatureTransformEstimateOptions(): remove_offset(true), dim(200),
                                      within_class_factor(0.001), max_singular_value(5.0) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("remove-offset", &remove_offset, "If true, output an affine "
                  "transform that makes the projected data mean equal to zero.");
     po->Register("dim", &dim, "Dimension to project to with LDA");

--- a/src/nnet2/mixup-nnet.h
+++ b/src/nnet2/mixup-nnet.h
@@ -37,7 +37,7 @@ struct NnetMixupConfig {
   NnetMixupConfig(): power(0.25), min_count(1000.0),
                      num_mixtures(-1), perturb_stddev(0.01) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("power", &power, "Scaling factor used in determining the "
                  "number of mixture components to use for each HMM state "
                  "(or group of HMM states)");

--- a/src/nnet2/nnet-compute-discriminative.h
+++ b/src/nnet2/nnet-compute-discriminative.h
@@ -48,7 +48,7 @@ struct NnetDiscriminativeUpdateOptions {
                                      one_silence_class(false),
                                      boost(0.0) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("criterion", &criterion, "Criterion, 'mmi'|'mpfe'|'smbr', "
                  "determines the objective function to use.  Should match "
                  "option used when we created the examples.");

--- a/src/nnet2/nnet-example-functions.h
+++ b/src/nnet2/nnet-example-functions.h
@@ -89,7 +89,7 @@ struct SplitDiscriminativeExampleConfig {
       determinize(true), minimize(true), test(false), drop_frames(false),
       split(true), excise(true) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
 
     po->Register("max-length", &max_length, "Maximum length allowed for any "
                 "segment (i.e. max #frames for any example");

--- a/src/nnet2/nnet-fix.h
+++ b/src/nnet2/nnet-fix.h
@@ -51,7 +51,7 @@ struct NnetFixConfig {
 
   NnetFixConfig(): min_average_deriv(0.1), max_average_deriv(0.75),
                    parameter_factor(2.0), relu_bias_change(1.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("min-average-deriv", &min_average_deriv, "Miniumum derivative, "
                  "averaged over the training data, that we allow for a nonlinearity,"
                  "expressed relative to the maximum derivative of the nonlinearity,"

--- a/src/nnet2/nnet-limit-rank.h
+++ b/src/nnet2/nnet-limit-rank.h
@@ -35,7 +35,7 @@ struct NnetLimitRankOpts {
   
   NnetLimitRankOpts(): num_threads(1), parameter_proportion(0.75) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-threads", &num_threads, "Number of threads used for "
                  "rank-limiting operation; note, will never use more than "
                  "#layers.");

--- a/src/nnet2/nnet-stats.h
+++ b/src/nnet2/nnet-stats.h
@@ -35,7 +35,7 @@ struct NnetStatsConfig {
   BaseFloat bucket_width;
   NnetStatsConfig(): bucket_width(0.025) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("bucket-width", &bucket_width, "Width of bucket in average-derivative "
                  "stats for analysis.");
   }

--- a/src/nnet2/online-nnet2-decodable.h
+++ b/src/nnet2/online-nnet2-decodable.h
@@ -44,7 +44,7 @@ struct DecodableNnet2OnlineOptions {
       pad_input(true),
       max_nnet_batch_size(256) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("acoustic-scale", &acoustic_scale,
                  "Scaling factor for acoustic likelihoods");
     po->Register("pad-input", &pad_input,

--- a/src/nnet2/rescale-nnet.h
+++ b/src/nnet2/rescale-nnet.h
@@ -54,7 +54,7 @@ struct NnetRescaleConfig {
                        delta(0.01),
                        max_change(0.2), min_change(1.0e-05) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("target-avg-deriv", &target_avg_deriv, "Target average derivative "
                  "for hidden layers that are the not the first or last hidden layer "
                  "(as fraction of maximum derivative of the nonlinearity)");

--- a/src/nnet2/shrink-nnet.h
+++ b/src/nnet2/shrink-nnet.h
@@ -39,7 +39,7 @@ struct NnetShrinkConfig {
   BaseFloat initial_step;
   
   NnetShrinkConfig(): num_bfgs_iters(10), initial_step(0.1) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-bfgs-iters", &num_bfgs_iters, "Number of iterations of "
                  "BFGS to use when optimizing shrinkage parameters");
     po->Register("initial-step", &initial_step, "Parameter in the optimization, "

--- a/src/nnet2/train-nnet-ensemble.h
+++ b/src/nnet2/train-nnet-ensemble.h
@@ -38,7 +38,7 @@ struct NnetEnsembleTrainerConfig {
                              minibatches_per_phase(50),
                              beta(0.5) { }
   
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("minibatch-size", &minibatch_size,
                  "Number of samples per minibatch of training data.");
     po->Register("minibatches-per-phase", &minibatches_per_phase,

--- a/src/nnet2/train-nnet-perturbed.h
+++ b/src/nnet2/train-nnet-perturbed.h
@@ -191,7 +191,7 @@ struct NnetPerturbedTrainerConfig {
                                 tune_d_power(0.5),
                                 max_d_factor(2.0){ }
   
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("minibatch-size", &minibatch_size,
                  "Number of samples per minibatch of training data.");
     po->Register("minibatches-per-phase", &minibatches_per_phase,

--- a/src/nnet2/train-nnet.h
+++ b/src/nnet2/train-nnet.h
@@ -35,7 +35,7 @@ struct NnetSimpleTrainerConfig {
   NnetSimpleTrainerConfig(): minibatch_size(500),
                              minibatches_per_phase(50) { }
   
-  void Register (OptionsItf *po) {
+  void Register (OptionsItf *opts) {
     po->Register("minibatch-size", &minibatch_size,
                  "Number of samples per minibatch of training data.");
     po->Register("minibatches-per-phase", &minibatches_per_phase,

--- a/src/nnet2/widen-nnet.h
+++ b/src/nnet2/widen-nnet.h
@@ -39,7 +39,7 @@ struct NnetWidenConfig {
                      param_stddev_factor(1.0),
                      bias_stddev(0.5) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("hidden-layer-dim", &hidden_layer_dim, "[required option]: "
                  "target dimension of hidden layers");
     po->Register("param-stddev-factor", &param_stddev_factor, "Factor in "

--- a/src/online/online-faster-decoder.h
+++ b/src/online/online-faster-decoder.h
@@ -48,7 +48,7 @@ struct OnlineFasterDecoderOpts : public FasterDecoderOptions {
     update_interval(3), beam_update(.01),
     max_beam_update(0.05) {}
 
-  void Register(OptionsItf *po, bool full) {
+  void Register(OptionsItf *opts, bool full) {
     FasterDecoderOptions::Register(po, full);
     po->Register("rt-min", &rt_min,
                  "Approximate minimum decoding run time factor");

--- a/src/online/online-feat-input.h
+++ b/src/online/online-feat-input.h
@@ -335,7 +335,7 @@ struct OnlineFeatureMatrixOptions {
                    // before we give up.
   OnlineFeatureMatrixOptions(): batch_size(27),
                                 num_tries(5) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("batch-size", &batch_size,
                  "Number of feature vectors processed w/o interruption");
     po->Register("num-tries", &num_tries,

--- a/src/online2/online-endpoint.h
+++ b/src/online2/online-endpoint.h
@@ -99,7 +99,7 @@ struct OnlineEndpointRule {
       max_relative_cost(max_relative_cost),
       min_utterance_length(min_utterance_length) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("must-contain-nonsilence", &must_contain_nonsilence,
                  "If true, for this endpointing rule to apply there must"
                  "be nonsilence in the best-path traceback.");
@@ -117,7 +117,7 @@ struct OnlineEndpointRule {
   // for convenience add this RegisterWithPrefix function, because
   // we'll be registering this as a config with several different
   // prefixes.
-  void RegisterWithPrefix(const std::string &prefix, OptionsItf *po) {
+  void RegisterWithPrefix(const std::string &prefix, OptionsItf *opts) {
     ParseOptions po_prefix(prefix, po);
     this->Register(&po_prefix);
   }
@@ -155,7 +155,7 @@ struct OnlineEndpointConfig {
       rule4(true, 2.0, std::numeric_limits<BaseFloat>::infinity(), 0.0),
       rule5(false, 0.0, std::numeric_limits<BaseFloat>::infinity(), 20.0) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("endpoint.silence-phones", &silence_phones, "List of phones "
                  "that are considered to be silence phones by the "
                  "endpointing code.");

--- a/src/online2/online-feature-pipeline.h
+++ b/src/online2/online-feature-pipeline.h
@@ -66,7 +66,7 @@ struct OnlineFeaturePipelineCommandLineConfig {
     feature_type("mfcc"), add_pitch(false), add_deltas(false),
     splice_feats(false) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("feature-type", &feature_type,
                  "Base feature type [mfcc, plp, fbank]");
     po->Register("mfcc-config", &mfcc_config, "Configuration file for "

--- a/src/online2/online-gmm-decoding.h
+++ b/src/online2/online-gmm-decoding.h
@@ -64,7 +64,7 @@ struct OnlineGmmDecodingAdaptationPolicyConfig {
       adaptation_delay(5.0),
       adaptation_ratio(2.0) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("adaptation-first-utt-delay", &adaptation_first_utt_delay,
                  "Delay before first basis-fMLLR adaptation for first utterance "
                  "of each speaker");
@@ -122,7 +122,7 @@ struct OnlineGmmDecodingConfig {
   OnlineGmmDecodingConfig():  fmllr_lattice_beam(3.0), acoustic_scale(0.1),
                               silence_weight(0.1) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     { // register basis_opts with prefix, there are getting to be too many
       // options.
       ParseOptions basis_po("basis", po);

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -106,7 +106,7 @@ struct OnlineIvectorExtractionConfig {
                                    greedy_ivector_extractor(false),
                                    max_remembered_frames(1000) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("lda-matrix", &lda_mat_rxfilename, "Filename of LDA matrix, "
                  "e.g. final.mat; used for iVector extraction. ");
     po->Register("global-cmvn-stats", &global_cmvn_stats_rxfilename,
@@ -410,7 +410,7 @@ struct OnlineSilenceWeightingConfig {
   OnlineSilenceWeightingConfig():
       silence_weight(1.0), max_state_duration(-1) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("silence-phones", &silence_phones_str, "(RE weighting in "
                  "iVector estimation for online decoding) List of integer ids of "
                  "silence phones, separated by colons (or commas).  Data that "
@@ -426,7 +426,7 @@ struct OnlineSilenceWeightingConfig {
                  "than this will be weighted down to the silence-weight.");
   }
   // e.g. prefix = "ivector-silence-weighting"
-  void RegisterWithPrefix(std::string prefix, OptionsItf *po) {
+  void RegisterWithPrefix(std::string prefix, OptionsItf *opts) {
     ParseOptions po_prefix(prefix, po);
     this->Register(&po_prefix);
   }

--- a/src/online2/online-nnet2-decoding-threaded.h
+++ b/src/online2/online-nnet2-decoding-threaded.h
@@ -160,7 +160,7 @@ struct OnlineNnet2DecodingThreadedConfig {
 
   void Check();
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     decoder_opts.Register(po);
     po->Register("acoustic-scale", &acoustic_scale, "Scale used on acoustics "
                  "when decoding");

--- a/src/online2/online-nnet2-decoding.h
+++ b/src/online2/online-nnet2-decoding.h
@@ -54,7 +54,7 @@ struct OnlineNnet2DecodingConfig {
   
   OnlineNnet2DecodingConfig() {  decodable_opts.acoustic_scale = 0.1; }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     decoder_opts.Register(po);
     decodable_opts.Register(po);
   }

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -89,7 +89,7 @@ struct OnlineNnet2FeaturePipelineConfig {
       feature_type("mfcc"), add_pitch(false) { }
       
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("feature-type", &feature_type,
                  "Base feature type [mfcc, plp, fbank]");
     po->Register("mfcc-config", &mfcc_config, "Configuration file for "

--- a/src/online2/online-speex-wrapper.h
+++ b/src/online2/online-speex-wrapper.h
@@ -61,7 +61,7 @@ struct SpeexOptions {
                   speex_bits_frame_size(106),
                   speex_wave_frame_size(320) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("sample-rate", &sample_rate, "Sample frequency of the waveform.");
     po->Register("speex-quality", &speex_quality, "Speex speech quality.");
     po->Register("speex-bits-frame-size", &speex_bits_frame_size,

--- a/src/sgmm/am-sgmm.h
+++ b/src/sgmm/am-sgmm.h
@@ -47,7 +47,7 @@ struct SgmmGselectConfig {
     diag_gmm_nbest = 50;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
         " full-covariance Gaussians selected per frame.");
     po->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"

--- a/src/sgmm/estimate-am-sgmm-ebw.h
+++ b/src/sgmm/estimate-am-sgmm-ebw.h
@@ -94,7 +94,7 @@ struct EbwAmSgmmOptions {
     epsilon = 1.0e-40;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwAmSgmmOptions: ";
     po->Register("tau-v", &tau_v, module+
                  "Smoothing constant for phone vector estimation.");

--- a/src/sgmm/estimate-am-sgmm.h
+++ b/src/sgmm/estimate-am-sgmm.h
@@ -100,7 +100,7 @@ struct MleAmSgmmOptions {
     full_col_cov = false;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleAmSgmmOptions: ";
     po->Register("tau-vec", &tau_vec, module+
                  "Smoothing for phone vector estimation.");

--- a/src/sgmm/fmllr-sgmm.h
+++ b/src/sgmm/fmllr-sgmm.h
@@ -63,10 +63,10 @@ struct SgmmFmllrConfig {
     bases_occ_scale = 0.2;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void SgmmFmllrConfig::Register(OptionsItf *po) {
+inline void SgmmFmllrConfig::Register(OptionsItf *opts) {
   std::string module = "SgmmFmllrConfig: ";
   po->Register("fmllr-iters", &fmllr_iters, module+
                "Number of iterations in FMLLR estimation.");

--- a/src/sgmm2/am-sgmm2.h
+++ b/src/sgmm2/am-sgmm2.h
@@ -99,7 +99,7 @@ struct Sgmm2SplitSubstatesConfig {
                                power(0.2),
                                max_cond(100.0),
                                min_count(40.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("split-substates", &split_substates, "Increase number of "
                  "substates to this overall target.");
     po->Register("max-cond-split", &max_cond, "Max condition number of smoothing "
@@ -126,7 +126,7 @@ struct Sgmm2GselectConfig {
     diag_gmm_nbest = 50;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
         " full-covariance Gaussians selected per frame.");
     po->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"

--- a/src/sgmm2/estimate-am-sgmm2-ebw.h
+++ b/src/sgmm2/estimate-am-sgmm2-ebw.h
@@ -100,7 +100,7 @@ struct EbwAmSgmm2Options {
     epsilon = 1.0e-40;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwAmSgmm2Options: ";
     po->Register("tau-v", &tau_v, module+
                  "Smoothing constant for phone vector estimation.");

--- a/src/sgmm2/estimate-am-sgmm2.h
+++ b/src/sgmm2/estimate-am-sgmm2.h
@@ -88,7 +88,7 @@ struct MleAmSgmm2Options {
     full_col_cov = false;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleAmSgmm2Options: ";
     po->Register("tau-c", &tau_c, module+
                  "Count for smoothing weight update.");

--- a/src/sgmm2/fmllr-sgmm2.h
+++ b/src/sgmm2/fmllr-sgmm2.h
@@ -63,10 +63,10 @@ struct Sgmm2FmllrConfig {
     bases_occ_scale = 0.2;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void Sgmm2FmllrConfig::Register(OptionsItf *po) {
+inline void Sgmm2FmllrConfig::Register(OptionsItf *opts) {
   std::string module = "Sgmm2FmllrConfig: ";
   po->Register("fmllr-iters", &fmllr_iters, module+
                "Number of iterations in FMLLR estimation.");

--- a/src/thread/kaldi-task-sequence.h
+++ b/src/thread/kaldi-task-sequence.h
@@ -61,7 +61,7 @@ struct TaskSequencerConfig {
   int32 num_threads;
   int32 num_threads_total;
   TaskSequencerConfig(): num_threads(1), num_threads_total(0)  { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-threads", &num_threads, "Number of actively processing "
                  "threads to run in parallel");
     po->Register("num-threads-total", &num_threads_total, "Total number of "

--- a/src/transform/basis-fmllr-diag-gmm.h
+++ b/src/transform/basis-fmllr-diag-gmm.h
@@ -51,7 +51,7 @@ struct BasisFmllrOptions {
   BaseFloat min_count;
   int32 step_size_iters;
   BasisFmllrOptions(): num_iters(10), size_scale(0.2), min_count(50.0), step_size_iters(3) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("num-iters", &num_iters,
                  "Number of iterations in basis fMLLR update during testing");
     po->Register("size-scale", &size_scale,

--- a/src/transform/fmllr-diag-gmm.h
+++ b/src/transform/fmllr-diag-gmm.h
@@ -45,7 +45,7 @@ struct FmllrOptions {
   BaseFloat min_count;
   int32 num_iters;
   FmllrOptions(): update_type("full"), min_count(500.0), num_iters(40) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("fmllr-update-type", &update_type,
                  "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
     po->Register("fmllr-min-count", &min_count,

--- a/src/transform/fmllr-raw.h
+++ b/src/transform/fmllr-raw.h
@@ -70,7 +70,7 @@ struct FmllrRawOptions {
   BaseFloat min_count;
   int32 num_iters;
   FmllrRawOptions(): min_count(100.0), num_iters(20) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("fmllr-min-count", &min_count,
                  "Minimum count required to update fMLLR");
     po->Register("fmllr-num-iters", &num_iters,

--- a/src/transform/fmpe.h
+++ b/src/transform/fmpe.h
@@ -72,7 +72,7 @@ struct FmpeOptions {
   FmpeOptions(): context_expansion("0,1.0:-1,1.0:1,1.0:-2,0.5;-3,0.5:2,0.5;3,0.5:-4,0.5;-5,0.5:4,0.5;5,0.5:-6,0.333;-7,0.333;-8,0.333:6,0.333;7,0.333;8,0.333"),
                 post_scale(5.0) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("post-scale", &post_scale, "Scaling constant on posterior "
                  "element of offset features, to give it a faster learning "
                  "rate.");
@@ -92,7 +92,7 @@ struct FmpeUpdateOptions {
   
   FmpeUpdateOptions(): learning_rate(0.1), l2_weight(100.0) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("learning-rate", &learning_rate,
                  "Learning rate constant (like inverse of E in fMPE papers)");
     po->Register("l2-weight", &l2_weight,

--- a/src/transform/lda-estimate.h
+++ b/src/transform/lda-estimate.h
@@ -35,7 +35,7 @@ struct LdaEstimateOptions {
   LdaEstimateOptions(): remove_offset(false), dim(40), allow_large_dim(false),
                         within_class_factor(1.0) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("remove-offset", &remove_offset, "If true, output an affine "
                  "transform that makes the projected data mean equal to zero.");
     po->Register("dim", &dim, "Dimension to project to with LDA");

--- a/src/transform/regtree-fmllr-diag-gmm.h
+++ b/src/transform/regtree-fmllr-diag-gmm.h
@@ -45,7 +45,7 @@ struct RegtreeFmllrOptions {
   RegtreeFmllrOptions(): update_type("full"), min_count(1000.0),
                          num_iters(10), use_regtree(true) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("fmllr-update-type", &update_type,
                  "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
     po->Register("fmllr-min-count", &min_count,

--- a/src/transform/regtree-mllr-diag-gmm.h
+++ b/src/transform/regtree-mllr-diag-gmm.h
@@ -41,7 +41,7 @@ struct RegtreeMllrOptions {
 
   RegtreeMllrOptions(): min_count(1000.0), use_regtree(true) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     po->Register("mllr-min-count", &min_count,
                  "Minimum count to estimate an MLLR transform.");
     po->Register("mllr-use-regtree", &use_regtree,

--- a/src/util/parse-options.h
+++ b/src/util/parse-options.h
@@ -232,7 +232,7 @@ class ParseOptions : public OptionsItf {
 /// This template is provided for convenience in reading config classes from
 /// files; this is not the standard way to read configuration options, but may
 /// occasionally be needed.  This function assumes the config has a function
-/// "void Register(OptionsItf *po)" which it can call to register the
+/// "void Register(OptionsItf *opts)" which it can call to register the
 /// ParseOptions object.
 template<class C> void ReadConfigFromFile(const std::string config_filename,
                                           C *c) {


### PR DESCRIPTION
The command used was:
egrep -ril 'OptionsItf *\*po' ./* | xargs -I@ sed -Eie 's/OptionsItf\s*\*po/OptionsItf \*opts/g' @

As requested in issue #37