### PR TITLE
Cosmetic variable name change: OptionsItf po -> OptionsItf opts

### DIFF
--- a/src/decoder/decoder-wrappers.h
+++ b/src/decoder/decoder-wrappers.h
@@ -38,13 +38,13 @@ struct AlignConfig {
 
   AlignConfig(): beam(200.0), retry_beam(0.0), careful(false) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("beam", &beam, "Decoding beam used in alignment");
-    po->Register("retry-beam", &retry_beam,
-                 "Decoding beam for second try at alignment");
-    po->Register("careful", &careful,
-                 "If true, do 'careful' alignment, which is better at detecting "
-                 "alignment failure (involves loop to start of decoding graph).");
+  void Register(OptionsItf *opts) {
+    opts->Register("beam", &beam, "Decoding beam used in alignment");
+    opts->Register("retry-beam", &retry_beam,
+                   "Decoding beam for second try at alignment");
+    opts->Register("careful", &careful,
+                   "If true, do 'careful' alignment, which is better at detecting "
+                   "alignment failure (involves loop to start of decoding graph).");
   }
 };
 

--- a/src/decoder/faster-decoder.h
+++ b/src/decoder/faster-decoder.h
@@ -42,18 +42,18 @@ struct FasterDecoderOptions {
                                           // alignment, use small default.
                           beam_delta(0.5),
                           hash_ratio(2.0) { }
-  void Register(OptionsItf *po, bool full) {  /// if "full", use obscure
+  void Register(OptionsItf *opts, bool full) {  /// if "full", use obscure
     /// options too.
     /// Depends on program.
-    po->Register("beam", &beam, "Decoder beam");
-    po->Register("max-active", &max_active, "Decoder max active states.");
-    po->Register("min-active", &min_active,
-                 "Decoder min active states (don't prune if #active less than this).");
+    opts->Register("beam", &beam, "Decoder beam");
+    opts->Register("max-active", &max_active, "Decoder max active states.");
+    opts->Register("min-active", &min_active,
+                   "Decoder min active states (don't prune if #active less than this).");
     if (full) {
-      po->Register("beam-delta", &beam_delta,
-                   "Increment used in decoder [obscure setting]");
-      po->Register("hash-ratio", &hash_ratio,
-                   "Setting used in decoder to control hash behavior");
+      opts->Register("beam-delta", &beam_delta,
+                     "Increment used in decoder [obscure setting]");
+      opts->Register("hash-ratio", &hash_ratio,
+                     "Setting used in decoder to control hash behavior");
     }
   }
 };

--- a/src/decoder/lattice-faster-decoder.h
+++ b/src/decoder/lattice-faster-decoder.h
@@ -64,22 +64,22 @@ struct LatticeFasterDecoderConfig {
                                 beam_delta(0.5),
                                 hash_ratio(2.0),
                                 prune_scale(0.1) { }
-  void Register(OptionsItf *po) {
-    det_opts.Register(po);
-    po->Register("beam", &beam, "Decoding beam.");
-    po->Register("max-active", &max_active, "Decoder max active states.");
-    po->Register("min-active", &min_active, "Decoder minimum #active states.");
-    po->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
-    po->Register("prune-interval", &prune_interval, "Interval (in frames) at "
-                 "which to prune tokens");
-    po->Register("determinize-lattice", &determinize_lattice, "If true, "
-                 "determinize the lattice (in a special sense, keeping only "
-                 "best pdf-sequence for each word-sequence).");
-    po->Register("beam-delta", &beam_delta, "Increment used in decoding-- this "
-                 "parameter is obscure and relates to a speedup in the way the "
-                 "max-active constraint is applied.  Larger is more accurate.");
-    po->Register("hash-ratio", &hash_ratio, "Setting used in decoder to control"
-                 " hash behavior");
+  void Register(OptionsItf *opts) {
+    det_opts.Register(opts);
+    opts->Register("beam", &beam, "Decoding beam.");
+    opts->Register("max-active", &max_active, "Decoder max active states.");
+    opts->Register("min-active", &min_active, "Decoder minimum #active states.");
+    opts->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
+    opts->Register("prune-interval", &prune_interval, "Interval (in frames) at "
+                   "which to prune tokens");
+    opts->Register("determinize-lattice", &determinize_lattice, "If true, "
+                   "determinize the lattice (in a special sense, keeping only "
+                   "best pdf-sequence for each word-sequence).");
+    opts->Register("beam-delta", &beam_delta, "Increment used in decoding-- this "
+                   "parameter is obscure and relates to a speedup in the way the "
+                   "max-active constraint is applied.  Larger is more accurate.");
+    opts->Register("hash-ratio", &hash_ratio, "Setting used in decoder to control"
+                   " hash behavior");
   }
   void Check() const {
     KALDI_ASSERT(beam > 0.0 && max_active > 1 && lattice_beam > 0.0

--- a/src/decoder/lattice-simple-decoder.h
+++ b/src/decoder/lattice-simple-decoder.h
@@ -53,15 +53,15 @@ struct LatticeSimpleDecoderConfig {
                                 determinize_lattice(true),
                                 beam_ratio(0.9),
                                 prune_scale(0.1) { }
-  void Register(OptionsItf *po) {
-    det_opts.Register(po);
-    po->Register("beam", &beam, "Decoding beam.");
-    po->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
-    po->Register("prune-interval", &prune_interval, "Interval (in frames) at "
-                 "which to prune tokens");
-    po->Register("determinize-lattice", &determinize_lattice, "If true, "
-                 "determinize the lattice (in a special sense, keeping only "
-                 "best pdf-sequence for each word-sequence).");
+  void Register(OptionsItf *opts) {
+    det_opts.Register(opts);
+    opts->Register("beam", &beam, "Decoding beam.");
+    opts->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
+    opts->Register("prune-interval", &prune_interval, "Interval (in frames) at "
+                   "which to prune tokens");
+    opts->Register("determinize-lattice", &determinize_lattice, "If true, "
+                   "determinize the lattice (in a special sense, keeping only "
+                   "best pdf-sequence for each word-sequence).");
   }
   void Check() const {
     KALDI_ASSERT(beam > 0.0 && lattice_beam > 0.0 && prune_interval > 0);

--- a/src/decoder/lattice-tracking-decoder.h
+++ b/src/decoder/lattice-tracking-decoder.h
@@ -54,23 +54,23 @@ struct LatticeTrackingDecoderConfig {
                                 hash_ratio(2.0),
                                 extra_beam(4.0),
                                 max_beam(40.0) { }
-  void Register(OptionsItf *po) {
-    det_opts.Register(po);
-    po->Register("beam", &beam, "Decoding beam.");
-    po->Register("max-active", &max_active, "Decoder max active states.");
-    po->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
-    po->Register("prune-interval", &prune_interval, "Interval (in frames) at "
-                 "which to prune tokens");
-    po->Register("determinize-lattice", &determinize_lattice, "If true, "
-                 "determinize the lattice (in a special sense, keeping only "
-                 "best pdf-sequence for each word-sequence).");
-    po->Register("beam-delta", &beam_delta, "Increment used in decoding");
-    po->Register("hash-ratio", &hash_ratio, "Setting used in decoder to control"
-                 " hash behavior");
-    po->Register("extra-beam", &extra_beam, "Increment used in decoding (added "
-                 "to worst tracked token from first pass)");
-    po->Register("max-beam", &max_beam, "Maximum beam (in case tracked tokens "
-                 "go too far from beam)");
+  void Register(OptionsItf *opts) {
+    det_opts.Register(opts);
+    opts->Register("beam", &beam, "Decoding beam.");
+    opts->Register("max-active", &max_active, "Decoder max active states.");
+    opts->Register("lattice-beam", &lattice_beam, "Lattice generation beam");
+    opts->Register("prune-interval", &prune_interval, "Interval (in frames) at "
+                   "which to prune tokens");
+    opts->Register("determinize-lattice", &determinize_lattice, "If true, "
+                   "determinize the lattice (in a special sense, keeping only "
+                   "best pdf-sequence for each word-sequence).");
+    opts->Register("beam-delta", &beam_delta, "Increment used in decoding");
+    opts->Register("hash-ratio", &hash_ratio, "Setting used in decoder to control"
+                   " hash behavior");
+    opts->Register("extra-beam", &extra_beam, "Increment used in decoding (added "
+                   "to worst tracked token from first pass)");
+    opts->Register("max-beam", &max_beam, "Maximum beam (in case tracked tokens "
+                   "go too far from beam)");
 
   }
   void Check() const {

--- a/src/decoder/nbest-decoder.h
+++ b/src/decoder/nbest-decoder.h
@@ -41,17 +41,17 @@ struct NBestDecoderOptions {
                          max_active(std::numeric_limits<int32>::max()),
                          n_best(1),
                          beam_delta(0.5), hash_ratio(2.0) { }
-  void Register(OptionsItf *po, bool full) {  /// if "full", use obscure
+  void Register(OptionsItf *opts, bool full) {  /// if "full", use obscure
     /// options too.
     /// Depends on program.
-    po->Register("beam", &beam, "Decoder beam");
-    po->Register("max-active", &max_active, "Decoder max active states.");
-    po->Register("n-best", &n_best, "Decoder number of best tokens.");
+    opts->Register("beam", &beam, "Decoder beam");
+    opts->Register("max-active", &max_active, "Decoder max active states.");
+    opts->Register("n-best", &n_best, "Decoder number of best tokens.");
     if (full) {
-      po->Register("beam-delta", &beam_delta,
-                   "Increment used in decoder [obscure setting]");
-      po->Register("hash-ratio", &hash_ratio,
-                   "Setting used in decoder to control hash behavior");
+      opts->Register("beam-delta", &beam_delta,
+                     "Increment used in decoder [obscure setting]");
+      opts->Register("hash-ratio", &hash_ratio,
+                     "Setting used in decoder to control hash behavior");
     }
   }
 };

--- a/src/decoder/training-graph-compiler.h
+++ b/src/decoder/training-graph-compiler.h
@@ -42,14 +42,14 @@ struct TrainingGraphCompilerOptions {
       rm_eps(false),
       reorder(b) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("transition-scale", &transition_scale, "Scale of transition "
-                 "probabilities (excluding self-loops)");
-    po->Register("self-loop-scale", &self_loop_scale, "Scale of self-loop vs. "
-                 "non-self-loop probability mass ");
-    po->Register("reorder", &reorder, "Reorder transition ids for greater decoding efficiency.");
-    po->Register("rm-eps", &rm_eps,  "Remove [most] epsilons before minimization (only applicable "
-                 "if disambig symbols present)");
+  void Register(OptionsItf *opts) {
+    opts->Register("transition-scale", &transition_scale, "Scale of transition "
+                   "probabilities (excluding self-loops)");
+    opts->Register("self-loop-scale", &self_loop_scale, "Scale of self-loop vs. "
+                   "non-self-loop probability mass ");
+    opts->Register("reorder", &reorder, "Reorder transition ids for greater decoding efficiency.");
+    opts->Register("rm-eps", &rm_eps,  "Remove [most] epsilons before minimization (only applicable "
+                   "if disambig symbols present)");
   }
 };
 

--- a/src/feat/feature-fbank.h
+++ b/src/feat/feature-fbank.h
@@ -53,20 +53,20 @@ struct FbankOptions {
                  htk_compat(false),
                  use_log_fbank(true) {}
 
-  void Register(OptionsItf *po) {
-    frame_opts.Register(po);
-    mel_opts.Register(po);
-    po->Register("use-energy", &use_energy,
-                 "Add an extra dimension with energy to the FBANK output.");
-    po->Register("energy-floor", &energy_floor,
-                 "Floor on energy (absolute, not relative) in FBANK computation");
-    po->Register("raw-energy", &raw_energy,
-                 "If true, compute energy before preemphasis and windowing");
-    po->Register("htk-compat", &htk_compat, "If true, put energy last.  "
-                 "Warning: not sufficient to get HTK compatible features (need "
-                 "to change other parameters).");
-    po->Register("use-log-fbank", &use_log_fbank,
-                 "If true, produce log-filterbank, else produce linear.");
+  void Register(OptionsItf *opts) {
+    frame_opts.Register(opts);
+    mel_opts.Register(opts);
+    opts->Register("use-energy", &use_energy,
+                   "Add an extra dimension with energy to the FBANK output.");
+    opts->Register("energy-floor", &energy_floor,
+                   "Floor on energy (absolute, not relative) in FBANK computation");
+    opts->Register("raw-energy", &raw_energy,
+                   "If true, compute energy before preemphasis and windowing");
+    opts->Register("htk-compat", &htk_compat, "If true, put energy last.  "
+                   "Warning: not sufficient to get HTK compatible features (need "
+                   "to change other parameters).");
+    opts->Register("use-log-fbank", &use_log_fbank,
+                   "If true, produce log-filterbank, else produce linear.");
   }
 };
 

--- a/src/feat/feature-functions.h
+++ b/src/feat/feature-functions.h
@@ -52,20 +52,20 @@ struct MelBanksOptions {
       : num_bins(num_bins), low_freq(20), high_freq(0), vtln_low(100),
         vtln_high(-500), debug_mel(false), htk_mode(false) {}
 
-  void Register(OptionsItf *po) {
-    po->Register("num-mel-bins", &num_bins,
-                 "Number of triangular mel-frequency bins");
-    po->Register("low-freq", &low_freq,
-                 "Low cutoff frequency for mel bins");
-    po->Register("high-freq", &high_freq,
-                 "High cutoff frequency for mel bins (if < 0, offset from Nyquist)");
-    po->Register("vtln-low", &vtln_low,
-                 "Low inflection point in piecewise linear VTLN warping function");
-    po->Register("vtln-high", &vtln_high,
-                 "High inflection point in piecewise linear VTLN warping function"
-                 " (if negative, offset from high-mel-freq");
-    po->Register("debug-mel", &debug_mel,
-                 "Print out debugging information for mel bin computation");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-mel-bins", &num_bins,
+                   "Number of triangular mel-frequency bins");
+    opts->Register("low-freq", &low_freq,
+                   "Low cutoff frequency for mel bins");
+    opts->Register("high-freq", &high_freq,
+                   "High cutoff frequency for mel bins (if < 0, offset from Nyquist)");
+    opts->Register("vtln-low", &vtln_low,
+                   "Low inflection point in piecewise linear VTLN warping function");
+    opts->Register("vtln-high", &vtln_high,
+                   "High inflection point in piecewise linear VTLN warping function"
+                   " (if negative, offset from high-mel-freq");
+    opts->Register("debug-mel", &debug_mel,
+                   "Print out debugging information for mel bin computation");
   }
 };
 
@@ -95,26 +95,26 @@ struct FrameExtractionOptions {
       round_to_power_of_two(true),
       snip_edges(true){ }
 
-  void Register(OptionsItf *po) {
-    po->Register("sample-frequency", &samp_freq,
-                 "Waveform data sample frequency (must match the waveform file, "
-                 "if specified there)");
-    po->Register("frame-length", &frame_length_ms, "Frame length in milliseconds");
-    po->Register("frame-shift", &frame_shift_ms, "Frame shift in milliseconds");
-    po->Register("preemphasis-coefficient", &preemph_coeff,
-                 "Coefficient for use in signal preemphasis");
-    po->Register("remove-dc-offset", &remove_dc_offset,
-                 "Subtract mean from waveform on each frame");
-    po->Register("dither", &dither, "Dithering constant (0.0 means no dither)");
-    po->Register("window-type", &window_type, "Type of window "
-                 "(\"hamming\"|\"hanning\"|\"povey\"|\"rectangular\")");
-    po->Register("round-to-power-of-two", &round_to_power_of_two,
-                 "If true, round window size to power of two.");
-    po->Register("snip-edges", &snip_edges,
-                 "If true, end effects will be handled by outputting only frames that "
-                 "completely fit in the file, and the number of frames depends on the "
-                 "frame-length.  If false, the number of frames depends only on the "
-                 "frame-shift, and we reflect the data at the ends.");
+  void Register(OptionsItf *opts) {
+    opts->Register("sample-frequency", &samp_freq,
+                   "Waveform data sample frequency (must match the waveform file, "
+                   "if specified there)");
+    opts->Register("frame-length", &frame_length_ms, "Frame length in milliseconds");
+    opts->Register("frame-shift", &frame_shift_ms, "Frame shift in milliseconds");
+    opts->Register("preemphasis-coefficient", &preemph_coeff,
+                   "Coefficient for use in signal preemphasis");
+    opts->Register("remove-dc-offset", &remove_dc_offset,
+                   "Subtract mean from waveform on each frame");
+    opts->Register("dither", &dither, "Dithering constant (0.0 means no dither)");
+    opts->Register("window-type", &window_type, "Type of window "
+                   "(\"hamming\"|\"hanning\"|\"povey\"|\"rectangular\")");
+    opts->Register("round-to-power-of-two", &round_to_power_of_two,
+                   "If true, round window size to power of two.");
+    opts->Register("snip-edges", &snip_edges,
+                   "If true, end effects will be handled by outputting only frames that "
+                   "completely fit in the file, and the number of frames depends on the "
+                   "frame-length.  If false, the number of frames depends only on the "
+                   "frame-shift, and we reflect the data at the ends.");
   }
   int32 WindowShift() const {
     return static_cast<int32>(samp_freq * 0.001 * frame_shift_ms);
@@ -197,11 +197,11 @@ struct DeltaFeaturesOptions {
 
   DeltaFeaturesOptions(int32 order = 2, int32 window = 2):
       order(order), window(window) { }
-  void Register(OptionsItf *po) {
-    po->Register("delta-order", &order, "Order of delta computation");
-    po->Register("delta-window", &window,
-                 "Parameter controlling window for delta computation (actual window"
-                 " size for each delta order is 1 + 2*delta-window-size)");
+  void Register(OptionsItf *opts) {
+    opts->Register("delta-order", &order, "Order of delta computation");
+    opts->Register("delta-window", &window,
+                   "Parameter controlling window for delta computation (actual window"
+                   " size for each delta order is 1 + 2*delta-window-size)");
   }
 };
 
@@ -233,11 +233,11 @@ struct ShiftedDeltaFeaturesOptions {
 
   ShiftedDeltaFeaturesOptions():
       window(1), num_blocks(7), block_shift(3) { }
-  void Register(OptionsItf *po) {
-    po->Register("delta-window", &window, "Size of delta advance and delay.");
-    po->Register("num-blocks", &num_blocks, "Number of delta blocks in advance"
-                 " of each frame to be concatenated");
-    po->Register("block-shift", &block_shift, "Distance between each block");
+  void Register(OptionsItf *opts) {
+    opts->Register("delta-window", &window, "Size of delta advance and delay.");
+    opts->Register("num-blocks", &num_blocks, "Number of delta blocks in advance"
+                   " of each frame to be concatenated");
+    opts->Register("block-shift", &block_shift, "Distance between each block");
   }
 };
 
@@ -320,17 +320,17 @@ struct SlidingWindowCmnOptions {
       normalize_variance(false),
       center(false) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("cmn-window", &cmn_window, "Window in frames for running "
-                 "average CMN computation");
-    po->Register("min-cmn-window", &min_window, "Minimum CMN window "
-                 "used at start of decoding (adds latency only at start). "
-                 "Only applicable if center == false, ignored if center==true");
-    po->Register("norm-vars", &normalize_variance, "If true, normalize "
-                 "variance to one."); // naming this as in apply-cmvn.cc
-    po->Register("center", &center, "If true, use a window centered on the "
-                 "current frame (to the extent possible, modulo end effects). "
-                 "If false, window is to the left.");
+  void Register(OptionsItf *opts) {
+    opts->Register("cmn-window", &cmn_window, "Window in frames for running "
+                   "average CMN computation");
+    opts->Register("min-cmn-window", &min_window, "Minimum CMN window "
+                   "used at start of decoding (adds latency only at start). "
+                   "Only applicable if center == false, ignored if center==true");
+    opts->Register("norm-vars", &normalize_variance, "If true, normalize "
+                   "variance to one."); // naming this as in apply-cmvn.cc
+    opts->Register("center", &center, "If true, use a window centered on the "
+                   "current frame (to the extent possible, modulo end effects). "
+                   "If false, window is to the left.");
   }
   void Check() const;
 };

--- a/src/feat/feature-mfcc.h
+++ b/src/feat/feature-mfcc.h
@@ -57,23 +57,23 @@ struct MfccOptions {
                   cepstral_lifter(22.0),
                   htk_compat(false) {}
 
-  void Register(OptionsItf *po) {
-    frame_opts.Register(po);
-    mel_opts.Register(po);
-    po->Register("num-ceps", &num_ceps,
-                 "Number of cepstra in MFCC computation (including C0)");
-    po->Register("use-energy", &use_energy,
-                 "Use energy (not C0) in MFCC computation");
-    po->Register("energy-floor", &energy_floor,
-                 "Floor on energy (absolute, not relative) in MFCC computation");
-    po->Register("raw-energy", &raw_energy,
-                 "If true, compute energy before preemphasis and windowing");
-    po->Register("cepstral-lifter", &cepstral_lifter,
-                 "Constant that controls scaling of MFCCs");
-    po->Register("htk-compat", &htk_compat,
-                 "If true, put energy or C0 last and use a factor of sqrt(2) on "
-                 "C0.  Warning: not sufficient to get HTK compatible features "
-                 "(need to change other parameters).");
+  void Register(OptionsItf *opts) {
+    frame_opts.Register(opts);
+    mel_opts.Register(opts);
+    opts->Register("num-ceps", &num_ceps,
+                   "Number of cepstra in MFCC computation (including C0)");
+    opts->Register("use-energy", &use_energy,
+                   "Use energy (not C0) in MFCC computation");
+    opts->Register("energy-floor", &energy_floor,
+                   "Floor on energy (absolute, not relative) in MFCC computation");
+    opts->Register("raw-energy", &raw_energy,
+                   "If true, compute energy before preemphasis and windowing");
+    opts->Register("cepstral-lifter", &cepstral_lifter,
+                   "Constant that controls scaling of MFCCs");
+    opts->Register("htk-compat", &htk_compat,
+                   "If true, put energy or C0 last and use a factor of sqrt(2) on "
+                   "C0.  Warning: not sufficient to get HTK compatible features "
+                   "(need to change other parameters).");
   }
 };
 

--- a/src/feat/feature-plp.h
+++ b/src/feat/feature-plp.h
@@ -66,29 +66,29 @@ struct PlpOptions {
                  cepstral_scale(1.0),
                  htk_compat(false) {}
 
-  void Register(OptionsItf *po) {
-    frame_opts.Register(po);
-    mel_opts.Register(po);
-    po->Register("lpc-order", &lpc_order,
-                 "Order of LPC analysis in PLP computation");
-    po->Register("num-ceps", &num_ceps,
-                 "Number of cepstra in PLP computation (including C0)");
-    po->Register("use-energy", &use_energy,
-                 "Use energy (not C0) for zeroth PLP feature");
-    po->Register("energy-floor", &energy_floor,
-                 "Floor on energy (absolute, not relative) in PLP computation");
-    po->Register("raw-energy", &raw_energy,
-                 "If true, compute energy before preemphasis and windowing");
-    po->Register("compress-factor", &compress_factor,
-                 "Compression factor in PLP computation");
-    po->Register("cepstral-lifter", &cepstral_lifter,
-                 "Constant that controls scaling of PLPs");
-    po->Register("cepstral-scale", &cepstral_scale,
-                 "Scaling constant in PLP computation");
-    po->Register("htk-compat", &htk_compat,
-                 "If true, put energy or C0 last and put factor of sqrt(2) on "
-                 "C0.  Warning: not sufficient to get HTK compatible features "
-                 "(need to change other parameters).");
+  void Register(OptionsItf *opts) {
+    frame_opts.Register(opts);
+    mel_opts.Register(opts);
+    opts->Register("lpc-order", &lpc_order,
+                   "Order of LPC analysis in PLP computation");
+    opts->Register("num-ceps", &num_ceps,
+                   "Number of cepstra in PLP computation (including C0)");
+    opts->Register("use-energy", &use_energy,
+                   "Use energy (not C0) for zeroth PLP feature");
+    opts->Register("energy-floor", &energy_floor,
+                   "Floor on energy (absolute, not relative) in PLP computation");
+    opts->Register("raw-energy", &raw_energy,
+                   "If true, compute energy before preemphasis and windowing");
+    opts->Register("compress-factor", &compress_factor,
+                   "Compression factor in PLP computation");
+    opts->Register("cepstral-lifter", &cepstral_lifter,
+                   "Constant that controls scaling of PLPs");
+    opts->Register("cepstral-scale", &cepstral_scale,
+                   "Scaling constant in PLP computation");
+    opts->Register("htk-compat", &htk_compat,
+                   "If true, put energy or C0 last and put factor of sqrt(2) on "
+                   "C0.  Warning: not sufficient to get HTK compatible features "
+                   "(need to change other parameters).");
   }
 };
 

--- a/src/feat/feature-spectrogram.h
+++ b/src/feat/feature-spectrogram.h
@@ -44,12 +44,12 @@ struct SpectrogramOptions {
     energy_floor(0.0),  // not in log scale: a small value e.g. 1.0e-10
     raw_energy(true) {}
 
-  void Register(OptionsItf *po) {
-    frame_opts.Register(po);
-    po->Register("energy-floor", &energy_floor,
-                 "Floor on energy (absolute, not relative) in Spectrogram computation");
-    po->Register("raw-energy", &raw_energy,
-                 "If true, compute energy before preemphasis and windowing");
+  void Register(OptionsItf *opts) {
+    frame_opts.Register(opts);
+    opts->Register("energy-floor", &energy_floor,
+                   "Floor on energy (absolute, not relative) in Spectrogram computation");
+    opts->Register("raw-energy", &raw_energy,
+                   "If true, compute energy before preemphasis and windowing");
   }
 };
 

--- a/src/feat/pitch-functions.h
+++ b/src/feat/pitch-functions.h
@@ -132,68 +132,68 @@ struct PitchExtractionOptions {
       nccf_ballast_online(false),
       snip_edges(true) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("sample-frequency", &samp_freq,
-                 "Waveform data sample frequency (must match the waveform "
-                 "file, if specified there)");
-    po->Register("frame-length", &frame_length_ms, "Frame length in "
-                 "milliseconds");
-    po->Register("frame-shift", &frame_shift_ms, "Frame shift in milliseconds");
-    po->Register("preemphasis-coefficient", &preemph_coeff,
-                 "Coefficient for use in signal preemphasis (deprecated)");
-    po->Register("min-f0", &min_f0,
-                 "min. F0 to search for (Hz)");
-    po->Register("max-f0", &max_f0,
-                 "max. F0 to search for (Hz)");
-    po->Register("soft-min-f0", &soft_min_f0,
-                 "Minimum f0, applied in soft way, must not exceed min-f0");
-    po->Register("penalty-factor", &penalty_factor,
-                 "cost factor for FO change.");
-    po->Register("lowpass-cutoff", &lowpass_cutoff,
-                 "cutoff frequency for LowPass filter (Hz) ");
-    po->Register("resample-frequency", &resample_freq,
-                 "Frequency that we down-sample the signal to.  Must be "
-                 "more than twice lowpass-cutoff");
-    po->Register("delta-pitch", &delta_pitch,
-                 "Smallest relative change in pitch that our algorithm "
-                 "measures");
-    po->Register("nccf-ballast", &nccf_ballast,
-                 "Increasing this factor reduces NCCF for quiet frames");
-    po->Register("nccf-ballast-online", &nccf_ballast_online,
-                 "This is useful mainly for debug; it affects how the NCCF "
-                 "ballast is computed.");
-    po->Register("lowpass-filter-width", &lowpass_filter_width,
-                 "Integer that determines filter width of "
-                 "lowpass filter, more gives sharper filter");
-    po->Register("upsample-filter-width", &upsample_filter_width,
-                 "Integer that determines filter width when upsampling NCCF");
-    po->Register("frames-per-chunk", &frames_per_chunk, "Only relevant for "
-                 "offline pitch extraction (e.g. compute-kaldi-pitch-feats), "
-                 "you can set it to a small nonzero value, such as 10, for "
-                 "better feature compatibility with online decoding (affects "
-                 "energy normalization in the algorithm)");
-    po->Register("simulate-first-pass-online", &simulate_first_pass_online,
-                 "If true, compute-kaldi-pitch-feats will output features "
-                 "that correspond to what an online decoder would see in the "
-                 "first pass of decoding-- not the final version of the "
-                 "features, which is the default.  Relevant if "
-                 "--frames-per-chunk > 0");
-    po->Register("recompute-frame", &recompute_frame, "Only relevant for "
-                 "online pitch extraction, or for compatibility with online "
-                 "pitch extraction.  A non-critical parameter; the frame at "
-                 "which we recompute some of the forward pointers, after "
-                 "revising our estimate of the signal energy.  Relevant if"
-                 "--frames-per-chunk > 0");
-    po->Register("max-frames-latency", &max_frames_latency, "Maximum number "
-                 "of frames of latency that we allow pitch tracking to "
-                 "introduce into the feature processing (affects output only "
-                 "if --frames-per-chunk > 0 and "
-                 "--simulate-first-pass-online=true");
-    po->Register("snip-edges", &snip_edges, "If this is set to false, the "
-                 "incomplete frames near the ending edge won't be snipped, so "
-                 "that the number of frames is the file size divided by the "
-                 "frame-shift. This makes different types of features give the "
-                 "same number of frames.");
+  void Register(OptionsItf *opts) {
+    opts->Register("sample-frequency", &samp_freq,
+                   "Waveform data sample frequency (must match the waveform "
+                   "file, if specified there)");
+    opts->Register("frame-length", &frame_length_ms, "Frame length in "
+                   "milliseconds");
+    opts->Register("frame-shift", &frame_shift_ms, "Frame shift in milliseconds");
+    opts->Register("preemphasis-coefficient", &preemph_coeff,
+                   "Coefficient for use in signal preemphasis (deprecated)");
+    opts->Register("min-f0", &min_f0,
+                   "min. F0 to search for (Hz)");
+    opts->Register("max-f0", &max_f0,
+                   "max. F0 to search for (Hz)");
+    opts->Register("soft-min-f0", &soft_min_f0,
+                   "Minimum f0, applied in soft way, must not exceed min-f0");
+    opts->Register("penalty-factor", &penalty_factor,
+                   "cost factor for FO change.");
+    opts->Register("lowpass-cutoff", &lowpass_cutoff,
+                   "cutoff frequency for LowPass filter (Hz) ");
+    opts->Register("resample-frequency", &resample_freq,
+                   "Frequency that we down-sample the signal to.  Must be "
+                   "more than twice lowpass-cutoff");
+    opts->Register("delta-pitch", &delta_pitch,
+                   "Smallest relative change in pitch that our algorithm "
+                   "measures");
+    opts->Register("nccf-ballast", &nccf_ballast,
+                   "Increasing this factor reduces NCCF for quiet frames");
+    opts->Register("nccf-ballast-online", &nccf_ballast_online,
+                   "This is useful mainly for debug; it affects how the NCCF "
+                   "ballast is computed.");
+    opts->Register("lowpass-filter-width", &lowpass_filter_width,
+                   "Integer that determines filter width of "
+                   "lowpass filter, more gives sharper filter");
+    opts->Register("upsample-filter-width", &upsample_filter_width,
+                   "Integer that determines filter width when upsampling NCCF");
+    opts->Register("frames-per-chunk", &frames_per_chunk, "Only relevant for "
+                   "offline pitch extraction (e.g. compute-kaldi-pitch-feats), "
+                   "you can set it to a small nonzero value, such as 10, for "
+                   "better feature compatibility with online decoding (affects "
+                   "energy normalization in the algorithm)");
+    opts->Register("simulate-first-pass-online", &simulate_first_pass_online,
+                   "If true, compute-kaldi-pitch-feats will output features "
+                   "that correspond to what an online decoder would see in the "
+                   "first pass of decoding-- not the final version of the "
+                   "features, which is the default.  Relevant if "
+                   "--frames-per-chunk > 0");
+    opts->Register("recompute-frame", &recompute_frame, "Only relevant for "
+                   "online pitch extraction, or for compatibility with online "
+                   "pitch extraction.  A non-critical parameter; the frame at "
+                   "which we recompute some of the forward pointers, after "
+                   "revising our estimate of the signal energy.  Relevant if"
+                   "--frames-per-chunk > 0");
+    opts->Register("max-frames-latency", &max_frames_latency, "Maximum number "
+                   "of frames of latency that we allow pitch tracking to "
+                   "introduce into the feature processing (affects output only "
+                   "if --frames-per-chunk > 0 and "
+                   "--simulate-first-pass-online=true");
+    opts->Register("snip-edges", &snip_edges, "If this is set to false, the "
+                   "incomplete frames near the ending edge won't be snipped, so "
+                   "that the number of frames is the file size divided by the "
+                   "frame-shift. This makes different types of features give the "
+                   "same number of frames.");
 
   }
   /// Returns the window-size in samples, after resampling.  This is the
@@ -246,43 +246,43 @@ struct ProcessPitchOptions {
       add_raw_log_pitch(false) { }
 
 
-  void Register(ParseOptions *po) {
-    po->Register("pitch-scale", &pitch_scale,
-                 "Scaling factor for the final normalized log-pitch value");
-    po->Register("pov-scale", &pov_scale,
-                 "Scaling factor for final POV (probability of voicing) "
-                 "feature");
-    po->Register("pov-offset", &pov_offset,
-                 "This can be used to add an offset to the POV feature. "
-                 "Intended for use in online decoding as a substitute for "
-                 " CMN.");
-    po->Register("delta-pitch-scale", &delta_pitch_scale,
-                 "Term to scale the final delta log-pitch feature");
-    po->Register("delta-pitch-noise-stddev", &delta_pitch_noise_stddev,
-                 "Standard deviation for noise we add to the delta log-pitch "
-                 "(before scaling); should be about the same as delta-pitch "
-                 "option to pitch creation.  The purpose is to get rid of "
-                 "peaks in the delta-pitch caused by discretization of pitch "
-                 "values.");
-    po->Register("normalization-left-context", &normalization_left_context,
-                 "Left-context (in frames) for moving window normalization");
-    po->Register("normalization-right-context", &normalization_right_context,
-                 "Right-context (in frames) for moving window normalization");
-    po->Register("delta-window", &delta_window,
-                 "Number of frames on each side of central frame, to use for "
-                 "delta window.");
-    po->Register("delay", &delay,
-                 "Number of frames by which the pitch information is delayed.");
-    po->Register("add-pov-feature", &add_pov_feature,
-                 "If true, the warped NCCF is added to output features");
-    po->Register("add-normalized-log-pitch", &add_normalized_log_pitch,
-                 "If true, the log-pitch with POV-weighted mean subtraction "
-                 "over 1.5 second window is added to output features");
-    po->Register("add-delta-pitch", &add_delta_pitch,
-                 "If true, time derivative of log-pitch is added to output "
-                 "features");
-    po->Register("add-raw-log-pitch", &add_raw_log_pitch,
-                 "If true, log(pitch) is added to output features");
+  void Register(ParseOptions *opts) {
+    opts->Register("pitch-scale", &pitch_scale,
+                   "Scaling factor for the final normalized log-pitch value");
+    opts->Register("pov-scale", &pov_scale,
+                   "Scaling factor for final POV (probability of voicing) "
+                   "feature");
+    opts->Register("pov-offset", &pov_offset,
+                   "This can be used to add an offset to the POV feature. "
+                   "Intended for use in online decoding as a substitute for "
+                   " CMN.");
+    opts->Register("delta-pitch-scale", &delta_pitch_scale,
+                   "Term to scale the final delta log-pitch feature");
+    opts->Register("delta-pitch-noise-stddev", &delta_pitch_noise_stddev,
+                   "Standard deviation for noise we add to the delta log-pitch "
+                   "(before scaling); should be about the same as delta-pitch "
+                   "option to pitch creation.  The purpose is to get rid of "
+                   "peaks in the delta-pitch caused by discretization of pitch "
+                   "values.");
+    opts->Register("normalization-left-context", &normalization_left_context,
+                   "Left-context (in frames) for moving window normalization");
+    opts->Register("normalization-right-context", &normalization_right_context,
+                   "Right-context (in frames) for moving window normalization");
+    opts->Register("delta-window", &delta_window,
+                   "Number of frames on each side of central frame, to use for "
+                   "delta window.");
+    opts->Register("delay", &delay,
+                   "Number of frames by which the pitch information is delayed.");
+    opts->Register("add-pov-feature", &add_pov_feature,
+                   "If true, the warped NCCF is added to output features");
+    opts->Register("add-normalized-log-pitch", &add_normalized_log_pitch,
+                   "If true, the log-pitch with POV-weighted mean subtraction "
+                   "over 1.5 second window is added to output features");
+    opts->Register("add-delta-pitch", &add_delta_pitch,
+                   "If true, time derivative of log-pitch is added to output "
+                   "features");
+    opts->Register("add-raw-log-pitch", &add_raw_log_pitch,
+                   "If true, log(pitch) is added to output features");
   }
 };
 

--- a/src/feat/sinusoid-detection.h
+++ b/src/feat/sinusoid-detection.h
@@ -271,30 +271,30 @@ struct MultiSinusoidDetectorConfig {
       max_freq(1800.0), subsample_freq(4000),
       subsample_filter_cutoff(1900.0), subsample_filter_zeros(5) {}
 
-  void Register(OptionsItf *po) {
-    po->Register("frame-length", &frame_length_ms,
-                 "Frame length in milliseconds");
-    po->Register("frame-shift", &frame_shift_ms,
-                 "Frame shift in milliseconds");
-    po->Register("two-freq-min-energy", &two_freq_min_energy,
-                 "For detecting two-frequency tones, minimum energy that "
-                 "the quieter frequency must have (relative to total "
-                 "enegy of frame)");
-    po->Register("two-freq-min-total-energy", &two_freq_min_total_energy,
-                 "For detecting two-frequency tones, minimum energy that "
-                 "the two frequencies together must have (relative to total "
-                 "energy of frame)");
-    po->Register("one-freq-min-energy", &one_freq_min_energy, "For detecting "
-                 "single-frequency tones, minimum energy that the frequency "
-                 "must have relative to total energy of frame");
-    po->Register("min-freq", &min_freq, "Minimum frequency of sinusoid that "
-                 "will be detected");
-    po->Register("max-freq", &max_freq, "Maximum frequency of sinusoid that "
-                 "will be detected");
-    po->Register("subsample-freq", &subsample_freq, "Frequency at which "
-                 "we subsample the signal");
-    po->Register("subsample-filter-cutoff", &subsample_filter_cutoff, "Filter "
-                 "cut-off frequency used in subsampling");
+  void Register(OptionsItf *opts) {
+    opts->Register("frame-length", &frame_length_ms,
+                   "Frame length in milliseconds");
+    opts->Register("frame-shift", &frame_shift_ms,
+                   "Frame shift in milliseconds");
+    opts->Register("two-freq-min-energy", &two_freq_min_energy,
+                   "For detecting two-frequency tones, minimum energy that "
+                   "the quieter frequency must have (relative to total "
+                   "enegy of frame)");
+    opts->Register("two-freq-min-total-energy", &two_freq_min_total_energy,
+                   "For detecting two-frequency tones, minimum energy that "
+                   "the two frequencies together must have (relative to total "
+                   "energy of frame)");
+    opts->Register("one-freq-min-energy", &one_freq_min_energy, "For detecting "
+                   "single-frequency tones, minimum energy that the frequency "
+                   "must have relative to total energy of frame");
+    opts->Register("min-freq", &min_freq, "Minimum frequency of sinusoid that "
+                   "will be detected");
+    opts->Register("max-freq", &max_freq, "Maximum frequency of sinusoid that "
+                   "will be detected");
+    opts->Register("subsample-freq", &subsample_freq, "Frequency at which "
+                   "we subsample the signal");
+    opts->Register("subsample-filter-cutoff", &subsample_filter_cutoff, "Filter "
+                   "cut-off frequency used in subsampling");
   }
   void Check() const {
     KALDI_ASSERT(frame_length_ms > 0 && frame_length_ms >= frame_shift_ms &&

--- a/src/featbin/interpolate-pitch.cc
+++ b/src/featbin/interpolate-pitch.cc
@@ -35,19 +35,19 @@ struct PitchInterpolatorOptions {
                               interpolator_factor(1.0e-05),
                               max_voicing_prob(0.9),
                               max_pitch_change_per_frame(10.0) { }
-  void Register(OptionsItf *po) {
-    po->Register("pitch-interval", &pitch_interval, "Frequency interval in Hz, used "
-                 "for the pitch interpolation and smoothing algorithm.");
-    po->Register("interpolator-factor", &interpolator_factor, "Factor affecting the "
-                 "interpolation algorithm; setting it closer to zero will cause "
-                 "it to follow the measured pitch more faithfully but less "
-                 "smoothly");
-    po->Register("max-voicing-prob", &max_voicing_prob, "Probability of voicing the "
-                 "algorithm uses as the observed p(voicing) approaches 1; having "
-                 "value <1 allows it to interpolate even if p(voicing) = 1");
-    po->Register("max-pitch-change-per-frame", &max_pitch_change_per_frame, 
-                 "This value should be set large enough to no longer affect the "
-                 "results, but the larger it is the slower the algorithm will be.");
+  void Register(OptionsItf *opts) {
+    opts->Register("pitch-interval", &pitch_interval, "Frequency interval in Hz, used "
+                   "for the pitch interpolation and smoothing algorithm.");
+    opts->Register("interpolator-factor", &interpolator_factor, "Factor affecting the "
+                   "interpolation algorithm; setting it closer to zero will cause "
+                   "it to follow the measured pitch more faithfully but less "
+                   "smoothly");
+    opts->Register("max-voicing-prob", &max_voicing_prob, "Probability of voicing the "
+                   "algorithm uses as the observed p(voicing) approaches 1; having "
+                   "value <1 allows it to interpolate even if p(voicing) = 1");
+    opts->Register("max-pitch-change-per-frame", &max_pitch_change_per_frame, 
+                   "This value should be set large enough to no longer affect the "
+                   "results, but the larger it is the slower the algorithm will be.");
   }
   void Check() const {
     KALDI_ASSERT(pitch_interval > 0.0 && pitch_interval < 20.0 &&
@@ -301,26 +301,26 @@ int main(int argc, char *argv[]) {
 
     
     // construct all the global objects
-    ParseOptions po(usage);
+    ParseOptions opts(usage);
 
     bool linear_interpolation = false;
     PitchInterpolatorOptions interpolate_opts;
     
-    po.Register("linear-interpolation",
+    opts.Register("linear-interpolation",
                 &linear_interpolation, "If true, just do simple linear "
                 "interpolation across gaps (else, model-based)");
-    interpolate_opts.Register(&po);
+    interpolate_opts.Register(&opts);
     
     // parse options (+filling the registered variables)
-    po.Read(argc, argv);
+    opts.Read(argc, argv);
 
-    if (po.NumArgs() != 2) {
-      po.PrintUsage();
+    if (opts.NumArgs() != 2) {
+      opts.PrintUsage();
       exit(1);
     }
     
-    std::string input_rspecifier = po.GetArg(1);
-    std::string output_wspecifier = po.GetArg(2);
+    std::string input_rspecifier = opts.GetArg(1);
+    std::string output_wspecifier = opts.GetArg(2);
 
     SequentialBaseFloatMatrixReader reader(input_rspecifier);
     BaseFloatMatrixWriter kaldi_writer;  // typedef to TableWriter<something>.

--- a/src/gmm/am-diag-gmm.h
+++ b/src/gmm/am-diag-gmm.h
@@ -173,22 +173,22 @@ struct UbmClusteringOptions {
         : ubm_num_gauss(ncomp), reduce_state_factor(red),
           intermediate_num_gauss(interm_gauss), cluster_varfloor(vfloor),
           max_am_gauss(max_am_gauss) {}
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "UbmClusteringOptions: ";
-    po->Register("max-am-gauss", &max_am_gauss, module+
-                 "We first reduce acoustic model to this max #Gauss before clustering.");
-    po->Register("ubm-num-gauss", &ubm_num_gauss, module+
-                 "Number of Gaussians components in the final UBM.");
-    po->Register("ubm-numcomps", &ubm_num_gauss, module+
-                 "Backward compatibility option (see ubm-num-gauss)");
-    po->Register("reduce-state-factor", &reduce_state_factor, module+
-                 "Intermediate number of clustered states (as fraction of total states).");
-    po->Register("intermediate-num-gauss", &intermediate_num_gauss, module+
-                 "Intermediate number of merged Gaussian components.");
-    po->Register("intermediate-numcomps", &intermediate_num_gauss, module+
-                 "Backward compatibility option (see intermediate-num-gauss)");
-    po->Register("cluster-varfloor", &cluster_varfloor, module+
-                 "Variance floor used in bottom-up state clustering.");
+    opts->Register("max-am-gauss", &max_am_gauss, module+
+                   "We first reduce acoustic model to this max #Gauss before clustering.");
+    opts->Register("ubm-num-gauss", &ubm_num_gauss, module+
+                   "Number of Gaussians components in the final UBM.");
+    opts->Register("ubm-numcomps", &ubm_num_gauss, module+
+                   "Backward compatibility option (see ubm-num-gauss)");
+    opts->Register("reduce-state-factor", &reduce_state_factor, module+
+                   "Intermediate number of clustered states (as fraction of total states).");
+    opts->Register("intermediate-num-gauss", &intermediate_num_gauss, module+
+                   "Intermediate number of merged Gaussian components.");
+    opts->Register("intermediate-numcomps", &intermediate_num_gauss, module+
+                   "Backward compatibility option (see intermediate-num-gauss)");
+    opts->Register("cluster-varfloor", &cluster_varfloor, module+
+                   "Variance floor used in bottom-up state clustering.");
   }
 
   void Check();

--- a/src/gmm/ebw-diag-gmm.h
+++ b/src/gmm/ebw-diag-gmm.h
@@ -36,11 +36,11 @@ struct EbwOptions {
   BaseFloat tau; // This is only useful for smoothing "to the model":
   // if you want to smooth to ML stats, you need to use gmm-ismooth-stats
   EbwOptions(): E(2.0), tau(0.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwOptions: ";
-    po->Register("E", &E, module+"Constant E for Extended Baum-Welch (EBW) update");
-    po->Register("tau", &tau, module+"Tau value for smoothing to the model "
-                 "parameters only (for smoothing to ML stats, use gmm-ismooth-stats");
+    opts->Register("E", &E, module+"Constant E for Extended Baum-Welch (EBW) update");
+    opts->Register("tau", &tau, module+"Tau value for smoothing to the model "
+                   "parameters only (for smoothing to ML stats, use gmm-ismooth-stats");
   }
 };
 
@@ -52,14 +52,14 @@ struct EbwWeightOptions {
   EbwWeightOptions(): min_num_count_weight_update(10.0),
                       min_gaussian_weight(1.0e-05),
                       tau(0.0) { }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwWeightOptions: ";
-    po->Register("min-num-count-weight-update", &min_num_count_weight_update,
+    opts->Register("min-num-count-weight-update", &min_num_count_weight_update,
                  module+"Minimum numerator count required at "
                  "state level before we update the weights (only active if tau == 0.0)");
-    po->Register("min-gaussian-weight", &min_gaussian_weight,
+    opts->Register("min-gaussian-weight", &min_gaussian_weight,
                  module+"Minimum Gaussian weight allowed in EBW update of weights");
-    po->Register("weight-tau", &tau,
+    opts->Register("weight-tau", &tau,
                  module+"Tau value for smoothing Gaussian weight update.");
   }
 };

--- a/src/gmm/mle-diag-gmm.h
+++ b/src/gmm/mle-diag-gmm.h
@@ -56,15 +56,15 @@ struct MleDiagGmmOptions {
     min_variance            = 0.001;
     remove_low_count_gaussians = true;
   }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleDiagGmmOptions: ";
-    po->Register("min-gaussian-weight", &min_gaussian_weight,
+    opts->Register("min-gaussian-weight", &min_gaussian_weight,
                  module+"Min Gaussian weight before we remove it.");
-    po->Register("min-gaussian-occupancy", &min_gaussian_occupancy,
+    opts->Register("min-gaussian-occupancy", &min_gaussian_occupancy,
                  module+"Minimum occupancy to update a Gaussian.");
-    po->Register("min-variance", &min_variance,
+    opts->Register("min-variance", &min_variance,
                  module+"Variance floor (absolute variance).");
-    po->Register("remove-low-count-gaussians", &remove_low_count_gaussians,
+    opts->Register("remove-low-count-gaussians", &remove_low_count_gaussians,
                  module+"If true, remove Gaussians that fall below the floors.");
   }
 };
@@ -90,14 +90,14 @@ struct MapDiagGmmOptions {
                              variance_tau(50.0),
                              weight_tau(10.0) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("mean-tau", &mean_tau,
-                 "Tau value for updating means.");
-    po->Register("variance-tau", &mean_tau,
-                 "Tau value for updating variances (note: only relevant if "
-                 "update-flags contains \"v\".");
-    po->Register("weight-tau", &weight_tau,
-                 "Tau value for updating weights.");
+  void Register(OptionsItf *opts) {
+    opts->Register("mean-tau", &mean_tau,
+                   "Tau value for updating means.");
+    opts->Register("variance-tau", &mean_tau,
+                   "Tau value for updating variances (note: only relevant if "
+                   "update-flags contains \"v\".");
+    opts->Register("weight-tau", &weight_tau,
+                   "Tau value for updating weights.");
   }
 };
 

--- a/src/gmm/mle-full-gmm.h
+++ b/src/gmm/mle-full-gmm.h
@@ -53,17 +53,17 @@ struct MleFullGmmOptions {
     max_condition          = 1.0e+04;
     remove_low_count_gaussians = true;
   }
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleFullGmmOptions: ";
-    po->Register("min-gaussian-weight", &min_gaussian_weight,
+    opts->Register("min-gaussian-weight", &min_gaussian_weight,
                  module+"Min Gaussian weight before we remove it.");
-    po->Register("min-gaussian-occupancy", &min_gaussian_occupancy,
+    opts->Register("min-gaussian-occupancy", &min_gaussian_occupancy,
                  module+"Minimum count before we remove a Gaussian.");
-    po->Register("variance-floor", &variance_floor,
+    opts->Register("variance-floor", &variance_floor,
                  module+"Minimum eigenvalue of covariance matrix.");
-    po->Register("max-condition", &max_condition,
+    opts->Register("max-condition", &max_condition,
                  module+"Maximum condition number of covariance matrix (use it to floor).");
-    po->Register("remove-low-count-gaussians", &remove_low_count_gaussians,
+    opts->Register("remove-low-count-gaussians", &remove_low_count_gaussians,
                  module+"If true, remove Gaussians that fall below the floors.");
   }
 };

--- a/src/hmm/hmm-utils.h
+++ b/src/hmm/hmm-utils.h
@@ -63,16 +63,16 @@ struct HTransducerConfig {
   // Note-- this Register registers the easy-to-register options
   // but not the "sym_type" which is an enum and should be handled
   // separately in main().
-  void Register (OptionsItf *po) {
-    po->Register("transition-scale", &transition_scale,
-                 "Scale of transition probs (relative to LM)");
-    po->Register("reverse", &reverse,
-                 "Set true to build time-reversed FST.");
-    po->Register("push-weights", &push_weights,
-                 "Push weights (only applicable if reverse == true)");
-    po->Register("push-delta", &push_delta,
-                 "Delta used in pushing weights (only applicable if "
-                 "reverse && push-weights");
+  void Register (OptionsItf *opts) {
+    opts->Register("transition-scale", &transition_scale,
+                   "Scale of transition probs (relative to LM)");
+    opts->Register("reverse", &reverse,
+                   "Set true to build time-reversed FST.");
+    opts->Register("push-weights", &push_weights,
+                   "Push weights (only applicable if reverse == true)");
+    opts->Register("push-delta", &push_delta,
+                   "Delta used in pushing weights (only applicable if "
+                   "reverse && push-weights");
   }
 };
 

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -93,14 +93,14 @@ struct MleTransitionUpdateConfig {
                             bool share_for_pdfs = false):
       floor(floor), mincount(mincount), share_for_pdfs(share_for_pdfs) {}
   
-  void Register (OptionsItf *po) {
-    po->Register("transition-floor", &floor,
-                 "Floor for transition probabilities");
-    po->Register("transition-min-count", &mincount,
-                 "Minimum count required to update transitions from a state");
-    po->Register("share-for-pdfs", &share_for_pdfs,
-                 "If true, share all transition parameters where the states "
-                 "have the same pdf.");
+  void Register (OptionsItf *opts) {
+    opts->Register("transition-floor", &floor,
+                   "Floor for transition probabilities");
+    opts->Register("transition-min-count", &mincount,
+                   "Minimum count required to update transitions from a state");
+    opts->Register("share-for-pdfs", &share_for_pdfs,
+                   "If true, share all transition parameters where the states "
+                   "have the same pdf.");
   }
 };
 
@@ -109,12 +109,12 @@ struct MapTransitionUpdateConfig {
   bool share_for_pdfs; // If true, share all transition parameters that have the same pdf.
   MapTransitionUpdateConfig(): tau(5.0), share_for_pdfs(false) { }
 
-  void Register (OptionsItf *po) {
-    po->Register("transition-tau", &tau, "Tau value for MAP estimation of transition "
-                 "probabilities.");
-    po->Register("share-for-pdfs", &share_for_pdfs,
-                 "If true, share all transition parameters where the states "
-                 "have the same pdf.");
+  void Register (OptionsItf *opts) {
+    opts->Register("transition-tau", &tau, "Tau value for MAP estimation of transition "
+                   "probabilities.");
+    opts->Register("share-for-pdfs", &share_for_pdfs,
+                   "If true, share all transition parameters where the states "
+                   "have the same pdf.");
   }
 };
 

--- a/src/ivector/ivector-extractor.h
+++ b/src/ivector/ivector-extractor.h
@@ -53,17 +53,17 @@ struct IvectorEstimationOptions {
   double acoustic_weight;
   double max_count;
   IvectorEstimationOptions(): acoustic_weight(1.0), max_count(0.0) {}
-  void Register(OptionsItf *po) {
-    po->Register("acoustic-weight", &acoustic_weight,
-                 "Weight on part of auxf that involves the data (e.g. 0.2); "
-                 "if this weight is small, the prior will have more effect.");
-    po->Register("max-count", &max_count,
-                 "Maximum frame count (affects prior scaling): if >0, the prior "
-                 "term will be scaled up after the frame count exceeds this "
-                 "value.  Note that this count is considered after posterior "
-                 "scaling (e.g. --acoustic-weight option, or scale argument to "
-                 "scale-post), so you would normally use a cutoff 10 times "
-                 "smaller than the corresponding number of frames.");
+  void Register(OptionsItf *opts) {
+    opts->Register("acoustic-weight", &acoustic_weight,
+                   "Weight on part of auxf that involves the data (e.g. 0.2); "
+                   "if this weight is small, the prior will have more effect.");
+    opts->Register("max-count", &max_count,
+                   "Maximum frame count (affects prior scaling): if >0, the prior "
+                   "term will be scaled up after the frame count exceeds this "
+                   "value.  Note that this count is considered after posterior "
+                   "scaling (e.g. --acoustic-weight option, or scale argument to "
+                   "scale-post), so you would normally use a cutoff 10 times "
+                   "smaller than the corresponding number of frames.");
   }
 };
 
@@ -110,12 +110,12 @@ struct IvectorExtractorOptions {
   bool use_weights;
   IvectorExtractorOptions(): ivector_dim(400), num_iters(2),
                              use_weights(true) { }
-  void Register(OptionsItf *po) {
-    po->Register("num-iters", &num_iters, "Number of iterations in "
-                 "iVector estimation (>1 needed due to weights)");
-    po->Register("ivector-dim", &ivector_dim, "Dimension of iVector");
-    po->Register("use-weights", &use_weights, "If true, regress the "
-                 "log-weights on the iVector");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-iters", &num_iters, "Number of iterations in "
+                   "iVector estimation (>1 needed due to weights)");
+    opts->Register("ivector-dim", &ivector_dim, "Dimension of iVector");
+    opts->Register("use-weights", &use_weights, "If true, regress the "
+                   "log-weights on the iVector");
   }
 };
 
@@ -428,17 +428,17 @@ struct IvectorExtractorStatsOptions {
                          compute_auxf(true),
                          num_samples_for_weights(10),
                          cache_size(100) { }
-  void Register(OptionsItf *po) {
-    po->Register("update-variances", &update_variances, "If true, update the "
-                 "Gaussian variances");
-    po->Register("compute-auxf", &compute_auxf, "If true, compute the "
-                 "auxiliary functions on training data; can be used to "
-                 "debug and check convergence.");
-    po->Register("num-samples-for-weights", &num_samples_for_weights,
-                 "Number of samples from iVector distribution to use "
-                 "for accumulating stats for weight update.  Must be >1");
-    po->Register("cache-size", &cache_size, "Size of an internal "
-                 "cache (not critical, only affects speed/memory)");
+  void Register(OptionsItf *opts) {
+    opts->Register("update-variances", &update_variances, "If true, update the "
+                   "Gaussian variances");
+    opts->Register("compute-auxf", &compute_auxf, "If true, compute the "
+                   "auxiliary functions on training data; can be used to "
+                   "debug and check convergence.");
+    opts->Register("num-samples-for-weights", &num_samples_for_weights,
+                   "Number of samples from iVector distribution to use "
+                   "for accumulating stats for weight update.  Must be >1");
+    opts->Register("cache-size", &cache_size, "Size of an internal "
+                   "cache (not critical, only affects speed/memory)");
   }
 };
 
@@ -452,17 +452,17 @@ struct IvectorExtractorEstimationOptions {
   IvectorExtractorEstimationOptions(): variance_floor_factor(0.1),
                                        gaussian_min_count(100.0),
                                        diagonalize(true) { }
-  void Register(OptionsItf *po) {
-    po->Register("variance-floor-factor", &variance_floor_factor,
-                 "Factor that determines variance flooring (we floor each covar "
-                 "to this times global average covariance");
-    po->Register("gaussian-min-count", &gaussian_min_count,
-                 "Minimum total count per Gaussian, below which we refuse to "
-                 "update any associated parameters.");
-    po->Register("diagonalize", &diagonalize, 
-                 "If true, diagonalize the quadratic term in the "
-                 "objective function. This reorders the ivector dimensions"
-                 "from most to least important.");
+  void Register(OptionsItf *opts) {
+    opts->Register("variance-floor-factor", &variance_floor_factor,
+                   "Factor that determines variance flooring (we floor each covar "
+                   "to this times global average covariance");
+    opts->Register("gaussian-min-count", &gaussian_min_count,
+                   "Minimum total count per Gaussian, below which we refuse to "
+                   "update any associated parameters.");
+    opts->Register("diagonalize", &diagonalize, 
+                   "If true, diagonalize the quadratic term in the "
+                   "objective function. This reorders the ivector dimensions"
+                   "from most to least important.");
   }
 };
 

--- a/src/ivector/logistic-regression.h
+++ b/src/ivector/logistic-regression.h
@@ -35,17 +35,17 @@ struct LogisticRegressionConfig {
          power;
   LogisticRegressionConfig(): max_steps(20), mix_up(0), 
                               normalizer(0.0025), power(0.15){ }
-  void Register(OptionsItf *po) {
-    po->Register("max-steps", &max_steps,
-                 "Maximum steps in L-BFGS.");
-    po->Register("normalizer", &normalizer,
-                 "Coefficient for L2 regularization.");
-    po->Register("mix-up", &mix_up,
-                 "Target number of mixture components to create, "
-                 "if supplied.");
-    po->Register("power", &power,
-                 "Power rule for determining the number of mixtures "
-                 "to create.");
+  void Register(OptionsItf *opts) {
+    opts->Register("max-steps", &max_steps,
+                   "Maximum steps in L-BFGS.");
+    opts->Register("normalizer", &normalizer,
+                   "Coefficient for L2 regularization.");
+    opts->Register("mix-up", &mix_up,
+                   "Target number of mixture components to create, "
+                   "if supplied.");
+    opts->Register("power", &power,
+                   "Power rule for determining the number of mixtures "
+                   "to create.");
   }
 };
 

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -53,11 +53,11 @@ struct PldaConfig {
   // prior to dot-product scoring.
   bool normalize_length;
   PldaConfig(): normalize_length(true) { }
-  void Register(OptionsItf *po) {
-    po->Register("normalize-length", &normalize_length,
-                 "If true, do length normalization as part of PLDA.  This "
-                 "normalizes the length of the iVectors to be equal to the "
-                 "square root of the iVector dimension.");
+  void Register(OptionsItf *opts) {
+    opts->Register("normalize-length", &normalize_length,
+                   "If true, do length normalization as part of PLDA.  This "
+                   "normalizes the length of the iVectors to be equal to the "
+                   "square root of the iVector dimension.");
   }
 };
 
@@ -188,9 +188,9 @@ class PldaStats {
 struct PldaEstimationConfig {
   int32 num_em_iters;
   PldaEstimationConfig(): num_em_iters(10){ }
-  void Register(OptionsItf *po) {
-    po->Register("num-em-iters", &num_em_iters,
-                 "Number of iterations of E-M used for PLDA estimation");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-em-iters", &num_em_iters,
+                   "Number of iterations of E-M used for PLDA estimation");
   }
 };
 
@@ -260,17 +260,17 @@ struct PldaUnsupervisedAdaptorConfig {
       within_covar_scale(0.3),
       between_covar_scale(0.7) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("mean-diff-scale", &mean_diff_scale,
-                 "Scale with which to add to the total data variance, the outer "
-                 "product of the difference between the original mean and the "
-                 "adaptation-data mean");
-    po->Register("within-covar-scale", &within_covar_scale,
-                 "Scale that determines how much of excess variance in a "
-                 "particular direction gets attributed to within-class covar.");
-    po->Register("between-covar-scale", &between_covar_scale,
-                 "Scale that determines how much of excess variance in a "
-                 "particular direction gets attributed to between-class covar.");
+  void Register(OptionsItf *opts) {
+    opts->Register("mean-diff-scale", &mean_diff_scale,
+                   "Scale with which to add to the total data variance, the outer "
+                   "product of the difference between the original mean and the "
+                   "adaptation-data mean");
+    opts->Register("within-covar-scale", &within_covar_scale,
+                   "Scale that determines how much of excess variance in a "
+                   "particular direction gets attributed to within-class covar.");
+    opts->Register("between-covar-scale", &between_covar_scale,
+                   "Scale that determines how much of excess variance in a "
+                   "particular direction gets attributed to between-class covar.");
 
   }
 };

--- a/src/ivector/voice-activity-detection.h
+++ b/src/ivector/voice-activity-detection.h
@@ -49,21 +49,21 @@ struct VadEnergyOptions {
                       vad_energy_mean_scale(0.5),
                       vad_frames_context(5),
                       vad_proportion_threshold(0.6) { }
-  void Register(OptionsItf *po) {
-    po->Register("vad-energy-threshold", &vad_energy_threshold,
-                 "Constant term in energy threshold for MFCC0 for VAD (also see "
-                 "--vad-energy-mean-scale)");
-    po->Register("vad-energy-mean-scale", &vad_energy_mean_scale,
-                 "If this is set to s, to get the actual threshold we "
-                 "let m be the mean log-energy of the file, and use "
-                 "s*m + vad-energy-threshold");
-    po->Register("vad-frames-context", &vad_frames_context,
-                 "Number of frames of context on each side of central frame, "
-                 "in window for which energy is monitored");
-    po->Register("vad-proportion-threshold", &vad_proportion_threshold,
-                 "Parameter controlling the proportion of frames within "
-                 "the window that need to have more energy than the "
-                 "threshold");
+  void Register(OptionsItf *opts) {
+    opts->Register("vad-energy-threshold", &vad_energy_threshold,
+                   "Constant term in energy threshold for MFCC0 for VAD (also see "
+                   "--vad-energy-mean-scale)");
+    opts->Register("vad-energy-mean-scale", &vad_energy_mean_scale,
+                   "If this is set to s, to get the actual threshold we "
+                   "let m be the mean log-energy of the file, and use "
+                   "s*m + vad-energy-threshold");
+    opts->Register("vad-frames-context", &vad_frames_context,
+                   "Number of frames of context on each side of central frame, "
+                   "in window for which energy is monitored");
+    opts->Register("vad-proportion-threshold", &vad_proportion_threshold,
+                   "Parameter controlling the proportion of frames within "
+                   "the window that need to have more energy than the "
+                   "threshold");
   }
 };
 

--- a/src/kws/kws-scoring.cc
+++ b/src/kws/kws-scoring.cc
@@ -110,10 +110,10 @@ typedef unordered_map <std::string, SweepThresholdStats> PerKwSweepStats;
 }  // namespace kws_internal
 
 
-void KwsTermsAlignerOptions::Register(OptionsItf *po) {
-  po->Register("max_distance", &max_distance,
-               "Max distance on the ref and hyp centers "
-               "to be considered as a potential match");
+void KwsTermsAlignerOptions::Register(OptionsItf *opts) {
+  opts->Register("max_distance", &max_distance,
+                 "Max distance on the ref and hyp centers "
+                 "to be considered as a potential match");
 }
 
 KwsTermsAligner::KwsTermsAligner(const KwsTermsAlignerOptions &opts):
@@ -294,17 +294,17 @@ TwvMetricsOptions::TwvMetricsOptions(): cost_fa(0.1f),
                                         sweep_step(0.05f),
                                         audio_duration(0.0f) {}
 
-void TwvMetricsOptions::Register(OptionsItf *po) {
-  po->Register("cost-fa", &cost_fa,
-              "The cost of an incorrect detection");
-  po->Register("value-corr", &value_corr,
-              "The value (gain) of a correct detection");
-  po->Register("prior-kw-probability", &prior_probability,
-              "The prior probability of a keyword");
-  po->Register("score-threshold", &score_threshold,
-              "The score threshold for computation of ATWV");
-  po->Register("sweep-step", &sweep_step,
-              "Size of the bin during sweeping for the oracle measures");
+void TwvMetricsOptions::Register(OptionsItf *opts) {
+  opts->Register("cost-fa", &cost_fa,
+                 "The cost of an incorrect detection");
+  opts->Register("value-corr", &value_corr,
+                 "The value (gain) of a correct detection");
+  opts->Register("prior-kw-probability", &prior_probability,
+                 "The prior probability of a keyword");
+  opts->Register("score-threshold", &score_threshold,
+                 "The score threshold for computation of ATWV");
+  opts->Register("sweep-step", &sweep_step,
+                 "Size of the bin during sweeping for the oracle measures");
 
   // We won't set the audio duration here, as it's supposed to be
   // a mandatory argument, not optional

--- a/src/kws/kws-scoring.h
+++ b/src/kws/kws-scoring.h
@@ -130,7 +130,7 @@ struct KwsTermsAlignerOptions {
                      // Default: 50 frames (usually 0.5 seconds)
 
   inline KwsTermsAlignerOptions(): max_distance(50) {}
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
 class KwsTermsAligner {
@@ -213,7 +213,7 @@ struct TwvMetricsOptions {
     return (cost_fa/value_corr) * (1.0/prior_probability - 1);
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
 class TwvMetricsStats;

--- a/src/lat/determinize-lattice-pruned.h
+++ b/src/lat/determinize-lattice-pruned.h
@@ -124,21 +124,21 @@ struct DeterminizeLatticePrunedOptions {
                                      max_states(-1),
                                      max_arcs(-1),
                                      retry_cutoff(0.5) { }
-  void Register (kaldi::OptionsItf *po) {
-    po->Register("delta", &delta, "Tolerance used in determinization");
-    po->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
-                "determinization (real usage might be many times this)");
-    po->Register("max-arcs", &max_arcs, "Maximum number of arcs in "
-                "output FST (total, not per state");
-    po->Register("max-states", &max_states, "Maximum number of arcs in output "
-                "FST (total, not per state");
-    po->Register("max-loop", &max_loop, "Option used to detect a particular "
-                "type of determinization failure, typically due to invalid input "
-                "(e.g., negative-cost loops)");
-    po->Register("retry-cutoff", &retry_cutoff, "Controls pruning un-determinized "
-                 "lattice and retrying determinization: if effective-beam < "
-                 "retry-cutoff * beam, we prune the raw lattice and retry.  Avoids "
-                 "ever getting empty output for long segments.");
+  void Register (kaldi::OptionsItf *opts) {
+    opts->Register("delta", &delta, "Tolerance used in determinization");
+    opts->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
+                   "determinization (real usage might be many times this)");
+    opts->Register("max-arcs", &max_arcs, "Maximum number of arcs in "
+                   "output FST (total, not per state");
+    opts->Register("max-states", &max_states, "Maximum number of arcs in output "
+                   "FST (total, not per state");
+    opts->Register("max-loop", &max_loop, "Option used to detect a particular "
+                   "type of determinization failure, typically due to invalid input "
+                   "(e.g., negative-cost loops)");
+    opts->Register("retry-cutoff", &retry_cutoff, "Controls pruning un-determinized "
+                   "lattice and retrying determinization: if effective-beam < "
+                   "retry-cutoff * beam, we prune the raw lattice and retry.  Avoids "
+                   "ever getting empty output for long segments.");
   }
 };
 
@@ -160,18 +160,18 @@ struct DeterminizeLatticePhonePrunedOptions {
                                           phone_determinize(true),
                                           word_determinize(true),
                                           minimize(false) {}
-  void Register (kaldi::OptionsItf *po) {
-    po->Register("delta", &delta, "Tolerance used in determinization");
-    po->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
-                "determinization (real usage might be many times this).");
-    po->Register("phone-determinize", &phone_determinize, "If true, do an "
-                 "initial pass of determinization on both phones and words (see"
-                 " also --word-determinize)");
-    po->Register("word-determinize", &word_determinize, "If true, do a second "
-                 "pass of determinization on words only (see also "
-                 "--phone-determinize)");
-    po->Register("minimize", &minimize, "If true, push and minimize after "
-                 "determinization.");
+  void Register (kaldi::OptionsItf *opts) {
+    opts->Register("delta", &delta, "Tolerance used in determinization");
+    opts->Register("max-mem", &max_mem, "Maximum approximate memory usage in "
+                   "determinization (real usage might be many times this).");
+    opts->Register("phone-determinize", &phone_determinize, "If true, do an "
+                   "initial pass of determinization on both phones and words (see"
+                   " also --word-determinize)");
+    opts->Register("word-determinize", &word_determinize, "If true, do a second "
+                   "pass of determinization on words only (see also "
+                   "--phone-determinize)");
+    opts->Register("minimize", &minimize, "If true, push and minimize after "
+                   "determinization.");
   }
 };
 

--- a/src/lat/phone-align-lattice.h
+++ b/src/lat/phone-align-lattice.h
@@ -38,15 +38,15 @@ struct PhoneAlignLatticeOptions {
   PhoneAlignLatticeOptions(): reorder(true),
                               remove_epsilon(true),
                               replace_output_symbols(false) { }
-  void Register(OptionsItf *po) {
-    po->Register("reorder", &reorder, "True if lattice was created from HCLG with "
-                 "--reorder=true option.");
-    po->Register("remove-epsilon", &remove_epsilon, "If true, removes epsilons from "
-                 "the phone lattice; if replace-output-symbols==false, this will "
-                 "mean that an arc can have multiple phones on it.");
-    po->Register("replace-output-symbols", &replace_output_symbols, "If true, "
-                 "the output symbols (typically words) will be replaced with "
-                 "phones.");
+  void Register(OptionsItf *opts) {
+    opts->Register("reorder", &reorder, "True if lattice was created from HCLG with "
+                   "--reorder=true option.");
+    opts->Register("remove-epsilon", &remove_epsilon, "If true, removes epsilons from "
+                   "the phone lattice; if replace-output-symbols==false, this will "
+                   "mean that an arc can have multiple phones on it.");
+    opts->Register("replace-output-symbols", &replace_output_symbols, "If true, "
+                   "the output symbols (typically words) will be replaced with "
+                   "phones.");
   }
 };
 

--- a/src/lat/word-align-lattice-lexicon.h
+++ b/src/lat/word-align-lattice-lexicon.h
@@ -126,23 +126,23 @@ struct WordAlignLatticeLexiconOpts {
   WordAlignLatticeLexiconOpts(): partial_word_label(0), reorder(true),
                                  test(false), max_expand(-1.0) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("partial-word-label", &partial_word_label, "Numeric id of "
-                 "word symbol that is to be used for arcs in the word-aligned "
-                 "lattice corresponding to partial words at the end of "
-                 "\"forced-out\" utterances (zero is OK)");
-    po->Register("reorder", &reorder, "True if the lattices were generated "
-                 "from graphs that had the --reorder option true, relating to "
-                 "reordering self-loops (typically true)");
-    po->Register("test", &test, "If true, testing code will be activated "
-                 "(the purpose of this is to validate the algorithm).");
-    po->Register("max-expand", &max_expand, "If >0.0, the maximum ratio "
-                 "by which we allow the lattice-alignment code to increase the #states"
-                 "in a lattice (vs. the phone-aligned lattice) before we fail and "
-                 "refuse to align the lattice.  This is helpful in order to "
-                 "prevent 'pathological' lattices from causing the program to "
-                 "exhaust memory.  Actual max-states is 1000 + max-expand * "
-                 "orig-num-states.");
+  void Register(OptionsItf *opts) {
+    opts->Register("partial-word-label", &partial_word_label, "Numeric id of "
+                   "word symbol that is to be used for arcs in the word-aligned "
+                   "lattice corresponding to partial words at the end of "
+                   "\"forced-out\" utterances (zero is OK)");
+    opts->Register("reorder", &reorder, "True if the lattices were generated "
+                   "from graphs that had the --reorder option true, relating to "
+                   "reordering self-loops (typically true)");
+    opts->Register("test", &test, "If true, testing code will be activated "
+                   "(the purpose of this is to validate the algorithm).");
+    opts->Register("max-expand", &max_expand, "If >0.0, the maximum ratio "
+                   "by which we allow the lattice-alignment code to increase the #states"
+                   "in a lattice (vs. the phone-aligned lattice) before we fail and "
+                   "refuse to align the lattice.  This is helpful in order to "
+                   "prevent 'pathological' lattices from causing the program to "
+                   "exhaust memory.  Actual max-states is 1000 + max-expand * "
+                   "orig-num-states.");
   }
 };
 

--- a/src/lat/word-align-lattice.h
+++ b/src/lat/word-align-lattice.h
@@ -59,35 +59,35 @@ struct WordBoundaryInfoOpts {
                           reorder(true), silence_may_be_word_internal(false),
                           silence_has_olabels(false) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("wbegin-phones", &wbegin_phones, "Colon-separated list of "
-                 "numeric ids of phones that begin a word");
-    po->Register("wend-phones", &wend_phones, "Colon-separated list of "
-                 "numeric ids of phones that end a word");
-    po->Register("winternal-phones", &winternal_phones, "Colon-separated list "
-                 "of numeric ids of phones that are internal to a word");
-    po->Register("wbegin-and-end-phones", &wbegin_and_end_phones, "Colon-separated "
-                 "list of numeric ids of phones that are used for "
-                 "single-phone words.");
-    po->Register("silence-phones", &silence_phones, "Colon-separated list of "
-                 "numeric ids of phones that are used for silence (and other "
-                 "non-word events such as noise - anything that doesn't have "
-                 "a corresponding symbol in the lexicon.");
-    po->Register("silence-label", &silence_label, "Numeric id of word symbol "
-                 "that is to be used for silence arcs in the word-aligned "
-                 "lattice (zero is OK)");
-    po->Register("partial-word-label", &partial_word_label, "Numeric id of "
-                 "word symbol that is to be used for arcs in the word-aligned "
-                 "lattice corresponding to partial words at the end of "
-                 "\"forced-out\" utterances (zero is OK)");
-    po->Register("reorder", &reorder, "True if the lattices were generated "
-                 "from graphs that had the --reorder option true, relating to "
-                 "reordering self-loops (typically true)");
-    po->Register("silence-may-be-word-internal", &silence_may_be_word_internal,
-                 "If true, silence may appear inside words' prons (but not at begin/end!)\n");
-    po->Register("silence-has-olabels", &silence_has_olabels, 
-                 "If true, silence phones have output labels in the lattice, just\n"
-                 "like regular words.  [This means you can't have un-labeled silences]");
+  void Register(OptionsItf *opts) {
+    opts->Register("wbegin-phones", &wbegin_phones, "Colon-separated list of "
+                   "numeric ids of phones that begin a word");
+    opts->Register("wend-phones", &wend_phones, "Colon-separated list of "
+                   "numeric ids of phones that end a word");
+    opts->Register("winternal-phones", &winternal_phones, "Colon-separated list "
+                   "of numeric ids of phones that are internal to a word");
+    opts->Register("wbegin-and-end-phones", &wbegin_and_end_phones, "Colon-separated "
+                   "list of numeric ids of phones that are used for "
+                   "single-phone words.");
+    opts->Register("silence-phones", &silence_phones, "Colon-separated list of "
+                   "numeric ids of phones that are used for silence (and other "
+                   "non-word events such as noise - anything that doesn't have "
+                   "a corresponding symbol in the lexicon.");
+    opts->Register("silence-label", &silence_label, "Numeric id of word symbol "
+                   "that is to be used for silence arcs in the word-aligned "
+                   "lattice (zero is OK)");
+    opts->Register("partial-word-label", &partial_word_label, "Numeric id of "
+                   "word symbol that is to be used for arcs in the word-aligned "
+                   "lattice corresponding to partial words at the end of "
+                   "\"forced-out\" utterances (zero is OK)");
+    opts->Register("reorder", &reorder, "True if the lattices were generated "
+                   "from graphs that had the --reorder option true, relating to "
+                   "reordering self-loops (typically true)");
+    opts->Register("silence-may-be-word-internal", &silence_may_be_word_internal,
+                   "If true, silence may appear inside words' prons (but not at begin/end!)\n");
+    opts->Register("silence-has-olabels", &silence_has_olabels, 
+                   "If true, silence phones have output labels in the lattice, just\n"
+                   "like regular words.  [This means you can't have un-labeled silences]");
   }
 };
 
@@ -101,17 +101,17 @@ struct WordBoundaryInfoNewOpts {
   WordBoundaryInfoNewOpts(): silence_label(0), partial_word_label(0),
                              reorder(true) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("silence-label", &silence_label, "Numeric id of word symbol "
-                 "that is to be used for silence arcs in the word-aligned "
-                 "lattice (zero is OK)");
-    po->Register("partial-word-label", &partial_word_label, "Numeric id of "
-                 "word symbol that is to be used for arcs in the word-aligned "
-                 "lattice corresponding to partial words at the end of "
-                 "\"forced-out\" utterances (zero is OK)");
-    po->Register("reorder", &reorder, "True if the lattices were generated "
-                 "from graphs that had the --reorder option true, relating to "
-                 "reordering self-loops (typically true)");
+  void Register(OptionsItf *opts) {
+    opts->Register("silence-label", &silence_label, "Numeric id of word symbol "
+                   "that is to be used for silence arcs in the word-aligned "
+                   "lattice (zero is OK)");
+    opts->Register("partial-word-label", &partial_word_label, "Numeric id of "
+                   "word symbol that is to be used for arcs in the word-aligned "
+                   "lattice corresponding to partial words at the end of "
+                   "\"forced-out\" utterances (zero is OK)");
+    opts->Register("reorder", &reorder, "True if the lattices were generated "
+                   "from graphs that had the --reorder option true, relating to "
+                   "reordering self-loops (typically true)");
   }
 };
 

--- a/src/matrix/kaldi-gpsr.h
+++ b/src/matrix/kaldi-gpsr.h
@@ -93,42 +93,42 @@ struct GpsrConfig {
     max_iters_debias = 50;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void GpsrConfig::Register(OptionsItf *po) {
+inline void GpsrConfig::Register(OptionsItf *opts) {
   std::string module = "GpsrConfig: ";
-  po->Register("use-gpsr-bb", &use_gpsr_bb, module+
-               "Use the Barzilai-Borwein gradient projection method.");
+  opts->Register("use-gpsr-bb", &use_gpsr_bb, module+
+                 "Use the Barzilai-Borwein gradient projection method.");
 
-  po->Register("stop-thresh", &stop_thresh, module+
-               "Stopping threshold for GPSR.");
-  po->Register("max-iters", &max_iters, module+
-               "Maximum number of iterations of GPSR.");
-  po->Register("gpsr-tau", &gpsr_tau, module+
-               "Regularization scale for GPSR.");
-  po->Register("alpha-min", &alpha_min, module+
-               "Minimum step size in feasible direction.");
-  po->Register("alpha-max", &alpha_max, module+
-               "Maximum step size in feasible direction.");
-  po->Register("max-sparsity", &max_sparsity, module+
-               "Maximum percentage of dimensions set to 0.");
-  po->Register("tau-reduction", &tau_reduction, module+
-               "Multiply tau by this if maximum sparsity is reached.");
+  opts->Register("stop-thresh", &stop_thresh, module+
+                 "Stopping threshold for GPSR.");
+  opts->Register("max-iters", &max_iters, module+
+                 "Maximum number of iterations of GPSR.");
+  opts->Register("gpsr-tau", &gpsr_tau, module+
+                 "Regularization scale for GPSR.");
+  opts->Register("alpha-min", &alpha_min, module+
+                 "Minimum step size in feasible direction.");
+  opts->Register("alpha-max", &alpha_max, module+
+                 "Maximum step size in feasible direction.");
+  opts->Register("max-sparsity", &max_sparsity, module+
+                 "Maximum percentage of dimensions set to 0.");
+  opts->Register("tau-reduction", &tau_reduction, module+
+                 "Multiply tau by this if maximum sparsity is reached.");
 
-  po->Register("gpsr-beta", &gpsr_beta, module+
-               "Step size reduction factor in backtracking line search (0<beta<1).");
-  po->Register("gpsr-mu", &gpsr_mu, module+
-               "Improvement factor in backtracking line search (0<mu<1).");
-  po->Register("max-iters-backtrack", &max_iters_backtrak, module+
-               "Maximum number of iterations of backtracking line search.");
+  opts->Register("gpsr-beta", &gpsr_beta, module+
+                 "Step size reduction factor in backtracking line search (0<beta<1).");
+  opts->Register("gpsr-mu", &gpsr_mu, module+
+                 "Improvement factor in backtracking line search (0<mu<1).");
+  opts->Register("max-iters-backtrack", &max_iters_backtrak, module+
+                 "Maximum number of iterations of backtracking line search.");
 
-  po->Register("debias", &debias, module+
-               "Do final debiasing step.");
-  po->Register("stop-thresh-debias", &stop_thresh_debias, module+
-               "Stopping threshold for debiaisng step.");
-  po->Register("max-iters-debias", &max_iters_debias, module+
-               "Maximum number of iterations of debiasing.");
+  opts->Register("debias", &debias, module+
+                 "Do final debiasing step.");
+  opts->Register("stop-thresh-debias", &stop_thresh_debias, module+
+                 "Stopping threshold for debiaisng step.");
+  opts->Register("max-iters-debias", &max_iters_debias, module+
+                 "Maximum number of iterations of debiasing.");
 }
 
 /// Solves a quadratic program in \f$ x \f$, with L_1 regularization:

--- a/src/nnet/nnet-pdf-prior.h
+++ b/src/nnet/nnet-pdf-prior.h
@@ -41,15 +41,15 @@ struct PdfPriorOptions {
                       prior_scale(1.0),
                       prior_floor(1e-10) {}
 
-  void Register(OptionsItf *po) {
-    po->Register("class-frame-counts", &class_frame_counts,
-                 "Vector with frame-counts of pdfs to compute log-priors."
-                 " (priors are typically subtracted from log-posteriors"
-                 " or pre-softmax activations)");
-    po->Register("prior-scale", &prior_scale,
-                 "Scaling factor to be applied on pdf-log-priors");
-    po->Register("prior-floor", &prior_floor,
-                 "Flooring constatnt for prior probability (i.e. label rel. frequency)");
+  void Register(OptionsItf *opts) {
+    opts->Register("class-frame-counts", &class_frame_counts,
+                   "Vector with frame-counts of pdfs to compute log-priors."
+                   " (priors are typically subtracted from log-posteriors"
+                   " or pre-softmax activations)");
+    opts->Register("prior-scale", &prior_scale,
+                   "Scaling factor to be applied on pdf-log-priors");
+    opts->Register("prior-floor", &prior_floor,
+                   "Flooring constatnt for prior probability (i.e. label rel. frequency)");
   }
 };
 

--- a/src/nnet/nnet-randomizer.h
+++ b/src/nnet/nnet-randomizer.h
@@ -39,10 +39,10 @@ struct NnetDataRandomizerOptions {
    : randomizer_size(32768), randomizer_seed(777), minibatch_size(256) 
   { }
 
-  void Register(OptionsItf *po) {
-    po->Register("randomizer-size", &randomizer_size, "Capacity of randomizer, length of concatenated utterances which are used for frame-level shuffling (in frames, affects memory consumption, max 8000000).");
-    po->Register("randomizer-seed", &randomizer_seed, "Seed value for srand, sets fixed order of frame-level shuffling");
-    po->Register("minibatch-size", &minibatch_size, "Size of a minibatch.");
+  void Register(OptionsItf *opts) {
+    opts->Register("randomizer-size", &randomizer_size, "Capacity of randomizer, length of concatenated utterances which are used for frame-level shuffling (in frames, affects memory consumption, max 8000000).");
+    opts->Register("randomizer-seed", &randomizer_seed, "Seed value for srand, sets fixed order of frame-level shuffling");
+    opts->Register("minibatch-size", &minibatch_size, "Size of a minibatch.");
   }
 };
 ///

--- a/src/nnet/nnet-trnopts.h
+++ b/src/nnet/nnet-trnopts.h
@@ -40,11 +40,11 @@ struct NnetTrainOptions {
                        l1_penalty(0.0) 
                        { }
   // register options
-  void Register(OptionsItf *po) {
-    po->Register("learn-rate", &learn_rate, "Learning rate");
-    po->Register("momentum", &momentum, "Momentum");
-    po->Register("l2-penalty", &l2_penalty, "L2 penalty (weight decay)");
-    po->Register("l1-penalty", &l1_penalty, "L1 penalty (promote sparsity)");
+  void Register(OptionsItf *opts) {
+    opts->Register("learn-rate", &learn_rate, "Learning rate");
+    opts->Register("momentum", &momentum, "Momentum");
+    opts->Register("l2-penalty", &l2_penalty, "L2 penalty (weight decay)");
+    opts->Register("l1-penalty", &l1_penalty, "L1 penalty (promote sparsity)");
   }
   // print for debug purposes
   friend std::ostream& operator<<(std::ostream& os, const NnetTrainOptions& opts) {
@@ -76,18 +76,18 @@ struct RbmTrainOptions {
                       l2_penalty(0.0002)
                       { }
   // register options
-  void Register(OptionsItf *po) {
-    po->Register("learn-rate", &learn_rate, "Learning rate");
+  void Register(OptionsItf *opts) {
+    opts->Register("learn-rate", &learn_rate, "Learning rate");
 
-    po->Register("momentum", &momentum, "Initial momentum for linear scheduling");
-    po->Register("momentum-max", &momentum_max, "Final momentum for linear scheduling");
-    po->Register("momentum-steps", &momentum_steps, 
-                 "Number of steps of linear momentum scheduling");
-    po->Register("momentum-step-period", &momentum_step_period, 
-                 "Number of datapoints per single momentum increase step");
+    opts->Register("momentum", &momentum, "Initial momentum for linear scheduling");
+    opts->Register("momentum-max", &momentum_max, "Final momentum for linear scheduling");
+    opts->Register("momentum-steps", &momentum_steps, 
+                   "Number of steps of linear momentum scheduling");
+    opts->Register("momentum-step-period", &momentum_step_period, 
+                   "Number of datapoints per single momentum increase step");
 
-    po->Register("l2-penalty", &l2_penalty, 
-                 "L2 penalty (weight decay, increases mixing-rate)");
+    opts->Register("l2-penalty", &l2_penalty, 
+                   "L2 penalty (weight decay, increases mixing-rate)");
   }
   // print for debug purposes
   friend std::ostream& operator<<(std::ostream& os, const RbmTrainOptions& opts) {

--- a/src/nnet2/combine-nnet-a.h
+++ b/src/nnet2/combine-nnet-a.h
@@ -49,26 +49,26 @@ struct NnetCombineAconfig {
                         max_learning_rate_factor(2.0),
                         min_learning_rate(0.0001) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
-                 "evaluations for BFGS to use when optimizing combination weights");
-    po->Register("initial-step", &initial_step, "Parameter in the optimization, "
-                 "used to set the initial step length; the default value should be "
-                 "suitable.");
-    po->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
-                 "evaluations for BFGS to use when optimizing combination weights");
-    po->Register("valid-impr-thresh", &valid_impr_thresh, "Threshold of improvement "
-                 "in validation-set objective function for one iteratin; below this, "
-                 "we start using the \"overshoot\" mechanism to keep learning rates high.");
-    po->Register("overshoot", &overshoot, "Factor by which we overshoot the step "
-                 "size obtained by BFGS; only applies when validation set impr is less "
-                 "than valid-impr-thresh.");
-    po->Register("max-learning-rate-factor", &max_learning_rate_factor,
-                 "Maximum factor by which to increase the learning rate for any layer.");
-    po->Register("min-learning-rate-factor", &min_learning_rate_factor,
-                 "Minimum factor by which to increase the learning rate for any layer.");
-    po->Register("min-learning-rate", &min_learning_rate,
-                 "Floor on the automatically updated learning rates");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
+                   "evaluations for BFGS to use when optimizing combination weights");
+    opts->Register("initial-step", &initial_step, "Parameter in the optimization, "
+                   "used to set the initial step length; the default value should be "
+                   "suitable.");
+    opts->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
+                   "evaluations for BFGS to use when optimizing combination weights");
+    opts->Register("valid-impr-thresh", &valid_impr_thresh, "Threshold of improvement "
+                   "in validation-set objective function for one iteratin; below this, "
+                   "we start using the \"overshoot\" mechanism to keep learning rates high.");
+    opts->Register("overshoot", &overshoot, "Factor by which we overshoot the step "
+                   "size obtained by BFGS; only applies when validation set impr is less "
+                   "than valid-impr-thresh.");
+    opts->Register("max-learning-rate-factor", &max_learning_rate_factor,
+                   "Maximum factor by which to increase the learning rate for any layer.");
+    opts->Register("min-learning-rate-factor", &min_learning_rate_factor,
+                   "Minimum factor by which to increase the learning rate for any layer.");
+    opts->Register("min-learning-rate", &min_learning_rate,
+                   "Floor on the automatically updated learning rates");
   }  
 };
 

--- a/src/nnet2/combine-nnet-fast.h
+++ b/src/nnet2/combine-nnet-fast.h
@@ -70,32 +70,32 @@ struct NnetCombineFastConfig {
                            alpha(0.01), fisher_minibatch_size(64), minibatch_size(1024),
                            max_lbfgs_dim(10), regularizer(0.0) {}
   
-  void Register(OptionsItf *po) {
-    po->Register("initial-model", &initial_model, "Specifies where to start the "
-                 "optimization from.  If 0 ... #models-1, then specifies the model; "
-                 "if >= #models, then the average of all inputs; if <0, chosen "
-                 "automatically from the previous options.");
-    po->Register("num-lbfgs-iters", &num_lbfgs_iters, "Maximum number of function "
-                 "evaluations for L-BFGS to use when optimizing combination weights");
-    po->Register("initial-impr", &initial_impr, "Amount of objective-function change "
-                 "We aim for on the first iteration.");
-    po->Register("num-threads", &num_threads, "Number of threads to use in "
-                 "multi-core computation");
-    po->Register("fisher-floor", &fisher_floor,
-                 "Floor for diagonal of Fisher matrix (used in preconditioning)");
-    po->Register("alpha", &alpha, "Value we use in smoothing the Fisher matrix "
-                 "with its diagonal, in preconditioning the update.");
-    po->Register("fisher-minibatch-size", &fisher_minibatch_size, "Size of minibatch "
-                 "used in computation of Fisher matrix (smaller -> better "
-                 "preconditioning");
-    po->Register("minibatch-size", &minibatch_size, "Minibatch size used in computing "
-                 "gradients (only affects speed)");
-    po->Register("max-lbfgs-dim", &max_lbfgs_dim, "Maximum dimension to use in "
-                 "L-BFGS (will not get higher than this even if the dimension "
-                 "of the space gets higher.)");
-    po->Register("regularizer", &regularizer, "Add to the objective "
-                 "function (which is average log-like per frame), -0.5 * "
-                 "regularizer * square of parameters.");
+  void Register(OptionsItf *opts) {
+    opts->Register("initial-model", &initial_model, "Specifies where to start the "
+                   "optimization from.  If 0 ... #models-1, then specifies the model; "
+                   "if >= #models, then the average of all inputs; if <0, chosen "
+                   "automatically from the previous options.");
+    opts->Register("num-lbfgs-iters", &num_lbfgs_iters, "Maximum number of function "
+                   "evaluations for L-BFGS to use when optimizing combination weights");
+    opts->Register("initial-impr", &initial_impr, "Amount of objective-function change "
+                   "We aim for on the first iteration.");
+    opts->Register("num-threads", &num_threads, "Number of threads to use in "
+                   "multi-core computation");
+    opts->Register("fisher-floor", &fisher_floor,
+                   "Floor for diagonal of Fisher matrix (used in preconditioning)");
+    opts->Register("alpha", &alpha, "Value we use in smoothing the Fisher matrix "
+                   "with its diagonal, in preconditioning the update.");
+    opts->Register("fisher-minibatch-size", &fisher_minibatch_size, "Size of minibatch "
+                   "used in computation of Fisher matrix (smaller -> better "
+                   "preconditioning");
+    opts->Register("minibatch-size", &minibatch_size, "Minibatch size used in computing "
+                   "gradients (only affects speed)");
+    opts->Register("max-lbfgs-dim", &max_lbfgs_dim, "Maximum dimension to use in "
+                   "L-BFGS (will not get higher than this even if the dimension "
+                   "of the space gets higher.)");
+    opts->Register("regularizer", &regularizer, "Add to the objective "
+                   "function (which is average log-like per frame), -0.5 * "
+                   "regularizer * square of parameters.");
   }  
 };
 

--- a/src/nnet2/combine-nnet.h
+++ b/src/nnet2/combine-nnet.h
@@ -47,17 +47,17 @@ struct NnetCombineConfig {
                        initial_impr(0.01),
                        test_gradient(false) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("initial-model", &initial_model, "Specifies where to start the "
-                 "optimization from.  If 0 ... #models-1, then specifies the model; "
-                 "if #models, then the average of all inputs; otherwise, chosen "
-                 "automatically from the previous options.");
-    po->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
-                 "evaluations for BFGS to use when optimizing combination weights");
-    po->Register("initial-impr", &initial_impr, "Amount of objective-function change "
-                 "we aim for on the first iteration.");
-    po->Register("test-gradient", &test_gradient, "If true, activate code that "
-                 "tests the gradient is accurate.");
+  void Register(OptionsItf *opts) {
+    opts->Register("initial-model", &initial_model, "Specifies where to start the "
+                   "optimization from.  If 0 ... #models-1, then specifies the model; "
+                   "if #models, then the average of all inputs; otherwise, chosen "
+                   "automatically from the previous options.");
+    opts->Register("num-bfgs-iters", &num_bfgs_iters, "Maximum number of function "
+                   "evaluations for BFGS to use when optimizing combination weights");
+    opts->Register("initial-impr", &initial_impr, "Amount of objective-function change "
+                   "we aim for on the first iteration.");
+    opts->Register("test-gradient", &test_gradient, "If true, activate code that "
+                   "tests the gradient is accurate.");
   }  
 };
 

--- a/src/nnet2/get-feature-transform.h
+++ b/src/nnet2/get-feature-transform.h
@@ -44,18 +44,18 @@ struct FeatureTransformEstimateOptions {
   FeatureTransformEstimateOptions(): remove_offset(true), dim(200),
                                      within_class_factor(0.001), max_singular_value(5.0) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("remove-offset", &remove_offset, "If true, output an affine "
-                 "transform that makes the projected data mean equal to zero.");
-    po->Register("dim", &dim, "Dimension to project to with LDA");
-    po->Register("within-class-factor", &within_class_factor, "If 1.0, do "
-                 "conventional LDA where the within-class variance will be "
-                 "unit in the projected space.  May be set to less than 1.0, "
-                 "which scales the features to have less variance, particularly "
-                 "for dimensions where between-class variance is small. ");
-    po->Register("max-singular-value", &max_singular_value, "If >0, maximum "
-                 "allowed singular value of final transform (they are floored "
-                 "to this)");
+  void Register(OptionsItf *opts) {
+    opts->Register("remove-offset", &remove_offset, "If true, output an affine "
+                   "transform that makes the projected data mean equal to zero.");
+    opts->Register("dim", &dim, "Dimension to project to with LDA");
+    opts->Register("within-class-factor", &within_class_factor, "If 1.0, do "
+                   "conventional LDA where the within-class variance will be "
+                   "unit in the projected space.  May be set to less than 1.0, "
+                   "which scales the features to have less variance, particularly "
+                   "for dimensions where between-class variance is small. ");
+    opts->Register("max-singular-value", &max_singular_value, "If >0, maximum "
+                   "allowed singular value of final transform (they are floored "
+                   "to this)");
   }    
 };
 

--- a/src/nnet2/mixup-nnet.h
+++ b/src/nnet2/mixup-nnet.h
@@ -37,17 +37,17 @@ struct NnetMixupConfig {
   NnetMixupConfig(): power(0.25), min_count(1000.0),
                      num_mixtures(-1), perturb_stddev(0.01) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("power", &power, "Scaling factor used in determining the "
-                 "number of mixture components to use for each HMM state "
-                 "(or group of HMM states)");
-    po->Register("min-count", &min_count, "Minimum count for a quasi-Gaussian, "
-                 "enforced while allocating mixtures (obscure parameter).");
-    po->Register("num-mixtures", &num_mixtures, "If specified, total number of "
-                 "mixture components to mix up to (should be at least the "
-                 "#leaves in the system");
-    po->Register("perturb-stddev", &perturb_stddev, "Standard deviation used "
-                 "when perturbing parameters during mixing up");
+  void Register(OptionsItf *opts) {
+    opts->Register("power", &power, "Scaling factor used in determining the "
+                   "number of mixture components to use for each HMM state "
+                   "(or group of HMM states)");
+    opts->Register("min-count", &min_count, "Minimum count for a quasi-Gaussian, "
+                   "enforced while allocating mixtures (obscure parameter).");
+    opts->Register("num-mixtures", &num_mixtures, "If specified, total number of "
+                   "mixture components to mix up to (should be at least the "
+                   "#leaves in the system");
+    opts->Register("perturb-stddev", &perturb_stddev, "Standard deviation used "
+                   "when perturbing parameters during mixing up");
   }  
 };
 

--- a/src/nnet2/nnet-compute-discriminative.h
+++ b/src/nnet2/nnet-compute-discriminative.h
@@ -48,20 +48,20 @@ struct NnetDiscriminativeUpdateOptions {
                                      one_silence_class(false),
                                      boost(0.0) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("criterion", &criterion, "Criterion, 'mmi'|'mpfe'|'smbr', "
-                 "determines the objective function to use.  Should match "
-                 "option used when we created the examples.");
-    po->Register("acoustic-scale", &acoustic_scale, "Weighting factor to "
-                 "apply to acoustic likelihoods.");
-    po->Register("drop-frames", &drop_frames, "For MMI, if true we drop frames "
-                 "with no overlap of num and den frames");
-    po->Register("boost", &boost, "Boosting factor for boosted MMI (e.g. 0.1)");
-    po->Register("one-silence-class", &one_silence_class, "If true, newer "
-                 "behavior which will tend to reduce insertions.");
-    po->Register("silence-phones", &silence_phones_str,
-                 "For MPFE or SMBR, colon-separated list of integer ids of "
-                 "silence phones, e.g. 1:2:3");
+  void Register(OptionsItf *opts) {
+    opts->Register("criterion", &criterion, "Criterion, 'mmi'|'mpfe'|'smbr', "
+                   "determines the objective function to use.  Should match "
+                   "option used when we created the examples.");
+    opts->Register("acoustic-scale", &acoustic_scale, "Weighting factor to "
+                   "apply to acoustic likelihoods.");
+    opts->Register("drop-frames", &drop_frames, "For MMI, if true we drop frames "
+                   "with no overlap of num and den frames");
+    opts->Register("boost", &boost, "Boosting factor for boosted MMI (e.g. 0.1)");
+    opts->Register("one-silence-class", &one_silence_class, "If true, newer "
+                   "behavior which will tend to reduce insertions.");
+    opts->Register("silence-phones", &silence_phones_str,
+                   "For MPFE or SMBR, colon-separated list of integer ids of "
+                   "silence phones, e.g. 1:2:3");
     
   }
 };

--- a/src/nnet2/nnet-example-functions.h
+++ b/src/nnet2/nnet-example-functions.h
@@ -89,28 +89,28 @@ struct SplitDiscriminativeExampleConfig {
       determinize(true), minimize(true), test(false), drop_frames(false),
       split(true), excise(true) { }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
 
-    po->Register("max-length", &max_length, "Maximum length allowed for any "
-                "segment (i.e. max #frames for any example");
-    //po->Register("target-length", &target_length, "Target length for a "
+    opts->Register("max-length", &max_length, "Maximum length allowed for any "
+                   "segment (i.e. max #frames for any example");
+    //opts->Register("target-length", &target_length, "Target length for a "
     // "segment");
-    po->Register("criterion", &criterion, "Criterion, 'mmi'|'mpfe'|'smbr'. "
-                 "Determines which frames may be dropped from lattices.");
-    po->Register("collapse-transition-ids", &collapse_transition_ids,
-                 "This option included for debugging purposes");
-    po->Register("determinize", &determinize, "If true, we determinize "
-                 "lattices (as Lattice) before splitting and possibly minimize");
-    po->Register("minimize", &minimize, "If true, we push and "
-                 "minimize lattices (as Lattice) before splitting");
-    po->Register("test", &test, "If true, activate self-testing code.");
+    opts->Register("criterion", &criterion, "Criterion, 'mmi'|'mpfe'|'smbr'. "
+                   "Determines which frames may be dropped from lattices.");
+    opts->Register("collapse-transition-ids", &collapse_transition_ids,
+                   "This option included for debugging purposes");
+    opts->Register("determinize", &determinize, "If true, we determinize "
+                   "lattices (as Lattice) before splitting and possibly minimize");
+    opts->Register("minimize", &minimize, "If true, we push and "
+                   "minimize lattices (as Lattice) before splitting");
+    opts->Register("test", &test, "If true, activate self-testing code.");
     // See "Sequence-discriminative training of deep neural networks", Vesely et al,
     // ICASSP 2013 for explanation of frame dropping.
-    po->Register("drop-frames", &drop_frames, "For MMI, if true we drop frames "
-                 "with no overlap of num and den frames");
-    po->Register("split", &split, "Set to false to disable lattice-splitting.");
-    po->Register("excise", &excise, "Set to false to disable excising un-needed "
-                 "frames (option included for debug purposes)");
+    opts->Register("drop-frames", &drop_frames, "For MMI, if true we drop frames "
+                   "with no overlap of num and den frames");
+    opts->Register("split", &split, "Set to false to disable lattice-splitting.");
+    opts->Register("excise", &excise, "Set to false to disable excising un-needed "
+                   "frames (option included for debug purposes)");
   }
 };
 

--- a/src/nnet2/nnet-fix.h
+++ b/src/nnet2/nnet-fix.h
@@ -51,18 +51,18 @@ struct NnetFixConfig {
 
   NnetFixConfig(): min_average_deriv(0.1), max_average_deriv(0.75),
                    parameter_factor(2.0), relu_bias_change(1.0) { }
-  void Register(OptionsItf *po) {
-    po->Register("min-average-deriv", &min_average_deriv, "Miniumum derivative, "
-                 "averaged over the training data, that we allow for a nonlinearity,"
-                 "expressed relative to the maximum derivative of the nonlinearity,"
-                 "i.e. 1.0 for tanh or 0.25 for sigmoid, 1.0 for rectified linear.");
-    po->Register("max-average-deriv", &max_average_deriv, "Maximum derivative, "
-                 "averaged over the training data, that we allow for the nonlinearity "
-                 "associated with one neuron.");
-    po->Register("parameter-factor", &parameter_factor, "Maximum factor by which we change "
-                 "the set of parameters associated with a neuron.");
-    po->Register("relu-bias-change", &relu_bias_change, "For ReLUs, change in bias when "
-                 "we identify a component that's too frequently on or off.");
+  void Register(OptionsItf *opts) {
+    opts->Register("min-average-deriv", &min_average_deriv, "Miniumum derivative, "
+                   "averaged over the training data, that we allow for a nonlinearity,"
+                   "expressed relative to the maximum derivative of the nonlinearity,"
+                   "i.e. 1.0 for tanh or 0.25 for sigmoid, 1.0 for rectified linear.");
+    opts->Register("max-average-deriv", &max_average_deriv, "Maximum derivative, "
+                   "averaged over the training data, that we allow for the nonlinearity "
+                   "associated with one neuron.");
+    opts->Register("parameter-factor", &parameter_factor, "Maximum factor by which we change "
+                   "the set of parameters associated with a neuron.");
+    opts->Register("relu-bias-change", &relu_bias_change, "For ReLUs, change in bias when "
+                   "we identify a component that's too frequently on or off.");
   }
 };
 

--- a/src/nnet2/nnet-limit-rank.h
+++ b/src/nnet2/nnet-limit-rank.h
@@ -35,12 +35,12 @@ struct NnetLimitRankOpts {
   
   NnetLimitRankOpts(): num_threads(1), parameter_proportion(0.75) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("num-threads", &num_threads, "Number of threads used for "
-                 "rank-limiting operation; note, will never use more than "
-                 "#layers.");
-    po->Register("parameter-proportion", &parameter_proportion, "Proportion of "
-                 "dimension of each transform to limit the rank to.");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-threads", &num_threads, "Number of threads used for "
+                   "rank-limiting operation; note, will never use more than "
+                   "#layers.");
+    opts->Register("parameter-proportion", &parameter_proportion, "Proportion of "
+                   "dimension of each transform to limit the rank to.");
   }  
 };
 

--- a/src/nnet2/nnet-stats.h
+++ b/src/nnet2/nnet-stats.h
@@ -35,9 +35,9 @@ struct NnetStatsConfig {
   BaseFloat bucket_width;
   NnetStatsConfig(): bucket_width(0.025) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("bucket-width", &bucket_width, "Width of bucket in average-derivative "
-                 "stats for analysis.");
+  void Register(OptionsItf *opts) {
+    opts->Register("bucket-width", &bucket_width, "Width of bucket in average-derivative "
+                   "stats for analysis.");
   }
 };
 

--- a/src/nnet2/online-nnet2-decodable.h
+++ b/src/nnet2/online-nnet2-decodable.h
@@ -44,16 +44,16 @@ struct DecodableNnet2OnlineOptions {
       pad_input(true),
       max_nnet_batch_size(256) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("acoustic-scale", &acoustic_scale,
-                 "Scaling factor for acoustic likelihoods");
-    po->Register("pad-input", &pad_input,
-                 "If true, pad acoustic features with required acoustic context "
-                 "past edges of file.");
-    po->Register("max-nnet-batch-size", &max_nnet_batch_size,
-                 "Maximum batch size we use in neural-network decodable object, "
-                 "in cases where we are not constrained by currently available "
-                 "frames (this will rarely make a difference)");
+  void Register(OptionsItf *opts) {
+    opts->Register("acoustic-scale", &acoustic_scale,
+                   "Scaling factor for acoustic likelihoods");
+    opts->Register("pad-input", &pad_input,
+                   "If true, pad acoustic features with required acoustic context "
+                   "past edges of file.");
+    opts->Register("max-nnet-batch-size", &max_nnet_batch_size,
+                   "Maximum batch size we use in neural-network decodable object, "
+                   "in cases where we are not constrained by currently available "
+                   "frames (this will rarely make a difference)");
                  
   }
 };

--- a/src/nnet2/rescale-nnet.h
+++ b/src/nnet2/rescale-nnet.h
@@ -54,17 +54,17 @@ struct NnetRescaleConfig {
                        delta(0.01),
                        max_change(0.2), min_change(1.0e-05) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("target-avg-deriv", &target_avg_deriv, "Target average derivative "
-                 "for hidden layers that are the not the first or last hidden layer "
-                 "(as fraction of maximum derivative of the nonlinearity)");
-    po->Register("target-first-layer-avg-deriv", &target_first_layer_avg_deriv,
-                 "Target average derivative for the first hidden layer"
-                 "(as fraction of maximum derivative of the nonlinearity)");
-    po->Register("target-last-layer-avg-deriv", &target_last_layer_avg_deriv,
-                 "Target average derivative for the last hidden layer, if "
-                 "#hid-layers > 1"
-                 "(as fraction of maximum derivative of the nonlinearity)");
+  void Register(OptionsItf *opts) {
+    opts->Register("target-avg-deriv", &target_avg_deriv, "Target average derivative "
+                   "for hidden layers that are the not the first or last hidden layer "
+                   "(as fraction of maximum derivative of the nonlinearity)");
+    opts->Register("target-first-layer-avg-deriv", &target_first_layer_avg_deriv,
+                   "Target average derivative for the first hidden layer"
+                   "(as fraction of maximum derivative of the nonlinearity)");
+    opts->Register("target-last-layer-avg-deriv", &target_last_layer_avg_deriv,
+                   "Target average derivative for the last hidden layer, if "
+                   "#hid-layers > 1"
+                   "(as fraction of maximum derivative of the nonlinearity)");
   }  
 };
 

--- a/src/nnet2/shrink-nnet.h
+++ b/src/nnet2/shrink-nnet.h
@@ -39,11 +39,11 @@ struct NnetShrinkConfig {
   BaseFloat initial_step;
   
   NnetShrinkConfig(): num_bfgs_iters(10), initial_step(0.1) { }
-  void Register(OptionsItf *po) {
-    po->Register("num-bfgs-iters", &num_bfgs_iters, "Number of iterations of "
-                 "BFGS to use when optimizing shrinkage parameters");
-    po->Register("initial-step", &initial_step, "Parameter in the optimization, "
-                 "used to set the initial step length");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-bfgs-iters", &num_bfgs_iters, "Number of iterations of "
+                   "BFGS to use when optimizing shrinkage parameters");
+    opts->Register("initial-step", &initial_step, "Parameter in the optimization, "
+                   "used to set the initial step length");
   }  
 };
 

--- a/src/nnet2/train-nnet-ensemble.h
+++ b/src/nnet2/train-nnet-ensemble.h
@@ -38,15 +38,15 @@ struct NnetEnsembleTrainerConfig {
                              minibatches_per_phase(50),
                              beta(0.5) { }
   
-  void Register (OptionsItf *po) {
-    po->Register("minibatch-size", &minibatch_size,
-                 "Number of samples per minibatch of training data.");
-    po->Register("minibatches-per-phase", &minibatches_per_phase,
-                 "Number of minibatches to wait before printing training-set "
-                 "objective.");
-    po->Register("beta", &beta, 
-                 "weight of the second term in the objf, which is the cross-entropy "
-                 "between the output posteriors and the averaged posteriors from other nets.");
+  void Register (OptionsItf *opts) {
+    opts->Register("minibatch-size", &minibatch_size,
+                   "Number of samples per minibatch of training data.");
+    opts->Register("minibatches-per-phase", &minibatches_per_phase,
+                   "Number of minibatches to wait before printing training-set "
+                   "objective.");
+    opts->Register("beta", &beta, 
+                   "weight of the second term in the objf, which is the cross-entropy "
+                   "between the output posteriors and the averaged posteriors from other nets.");
   }  
 };
 

--- a/src/nnet2/train-nnet-perturbed.h
+++ b/src/nnet2/train-nnet-perturbed.h
@@ -191,17 +191,17 @@ struct NnetPerturbedTrainerConfig {
                                 tune_d_power(0.5),
                                 max_d_factor(2.0){ }
   
-  void Register (OptionsItf *po) {
-    po->Register("minibatch-size", &minibatch_size,
-                 "Number of samples per minibatch of training data.");
-    po->Register("minibatches-per-phase", &minibatches_per_phase,
-                 "Number of minibatches to wait before printing training-set "
-                 "objective.");
-    po->Register("target-objf-change", &target_objf_change, "Target objective "
-                 "function change from feature perturbation, used to set "
-                 "feature distance parameter D");
-    po->Register("initial-d", &initial_d, "Initial value of parameter D "
-                 "It will ultimately be set according to --target-objf-change");
+  void Register (OptionsItf *opts) {
+    opts->Register("minibatch-size", &minibatch_size,
+                   "Number of samples per minibatch of training data.");
+    opts->Register("minibatches-per-phase", &minibatches_per_phase,
+                   "Number of minibatches to wait before printing training-set "
+                   "objective.");
+    opts->Register("target-objf-change", &target_objf_change, "Target objective "
+                   "function change from feature perturbation, used to set "
+                   "feature distance parameter D");
+    opts->Register("initial-d", &initial_d, "Initial value of parameter D "
+                   "It will ultimately be set according to --target-objf-change");
   }  
 };
 

--- a/src/nnet2/train-nnet.h
+++ b/src/nnet2/train-nnet.h
@@ -35,12 +35,12 @@ struct NnetSimpleTrainerConfig {
   NnetSimpleTrainerConfig(): minibatch_size(500),
                              minibatches_per_phase(50) { }
   
-  void Register (OptionsItf *po) {
-    po->Register("minibatch-size", &minibatch_size,
-                 "Number of samples per minibatch of training data.");
-    po->Register("minibatches-per-phase", &minibatches_per_phase,
-                 "Number of minibatches to wait before printing training-set "
-                 "objective.");
+  void Register (OptionsItf *opts) {
+    opts->Register("minibatch-size", &minibatch_size,
+                   "Number of samples per minibatch of training data.");
+    opts->Register("minibatches-per-phase", &minibatches_per_phase,
+                   "Number of minibatches to wait before printing training-set "
+                   "objective.");
   }  
 };
 

--- a/src/nnet2/widen-nnet.h
+++ b/src/nnet2/widen-nnet.h
@@ -39,14 +39,14 @@ struct NnetWidenConfig {
                      param_stddev_factor(1.0),
                      bias_stddev(0.5) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("hidden-layer-dim", &hidden_layer_dim, "[required option]: "
-                 "target dimension of hidden layers");
-    po->Register("param-stddev-factor", &param_stddev_factor, "Factor in "
-                 "standard deviation of linear parameters of new part of "
-                 "transform (multiply by 1/sqrt of input-dim)");
-    po->Register("bias-stddev", &bias_stddev, "Standard deviation of added "
-                 "bias parameters");
+  void Register(OptionsItf *opts) {
+    opts->Register("hidden-layer-dim", &hidden_layer_dim, "[required option]: "
+                   "target dimension of hidden layers");
+    opts->Register("param-stddev-factor", &param_stddev_factor, "Factor in "
+                   "standard deviation of linear parameters of new part of "
+                   "transform (multiply by 1/sqrt of input-dim)");
+    opts->Register("bias-stddev", &bias_stddev, "Standard deviation of added "
+                   "bias parameters");
   }  
 };
 

--- a/src/online/online-faster-decoder.h
+++ b/src/online/online-faster-decoder.h
@@ -48,21 +48,21 @@ struct OnlineFasterDecoderOpts : public FasterDecoderOptions {
     update_interval(3), beam_update(.01),
     max_beam_update(0.05) {}
 
-  void Register(OptionsItf *po, bool full) {
-    FasterDecoderOptions::Register(po, full);
-    po->Register("rt-min", &rt_min,
-                 "Approximate minimum decoding run time factor");
-    po->Register("rt-max", &rt_max,
-                 "Approximate maximum decoding run time factor");
-    po->Register("update-interval", &update_interval,
-                 "Beam update interval in frames");
-    po->Register("beam-update", &beam_update, "Beam update rate");
-    po->Register("max-beam-update", &max_beam_update, "Max beam update rate");
-    po->Register("inter-utt-sil", &inter_utt_sil,
-                 "Maximum # of silence frames to trigger new utterance");
-    po->Register("max-utt-length", &max_utt_len_,
-                 "If the utterance becomes longer than this number of frames, "
-                 "shorter silence is acceptable as an utterance separator");
+  void Register(OptionsItf *opts, bool full) {
+    FasterDecoderOptions::Register(opts, full);
+    opts->Register("rt-min", &rt_min,
+                   "Approximate minimum decoding run time factor");
+    opts->Register("rt-max", &rt_max,
+                   "Approximate maximum decoding run time factor");
+    opts->Register("update-interval", &update_interval,
+                   "Beam update interval in frames");
+    opts->Register("beam-update", &beam_update, "Beam update rate");
+    opts->Register("max-beam-update", &max_beam_update, "Max beam update rate");
+    opts->Register("inter-utt-sil", &inter_utt_sil,
+                   "Maximum # of silence frames to trigger new utterance");
+    opts->Register("max-utt-length", &max_utt_len_,
+                   "If the utterance becomes longer than this number of frames, "
+                   "shorter silence is acceptable as an utterance separator");
   }
 };
 

--- a/src/online/online-feat-input.h
+++ b/src/online/online-feat-input.h
@@ -335,12 +335,12 @@ struct OnlineFeatureMatrixOptions {
                    // before we give up.
   OnlineFeatureMatrixOptions(): batch_size(27),
                                 num_tries(5) { }
-  void Register(OptionsItf *po) {
-    po->Register("batch-size", &batch_size,
-                 "Number of feature vectors processed w/o interruption");
-    po->Register("num-tries", &num_tries,
-                 "Number of successive repetitions of timeout before we "
-                 "terminate stream");
+  void Register(OptionsItf *opts) {
+    opts->Register("batch-size", &batch_size,
+                   "Number of feature vectors processed w/o interruption");
+    opts->Register("num-tries", &num_tries,
+                   "Number of successive repetitions of timeout before we "
+                   "terminate stream");
   }
 };
 

--- a/src/online2/online-endpoint.h
+++ b/src/online2/online-endpoint.h
@@ -99,26 +99,26 @@ struct OnlineEndpointRule {
       max_relative_cost(max_relative_cost),
       min_utterance_length(min_utterance_length) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("must-contain-nonsilence", &must_contain_nonsilence,
-                 "If true, for this endpointing rule to apply there must"
-                 "be nonsilence in the best-path traceback.");
-    po->Register("min-trailing-silence", &min_trailing_silence,
-                 "This endpointing rule requires duration of trailing silence"
-                 "to be >= this value.");
-    po->Register("max-relative-cost", &max_relative_cost,
-                 "This endpointing rule requires relative-cost of final-states "
-                 "to be <= this value (describes how good the probability "
-                 "of final-states is).");
-    po->Register("min-utterance-length", &min_utterance_length,
-                 "This endpointing rule requires utterance-length (in seconds) "
-                 "to be >= this value.");
+  void Register(OptionsItf *opts) {
+    opts->Register("must-contain-nonsilence", &must_contain_nonsilence,
+                   "If true, for this endpointing rule to apply there must"
+                   "be nonsilence in the best-path traceback.");
+    opts->Register("min-trailing-silence", &min_trailing_silence,
+                   "This endpointing rule requires duration of trailing silence"
+                   "to be >= this value.");
+    opts->Register("max-relative-cost", &max_relative_cost,
+                   "This endpointing rule requires relative-cost of final-states "
+                   "to be <= this value (describes how good the probability "
+                   "of final-states is).");
+    opts->Register("min-utterance-length", &min_utterance_length,
+                   "This endpointing rule requires utterance-length (in seconds) "
+                   "to be >= this value.");
   };
   // for convenience add this RegisterWithPrefix function, because
   // we'll be registering this as a config with several different
   // prefixes.
-  void RegisterWithPrefix(const std::string &prefix, OptionsItf *po) {
-    ParseOptions po_prefix(prefix, po);
+  void RegisterWithPrefix(const std::string &prefix, OptionsItf *opts) {
+    ParseOptions po_prefix(prefix, opts);
     this->Register(&po_prefix);
   }
 };
@@ -155,15 +155,15 @@ struct OnlineEndpointConfig {
       rule4(true, 2.0, std::numeric_limits<BaseFloat>::infinity(), 0.0),
       rule5(false, 0.0, std::numeric_limits<BaseFloat>::infinity(), 20.0) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("endpoint.silence-phones", &silence_phones, "List of phones "
-                 "that are considered to be silence phones by the "
-                 "endpointing code.");
-    rule1.RegisterWithPrefix("endpoint.rule1", po);
-    rule2.RegisterWithPrefix("endpoint.rule2", po);
-    rule3.RegisterWithPrefix("endpoint.rule3", po);
-    rule4.RegisterWithPrefix("endpoint.rule4", po);
-    rule5.RegisterWithPrefix("endpoint.rule5", po);
+  void Register(OptionsItf *opts) {
+    opts->Register("endpoint.silence-phones", &silence_phones, "List of phones "
+                   "that are considered to be silence phones by the "
+                   "endpointing code.");
+    rule1.RegisterWithPrefix("endpoint.rule1", opts);
+    rule2.RegisterWithPrefix("endpoint.rule2", opts);
+    rule3.RegisterWithPrefix("endpoint.rule3", opts);
+    rule4.RegisterWithPrefix("endpoint.rule4", opts);
+    rule5.RegisterWithPrefix("endpoint.rule5", opts);
   }
 };
 

--- a/src/online2/online-feature-pipeline.h
+++ b/src/online2/online-feature-pipeline.h
@@ -66,38 +66,38 @@ struct OnlineFeaturePipelineCommandLineConfig {
     feature_type("mfcc"), add_pitch(false), add_deltas(false),
     splice_feats(false) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("feature-type", &feature_type,
-                 "Base feature type [mfcc, plp, fbank]");
-    po->Register("mfcc-config", &mfcc_config, "Configuration file for "
-                 "MFCC features (e.g. conf/mfcc.conf)");
-    po->Register("plp-config", &plp_config, "Configuration file for "
-                 "PLP features (e.g. conf/plp.conf)");
-    po->Register("fbank-config", &fbank_config, "Configuration file for "
-                 "filterbank features (e.g. conf/fbank.conf)");
-    po->Register("add-pitch", &add_pitch, "Append pitch features to raw "
-                 "MFCC/PLP features.");
-    po->Register("pitch-config", &pitch_config, "Configuration file for "
-                 "pitch features (e.g. conf/pitch.conf)");
-    po->Register("pitch-process-config", &pitch_process_config,
-                 "Configuration file for post-processing pitch features "
-                 "(e.g. conf/pitch_process.conf)");
-    po->Register("cmvn-config", &cmvn_config, "Configuration class "
-                 "file for online CMVN features (e.g. conf/online_cmvn.conf)");
-    po->Register("global-cmvn-stats", &global_cmvn_stats_rxfilename,
-                 "(Extended) filename for global CMVN stats, e.g. obtained "
-                 "from 'matrix-sum scp:data/train/cmvn.scp -'");
-    po->Register("add-deltas", &add_deltas,
-                 "Append delta features.");
-    po->Register("delta-config", &delta_config, "Configuration file for "
-                 "delta feature computation (if not supplied, will not apply "
-                 "delta features; supply empty config to use defaults.)");
-    po->Register("splice-feats", &splice_feats, "Splice features with left and "
-                 "right context.");
-    po->Register("splice-config", &splice_config, "Configuration file "
-                 "for frame splicing, if done (e.g. prior to LDA)");
-    po->Register("lda-matrix", &lda_rxfilename, "Filename of LDA matrix (if "
-                 "using LDA), e.g. exp/foo/final.mat");
+  void Register(OptionsItf *opts) {
+    opts->Register("feature-type", &feature_type,
+                   "Base feature type [mfcc, plp, fbank]");
+    opts->Register("mfcc-config", &mfcc_config, "Configuration file for "
+                   "MFCC features (e.g. conf/mfcc.conf)");
+    opts->Register("plp-config", &plp_config, "Configuration file for "
+                   "PLP features (e.g. conf/plp.conf)");
+    opts->Register("fbank-config", &fbank_config, "Configuration file for "
+                   "filterbank features (e.g. conf/fbank.conf)");
+    opts->Register("add-pitch", &add_pitch, "Append pitch features to raw "
+                   "MFCC/PLP features.");
+    opts->Register("pitch-config", &pitch_config, "Configuration file for "
+                   "pitch features (e.g. conf/pitch.conf)");
+    opts->Register("pitch-process-config", &pitch_process_config,
+                   "Configuration file for post-processing pitch features "
+                   "(e.g. conf/pitch_process.conf)");
+    opts->Register("cmvn-config", &cmvn_config, "Configuration class "
+                   "file for online CMVN features (e.g. conf/online_cmvn.conf)");
+    opts->Register("global-cmvn-stats", &global_cmvn_stats_rxfilename,
+                   "(Extended) filename for global CMVN stats, e.g. obtained "
+                   "from 'matrix-sum scp:data/train/cmvn.scp -'");
+    opts->Register("add-deltas", &add_deltas,
+                   "Append delta features.");
+    opts->Register("delta-config", &delta_config, "Configuration file for "
+                   "delta feature computation (if not supplied, will not apply "
+                   "delta features; supply empty config to use defaults.)");
+    opts->Register("splice-feats", &splice_feats, "Splice features with left and "
+                   "right context.");
+    opts->Register("splice-config", &splice_config, "Configuration file "
+                   "for frame splicing, if done (e.g. prior to LDA)");
+    opts->Register("lda-matrix", &lda_rxfilename, "Filename of LDA matrix (if "
+                   "using LDA), e.g. exp/foo/final.mat");
   }
 };
 

--- a/src/online2/online-gmm-decoding.h
+++ b/src/online2/online-gmm-decoding.h
@@ -64,19 +64,19 @@ struct OnlineGmmDecodingAdaptationPolicyConfig {
       adaptation_delay(5.0),
       adaptation_ratio(2.0) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("adaptation-first-utt-delay", &adaptation_first_utt_delay,
-                 "Delay before first basis-fMLLR adaptation for first utterance "
-                 "of each speaker");
-    po->Register("adaptation-first-utt-ratio", &adaptation_first_utt_ratio,
-                 "Ratio that controls frequency of fMLLR adaptation for first "
-                 "utterance of each speaker");
-    po->Register("adaptation-delay", &adaptation_first_utt_delay,
-                 "Delay before first basis-fMLLR adaptation for not-first "
-                 "utterances of each speaker");
-    po->Register("adaptation-ratio", &adaptation_first_utt_ratio,
-                 "Ratio that controls frequency of fMLLR adaptation for "
-                 "not-first utterances of each speaker");
+  void Register(OptionsItf *opts) {
+    opts->Register("adaptation-first-utt-delay", &adaptation_first_utt_delay,
+                   "Delay before first basis-fMLLR adaptation for first utterance "
+                   "of each speaker");
+    opts->Register("adaptation-first-utt-ratio", &adaptation_first_utt_ratio,
+                   "Ratio that controls frequency of fMLLR adaptation for first "
+                   "utterance of each speaker");
+    opts->Register("adaptation-delay", &adaptation_first_utt_delay,
+                   "Delay before first basis-fMLLR adaptation for not-first "
+                   "utterances of each speaker");
+    opts->Register("adaptation-ratio", &adaptation_first_utt_ratio,
+                   "Ratio that controls frequency of fMLLR adaptation for "
+                   "not-first utterances of each speaker");
   }
   
   /// Check that configuration values make sense.
@@ -122,35 +122,35 @@ struct OnlineGmmDecodingConfig {
   OnlineGmmDecodingConfig():  fmllr_lattice_beam(3.0), acoustic_scale(0.1),
                               silence_weight(0.1) { }
   
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     { // register basis_opts with prefix, there are getting to be too many
       // options.
-      ParseOptions basis_po("basis", po);
+      ParseOptions basis_po("basis", opts);
       basis_opts.Register(&basis_po);
     }
-    adaptation_policy_opts.Register(po);
-    faster_decoder_opts.Register(po);
-    po->Register("acoustic-scale", &acoustic_scale,
-                "Scaling factor for acoustic likelihoods");
-    po->Register("silence-phones", &silence_phones,
-                 "Colon-separated list of integer ids of silence phones, e.g. "
-                 "1:2:3 (affects adaptation).");
-    po->Register("silence-weight", &silence_weight,
-                 "Weight applied to silence frames for fMLLR estimation (if "
-                 "--silence-phones option is supplied)");
-    po->Register("fmllr-lattice-beam", &fmllr_lattice_beam, "Beam used in "
-                 "pruning lattices for fMLLR estimation");
-    po->Register("online-alignment-model", &online_alimdl_rxfilename,
-                 "(Extended) filename for model trained with online CMN "
-                 "features, e.g. from apply-cmvn-online.");
-    po->Register("model", &model_rxfilename, "(Extended) filename for model, "
-                 "typically the one used for fMLLR computation.  Required option.");
-    po->Register("rescore-model", &rescore_model_rxfilename, "(Extended) filename "
-                 "for model to rescore lattices with, e.g. discriminatively trained"
-                 "model, if it differs from that supplied to --model option.  Must"
-                 "have the same tree.");
-    po->Register("fmllr-basis", &fmllr_basis_rxfilename, "(Extended) filename "
-                 "of fMLLR basis object, as output by gmm-basis-fmllr-training");
+    adaptation_policy_opts.Register(opts);
+    faster_decoder_opts.Register(opts);
+    opts->Register("acoustic-scale", &acoustic_scale,
+                   "Scaling factor for acoustic likelihoods");
+    opts->Register("silence-phones", &silence_phones,
+                   "Colon-separated list of integer ids of silence phones, e.g. "
+                   "1:2:3 (affects adaptation).");
+    opts->Register("silence-weight", &silence_weight,
+                   "Weight applied to silence frames for fMLLR estimation (if "
+                   "--silence-phones option is supplied)");
+    opts->Register("fmllr-lattice-beam", &fmllr_lattice_beam, "Beam used in "
+                   "pruning lattices for fMLLR estimation");
+    opts->Register("online-alignment-model", &online_alimdl_rxfilename,
+                   "(Extended) filename for model trained with online CMN "
+                   "features, e.g. from apply-cmvn-online.");
+    opts->Register("model", &model_rxfilename, "(Extended) filename for model, "
+                   "typically the one used for fMLLR computation.  Required option.");
+    opts->Register("rescore-model", &rescore_model_rxfilename, "(Extended) filename "
+                   "for model to rescore lattices with, e.g. discriminatively trained"
+                   "model, if it differs from that supplied to --model option.  Must"
+                   "have the same tree.");
+    opts->Register("fmllr-basis", &fmllr_basis_rxfilename, "(Extended) filename "
+                   "of fMLLR basis object, as output by gmm-basis-fmllr-training");
   }
 };
 

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -106,51 +106,51 @@ struct OnlineIvectorExtractionConfig {
                                    greedy_ivector_extractor(false),
                                    max_remembered_frames(1000) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("lda-matrix", &lda_mat_rxfilename, "Filename of LDA matrix, "
-                 "e.g. final.mat; used for iVector extraction. ");
-    po->Register("global-cmvn-stats", &global_cmvn_stats_rxfilename,
-                 "(Extended) filename for global CMVN stats, used in iVector "
-                 "extraction, obtained for example from "
-                 "'matrix-sum scp:data/train/cmvn.scp -', only used for "
-                 "iVector extraction");
-    po->Register("cmvn-config", &cmvn_config_rxfilename, "Configuration "
-                 "file for online CMVN features (e.g. conf/online_cmvn.conf),"
-                 "only used for iVector extraction.  Contains options "
-                 "as for the program 'apply-cmvn-online'");
-    po->Register("splice-config", &splice_config_rxfilename, "Configuration file "
-                 "for frame splicing (--left-context and --right-context "
-                 "options); used for iVector extraction.");
-    po->Register("diag-ubm", &diag_ubm_rxfilename, "Filename of diagonal UBM "
-                 "used to obtain posteriors for iVector extraction, e.g. "
-                 "final.dubm");
-    po->Register("ivector-extractor", &ivector_extractor_rxfilename,
-                 "Filename of iVector extractor, e.g. final.ie");
-    po->Register("ivector-period", &ivector_period, "Frequency with which "
-                 "we extract iVectors for neural network adaptation");
-    po->Register("num-gselect", &num_gselect, "Number of Gaussians to select "
-                 "for iVector extraction");
-    po->Register("min-post", &min_post, "Threshold for posterior pruning in "
-                 "iVector extraction");
-    po->Register("posterior-scale", &posterior_scale, "Scale for posteriors in "
-                 "iVector extraction (may be viewed as inverse of prior scale)");
-    po->Register("max-count", &max_count, "Maximum data count we allow before "
-                 "we start scaling the stats down (if nonzero)... helps to make "
-                 "iVectors from long utterances look more typical.  Interpret "
-                 "as a frame-count times --posterior-scale, typically 1/10 of "
-                 "a number of frames.  Suggest 100.");
-    po->Register("use-most-recent-ivector", &use_most_recent_ivector, "If true, "
-                 "always use most recent available iVector, rather than the "
-                 "one for the designated frame.");
-    po->Register("greedy-ivector-extractor", &greedy_ivector_extractor, "If "
-                 "true, 'read ahead' as many frames as we currently have available "
-                 "when extracting the iVector.  May improve iVector quality.");
-    po->Register("max-remembered-frames", &max_remembered_frames, "The maximum "
-                 "number of frames of adaptation history that we carry through "
-                 "to later utterances of the same speaker (having a finite "
-                 "number allows the speaker adaptation state to change over "
-                 "time).  Interpret as a real frame count, i.e. not a count "
-                 "scaled by --posterior-scale.");
+  void Register(OptionsItf *opts) {
+    opts->Register("lda-matrix", &lda_mat_rxfilename, "Filename of LDA matrix, "
+                   "e.g. final.mat; used for iVector extraction. ");
+    opts->Register("global-cmvn-stats", &global_cmvn_stats_rxfilename,
+                   "(Extended) filename for global CMVN stats, used in iVector "
+                   "extraction, obtained for example from "
+                   "'matrix-sum scp:data/train/cmvn.scp -', only used for "
+                   "iVector extraction");
+    opts->Register("cmvn-config", &cmvn_config_rxfilename, "Configuration "
+                   "file for online CMVN features (e.g. conf/online_cmvn.conf),"
+                   "only used for iVector extraction.  Contains options "
+                   "as for the program 'apply-cmvn-online'");
+    opts->Register("splice-config", &splice_config_rxfilename, "Configuration file "
+                   "for frame splicing (--left-context and --right-context "
+                   "options); used for iVector extraction.");
+    opts->Register("diag-ubm", &diag_ubm_rxfilename, "Filename of diagonal UBM "
+                   "used to obtain posteriors for iVector extraction, e.g. "
+                   "final.dubm");
+    opts->Register("ivector-extractor", &ivector_extractor_rxfilename,
+                   "Filename of iVector extractor, e.g. final.ie");
+    opts->Register("ivector-period", &ivector_period, "Frequency with which "
+                   "we extract iVectors for neural network adaptation");
+    opts->Register("num-gselect", &num_gselect, "Number of Gaussians to select "
+                   "for iVector extraction");
+    opts->Register("min-post", &min_post, "Threshold for posterior pruning in "
+                   "iVector extraction");
+    opts->Register("posterior-scale", &posterior_scale, "Scale for posteriors in "
+                   "iVector extraction (may be viewed as inverse of prior scale)");
+    opts->Register("max-count", &max_count, "Maximum data count we allow before "
+                   "we start scaling the stats down (if nonzero)... helps to make "
+                   "iVectors from long utterances look more typical.  Interpret "
+                   "as a frame-count times --posterior-scale, typically 1/10 of "
+                   "a number of frames.  Suggest 100.");
+    opts->Register("use-most-recent-ivector", &use_most_recent_ivector, "If true, "
+                   "always use most recent available iVector, rather than the "
+                   "one for the designated frame.");
+    opts->Register("greedy-ivector-extractor", &greedy_ivector_extractor, "If "
+                   "true, 'read ahead' as many frames as we currently have available "
+                   "when extracting the iVector.  May improve iVector quality.");
+    opts->Register("max-remembered-frames", &max_remembered_frames, "The maximum "
+                   "number of frames of adaptation history that we carry through "
+                   "to later utterances of the same speaker (having a finite "
+                   "number allows the speaker adaptation state to change over "
+                   "time).  Interpret as a real frame count, i.e. not a count "
+                   "scaled by --posterior-scale.");
   }
 };
 
@@ -410,24 +410,24 @@ struct OnlineSilenceWeightingConfig {
   OnlineSilenceWeightingConfig():
       silence_weight(1.0), max_state_duration(-1) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("silence-phones", &silence_phones_str, "(RE weighting in "
-                 "iVector estimation for online decoding) List of integer ids of "
-                 "silence phones, separated by colons (or commas).  Data that "
-                 "(according to the traceback of the decoder) corresponds to "
-                 "these phones will be downweighted by --silence-weight.");
-    po->Register("silence-weight", &silence_weight, "(RE weighting in "
-                 "iVector estimation for online decoding) Weighting factor for frames "
-                 "that the decoder trace-back identifies as silence; only "
-                 "relevant if the --silence-phones option is set.");
-    po->Register("max-state-duration", &max_state_duration, "(RE weighting in "
-                 "iVector estimation for online decoding) Maximum allowed "
-                 "duration of a single transition-id; runs with durations longer "
-                 "than this will be weighted down to the silence-weight.");
+  void Register(OptionsItf *opts) {
+    opts->Register("silence-phones", &silence_phones_str, "(RE weighting in "
+                   "iVector estimation for online decoding) List of integer ids of "
+                   "silence phones, separated by colons (or commas).  Data that "
+                   "(according to the traceback of the decoder) corresponds to "
+                   "these phones will be downweighted by --silence-weight.");
+    opts->Register("silence-weight", &silence_weight, "(RE weighting in "
+                   "iVector estimation for online decoding) Weighting factor for frames "
+                   "that the decoder trace-back identifies as silence; only "
+                   "relevant if the --silence-phones option is set.");
+    opts->Register("max-state-duration", &max_state_duration, "(RE weighting in "
+                   "iVector estimation for online decoding) Maximum allowed "
+                   "duration of a single transition-id; runs with durations longer "
+                   "than this will be weighted down to the silence-weight.");
   }
   // e.g. prefix = "ivector-silence-weighting"
-  void RegisterWithPrefix(std::string prefix, OptionsItf *po) {
-    ParseOptions po_prefix(prefix, po);
+  void RegisterWithPrefix(std::string prefix, OptionsItf *opts) {
+    ParseOptions po_prefix(prefix, opts);
     this->Register(&po_prefix);
   }
 };

--- a/src/online2/online-nnet2-decoding-threaded.h
+++ b/src/online2/online-nnet2-decoding-threaded.h
@@ -160,20 +160,20 @@ struct OnlineNnet2DecodingThreadedConfig {
 
   void Check();
   
-  void Register(OptionsItf *po) {
-    decoder_opts.Register(po);
-    po->Register("acoustic-scale", &acoustic_scale, "Scale used on acoustics "
-                 "when decoding");
-    po->Register("max-buffered-features", &max_buffered_features, "Obscure "
-                 "setting, affects multi-threaded decoding.");
-    po->Register("feature-batch-size", &max_buffered_features, "Obscure "
-                 "setting, affects multi-threaded decoding.");
-    po->Register("nnet-batch-size", &nnet_batch_size, "Maximum batch size "
-                 "(in frames) used when evaluating neural net likelihoods");
-    po->Register("max-loglikes-copy", &max_loglikes_copy,  "Obscure "
-                 "setting, affects multi-threaded decoding.");
-    po->Register("decode-batch-sie", &decode_batch_size, "Obscure "
-                 "setting, affects multi-threaded decoding.");
+  void Register(OptionsItf *opts) {
+    decoder_opts.Register(opts);
+    opts->Register("acoustic-scale", &acoustic_scale, "Scale used on acoustics "
+                   "when decoding");
+    opts->Register("max-buffered-features", &max_buffered_features, "Obscure "
+                   "setting, affects multi-threaded decoding.");
+    opts->Register("feature-batch-size", &max_buffered_features, "Obscure "
+                   "setting, affects multi-threaded decoding.");
+    opts->Register("nnet-batch-size", &nnet_batch_size, "Maximum batch size "
+                   "(in frames) used when evaluating neural net likelihoods");
+    opts->Register("max-loglikes-copy", &max_loglikes_copy,  "Obscure "
+                   "setting, affects multi-threaded decoding.");
+    opts->Register("decode-batch-sie", &decode_batch_size, "Obscure "
+                   "setting, affects multi-threaded decoding.");
   }
 };
 

--- a/src/online2/online-nnet2-decoding.h
+++ b/src/online2/online-nnet2-decoding.h
@@ -54,9 +54,9 @@ struct OnlineNnet2DecodingConfig {
   
   OnlineNnet2DecodingConfig() {  decodable_opts.acoustic_scale = 0.1; }
   
-  void Register(OptionsItf *po) {
-    decoder_opts.Register(po);
-    decodable_opts.Register(po);
+  void Register(OptionsItf *opts) {
+    decoder_opts.Register(opts);
+    decodable_opts.Register(opts);
   }
 };
 

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -89,24 +89,24 @@ struct OnlineNnet2FeaturePipelineConfig {
       feature_type("mfcc"), add_pitch(false) { }
       
 
-  void Register(OptionsItf *po) {
-    po->Register("feature-type", &feature_type,
-                 "Base feature type [mfcc, plp, fbank]");
-    po->Register("mfcc-config", &mfcc_config, "Configuration file for "
-                 "MFCC features (e.g. conf/mfcc.conf)");
-    po->Register("plp-config", &plp_config, "Configuration file for "
-                 "PLP features (e.g. conf/plp.conf)");
-    po->Register("fbank-config", &fbank_config, "Configuration file for "
-                 "filterbank features (e.g. conf/fbank.conf)");
-    po->Register("add-pitch", &add_pitch, "Append pitch features to raw "
-                 "MFCC/PLP/filterbank features [but not for iVector extraction]");
-    po->Register("online-pitch-config", &online_pitch_config, "Configuration "
-                 "file for online pitch features, if --add-pitch=true (e.g. "
-                 "conf/online_pitch.conf)");
-    po->Register("ivector-extraction-config", &ivector_extraction_config,
-                 "Configuration file for online iVector extraction, "
-                 "see class OnlineIvectorExtractionConfig in the code");
-    silence_weighting_config.RegisterWithPrefix("ivector-silence-weighting", po);
+  void Register(OptionsItf *opts) {
+    opts->Register("feature-type", &feature_type,
+                   "Base feature type [mfcc, plp, fbank]");
+    opts->Register("mfcc-config", &mfcc_config, "Configuration file for "
+                   "MFCC features (e.g. conf/mfcc.conf)");
+    opts->Register("plp-config", &plp_config, "Configuration file for "
+                   "PLP features (e.g. conf/plp.conf)");
+    opts->Register("fbank-config", &fbank_config, "Configuration file for "
+                   "filterbank features (e.g. conf/fbank.conf)");
+    opts->Register("add-pitch", &add_pitch, "Append pitch features to raw "
+                   "MFCC/PLP/filterbank features [but not for iVector extraction]");
+    opts->Register("online-pitch-config", &online_pitch_config, "Configuration "
+                   "file for online pitch features, if --add-pitch=true (e.g. "
+                   "conf/online_pitch.conf)");
+    opts->Register("ivector-extraction-config", &ivector_extraction_config,
+                   "Configuration file for online iVector extraction, "
+                   "see class OnlineIvectorExtractionConfig in the code");
+    silence_weighting_config.RegisterWithPrefix("ivector-silence-weighting", opts);
   }
 };
 

--- a/src/online2/online-speex-wrapper.h
+++ b/src/online2/online-speex-wrapper.h
@@ -61,13 +61,13 @@ struct SpeexOptions {
                   speex_bits_frame_size(106),
                   speex_wave_frame_size(320) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("sample-rate", &sample_rate, "Sample frequency of the waveform.");
-    po->Register("speex-quality", &speex_quality, "Speex speech quality.");
-    po->Register("speex-bits-frame-size", &speex_bits_frame_size,
-                 "#bytes of each Speex compressed frame.");
-    po->Register("speex-wave-frame-size", &speex_wave_frame_size,
-                 "#samples of each waveform frame.");
+  void Register(OptionsItf *opts) {
+    opts->Register("sample-rate", &sample_rate, "Sample frequency of the waveform.");
+    opts->Register("speex-quality", &speex_quality, "Speex speech quality.");
+    opts->Register("speex-bits-frame-size", &speex_bits_frame_size,
+                   "#bytes of each Speex compressed frame.");
+    opts->Register("speex-wave-frame-size", &speex_wave_frame_size,
+                   "#samples of each waveform frame.");
   }
 };
 

--- a/src/sgmm/am-sgmm.h
+++ b/src/sgmm/am-sgmm.h
@@ -47,11 +47,11 @@ struct SgmmGselectConfig {
     diag_gmm_nbest = 50;
   }
 
-  void Register(OptionsItf *po) {
-    po->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
-        " full-covariance Gaussians selected per frame.");
-    po->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"
-        " diagonal-covariance Gaussians selected per frame.");
+  void Register(OptionsItf *opts) {
+    opts->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
+                   " full-covariance Gaussians selected per frame.");
+    opts->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"
+                   " diagonal-covariance Gaussians selected per frame.");
   }
 };
 

--- a/src/sgmm/estimate-am-sgmm-ebw.h
+++ b/src/sgmm/estimate-am-sgmm-ebw.h
@@ -94,39 +94,39 @@ struct EbwAmSgmmOptions {
     epsilon = 1.0e-40;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwAmSgmmOptions: ";
-    po->Register("tau-v", &tau_v, module+
-                 "Smoothing constant for phone vector estimation.");
-    po->Register("lrate-v", &lrate_v, module+
-                 "Learning rate constant for phone vector estimation.");
-    po->Register("tau-m", &tau_M, module+
-                 "Smoothing constant for estimation of phonetic-subspace projections (M).");
-    po->Register("lrate-m", &lrate_M, module+
-                 "Learning rate constant for phonetic-subspace projections.");
-    po->Register("tau-n", &tau_N, module+
-                 "Smoothing constant for estimation of speaker-subspace projections (N).");
-    po->Register("lrate-n", &lrate_N, module+
-                 "Learning rate constant for speaker-subspace projections.");
-    po->Register("tau-c", &tau_c, module+
-                 "Smoothing constant for estimation of substate weights (c)");
-    po->Register("tau-w", &tau_w, module+
-                 "Smoothing constant for estimation of weight projections (w)");
-    po->Register("lrate-w", &lrate_w, module+
-                 "Learning rate constant for weight-projections");
-    po->Register("tau-sigma", &tau_Sigma, module+
-                 "Smoothing constant for estimation of within-class covariances (Sigma)");
-    po->Register("lrate-sigma", &lrate_Sigma, module+
-                 "Constant that controls speed of learning for variances (larger->slower)");
-    po->Register("cov-min-value", &cov_min_value, module+
-                 "Minimum value that an eigenvalue of the updated covariance matrix can take, "
-                 "relative to its old value (maximum is inverse of this.)");
-    po->Register("min-substate-weight", &min_substate_weight, module+
-                 "Floor for weights of sub-states.");
-    po->Register("max-cond", &max_cond, module+
-                 "Value used in handling singular matrices during update.");
-    po->Register("epsilon", &max_cond, module+
-                 "Value used in handling singular matrices during update.");
+    opts->Register("tau-v", &tau_v, module+
+                   "Smoothing constant for phone vector estimation.");
+    opts->Register("lrate-v", &lrate_v, module+
+                   "Learning rate constant for phone vector estimation.");
+    opts->Register("tau-m", &tau_M, module+
+                   "Smoothing constant for estimation of phonetic-subspace projections (M).");
+    opts->Register("lrate-m", &lrate_M, module+
+                   "Learning rate constant for phonetic-subspace projections.");
+    opts->Register("tau-n", &tau_N, module+
+                   "Smoothing constant for estimation of speaker-subspace projections (N).");
+    opts->Register("lrate-n", &lrate_N, module+
+                   "Learning rate constant for speaker-subspace projections.");
+    opts->Register("tau-c", &tau_c, module+
+                   "Smoothing constant for estimation of substate weights (c)");
+    opts->Register("tau-w", &tau_w, module+
+                   "Smoothing constant for estimation of weight projections (w)");
+    opts->Register("lrate-w", &lrate_w, module+
+                   "Learning rate constant for weight-projections");
+    opts->Register("tau-sigma", &tau_Sigma, module+
+                   "Smoothing constant for estimation of within-class covariances (Sigma)");
+    opts->Register("lrate-sigma", &lrate_Sigma, module+
+                   "Constant that controls speed of learning for variances (larger->slower)");
+    opts->Register("cov-min-value", &cov_min_value, module+
+                   "Minimum value that an eigenvalue of the updated covariance matrix can take, "
+                   "relative to its old value (maximum is inverse of this.)");
+    opts->Register("min-substate-weight", &min_substate_weight, module+
+                   "Floor for weights of sub-states.");
+    opts->Register("max-cond", &max_cond, module+
+                   "Value used in handling singular matrices during update.");
+    opts->Register("epsilon", &max_cond, module+
+                   "Value used in handling singular matrices during update.");
   }
 };
 

--- a/src/sgmm/estimate-am-sgmm.h
+++ b/src/sgmm/estimate-am-sgmm.h
@@ -100,36 +100,36 @@ struct MleAmSgmmOptions {
     full_col_cov = false;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleAmSgmmOptions: ";
-    po->Register("tau-vec", &tau_vec, module+
-                 "Smoothing for phone vector estimation.");
-    po->Register("tau-c", &tau_c, module+
-                 "Smoothing for substate weights estimation.");
-    po->Register("cov-floor", &cov_floor, module+
-                 "Covariance floor (fraction of average covariance).");
-    po->Register("cov-diag-ratio", &cov_diag_ratio, module+
-                 "Minimum occ/dim ratio below which use diagonal covariances.");
-    po->Register("max-cond", &max_cond, module+"Maximum condition number beyond"
-                 " which matrices are not updated.");
-    po->Register("weight-projections-iters", &weight_projections_iters, module+
-                 "Number for iterations for weight projection estimation.");
-    po->Register("renormalize-v", &renormalize_V, module+"If true, renormalize "
-                 "the phonetic-subspace vectors to have meaningful sizes.");
-    po->Register("check-v", &check_v, module+"If true, check real auxf "
-                 "improvement in update of v and backtrack if needed "
-                 "(not compatible with smoothing v)");
-    po->Register("renormalize-n", &renormalize_N, module+"If true, renormalize "
-                 "the speaker subspace to have meaningful sizes.");
+    opts->Register("tau-vec", &tau_vec, module+
+                   "Smoothing for phone vector estimation.");
+    opts->Register("tau-c", &tau_c, module+
+                   "Smoothing for substate weights estimation.");
+    opts->Register("cov-floor", &cov_floor, module+
+                   "Covariance floor (fraction of average covariance).");
+    opts->Register("cov-diag-ratio", &cov_diag_ratio, module+
+                   "Minimum occ/dim ratio below which use diagonal covariances.");
+    opts->Register("max-cond", &max_cond, module+"Maximum condition number beyond"
+                   " which matrices are not updated.");
+    opts->Register("weight-projections-iters", &weight_projections_iters, module+
+                   "Number for iterations for weight projection estimation.");
+    opts->Register("renormalize-v", &renormalize_V, module+"If true, renormalize "
+                   "the phonetic-subspace vectors to have meaningful sizes.");
+    opts->Register("check-v", &check_v, module+"If true, check real auxf "
+                   "improvement in update of v and backtrack if needed "
+                   "(not compatible with smoothing v)");
+    opts->Register("renormalize-n", &renormalize_N, module+"If true, renormalize "
+                   "the speaker subspace to have meaningful sizes.");
 
-    po->Register("tau-map-M", &tau_map_M, module+"Smoothing for MAP estimate "
-                 "of M (0 means ML update).");
-    po->Register("map-M-prior-iters", &map_M_prior_iters, module+
-                 "Number of iterations to estimate prior covariances for M.");
-    po->Register("full-row-cov", &full_row_cov, module+
-                 "Estimate row covariance instead of using I.");
-    po->Register("full-col-cov", &full_col_cov, module+
-                 "Estimate column covariance instead of using I.");
+    opts->Register("tau-map-M", &tau_map_M, module+"Smoothing for MAP estimate "
+                   "of M (0 means ML update).");
+    opts->Register("map-M-prior-iters", &map_M_prior_iters, module+
+                   "Number of iterations to estimate prior covariances for M.");
+    opts->Register("full-row-cov", &full_row_cov, module+
+                   "Estimate row covariance instead of using I.");
+    opts->Register("full-col-cov", &full_col_cov, module+
+                   "Estimate column covariance instead of using I.");
   }
 };
 

--- a/src/sgmm/fmllr-sgmm.h
+++ b/src/sgmm/fmllr-sgmm.h
@@ -63,25 +63,25 @@ struct SgmmFmllrConfig {
     bases_occ_scale = 0.2;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void SgmmFmllrConfig::Register(OptionsItf *po) {
+inline void SgmmFmllrConfig::Register(OptionsItf *opts) {
   std::string module = "SgmmFmllrConfig: ";
-  po->Register("fmllr-iters", &fmllr_iters, module+
-               "Number of iterations in FMLLR estimation.");
-  po->Register("fmllr-step-iters", &step_iters, module+
-               "Number of iterations to find optimal FMLLR step size.");
-  po->Register("fmllr-min-count-bases", &fmllr_min_count_basis, module+
-               "Minimum occupancy count to estimate FMLLR using basis matrices.");
-  po->Register("fmllr-min-count", &fmllr_min_count, module+
-               "Minimum occupancy count to estimate FMLLR (without bases).");
-  po->Register("fmllr-min-count-full", &fmllr_min_count_full, module+
-      "Minimum occupancy count to stop using basis matrices for FMLLR.");
-  po->Register("fmllr-num-bases", &num_fmllr_bases, module+
-               "Number of FMLLR basis matrices.");
-  po->Register("fmllr-bases-occ-scale", &bases_occ_scale, module+
-               "Scale per-speaker count to determine number of CMLLR bases.");
+  opts->Register("fmllr-iters", &fmllr_iters, module+
+                 "Number of iterations in FMLLR estimation.");
+  opts->Register("fmllr-step-iters", &step_iters, module+
+                 "Number of iterations to find optimal FMLLR step size.");
+  opts->Register("fmllr-min-count-bases", &fmllr_min_count_basis, module+
+                 "Minimum occupancy count to estimate FMLLR using basis matrices.");
+  opts->Register("fmllr-min-count", &fmllr_min_count, module+
+                 "Minimum occupancy count to estimate FMLLR (without bases).");
+  opts->Register("fmllr-min-count-full", &fmllr_min_count_full, module+
+                 "Minimum occupancy count to stop using basis matrices for FMLLR.");
+  opts->Register("fmllr-num-bases", &num_fmllr_bases, module+
+                 "Number of FMLLR basis matrices.");
+  opts->Register("fmllr-bases-occ-scale", &bases_occ_scale, module+
+                 "Scale per-speaker count to determine number of CMLLR bases.");
 }
 
 

--- a/src/sgmm2/am-sgmm2.h
+++ b/src/sgmm2/am-sgmm2.h
@@ -99,17 +99,17 @@ struct Sgmm2SplitSubstatesConfig {
                                power(0.2),
                                max_cond(100.0),
                                min_count(40.0) { }
-  void Register(OptionsItf *po) {
-    po->Register("split-substates", &split_substates, "Increase number of "
-                 "substates to this overall target.");
-    po->Register("max-cond-split", &max_cond, "Max condition number of smoothing "
-                "matrix used in substate splitting.");
-    po->Register("perturb-factor", &perturb_factor, "Perturbation factor for "
-                "state vectors while splitting substates.");
-    po->Register("power", &power, "Exponent for substate occupancies used while "
-                "splitting substates.");
-    po->Register("min-count", &min_count, "Minimum allowed count, used in allocating "
-                 "sub-states to state in mixture splitting.");
+  void Register(OptionsItf *opts) {
+    opts->Register("split-substates", &split_substates, "Increase number of "
+                   "substates to this overall target.");
+    opts->Register("max-cond-split", &max_cond, "Max condition number of smoothing "
+                   "matrix used in substate splitting.");
+    opts->Register("perturb-factor", &perturb_factor, "Perturbation factor for "
+                   "state vectors while splitting substates.");
+    opts->Register("power", &power, "Exponent for substate occupancies used while "
+                   "splitting substates.");
+    opts->Register("min-count", &min_count, "Minimum allowed count, used in allocating "
+                   "sub-states to state in mixture splitting.");
   }
 };
 
@@ -126,11 +126,11 @@ struct Sgmm2GselectConfig {
     diag_gmm_nbest = 50;
   }
 
-  void Register(OptionsItf *po) {
-    po->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
-        " full-covariance Gaussians selected per frame.");
-    po->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"
-        " diagonal-covariance Gaussians selected per frame.");
+  void Register(OptionsItf *opts) {
+    opts->Register("full-gmm-nbest", &full_gmm_nbest, "Number of highest-scoring"
+                   " full-covariance Gaussians selected per frame.");
+    opts->Register("diag-gmm-nbest", &diag_gmm_nbest, "Number of highest-scoring"
+                   " diagonal-covariance Gaussians selected per frame.");
   }
 };
 

--- a/src/sgmm2/estimate-am-sgmm2-ebw.h
+++ b/src/sgmm2/estimate-am-sgmm2-ebw.h
@@ -100,43 +100,43 @@ struct EbwAmSgmm2Options {
     epsilon = 1.0e-40;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "EbwAmSgmm2Options: ";
-    po->Register("tau-v", &tau_v, module+
-                 "Smoothing constant for phone vector estimation.");
-    po->Register("lrate-v", &lrate_v, module+
-                 "Learning rate constant for phone vector estimation.");
-    po->Register("tau-m", &tau_M, module+
-                 "Smoothing constant for estimation of phonetic-subspace projections (M).");
-    po->Register("lrate-m", &lrate_M, module+
-                 "Learning rate constant for phonetic-subspace projections.");
-    po->Register("tau-n", &tau_N, module+
-                 "Smoothing constant for estimation of speaker-subspace projections (N).");
-    po->Register("lrate-n", &lrate_N, module+
-                 "Learning rate constant for speaker-subspace projections.");
-    po->Register("tau-c", &tau_c, module+
-                 "Smoothing constant for estimation of substate weights (c)");
-    po->Register("tau-w", &tau_w, module+
-                 "Smoothing constant for estimation of phonetic-space weight projections (w)");
-    po->Register("lrate-w", &lrate_w, module+
-                 "Learning rate constant for phonetic-space weight-projections (w)");
-    po->Register("tau-u", &tau_u, module+
-                 "Smoothing constant for estimation of speaker-space weight projections (u)");
-    po->Register("lrate-u", &lrate_u, module+
-                 "Learning rate constant for speaker-space weight-projections (u)");
-    po->Register("tau-sigma", &tau_Sigma, module+
-                 "Smoothing constant for estimation of within-class covariances (Sigma)");
-    po->Register("lrate-sigma", &lrate_Sigma, module+
-                 "Constant that controls speed of learning for variances (larger->slower)");
-    po->Register("cov-min-value", &cov_min_value, module+
-                 "Minimum value that an eigenvalue of the updated covariance matrix can take, "
-                 "relative to its old value (maximum is inverse of this.)");
-    po->Register("min-substate-weight", &min_substate_weight, module+
-                 "Floor for weights of sub-states.");
-    po->Register("max-cond", &max_cond, module+
-                 "Value used in handling singular matrices during update.");
-    po->Register("epsilon", &max_cond, module+
-                 "Value used in handling singular matrices during update.");
+    opts->Register("tau-v", &tau_v, module+
+                   "Smoothing constant for phone vector estimation.");
+    opts->Register("lrate-v", &lrate_v, module+
+                   "Learning rate constant for phone vector estimation.");
+    opts->Register("tau-m", &tau_M, module+
+                   "Smoothing constant for estimation of phonetic-subspace projections (M).");
+    opts->Register("lrate-m", &lrate_M, module+
+                   "Learning rate constant for phonetic-subspace projections.");
+    opts->Register("tau-n", &tau_N, module+
+                   "Smoothing constant for estimation of speaker-subspace projections (N).");
+    opts->Register("lrate-n", &lrate_N, module+
+                   "Learning rate constant for speaker-subspace projections.");
+    opts->Register("tau-c", &tau_c, module+
+                   "Smoothing constant for estimation of substate weights (c)");
+    opts->Register("tau-w", &tau_w, module+
+                   "Smoothing constant for estimation of phonetic-space weight projections (w)");
+    opts->Register("lrate-w", &lrate_w, module+
+                   "Learning rate constant for phonetic-space weight-projections (w)");
+    opts->Register("tau-u", &tau_u, module+
+                   "Smoothing constant for estimation of speaker-space weight projections (u)");
+    opts->Register("lrate-u", &lrate_u, module+
+                   "Learning rate constant for speaker-space weight-projections (u)");
+    opts->Register("tau-sigma", &tau_Sigma, module+
+                   "Smoothing constant for estimation of within-class covariances (Sigma)");
+    opts->Register("lrate-sigma", &lrate_Sigma, module+
+                   "Constant that controls speed of learning for variances (larger->slower)");
+    opts->Register("cov-min-value", &cov_min_value, module+
+                   "Minimum value that an eigenvalue of the updated covariance matrix can take, "
+                   "relative to its old value (maximum is inverse of this.)");
+    opts->Register("min-substate-weight", &min_substate_weight, module+
+                   "Floor for weights of sub-states.");
+    opts->Register("max-cond", &max_cond, module+
+                   "Value used in handling singular matrices during update.");
+    opts->Register("epsilon", &max_cond, module+
+                   "Value used in handling singular matrices during update.");
   }
 };
 

--- a/src/sgmm2/estimate-am-sgmm2.h
+++ b/src/sgmm2/estimate-am-sgmm2.h
@@ -88,34 +88,34 @@ struct MleAmSgmm2Options {
     full_col_cov = false;
   }
 
-  void Register(OptionsItf *po) {
+  void Register(OptionsItf *opts) {
     std::string module = "MleAmSgmm2Options: ";
-    po->Register("tau-c", &tau_c, module+
-                 "Count for smoothing weight update.");
-    po->Register("cov-floor", &cov_floor, module+
-                 "Covariance floor (fraction of average covariance).");
-    po->Register("cov-diag-ratio", &cov_diag_ratio, module+
-                 "Minimum occ/dim ratio below which use diagonal covariances.");
-    po->Register("max-cond", &max_cond, module+"Maximum condition number used to "
-                "regularize the solution of certain quadratic auxiliary functions.");
-    po->Register("weight-projections-iters", &weight_projections_iters, module+
-                 "Number for iterations for weight projection estimation.");
-    po->Register("renormalize-v", &renormalize_V, module+"If true, renormalize "
-                 "the phonetic-subspace vectors to have meaningful sizes.");
-    po->Register("renormalize-n", &renormalize_N, module+"If true, renormalize "
-                 "the speaker subspace to have meaningful sizes.");
-    po->Register("max-impr-u", &max_impr_u, module+"Maximum objective function "
-                 "improvement per frame allowed in update of u (to "
-                 "maintain stability.");
+    opts->Register("tau-c", &tau_c, module+
+                   "Count for smoothing weight update.");
+    opts->Register("cov-floor", &cov_floor, module+
+                   "Covariance floor (fraction of average covariance).");
+    opts->Register("cov-diag-ratio", &cov_diag_ratio, module+
+                   "Minimum occ/dim ratio below which use diagonal covariances.");
+    opts->Register("max-cond", &max_cond, module+"Maximum condition number used to "
+                   "regularize the solution of certain quadratic auxiliary functions.");
+    opts->Register("weight-projections-iters", &weight_projections_iters, module+
+                   "Number for iterations for weight projection estimation.");
+    opts->Register("renormalize-v", &renormalize_V, module+"If true, renormalize "
+                   "the phonetic-subspace vectors to have meaningful sizes.");
+    opts->Register("renormalize-n", &renormalize_N, module+"If true, renormalize "
+                   "the speaker subspace to have meaningful sizes.");
+    opts->Register("max-impr-u", &max_impr_u, module+"Maximum objective function "
+                   "improvement per frame allowed in update of u (to "
+                   "maintain stability.");
 
-    po->Register("tau-map-M", &tau_map_M, module+"Smoothing for MAP estimate "
-                 "of M (0 means ML update).");
-    po->Register("map-M-prior-iters", &map_M_prior_iters, module+
-                 "Number of iterations to estimate prior covariances for M.");
-    po->Register("full-row-cov", &full_row_cov, module+
-                 "Estimate row covariance instead of using I.");
-    po->Register("full-col-cov", &full_col_cov, module+
-                 "Estimate column covariance instead of using I.");
+    opts->Register("tau-map-M", &tau_map_M, module+"Smoothing for MAP estimate "
+                   "of M (0 means ML update).");
+    opts->Register("map-M-prior-iters", &map_M_prior_iters, module+
+                   "Number of iterations to estimate prior covariances for M.");
+    opts->Register("full-row-cov", &full_row_cov, module+
+                   "Estimate row covariance instead of using I.");
+    opts->Register("full-col-cov", &full_col_cov, module+
+                   "Estimate column covariance instead of using I.");
   }
 };
 

--- a/src/sgmm2/fmllr-sgmm2.h
+++ b/src/sgmm2/fmllr-sgmm2.h
@@ -63,25 +63,25 @@ struct Sgmm2FmllrConfig {
     bases_occ_scale = 0.2;
   }
 
-  void Register(OptionsItf *po);
+  void Register(OptionsItf *opts);
 };
 
-inline void Sgmm2FmllrConfig::Register(OptionsItf *po) {
+inline void Sgmm2FmllrConfig::Register(OptionsItf *opts) {
   std::string module = "Sgmm2FmllrConfig: ";
-  po->Register("fmllr-iters", &fmllr_iters, module+
-               "Number of iterations in FMLLR estimation.");
-  po->Register("fmllr-step-iters", &step_iters, module+
-               "Number of iterations to find optimal FMLLR step size.");
-  po->Register("fmllr-min-count-bases", &fmllr_min_count_basis, module+
-               "Minimum occupancy count to estimate FMLLR using basis matrices.");
-  po->Register("fmllr-min-count", &fmllr_min_count, module+
-               "Minimum occupancy count to estimate FMLLR (without bases).");
-  po->Register("fmllr-min-count-full", &fmllr_min_count_full, module+
-      "Minimum occupancy count to stop using basis matrices for FMLLR.");
-  po->Register("fmllr-num-bases", &num_fmllr_bases, module+
-               "Number of FMLLR basis matrices.");
-  po->Register("fmllr-bases-occ-scale", &bases_occ_scale, module+
-               "Scale per-speaker count to determine number of CMLLR bases.");
+  opts->Register("fmllr-iters", &fmllr_iters, module+
+                 "Number of iterations in FMLLR estimation.");
+  opts->Register("fmllr-step-iters", &step_iters, module+
+                 "Number of iterations to find optimal FMLLR step size.");
+  opts->Register("fmllr-min-count-bases", &fmllr_min_count_basis, module+
+                 "Minimum occupancy count to estimate FMLLR using basis matrices.");
+  opts->Register("fmllr-min-count", &fmllr_min_count, module+
+                 "Minimum occupancy count to estimate FMLLR (without bases).");
+  opts->Register("fmllr-min-count-full", &fmllr_min_count_full, module+
+                 "Minimum occupancy count to stop using basis matrices for FMLLR.");
+  opts->Register("fmllr-num-bases", &num_fmllr_bases, module+
+                 "Number of FMLLR basis matrices.");
+  opts->Register("fmllr-bases-occ-scale", &bases_occ_scale, module+
+                 "Scale per-speaker count to determine number of CMLLR bases.");
 }
 
 

--- a/src/thread/kaldi-task-sequence.h
+++ b/src/thread/kaldi-task-sequence.h
@@ -61,14 +61,14 @@ struct TaskSequencerConfig {
   int32 num_threads;
   int32 num_threads_total;
   TaskSequencerConfig(): num_threads(1), num_threads_total(0)  { }
-  void Register(OptionsItf *po) {
-    po->Register("num-threads", &num_threads, "Number of actively processing "
-                 "threads to run in parallel");
-    po->Register("num-threads-total", &num_threads_total, "Total number of "
-                 "threads, including those that are waiting on other threads "
-                 "to produce their output.  Controls memory use.  If <= 0, "
-                 "defaults to --num-threads plus 20.  Otherwise, must "
-                 "be >= num-threads.");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-threads", &num_threads, "Number of actively processing "
+                   "threads to run in parallel");
+    opts->Register("num-threads-total", &num_threads_total, "Total number of "
+                   "threads, including those that are waiting on other threads "
+                   "to produce their output.  Controls memory use.  If <= 0, "
+                   "defaults to --num-threads plus 20.  Otherwise, must "
+                   "be >= num-threads.");
   }
 };
 

--- a/src/transform/basis-fmllr-diag-gmm.h
+++ b/src/transform/basis-fmllr-diag-gmm.h
@@ -51,16 +51,16 @@ struct BasisFmllrOptions {
   BaseFloat min_count;
   int32 step_size_iters;
   BasisFmllrOptions(): num_iters(10), size_scale(0.2), min_count(50.0), step_size_iters(3) { }
-  void Register(OptionsItf *po) {
-    po->Register("num-iters", &num_iters,
-                 "Number of iterations in basis fMLLR update during testing");
-    po->Register("size-scale", &size_scale,
-                 "Scale (< 1.0) on speaker occupancy that gives number of "
-                 "basis elements.");
-    po->Register("fmllr-min-count", &min_count,
-                 "Minimum count required to update fMLLR");
-    po->Register("step-size-iters", &step_size_iters,
-                 "Number of iterations in computing step size");
+  void Register(OptionsItf *opts) {
+    opts->Register("num-iters", &num_iters,
+                   "Number of iterations in basis fMLLR update during testing");
+    opts->Register("size-scale", &size_scale,
+                   "Scale (< 1.0) on speaker occupancy that gives number of "
+                   "basis elements.");
+    opts->Register("fmllr-min-count", &min_count,
+                   "Minimum count required to update fMLLR");
+    opts->Register("step-size-iters", &step_size_iters,
+                   "Number of iterations in computing step size");
   }
 };
 

--- a/src/transform/fmllr-diag-gmm.h
+++ b/src/transform/fmllr-diag-gmm.h
@@ -45,13 +45,13 @@ struct FmllrOptions {
   BaseFloat min_count;
   int32 num_iters;
   FmllrOptions(): update_type("full"), min_count(500.0), num_iters(40) { }
-  void Register(OptionsItf *po) {
-    po->Register("fmllr-update-type", &update_type,
-                 "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
-    po->Register("fmllr-min-count", &min_count,
-                 "Minimum count required to update fMLLR");
-    po->Register("fmllr-num-iters", &num_iters,
-                 "Number of iterations in fMLLR update phase.");
+  void Register(OptionsItf *opts) {
+    opts->Register("fmllr-update-type", &update_type,
+                   "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
+    opts->Register("fmllr-min-count", &min_count,
+                   "Minimum count required to update fMLLR");
+    opts->Register("fmllr-num-iters", &num_iters,
+                   "Number of iterations in fMLLR update phase.");
   }
 };
 

--- a/src/transform/fmllr-raw.h
+++ b/src/transform/fmllr-raw.h
@@ -70,11 +70,11 @@ struct FmllrRawOptions {
   BaseFloat min_count;
   int32 num_iters;
   FmllrRawOptions(): min_count(100.0), num_iters(20) { }
-  void Register(OptionsItf *po) {
-    po->Register("fmllr-min-count", &min_count,
-                 "Minimum count required to update fMLLR");
-    po->Register("fmllr-num-iters", &num_iters,
-                 "Number of iterations in fMLLR update phase.");
+  void Register(OptionsItf *opts) {
+    opts->Register("fmllr-min-count", &min_count,
+                   "Minimum count required to update fMLLR");
+    opts->Register("fmllr-num-iters", &num_iters,
+                   "Number of iterations in fMLLR update phase.");
   }
 };
 

--- a/src/transform/fmpe.h
+++ b/src/transform/fmpe.h
@@ -72,12 +72,12 @@ struct FmpeOptions {
   FmpeOptions(): context_expansion("0,1.0:-1,1.0:1,1.0:-2,0.5;-3,0.5:2,0.5;3,0.5:-4,0.5;-5,0.5:4,0.5;5,0.5:-6,0.333;-7,0.333;-8,0.333:6,0.333;7,0.333;8,0.333"),
                 post_scale(5.0) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("post-scale", &post_scale, "Scaling constant on posterior "
-                 "element of offset features, to give it a faster learning "
-                 "rate.");
-    po->Register("context-expansion", &context_expansion, "Specifies the "
-                 "temporal context-splicing of high-dimensional features.");
+  void Register(OptionsItf *opts) {
+    opts->Register("post-scale", &post_scale, "Scaling constant on posterior "
+                   "element of offset features, to give it a faster learning "
+                   "rate.");
+    opts->Register("context-expansion", &context_expansion, "Specifies the "
+                   "temporal context-splicing of high-dimensional features.");
   }
   // We include write and read functions, since this
   // object is included as a member of the fMPE object.
@@ -92,11 +92,11 @@ struct FmpeUpdateOptions {
   
   FmpeUpdateOptions(): learning_rate(0.1), l2_weight(100.0) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("learning-rate", &learning_rate,
-                 "Learning rate constant (like inverse of E in fMPE papers)");
-    po->Register("l2-weight", &l2_weight,
-                 "Weight on l2 regularization term in objective function.");
+  void Register(OptionsItf *opts) {
+    opts->Register("learning-rate", &learning_rate,
+                   "Learning rate constant (like inverse of E in fMPE papers)");
+    opts->Register("l2-weight", &l2_weight,
+                   "Weight on l2 regularization term in objective function.");
   }  
 };
 

--- a/src/transform/lda-estimate.h
+++ b/src/transform/lda-estimate.h
@@ -35,19 +35,19 @@ struct LdaEstimateOptions {
   LdaEstimateOptions(): remove_offset(false), dim(40), allow_large_dim(false),
                         within_class_factor(1.0) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("remove-offset", &remove_offset, "If true, output an affine "
-                 "transform that makes the projected data mean equal to zero.");
-    po->Register("dim", &dim, "Dimension to project to with LDA");
-    po->Register("allow-large-dim", &allow_large_dim, "If true, allow an LDA "
-                 "dimension larger than the number of classes.");
-    po->Register("within-class-factor", &within_class_factor, "(Deprecated) If 1.0, do "
-                 "conventional LDA where the within-class variance will be "
-                 "unit in the projected space.  May be set to less than 1.0, "
-                 "which scales the features to have less variance, particularly "
-                 "for dimensions where between-class variance is small; "
-                 "this is a feature being experimented with for neural-net "
-                 "input.");
+  void Register(OptionsItf *opts) {
+    opts->Register("remove-offset", &remove_offset, "If true, output an affine "
+                   "transform that makes the projected data mean equal to zero.");
+    opts->Register("dim", &dim, "Dimension to project to with LDA");
+    opts->Register("allow-large-dim", &allow_large_dim, "If true, allow an LDA "
+                   "dimension larger than the number of classes.");
+    opts->Register("within-class-factor", &within_class_factor, "(Deprecated) If 1.0, do "
+                   "conventional LDA where the within-class variance will be "
+                   "unit in the projected space.  May be set to less than 1.0, "
+                   "which scales the features to have less variance, particularly "
+                   "for dimensions where between-class variance is small; "
+                   "this is a feature being experimented with for neural-net "
+                   "input.");
   }    
 };
 

--- a/src/transform/regtree-fmllr-diag-gmm.h
+++ b/src/transform/regtree-fmllr-diag-gmm.h
@@ -45,15 +45,15 @@ struct RegtreeFmllrOptions {
   RegtreeFmllrOptions(): update_type("full"), min_count(1000.0),
                          num_iters(10), use_regtree(true) { }
   
-  void Register(OptionsItf *po) {
-    po->Register("fmllr-update-type", &update_type,
-                 "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
-    po->Register("fmllr-min-count", &min_count,
-                 "Minimum count to estimate an fMLLR transform.");
-    po->Register("fmllr-num-iters", &num_iters,
-                 "Number of fMLLR iterations (if using an iterative update).");
-    po->Register("fmllr-use-regtree", &use_regtree,
-                 "Use a regression-class tree for fMLLR.");
+  void Register(OptionsItf *opts) {
+    opts->Register("fmllr-update-type", &update_type,
+                   "Update type for fMLLR (\"full\"|\"diag\"|\"offset\"|\"none\")");
+    opts->Register("fmllr-min-count", &min_count,
+                   "Minimum count to estimate an fMLLR transform.");
+    opts->Register("fmllr-num-iters", &num_iters,
+                   "Number of fMLLR iterations (if using an iterative update).");
+    opts->Register("fmllr-use-regtree", &use_regtree,
+                   "Use a regression-class tree for fMLLR.");
   }
 };
 

--- a/src/transform/regtree-mllr-diag-gmm.h
+++ b/src/transform/regtree-mllr-diag-gmm.h
@@ -41,11 +41,11 @@ struct RegtreeMllrOptions {
 
   RegtreeMllrOptions(): min_count(1000.0), use_regtree(true) { }
 
-  void Register(OptionsItf *po) {
-    po->Register("mllr-min-count", &min_count,
-                 "Minimum count to estimate an MLLR transform.");
-    po->Register("mllr-use-regtree", &use_regtree,
-                 "Use a regression-class tree for MLLR.");
+  void Register(OptionsItf *opts) {
+    opts->Register("mllr-min-count", &min_count,
+                   "Minimum count to estimate an MLLR transform.");
+    opts->Register("mllr-use-regtree", &use_regtree,
+                   "Use a regression-class tree for MLLR.");
   }
 };
 

--- a/src/util/parse-options.h
+++ b/src/util/parse-options.h
@@ -232,7 +232,7 @@ class ParseOptions : public OptionsItf {
 /// This template is provided for convenience in reading config classes from
 /// files; this is not the standard way to read configuration options, but may
 /// occasionally be needed.  This function assumes the config has a function
-/// "void Register(OptionsItf *po)" which it can call to register the
+/// "void Register(OptionsItf *opts)" which it can call to register the
 /// ParseOptions object.
 template<class C> void ReadConfigFromFile(const std::string config_filename,
                                           C *c) {


### PR DESCRIPTION
As requested in issue #37. I've tested it and it at least compiles OK. The changes were done using a short Python script(I can modify this PR to include the script under misc/maintenance, but it's probably not worth it). The indentation for Register() should be correct in most cases.