### PR TITLE
Added nnet3_to_dot.py script to convert nnet3 models to dot graphs

### DIFF
--- a/egs/ami/s5/local/nnet3/run_lstm.sh
+++ b/egs/ami/s5/local/nnet3/run_lstm.sh
@@ -15,6 +15,7 @@ use_sat_alignments=true
 affix=
 speed_perturb=true
 splice_indexes="-2,-1,0,1,2 0"
+common_egs_dir=
 
 . cmd.sh
 . ./path.sh
@@ -28,7 +29,7 @@ where "nvcc" is installed.
 EOF
 fi
 
-dir=exp/$mic/nnet2_online/nnet_lstm${speed_perturb:+_sp}${affix:+_$affix}
+dir=exp/$mic/nnet3/lstm${speed_perturb:+_sp}${affix:+_$affix}
 if [ "$use_sat_alignments" == "true" ] ; then
   gmm_dir=exp/$mic/tri4a
 else
@@ -66,13 +67,14 @@ if [ $stage -le 7 ]; then
     --io-opts "-tc 12" \
     --initial-effective-lrate 0.0015 --final-effective-lrate 0.00015 \
     --cmd "$decode_cmd" \
-    --num-lstm-layers 3 \
+    --num-lstm-layers 1 \
     --cell-dim 1024 \
     --hidden-dim 1024 \
     --recurrent-projection-dim 256 \
     --non-recurrent-projection-dim 256 \
     --bptt-truncation-width 20 \
     --context-sensitive-chunk-width 20 \
+    --egs-dir "$common_egs_dir" \
     data/$mic/${train_set}_hires data/lang $ali_dir $dir  || exit 1;
 fi
 exit;

--- a/egs/ami/s5/run_sdm_lstm.sh
+++ b/egs/ami/s5/run_sdm_lstm.sh
@@ -168,9 +168,10 @@ fi
 if [ $stage -le 14 ]; then
   local/nnet3/run_lstm.sh \
     --mic $mic \
-    --train-stage -6 \
+    --train-stage -5 \
     --speed-perturb true \
     --stage 7 \
+    --common-egs-dir exp/sdm1/nnet3/lstm_sp/egs \
     --use-sat-alignments false
 fi
 

--- a/egs/wsj/s5/steps/nnet3/dot/descriptor_parser.py
+++ b/egs/wsj/s5/steps/nnet3/dot/descriptor_parser.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+# we're using python 3.x style print but want it to work in python 2.x,
+from __future__ import print_function
+import pprint
+import re
+import sys
+
+start_identifier = "("
+end_identifier = ")"
+
+def ParseSubsegmentsAndArguments(segment_endpoints, sub_segments, arguments, input_string):
+    # name the sub_segments, and other arguments
+    arg_name_start_index = segment_endpoints[0]
+    args = ''
+    for sub_segment in sub_segments:
+        endpoints = sub_segment['endpoints']
+        args += input_string[arg_name_start_index:endpoints[0]+1]
+        arg_name_start_index=endpoints[1]+1
+    args += input_string[arg_name_start_index:segment_endpoints[1]+1]
+
+    args = args.split(',')
+    if len(sub_segments) > 0:
+        sub_segment_index = 0
+        for sub_segment_name in args:
+            sub_segment_name = sub_segment_name.strip()
+            if sub_segment_name[-1] == "(":
+                # this subsegment is a function
+                sub_segment_name = sub_segment_name[:-1]
+                sub_segments[sub_segment_index]['name'] = sub_segment_name
+                sub_segment_index += 1
+
+            else:
+                arguments.append(sub_segment_name)
+    else:
+        arguments = map(lambda x: re.sub(',','', x.strip()), input_string[segment_endpoints[0]:segment_endpoints[1]+1].split())
+        sub_segments = []
+    return sub_segments, arguments
+
+def IdentifyNestedSegments(input_string):
+    indices = []
+    segments = []
+    for i in range(len(input_string)):
+        if input_string[i] == start_identifier:
+            indices.append(i)
+        if input_string[i] == end_identifier:
+            # new segment has been found
+            current_segment_endpoints = [indices.pop(), i]
+            sub_segments = []
+            arguments = []
+            # identify the sub-segments
+            # the sub-segments would be on the top of the stack
+            # with start index greater than current segment
+            # and end index less than current segment
+            # these sub-segments are listed in reverse order on the stack,
+            # the final segment is on the top
+            while len(segments) > 0:
+                if ((segments[-1]['endpoints'][0] > current_segment_endpoints[0]) and
+                    (segments[-1]['endpoints'][1] < current_segment_endpoints[1])):
+                    sub_segments.insert(0, segments.pop())
+                else:
+                    break
+
+            sub_segments, arguments = ParseSubsegmentsAndArguments([current_segment_endpoints[0]+1, current_segment_endpoints[1]-1], sub_segments, arguments, input_string)
+            segments.append({
+                             'name':'',
+                             'endpoints':current_segment_endpoints,
+                             'sub_segments':sub_segments,
+                             'arguments':arguments
+                             })
+    arguments = []
+    segments, arguments = ParseSubsegmentsAndArguments([0, len(input_string)], segments, arguments, input_string)
+    if arguments:
+        if segments:
+            raise Exception('Arguments not expected outside top level braces : {0}'.format(input_string))
+    if len(segments) > 1:
+        raise Exception('only one parent segment expected : {0}'.format(input_string))
+
+    return [segments, arguments]
+
+if __name__ == "__main__":
+    strings= [
+        "Append(Offset-2(input, -2), Offset-1(input, -1), input, Offset+1(input, 1), Offset+2(input, 2), ReplaceIndex(ivector, t, 0))",
+        "Wx"]
+    for string in strings:
+        segments = IdentifyNestedSegments(string)
+        pprint.pprint(segments)
+

