### PR TITLE
Ivector scp path fix

### DIFF
--- a/egs/wsj/s5/steps/online/nnet2/extract_ivectors.sh
+++ b/egs/wsj/s5/steps/online/nnet2/extract_ivectors.sh
@@ -258,7 +258,7 @@ base_feat_dim=$(feat-to-dim scp:$data/feats.scp -) || exit 1;
 
 start_dim=$base_feat_dim
 end_dim=$[$base_feat_dim+$ivector_dim-1]
-
+absdir=$(readlink -f $dir)
 
 if [ $stage -le 4 ]; then
   # here, we are just using the original features in $sdata/JOB/feats.scp for
@@ -269,7 +269,7 @@ if [ $stage -le 4 ]; then
     select-feats "$start_dim-$end_dim" ark:- ark:- \| \
     subsample-feats --n=$ivector_period ark:- ark:- \| \
     copy-feats --compress=$compress ark:- \
-    ark,scp:$dir/ivector_online.JOB.ark,$dir/ivector_online.JOB.scp || exit 1;
+    ark,scp:$absdir/ivector_online.JOB.ark,$absdir/ivector_online.JOB.scp || exit 1;
 fi
 
 if [ $stage -le 5 ]; then

--- a/egs/wsj/s5/steps/online/nnet2/extract_ivectors_online.sh
+++ b/egs/wsj/s5/steps/online/nnet2/extract_ivectors_online.sh
@@ -44,8 +44,7 @@ max_count=0         # The use of this option (e.g. --max-count 100) can make
 
 # End configuration section.
 
-echo "$0 $@"  # Print the command line for logging
-
+echo "$0 $@"  # Print the command line for loggdir
 if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 
@@ -106,6 +105,7 @@ echo "--max-remembered-frames=1000" >>$ieconf # the default
 echo "--max-count=$max_count" >>$ieconf
 
 
+absdir=$(readlink -f $dir)
 
 for n in $(seq $nj); do
   # This will do nothing unless the directory $dir/storage exists;
@@ -118,7 +118,7 @@ if [ $stage -le 0 ]; then
   $cmd JOB=1:$nj $dir/log/extract_ivectors.JOB.log \
      ivector-extract-online2 --config=$ieconf ark:$sdata/JOB/spk2utt scp:$sdata/JOB/feats.scp ark:- \| \
      copy-feats --compress=$compress ark:- \
-      ark,scp:$dir/ivector_online.JOB.ark,$dir/ivector_online.JOB.scp || exit 1;
+      ark,scp:$absdir/ivector_online.JOB.ark,$absdir/ivector_online.JOB.scp || exit 1;
 fi
 
 if [ $stage -le 1 ]; then

--- a/egs/wsj/s5/steps/online/nnet2/extract_ivectors_online.sh
+++ b/egs/wsj/s5/steps/online/nnet2/extract_ivectors_online.sh
@@ -44,7 +44,7 @@ max_count=0         # The use of this option (e.g. --max-count 100) can make
 
 # End configuration section.
 
-echo "$0 $@"  # Print the command line for loggdir
+echo "$0 $@"  # Print the command line for logging
 if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 


### PR DESCRIPTION
the ivectors scp files weren't using the proper absolute filenames/paths