### PR TITLE
Added Travis CI integration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 *.a
 *.lib
 
+# Test log files
+*.testlog
+
 # emacs saves
 [#]*[#]
 .[#]*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - gdb
       - gcc-4.9
       - g++-4.9
       - gfortran-4.9
@@ -23,6 +24,7 @@ branches:
     - master
 
 before_install:
+  - cat /proc/sys/kernel/core_pattern
   - export XROOT=~/xroot
   - tools/extras/travis_install_bindeps.sh $XROOT
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+notifications:
+  email: false
+
+language: cpp
+
+os:
+  - linux
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+      - gfortran-4.9
+      - liblapack-dev
+#      - libopenblas-dev
+#      - libblas-dev
+
+branches:
+  only:
+    - master
+
+before_install:
+  - export XROOT=~/xroot
+  - tools/extras/travis_install_bindeps.sh $XROOT
+
+script:
+  - CXX=g++-4.9
+    CFLAGS="-march=native"
+    LDFLAGS="-llapack"
+    INCDIRS="$XROOT/usr/include"
+    LIBDIRS="$XROOT/usr/lib"
+      tools/extras/travis_script.sh
+
+after_failure:
+  - tools/extras/travis_show_failures.sh
+  - ldd -v src/matrix/matrix-lib-test

--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/kaldi-asr/kaldi.svg?branch=master)]
+(https://travis-ci.org/kaldi-asr/kaldi)
+
 *README*
 
 To build the toolkit: see ./INSTALL.  These instructions are valid for UNIX
@@ -20,7 +23,7 @@ Documentation of Kaldi: http://kaldi-asr.org/doc/
 - info about the project, description of techniques, tutorial for C++ coding
 - Doxygen reference of the C++ code
 
-Kaldi forum, mailing-lists: http://kaldi-asr.org/forums.html 
+Kaldi forum, mailing-lists: http://kaldi-asr.org/forums.html
 - User list : https://groups.google.com/forum/#!forum/kaldi-help (kaldi-help@googlegroups.com).
 - Developer list : https://groups.google.com/forum/#!forum/kaldi-developers (kaldi-developers@googlegroups.com)
 - also try luck and search in SourceForge archives: https://sourceforge.net/p/kaldi/discussion/
@@ -28,9 +31,9 @@ Kaldi forum, mailing-lists: http://kaldi-asr.org/forums.html
 Development pattern for contributors:
 A) create a personal fork of the kaldi-asr/kaldi repository in github,
 B) make your changes in a named branch different from "master", e.g. you create
-   a branch "my-awesome-feature". 
+   a branch "my-awesome-feature".
 C) generate a pull request through the web interface of github
-D) as a general rule, please follow Google C++ Style Guide. There are a few 
+D) as a general rule, please follow Google C++ Style Guide. There are a few
    exceptions in Kaldi -- please consult http://kaldi-asr.org/doc/style.html
    You can use the Google's cpplint.py to verify that your code is free
-   of some basic mistakes. 
+   of some basic mistakes.