--- a/egs/wsj/s5/steps/nnet3/dot/nnet3_to_dot.py
+++ b/egs/wsj/s5/steps/nnet3/dot/nnet3_to_dot.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python
+
+# Copyright      2015  Johns Hopkins University (Author: Vijayaditya Peddinti)
+# Apache 2.0
+
+# script to convert nnet3-am-info output to a dot graph
+
+
+# we're using python 3.x style print but want it to work in python 2.x,
+from __future__ import print_function
+import re
+import os
+import argparse
+import sys
+import math
+import warnings
+import descriptor_parser
+import pprint
+
+node_attributes = {
+    'input-node':{
+        'shape':'oval'
+    },
+    'output-node':{
+        'shape':'oval'
+    },
+    'NaturalGradientAffineComponent':{
+        'color':'lightgrey',
+        'shape':'box',
+        'style':'filled'
+    },
+    'NaturalGradientPerElementScaleComponent':{
+        'color':'lightpink',
+        'shape':'box',
+        'style':'filled'
+    },
+    'FixedScaleComponent':{
+        'color':'blueviolet',
+        'shape':'box',
+        'style':'filled'
+    },
+    'FixedAffineComponent':{
+        'color':'darkolivegreen1',
+        'shape':'box',
+        'style':'filled'
+    },
+    'SigmoidComponent':{
+        'color':'bisque',
+        'shape':'rectangle',
+        'style':'filled'
+    },
+    'TanhComponent':{
+        'color':'bisque',
+        'shape':'rectangle',
+        'style':'filled'
+    },
+    'NormalizeComponent':{
+        'color':'aquamarine',
+        'shape':'rectangle',
+        'style':'filled'
+    },
+    'RectifiedLinearComponent':{
+        'color':'bisque',
+        'shape':'rectangle',
+        'style':'filled'
+    },
+    'ElementwiseProductComponent':{
+        'color':'green',
+        'shape':'rectangle',
+        'style':'filled'
+    },
+    'LogSoftmaxComponent':{
+        'color':'cyan',
+        'shape':'rectangle',
+        'style':'filled'
+    }
+}
+
+def GetDotNodeName(name_string, is_component = False):
+    # this function is required as dot does not allow all the component names
+    # allowed by nnet3.
+    # Identified incompatibilities :
+    #   1. dot does not allow hyphen(-) in names
+    #   2. Nnet3 names can be shared among components and component nodes
+    #      dot does not allow common names
+    #
+    name_string = re.sub("-", "hyphen", name_string)
+    if is_component:
+        name_string += name_string.strip() + "_component"
+    return name_string
+
+def ProcessAppendDescriptor(segment, parent_node_name, affix, edge_attributes = None):
+    dot_graph = []
+    names = []
+    desc_name = 'Append_{0}'.format(affix)
+    for i in range(len(segment['sub_segments'])):
+        sub_segment = segment['sub_segments'][i]
+        part_name = "{0}{1}{2}".format(desc_name, sub_segment['name'], i)
+        names.append("<{0}> part {1}".format(GetDotNodeName(part_name), i))
+        dot_graph += DescriptorSegmentToDot(sub_segment, "{0}:{1}".format(desc_name, part_name), desc_name)
+
+    part_index = len(segment['sub_segments'])
+    for i in range(len(segment['arguments'])):
+        part_name = "{0}{1}{2}".format(desc_name, segment['arguments'][i], part_index + i)
+        names.append("<{0}> part {1}".format(GetDotNodeName(part_name), part_index + i))
+        dot_graph.append("{0} -> {1}:{2}".format(GetDotNodeName(segment['arguments'][i]), GetDotNodeName(desc_name), GetDotNodeName(part_name)))
+
+    label = "|".join(names)
+    label = "{{"+label+"}|Append}"
+    dot_graph.append('{0} [shape=Mrecord, label="{1}"];'.format(GetDotNodeName(desc_name), label))
+
+    attr_string = ''
+    if edge_attributes is not None:
+        if edge_attributes.has_key('label'):
+            attr_string += " label={0} ".format(edge_attributes['label'])
+        if edge_attributes.has_key('style'):
+            attr_string += ' style={0} '.format(edge_attributes['style'])
+
+    dot_string = '{0} -> {1} [tailport=s]'.format(GetDotNodeName(desc_name), GetDotNodeName(parent_node_name))
+
+    if attr_string != '':
+        dot_string += ' [{0}] '.format(attr_string)
+    dot_graph.append(dot_string)
+
+
+    return dot_graph
+
+def ProcessOffsetDescriptor(segment, parent_node_name, affix, edge_attributes = None):
+    dot_graph = []
+
+    label = 'Offset ({0})'.format(segment['arguments'][1])
+    style = None
+    if edge_attributes is not None:
+        if edge_attributes.has_key('label'):
+            label = "{0} {1}".format(edge_attributes['label'], label)
+        if edge_attributes.has_key('style'):
+            style  = 'style={0}'.format(edge_attributes['style'])
+
+    attr_string = 'label="{0}"'.format(label)
+    if style is not None:
+        attr_string += ' {0}'.format(style)
+
+    dot_graph.append('{0}->{1} [ {2} ]'.format(GetDotNodeName(segment['arguments'][0]),
+                                                                    GetDotNodeName(parent_node_name),
+                                                                    attr_string))
+    if segment['sub_segments']:
+        raise Exception("Offset can just deal with forwarding descriptor, no sub-segments allowed")
+    return dot_graph
+
+def ProcessSumDescriptor(segment, parent_node_name, affix, edge_attributes = None):
+    dot_graph = []
+    names = []
+    desc_name = 'Sum_{0}'.format(affix)
+    for i in range(len(segment['sub_segments'])):
+        sub_segment = segment['sub_segments'][i]
+        part_name = "{0}{1}{2}".format(desc_name, sub_segment['name'], i)
+        names.append("<{0}> part {1}".format(GetDotNodeName(part_name), i))
+        dot_graph += DescriptorSegmentToDot(sub_segment, "{0}:{1}".format(desc_name, part_name), desc_name)
+
+    part_index = len(segment['sub_segments'])
+    for i in range(len(segment['arguments'])):
+        part_name = "{0}{1}{2}".format(desc_name, segment['arguments'][i], part_index + i)
+        names.append("<{0}> part {1}".format(GetDotNodeName(part_name), part_index + i))
+        dot_graph.append("{0} -> {1}:{2}".format(GetDotNodeName(segment['arguments'][i]), GetDotNodeName(desc_name), GetDotNodeName(part_name)))
+
+    label = "|".join(names)
+    label = '{{'+label+'}|Sum}'
+    dot_graph.append('{0} [shape=Mrecord, label="{1}", color=red];'.format(GetDotNodeName(desc_name), label))
+
+    attr_string = ''
+    if edge_attributes is not None:
+        if edge_attributes.has_key('label'):
+            attr_string += " label={0} ".format(edge_attributes['label'])
+        if edge_attributes.has_key('style'):
+            attr_string += ' style={0} '.format(edge_attributes['style'])
+
+    dot_string = '{0} -> {1}'.format(GetDotNodeName(desc_name), GetDotNodeName(parent_node_name))
+
+    dot_string += ' [{0} tailport=s ] '.format(attr_string)
+    dot_graph.append(dot_string)
+    return dot_graph
+
+def ProcessReplaceIndexDescriptor(segment, parent_node_name, affix, edge_attributes = None):
+    dot_graph = []
+
+    label = 'ReplaceIndex({0}, {1})'.format(segment['arguments'][1], segment['arguments'][2])
+    style = None
+    if edge_attributes is not None:
+        if edge_attributes.has_key('label'):
+            label = "{0} {1}".format(edge_attributes['label'], label)
+        if edge_attributes.has_key('style'):
+            style  = 'style={0}'.format(edge_attributes['style'])
+
+    attr_string = 'label="{0}"'.format(label)
+    if style is not None:
+        attr_string += ' {0}'.format(style)
+
+    dot_graph.append('{0}->{1} [{2}]'.format(GetDotNodeName(segment['arguments'][0]),
+                                                                    GetDotNodeName(parent_node_name),
+                                                                    attr_string))
+    if segment['sub_segments']:
+        raise Exception("ReplaceIndex can just deal with forwarding descriptor, no sub-segments allowed")
+    return dot_graph
+
+def ProcessIfDefinedDescriptor(segment, parent_node_name, affix, edge_attributes = None):
+    # IfDefined adds attributes to the edges
+    if edge_attributes is not None:
+        raise Exception("edge_attributes was not None, this means an IfDefined descriptor was calling the current IfDefined descriptor. This is not allowed")
+    dot_graph = []
+    dot_graph.append('#ProcessIfDefinedDescriptor')
+    names = []
+
+    if segment['sub_segments']:
+        sub_segment = segment['sub_segments'][0]
+        dot_graph += DescriptorSegmentToDot(sub_segment, parent_node_name, parent_node_name, edge_attributes={'style':'dotted', 'label':'IfDefined'})
+
+    if segment['arguments']:
+        dot_graph.append('{0} -> {1} [style=dotted, label="IfDefined"]'.format(GetDotNodeName(segment['arguments'][0]), GetDotNodeName(parent_node_name)))
+
+    return dot_graph
+
+def DescriptorSegmentToDot(segment, parent_node_name, affix, edge_attributes = None):
+    # segment is a dicionary which corresponds to a descriptor
+    dot_graph = []
+    if segment['name'] == "Append":
+        dot_graph += ProcessAppendDescriptor(segment, parent_node_name, affix, edge_attributes)
+    elif segment['name'] == "Offset":
+        dot_graph += ProcessOffsetDescriptor(segment, parent_node_name, affix, edge_attributes)
+    elif segment['name'] == "Sum":
+        dot_graph += ProcessSumDescriptor(segment, parent_node_name, affix, edge_attributes)
+    elif segment['name'] == "IfDefined":
+        dot_graph += ProcessIfDefinedDescriptor(segment, parent_node_name, affix, edge_attributes)
+    elif segment['name'] == "ReplaceIndex":
+        dot_graph += ProcessReplaceIndexDescriptor(segment, parent_node_name, affix, edge_attributes)
+    else:
+        raise Exception('Descriptor {0}, is not recognized by this script. Please add Process{0}Descriptor method'.format(segment['name']))
+    return dot_graph
+
+def Nnet3DescriptorToDot(descriptor, parent_node_name):
+    dot_lines = []
+    [segments, arguments] = descriptor_parser.IdentifyNestedSegments(descriptor)
+    if segments:
+        for segment in segments:
+            dot_lines += DescriptorSegmentToDot(segment, parent_node_name, parent_node_name)
+    elif arguments:
+        assert(len(arguments) == 1)
+        dot_lines.append("{0} -> {1}".format(GetDotNodeName(arguments[0]), GetDotNodeName(parent_node_name)))
+    return dot_lines
+
+def ParseNnet3String(string):
+    if re.search('^input-node|^component|^output-node|^component-node|^dim-range-node', string.strip()) is None:
+        return [None, None]
+
+    parts = string.split()
+    config_type = parts[0]
+    fields = []
+    prev_field = ''
+    for i in range(1, len(parts)):
+        if re.search('=', parts[i]) is None:
+            prev_field += ' '+parts[i]
+        else:
+            if not (prev_field.strip() == ''):
+                fields.append(prev_field)
+            sub_parts = parts[i].split('=')
+            if (len(sub_parts) != 2):
+                raise Exception('Malformed config line {0}'.format(string))
+            fields.append(sub_parts[0])
+            prev_field = sub_parts[1]
+    fields.append(prev_field)
+
+    parsed_string = {}
+    try:
+        while len(fields) > 0:
+            value = re.sub(',$', '', fields.pop().strip())
+            key = fields.pop()
+            parsed_string[key.strip()] = value.strip()
+    except IndexError:
+        raise Exception('Malformed config line {0}'.format(string))
+    return [config_type, parsed_string]
+
+# sample component config line
+# component name=L0_lda type=FixedAffineComponent, input-dim=300, output-dim=300, linear-params-stddev=0.00992724, bias-params-stddev=0.573973
+def Nnet3ComponentToDot(component_config, component_attributes = None):
+    label = ''
+    if component_attributes is None:
+        component_attributes = component_config.keys()
+    attributes_to_print = set(component_attributes).intersection(component_config.keys())
+    # process the known fields
+    for key in attributes_to_print:
+        if component_config.has_key(key):
+            label += '{0} = {1}\\n'.format(key, component_config[key])
+
+    attr_string = ''
+    try:
+        attributes = node_attributes[component_config['type']]
+        for key in attributes.keys():
+            attr_string += ' {0}={1} '.format(key, attributes[key])
+    except KeyError:
+        pass
+
+    return ['{0} [label="{1}" {2}]'.format(GetDotNodeName(component_config['name'], is_component = True), label, attr_string)]
+
+
+# input-node name=input dim=40
+def Nnet3InputToDot(parsed_config):
+    return ['{0} [ label="{1}\\ndim={2}"]'.format(GetDotNodeName(parsed_config['name']), parsed_config['name'], parsed_config['dim'] )]
+
+# output-node name=output input=Final_log_softmax dim=3940 objective=linear
+def Nnet3OutputToDot(parsed_config):
+    dot_graph = []
+    dot_graph.append('{0} [ label="{1}\\nobjective={2}"]'.format(GetDotNodeName(parsed_config['name']), parsed_config['name'], parsed_config['objective']))
+    dot_graph.append('{0} -> {1}'.format(GetDotNodeName(parsed_config['input']), GetDotNodeName(parsed_config['name'])))
+    return dot_graph
+
+# dim-range-node name=Lstm1_r_t input-node=Lstm1_rp_t dim-offset=0 dim=256
+def Nnet3DimrangeToDot(parsed_config):
+    dot_graph = []
+    dot_graph.append(parsed_config['name'])
+    dot_graph.append('{0} [shape=rectangle]'.format(GetDotNodeName(parsed_config['name'])))
+    dot_graph.append('{0} -> {1} [taillabel="dimrange({2}, {3})"]'.format(GetDotNodeName(parsed_config['input-node']),
+                                                           GetDotNodeName(parsed_config['name']),
+                                                           parsed_config['dim-offset'],
+                                                           parsed_config['dim']))
+    return dot_graph
+
+def Nnet3ComponentNodeToDot(parsed_config):
+    dot_graph = []
+    dot_graph += Nnet3DescriptorToDot(parsed_config['input'], parsed_config['name'])
+    dot_graph.append('{0} [ label="{1}", shape=box ]'.format(GetDotNodeName(parsed_config['name']), parsed_config['name']))
+    dot_graph.append('{0} -> {1} [ weight=10 ]'.format(GetDotNodeName(parsed_config['component'], is_component = True),
+                                                       GetDotNodeName(parsed_config['name'])))
+    return dot_graph
+
+def GroupConfigs(configs, node_prefixes = []):
+    # we make the assumption that nodes belonging to the same sub-graph have a
+    # commong prefix.
+    grouped_configs = {}
+    for node_prefix in node_prefixes:
+        group = []
+        rest = []
+        for config in configs:
+            if re.search('^{0}'.format(node_prefix), config[1]['name']) is not None:
+                group.append(config)
+            else:
+                rest.append(config)
+        configs = rest
+        grouped_configs[node_prefix] = group
+    grouped_configs[None] = configs
+
+    return grouped_configs
+
+def ParseConfigLines(lines, node_prefixes = [], component_attributes = None ):
+    config_lines = []
+    dot_graph=[]
+    configs = []
+    for line in lines:
+        config_type, parsed_config = ParseNnet3String(line)
+        if config_type is not None:
+            configs.append([config_type, parsed_config])
+
+    # process the config lines
+    grouped_configs = GroupConfigs(configs, node_prefixes)
+    for group in grouped_configs.keys():
+        configs = grouped_configs[group]
+        if not configs:
+            continue
+        if group is not None:
+            # subgraphs prefixed with cluster will be treated differently by
+            # dot
+            dot_graph.append('subgraph cluster_{0} '.format(group) + "{")
+            dot_graph.append('color=blue')
+
+        for config in configs:
+            config_type = config[0]
+            parsed_config = config[1]
+            if config_type is None:
+                continue
+            if config_type == 'input-node':
+                dot_graph += Nnet3InputToDot(parsed_config)
+            elif config_type == 'output-node':
+                dot_graph += Nnet3OutputToDot(parsed_config)
+            elif config_type == 'component-node':
+                dot_graph += Nnet3ComponentNodeToDot(parsed_config)
+            elif config_type == 'dim-range-node':
+                dot_graph += Nnet3DimrangeToDot(parsed_config)
+            elif config_type == 'component':
+                dot_graph += Nnet3ComponentToDot(parsed_config, component_attributes)
+
+        if group is not None:
+            dot_graph.append('label = "{0}"'.format(group))
+            dot_graph.append('}')
+
+    dot_graph.insert(0, 'digraph nnet3graph {')
+    dot_graph.append('}')
+
+    return dot_graph
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Converts the output of nnet3-am-info "
+                                                 "to dot graph. The output has to be compiled"
+                                                 " with dot to generate a displayable graph",
+                                    epilog="See steps/nnet3/nnet3_to_dot.sh for example.");
+    parser.add_argument("--component-attributes", type=str,
+                        help="Attributes of the components which should be displayed in the dot-graph "
+                             "e.g. --component-attributes name,type,input-dim,output-dim", default=None)
+    parser.add_argument("--node-prefixes", type=str,
+                        help="list of prefixes. Nnet3 components/component-nodes with the same prefix"
+                        " will be clustered together in the dot-graph"
+                        " --node-prefixes Lstm1,Lstm2,Layer1", default=None)
+
+    print(' '.join(sys.argv), file=sys.stderr)
+
+    args = parser.parse_args()
+    component_attributes = None
+    if args.component_attributes is not None:
+        component_attributes = args.component_attributes.split(',')
+    node_prefixes = []
+    if args.node_prefixes is not None:
+        node_prefixes = args.node_prefixes.split(',')
+
+    lines = sys.stdin.readlines()
+    dot_graph = ParseConfigLines(lines, component_attributes = component_attributes, node_prefixes = node_prefixes)
+    print("\n".join(dot_graph))

