### PR TITLE
#88 item 1: clip wave samples and print a warning.

### DIFF
--- a/src/feat/wave-reader.cc
+++ b/src/feat/wave-reader.cc
@@ -20,6 +20,7 @@
 // limitations under the License.
 
 #include <cstdio>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -157,10 +158,10 @@ void WaveData::Read(std::istream &is) {
     fmt_chunk_read = 40;
 
     // Support only KSDATAFORMAT_SUBTYPE_PCM for now. Interesting formats:
-    //("00000001-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_PCM)
-    //("00000003-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)
-    //("00000006-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_ALAW)
-    //("00000007-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_MULAW)
+    // ("00000001-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_PCM)
+    // ("00000003-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)
+    // ("00000006-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_ALAW)
+    // ("00000007-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_MULAW)
     if (guid1 != 0x00000001 || guid2 != 0x00100000 ||
         guid3 != 0xAA000080 || guid4 != 0x719B3800) {
       KALDI_ERR << "WaveData: unknown/unsupported WAVE_FORMAT_EXTENSIBLE format.";
@@ -221,8 +222,8 @@ void WaveData::Read(std::istream &is) {
   riff_chunk_read += 4;
 
   if (std::abs(static_cast<int64>(riff_chunk_read) +
-	       static_cast<int64>(data_chunk_size) -
-	       static_cast<int64>(riff_chunk_size)) > 1) {
+               static_cast<int64>(data_chunk_size) -
+               static_cast<int64>(riff_chunk_size)) > 1) {
     // we allow the size to be off by one, because there is a weirdness in the
     // format of RIFF files that means that the input may sometimes be padded
     // with 1 unused byte to make the total size even.
@@ -340,12 +341,18 @@ void WaveData::Write(std::ostream &os) const {
   const BaseFloat *data_ptr = data_.Data();
   int32 stride = data_.Stride();
 
+  int num_clipped = 0;
   for (int32 i = 0; i < num_samp; i++) {
     for (int32 j = 0; j < num_chan; j++) {
-      int32 elem = static_cast<int32>(data_ptr[j*stride + i]);
-      int16 elem_16(elem);
-      if (static_cast<int32>(elem_16) != elem)
-        KALDI_ERR << "Wave file is out of range for 16-bit.";
+      int32 elem = static_cast<int32>(trunc(data_ptr[j * stride + i]));
+      int16 elem_16 = static_cast<int16>(elem);
+      if (elem < std::numeric_limits<int16>::min()) {
+        elem_16 = std::numeric_limits<int16>::min();
+        ++num_clipped;
+      } else if (elem > std::numeric_limits<int16>::max()) {
+        elem_16 = std::numeric_limits<int16>::max();
+        ++num_clipped;
+      }
 #ifdef __BIG_ENDIAN__
       KALDI_SWAP2(elem_16);
 #endif
@@ -354,6 +361,10 @@ void WaveData::Write(std::ostream &os) const {
   }
   if (os.fail())
     KALDI_ERR << "Error writing wave data to stream.";
+  if (num_clipped > 0)
+    KALDI_WARN << "WARNING: clipped " << num_clipped
+               << " samples out of total " << num_chan * num_samp
+               << ". Reduce volume.";
 }
 
 

--- a/src/feat/wave-reader.cc
+++ b/src/feat/wave-reader.cc
@@ -364,7 +364,7 @@ void WaveData::Write(std::ostream &os) const {
   if (num_clipped > 0)
     KALDI_WARN << "WARNING: clipped " << num_clipped
                << " samples out of total " << num_chan * num_samp
-               << ". Reduce volume.";
+               << ". Reduce volume?";
 }
 
 

--- a/src/feat/wave-reader.h
+++ b/src/feat/wave-reader.h
@@ -54,7 +54,7 @@ namespace kaldi {
 
 /// For historical reasons, we scale waveforms to the range
 /// (2^15-1)*[-1, 1], not the usual default DSP range [-1, 1].
-const BaseFloat kWave0dBSampleValue = 32768.0;
+const BaseFloat kWaveSampleMax = 32768.0;
 
 /// This class's purpose is to read in Wave files.
 class WaveData {

--- a/src/feat/wave-reader.h
+++ b/src/feat/wave-reader.h
@@ -52,10 +52,13 @@
 
 namespace kaldi {
 
+/// For historical reasons, we scale waveforms to the range
+/// (2^15-1)*[-1, 1], not the usual default DSP range [-1, 1].
+const BaseFloat kWave0dBSampleValue = 32768.0;
+
 /// This class's purpose is to read in Wave files.
 class WaveData {
  public:
-
   WaveData(BaseFloat samp_freq, const MatrixBase<BaseFloat> &data)
       : data_(data), samp_freq_(samp_freq) {}
 
@@ -75,9 +78,9 @@ class WaveData {
   const Matrix<BaseFloat> &Data() const { return data_; }
 
   BaseFloat SampFreq() const { return samp_freq_; }
-  
+
   // Returns the duration in seconds
-  BaseFloat Duration() const { return data_.NumCols()/samp_freq_; }
+  BaseFloat Duration() const { return data_.NumCols() / samp_freq_; }
 
   void CopyFrom(const WaveData &other) {
     samp_freq_ = other.samp_freq_;
@@ -90,7 +93,7 @@ class WaveData {
   }
 
  private:
-  static const uint32 kBlockSize = 1048576;  // 1024 * 1024, use 1M bytes
+  static const uint32 kBlockSize = 1024 * 1024;  // Use 1M bytes.
   Matrix<BaseFloat> data_;
   BaseFloat samp_freq_;
   static void Expect4ByteTag(std::istream &is, const char *expected);
@@ -103,8 +106,6 @@ class WaveData {
 };
 
 
-
-
 // Holder class for .wav files that enables us to read (but not write)
 // .wav files. c.f. util/kaldi-holder.h
 class WaveHolder {
@@ -113,12 +114,12 @@ class WaveHolder {
 
   static bool Write(std::ostream &os, bool binary, const T &t) {
     // We don't write the binary-mode header here [always binary].
-    KALDI_ASSERT(binary == true
-                 && "Wave data can only be written in binary mode.");
+    if (!binary)
+      KALDI_ERR << "Wave data can only be written in binary mode.";
     try {
       t.Write(os);  // throws exception on failure.
       return true;
-    } catch(const std::exception &e) {
+    } catch (const std::exception &e) {
       KALDI_WARN << "Exception caught in WaveHolder object (writing).";
       if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
       return false;  // write failure.
@@ -145,12 +146,13 @@ class WaveHolder {
     try {
       t_.Read(is);  // throws exception on failure.
       return true;
-    } catch(const std::exception &e) {
+    } catch (const std::exception &e) {
       KALDI_WARN << "Exception caught in WaveHolder object (reading).";
       if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
       return false;  // write failure.
     }
   }
+
  private:
   T t_;
 };


### PR DESCRIPTION
`wave-reader` also sorely lacks unit tests. I had to write a skeleton of what can become one, but it is not ready for the prime time. I'll try to develop it into one.