--- a/src/makefiles/default_rules.mk
+++ b/src/makefiles/default_rules.mk
@@ -75,10 +75,14 @@ test: test_compile
 	@{ result=0;			\
 	for x in $(TESTFILES); do	\
 	  printf "Running $$x ...";	\
-	  ./$$x >$$x.testlog 2>1;	\
+	  ./$$x >$$x.testlog 2>&1;	\
 	  if [ $$? -ne 0 ]; then	\
 	    echo "... FAIL $$x";	\
 	    result=1;			\
+	    if [ -n "$TRAVIS" ] && [ -f core ] && command -v gdb >/dev/null 2>&1; then	\
+	      gdb $$x core -ex "thread apply all bt" -batch >>$$x.testlog 2>&1;		\
+	      rm -rf core;		\
+	    fi;				\
 	  else				\
 	    echo "... SUCCESS";		\
 	    rm -f $$x.testlog;		\

--- a/src/makefiles/default_rules.mk
+++ b/src/makefiles/default_rules.mk
@@ -65,22 +65,33 @@ $(BINFILES): $(LIBFILE) $(XDEPENDS)
 	$(MAKE) -C ${@D} ${@F}
 
 clean:
-	-rm -f *.o *.a *.so $(TESTFILES) $(BINFILES) $(TESTOUTPUTS) tmp* *.tmp
+	-rm -f *.o *.a *.so $(TESTFILES) $(BINFILES) $(TESTOUTPUTS) tmp* *.tmp *.testlog
 
 $(TESTFILES): $(LIBFILE) $(XDEPENDS)
 
 test_compile: $(TESTFILES)
-  
+
 test: test_compile
-	@result=0; for x in $(TESTFILES); do printf "Running $$x ..."; ./$$x >/dev/null 2>&1; if [ $$? -ne 0 ]; then echo "... FAIL $$x"; result=1; else echo "... SUCCESS";  fi;  done; exit $$result
+	@{ result=0;			\
+	for x in $(TESTFILES); do	\
+	  printf "Running $$x ...";	\
+	  ./$$x >$$x.testlog 2>1;	\
+	  if [ $$? -ne 0 ]; then	\
+	    echo "... FAIL $$x";	\
+	    result=1;			\
+	  else				\
+	    echo "... SUCCESS";		\
+	    rm -f $$x.testlog;		\
+	  fi;				\
+	done;				\
+	exit $$result; }
 
 .valgrind: $(BINFILES) $(TESTFILES)
 
 
 depend:
-	-$(CXX) -M $(CXXFLAGS) *.cc > .depend.mk  
+	-$(CXX) -M $(CXXFLAGS) *.cc > .depend.mk
 
 # removing automatic making of "depend" as it's quite slow.
 #.depend.mk: depend
 -include .depend.mk
-

--- a/tools/extras/travis_install_bindeps.sh
+++ b/tools/extras/travis_install_bindeps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+xroot=${1:-~/xroot}
+
+mkdir -p $xroot
+cd $xroot
+
+add_deb () {
+  echo "Adding deb package $1 to $xroot"
+  wget -nv $1
+  dpkg-deb -x ${1##*/} $xroot
+}
+
+# OpenBLAS and Netlib LAPACK binaries from Trusty.
+add_deb http://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke-dev_3.5.0-2ubuntu1_amd64.deb
+add_deb http://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke_3.5.0-2ubuntu1_amd64.deb
+add_deb http://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-dev_0.2.8-6ubuntu1_amd64.deb
+add_deb http://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-base_0.2.8-6ubuntu1_amd64.deb
+add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas-dev_1.2.20110419-7_amd64.deb
+add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas3_1.2.20110419-7_amd64.deb
+
+# Show extracted packages.
+find $xroot | sort

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -50,4 +50,4 @@ make_kaldi() {
 #make_kaldi matrix/test
 
 make_kaldi all -j$MAXPAR
-make_kaldi test
+make_kaldi test -k

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# We take into account dependency pointers optionally set in the enironment.
+# Typical usage shown below; any one can be safely left unset.
+#   INCDIRS="~/xroot/usr/include"
+#   LIBDIRS="~/xroot/usr/lib /usr/lib/openblas-base"
+#   CXX=gcc++-4.9
+#   CFLAGS="-march=native -O2"
+#   LDFLAGS="-llapack"
+
+# Maximum make parallelism. Simply -j runs out of memory on Travis VM.
+MAXPAR=3
+
+# Run verbose (run and echo) and exit if failed.
+runvx() {
+  echo "\$ $@"
+  "$@" || exit 1
+}
+
+# $(addsw -L foo bar) => "-Lfoo -Lbar".
+addsw() {
+  local v=() s=$1; shift;
+  for d; do v+=("$s$d"); done
+  echo ${v[@]};
+}
+
+# $(mtoken CXX gcc) => "CXX=gcc"; # $(mtoken CXX ) => "".
+mtoken() { echo ${2+$1=$2}; }
+
+# Print machine info and environment.
+runvx uname -a
+runvx env
+
+# Prepare make command fragments.
+CF="$CFLAGS -g $(addsw -I $INCDIRS)"
+LDF="$LDFLAGS $(addsw -L $LIBDIRS)"
+CCC="$(mtoken CC $CXX) $(mtoken CXX $CXX)"
+
+runvx cd tools
+runvx make openfst $CCC CXXFLAGS="$CF" -j$MAXPAR
+cd ..
+runvx cd src
+runvx ./configure --use-cuda=no  --mathlib=OPENBLAS --openblas-root=$XROOT/usr
+
+make_kaldi() {
+  runvx make "$@" $CCC EXTRA_CXXFLAGS="$CF" EXTRA_LDLIBS="$LDF"
+}
+
+#make_kaldi mklibdir base matrix -j$MAXPAR
+#make_kaldi matrix/test
+
+make_kaldi all -j$MAXPAR
+make_kaldi test

--- a/tools/extras/travis_show_failures.sh
+++ b/tools/extras/travis_show_failures.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script is called upon a test failure under Travis CI to report the
+# failure context. It prints a header followed by the last 200 lines of every
+# *.testlog file found recursively under ./src. src/makefiles/default_rules.mk,
+# in turn, keeps *.testlog files from failed tests only.
+
+for f in $(find src/ -name '*.testlog' | sort); do
+  printf "
+********************************************************************************
+* %-76s *
+********************************************************************************
+" $f
+  tail --lines=200 $f
+done


### PR DESCRIPTION
Added Travis CI integration scripts.
Modified makefiles so that failed tests keep their log files around, so that the CI can capture them.

See https://travis-ci.org/workflow-demo-org/kaldi/ (and https://travis-ci.org/kaldi-asr/kaldi/ after merge and first push). New PRs should automatically show a small information icon as to whether the Travis build is in progress, or has failed or succeeded.