--- a/egs/wsj/s5/steps/nnet3/lstm/make_configs.py
+++ b/egs/wsj/s5/steps/nnet3/lstm/make_configs.py
@@ -110,17 +110,17 @@ def AddLstmLayer(config_lines,
     components.append("# Input gate control : W_i* matrices")
     components.append("component name={0}_W_i-xr type=NaturalGradientAffineComponent input-dim={1} output-dim={2}".format(name, input_dim + recurrent_projection_dim, cell_dim))
     components.append("# note : the cell outputs pass through a diagonal matrix")
-    components.append("component name={0}_w_ic type=PerElementScaleComponent  dim={1}".format(name, cell_dim))
+    components.append("component name={0}_w_ic type=NaturalGradientPerElementScaleComponent  dim={1}".format(name, cell_dim))
 
     components.append("# Forget gate control : W_f* matrices")
     components.append("component name={0}_W_f-xr type=NaturalGradientAffineComponent input-dim={1} output-dim={2}".format(name, input_dim + recurrent_projection_dim, cell_dim))
     components.append("# note : the cell outputs pass through a diagonal matrix")
-    components.append("component name={0}_w_fc type=PerElementScaleComponent  dim={1}".format(name, cell_dim))
+    components.append("component name={0}_w_fc type=NaturalGradientPerElementScaleComponent  dim={1}".format(name, cell_dim))
 
     components.append("#  Output gate control : W_o* matrices")
     components.append("component name={0}_W_o-xr type=NaturalGradientAffineComponent input-dim={1} output-dim={2}".format(name, input_dim + recurrent_projection_dim, cell_dim))
     components.append("# note : the cell outputs pass through a diagonal matrix")
-    components.append("component name={0}_w_oc type=PerElementScaleComponent  dim={1}".format(name, cell_dim))
+    components.append("component name={0}_w_oc type=NaturalGradientPerElementScaleComponent  dim={1}".format(name, cell_dim))
 
     components.append("# Cell input matrices : W_c* matrices")
     components.append("component name={0}_W_c-xr type=NaturalGradientAffineComponent input-dim={1} output-dim={2}".format(name, input_dim + recurrent_projection_dim, cell_dim))
@@ -155,19 +155,19 @@ def AddLstmLayer(config_lines,
 
     component_nodes.append("# f_t")
     component_nodes.append("component-node name={0}_f1 component={0}_W_f-xr input=Append({1}, IfDefined(Offset({0}_{2}, -1)))".format(name, input_descriptor, recurrent_connection))
-    component_nodes.append("component-node name={0}_f2 component={0}_W_fc  input={1}".format(name, c_tminus1_descriptor))
+    component_nodes.append("component-node name={0}_f2 component={0}_w_fc  input={1}".format(name, c_tminus1_descriptor))
     component_nodes.append("component-node name={0}_f_t component={0}_f input=Sum({0}_f1,{0}_f2)".format(name))
 
     component_nodes.append("# o_t")
     component_nodes.append("component-node name={0}_o1 component={0}_W_o-xr input=Append({1}, IfDefined(Offset({0}_{2}, -1)))".format(name, input_descriptor, recurrent_connection))
-    component_nodes.append("component-node name={0}_o2 component={0}_W_oc input=Sum({0}_c1_t, {0}_c2_t)".format(name))
+    component_nodes.append("component-node name={0}_o2 component={0}_w_oc input=Sum({0}_c1_t, {0}_c2_t)".format(name))
     component_nodes.append("component-node name={0}_o_t component={0}_o input=Sum({0}_o1, {0}_o2)".format(name))
 
     component_nodes.append("# h_t")
     component_nodes.append("component-node name={0}_h_t component={0}_h input=Sum({0}_c1_t, {0}_c2_t)".format(name))
 
     component_nodes.append("# g_t")
-    component_nodes.append("component-node name={0}_g1 component={0}_W_c-xr input=Append({1}, IfDefined(Offset({2}, -1)))".format(name, input_descriptor, recurrent_connection))
+    component_nodes.append("component-node name={0}_g1 component={0}_W_c-xr input=Append({1}, IfDefined(Offset({0}_{2}, -1)))".format(name, input_descriptor, recurrent_connection))
     component_nodes.append("component-node name={0}_g_t component={0}_g input={0}_g1".format(name))
 
     component_nodes.append("# parts of c_t")

--- a/egs/wsj/s5/steps/nnet3/lstm/train.sh
+++ b/egs/wsj/s5/steps/nnet3/lstm/train.sh
@@ -15,9 +15,6 @@ num_epochs=15      # Number of epochs of training;
                    # the number of iterations is worked out from this.
 initial_effective_lrate=0.01
 final_effective_lrate=0.001
-pnorm_input_dim=3000 
-pnorm_output_dim=300
-relu_dim=  # you can use this to make it use ReLU's instead of p-norms.
 rand_prune=4.0 # Relates to a speedup we do for LDA.
 minibatch_size=512  # This default is suitable for GPU-based training.
                     # Set it to 128 for multi-threaded CPU-based training.
@@ -57,7 +54,7 @@ splice_indexes="-4,-3,-2,-1,0,1,2,3,4 0 0 0 0 0"
 # so hidden layer indexing is different from component count
 # LSTM parameters
 num_lstm_layers=3
-lstm_cell_dim=1024  # dimension of the LSTM cell
+cell_dim=1024  # dimension of the LSTM cell
 hidden_dim=1024  # the dimension of the fully connected hidden layer outputs
 recurrent_projection_dim=256  
 non_recurrent_projection_dim=256
@@ -204,19 +201,12 @@ fi
 if [ $stage -le -5 ]; then
   echo "$0: creating neural net configs";
 
-  if [ ! -z "$relu_dim" ]; then
-    dim_opts="--relu-dim $relu_dim"
-  else
-    dim_opts="--pnorm-input-dim $pnorm_input_dim --pnorm-output-dim  $pnorm_output_dim"
-  fi
-  
   # create the config files for nnet initialization
   python steps/nnet3/lstm/make_configs.py  \
     --splice-indexes "$splice_indexes" \
-    --num-lstm-layers 3 \
+    --num-lstm-layers $num_lstm_layers \
     --feat-dim $feat_dim \
     --ivector-dim $ivector_dim \
-      $dim_opts \
     --cell-dim $cell_dim \
     --hidden-dim $hidden_dim \
     --recurrent-projection-dim $recurrent_projection_dim \
@@ -225,7 +215,6 @@ if [ $stage -le -5 ]; then
     --context-sensitive-chunk-width $context_sensitive_chunk_width \
     --num-targets $num_leaves \
    $dir/configs || exit 1;
-
   # Initialize as "raw" nnet, prior to training the LDA-like preconditioning
   # matrix.  This first config just does any initial splicing that we do;
   # we do this as it's a convenient way to get the stats for the 'lda-like'

--- a/egs/wsj/s5/steps/nnet3/nnet3_to_dot.sh
+++ b/egs/wsj/s5/steps/nnet3/nnet3_to_dot.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# script showing use of nnet3_to_dot.py
+# Copyright 2015  Johns Hopkins University (Author: Vijayaditya Peddinti). 
+
+# Begin configuration section.
+component_attributes="name,type"
+node_prefixes=""
+echo "$0 $@"  # Print the command line for logging
+
+[ -f ./path.sh ] && . ./path.sh; # source the path.
+. parse_options.sh || exit 1;
+
+if [ $# != 3 ]; then
+  echo "Usage: $0 [opts] <nnet3-mdl-file> <output-dot-file> <output-png-file>"
+  echo " e.g.: $0 exp/sdm1/nnet3/lstm_sp/0.mdl lstm.dot lstm.png"
+  echo ""
+  echo "Main options (for others, see top of script file)"
+  echo "  --component-attributes <string|name,type>     # attributes to be printed in nnet3 components"
+  echo "  --node-prefixes <string|Lstm1,Lstm2>          # list of prefixes. Nnet3 components/component-nodes with the same prefix"
+  echo "                                                # will be clustered together in the dot-graph"
+
+  
+  exit 1;
+fi
+
+model=$1
+dot_file=$2
+output_file=$3
+
+attr=${node_prefixes:+ --node-prefixes "$node_prefixes"}
+nnet3-am-info $model | \
+  steps/nnet3/dot/nnet3_to_dot.py \
+    --component-attributes "$component_attributes" \
+    $attr  > $dot_file
+
+command -v dot >/dev/null 2>&1 || { echo >&2 "This script requires dot but it's not installed. Please compile $dot_file with dot"; exit 1; }
+dot -Tpng $dot_file -o $output_file

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -176,8 +176,8 @@ void ElementwiseProductComponent::Write(std::ostream &os, bool binary) const {
 
 std::string ElementwiseProductComponent::Info() const {
   std::stringstream stream;
-  stream << Type() << ", input-dim = " << input_dim_
-         << ", output-dim = " << output_dim_;
+  stream << Type() << ", input-dim=" << input_dim_
+         << ", output-dim=" << output_dim_;
   return stream.str();
 }
 


### PR DESCRIPTION
Added a script to convert nnet3-am-info output to a dot graph. This can be useful for debugging new nnet3 architectures. Tested on TDNN and LSTM architectures. 

Corrected minor bugs in lstm recipe and nnet3/nnet-simple-component.cc.

**Todo:**

1. Add processing code for additional descriptors: Switch, FailOver and Round
2. Add dot options for better display of complex graphs
3. Add logic to detect repeated sub-graphs and
    1. use a single sub-graph to represent these (e.g. recognizing the same input descriptor is used for     several components)
    2.  use an atomic representation for this sub-graph (e.g. recognizing that the Affine transform + Non-linearity + normalization layer can be collapsed into a single operation)

**LSTM model**
![lstm](https://cloud.githubusercontent.com/assets/3895456/9457184/fe1e44f6-4aad-11e5-9fb1-c317a1309737.png)

**TDNN model**
![tdnn](https://cloud.githubusercontent.com/assets/3895456/9457507/53bcd1a4-4ab1-11e5-8b1d-cd9204a8f8fd.png)

