### PR TITLE
Added AddMatMatBatched code

### DIFF
--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -69,15 +69,19 @@ template<typename Real> void TestCuMatrixMatMatBatched(int32 dim, int32 batchCou
     c[i] = new CuMatrix<Real>(dim, dim);
     a[i]->SetRandn();
     b[i]->SetRandn();
-    A.push_back(new CuSubMatrix<Real>(*(a[i]),0,a[i]->NumRows(),0,a[i]->NumCols()));
-    B.push_back(new CuSubMatrix<Real>(*(b[i]),0,b[i]->NumRows(),0,b[i]->NumCols()));
-    C.push_back(new CuSubMatrix<Real>(*(c[i]),0,c[i]->NumRows(),0,c[i]->NumCols()));
+    A.push_back(new CuSubMatrix<Real>(*(a[i]), 0, a[i]->NumRows(), 0, 
+			    a[i]->NumCols()));
+    B.push_back(new CuSubMatrix<Real>(*(b[i]), 0, b[i]->NumRows(), 0, 
+			    b[i]->NumCols()));
+    C.push_back(new CuSubMatrix<Real>(*(c[i]), 0, c[i]->NumRows(), 0, 
+			    c[i]->NumCols()));
   }
   BaseFloat time_in_secs = 0.025;
   Timer tim;
   int32 iter = 0;
   for (;tim.Elapsed() < time_in_secs; iter++) {
-    AddMatMatBatched(static_cast<Real>(1.0), C, A, kNoTrans, B, kNoTrans, static_cast<Real>(0.0));
+    AddMatMatBatched(static_cast<Real>(1.0), C, A, kNoTrans, B, kNoTrans, 
+		    static_cast<Real>(0.0));
   }
   for (int32 i = 0; i< batchCount; i++) {
     delete a[i]; delete b[i]; delete c[i];

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1274,6 +1274,63 @@ static void UnitTestCuMatrixAddMatMat() {
 }
 
 
+template<typename Real>
+static void UnitTestCuMatrixAddMatMatBatched() {
+  const int32 batchCount = 10;
+  std::vector<Matrix<Real>* > Ha(batchCount), Hb(batchCount), Hc1(batchCount), Hc2(batchCount);
+  std::vector<CuMatrix<Real>* > Da(batchCount), Db(batchCount), Dc1(batchCount), Dc2(batchCount);
+  std::vector<SubMatrix<Real>* > HA, HB, HC1, HC2;
+  std::vector<CuSubMatrix<Real>* > DA, DB, DC1, DC2;
+  
+  for (int32 i = 0; i < batchCount; i++) {
+    // first create a Matrix intance and then creat a SubMatrix instance from that
+    Ha[i] = new Matrix<Real>(200,100);
+    Hb[i] = new Matrix<Real>(100,200);
+    Hc1[i] = new Matrix<Real>(200,200);
+    Hc2[i] = new Matrix<Real>(100,100);
+    Ha[i]->SetRandn();
+    Hb[i]->SetRandn();
+    HA.push_back(new SubMatrix<Real>(*(Ha[i]),0,Ha[i]->NumRows(),0,Ha[i]->NumCols()));
+    HB.push_back(new SubMatrix<Real>(*(Hb[i]),0,Hb[i]->NumRows(),0,Hb[i]->NumCols()));
+    HC1.push_back(new SubMatrix<Real>(*(Hc1[i]),0,Hc1[i]->NumRows(),0,Hc1[i]->NumCols()));
+    HC2.push_back(new SubMatrix<Real>(*(Hc2[i]),0,Hc2[i]->NumRows(),0,Hc2[i]->NumCols()));
+
+    // first create a CuMatrix intance and then creat a CuSubMatrix instance from that
+    Da[i] = new CuMatrix<Real>(200,100);
+    Db[i] = new CuMatrix<Real>(100,200);
+    Dc1[i] = new CuMatrix<Real>(200,200);
+    Dc2[i] = new CuMatrix<Real>(100,100);
+    Da[i]->CopyFromMat(*(Ha[i]));
+    Db[i]->CopyFromMat(*(Hb[i]));
+    DA.push_back(new CuSubMatrix<Real>(*(Da[i]),0,Da[i]->NumRows(),0,Da[i]->NumCols()));
+    DB.push_back(new CuSubMatrix<Real>(*(Db[i]),0,Db[i]->NumRows(),0,Db[i]->NumCols()));
+    DC1.push_back(new CuSubMatrix<Real>(*(Dc1[i]),0,Dc1[i]->NumRows(),0,Dc1[i]->NumCols()));
+    DC2.push_back(new CuSubMatrix<Real>(*(Dc2[i]),0,Dc2[i]->NumRows(),0,Dc2[i]->NumCols()));
+  }
+
+  AddMatMatBatched(static_cast<Real>(0.5f),DC1,DA,kNoTrans,DB,kNoTrans,static_cast<Real>(0.0f));
+  AddMatMatBatched(static_cast<Real>(0.5f),DC2,DA,kTrans,DB,kTrans,static_cast<Real>(0.0f));
+
+  // used to store results from DC1 and DC2 for equality check
+  Matrix<Real> Hca1(200,200);
+  Matrix<Real> Hca2(100,100);
+
+  // equality check
+  for (int32 i = 0; i< batchCount; i++) {
+    (*HC1[i]).AddMatMat(0.5f, *(HA[i]),kNoTrans,*(HB[i]),kNoTrans,0.0f);
+    (*HC2[i]).AddMatMat(0.5f, *(HA[i]),kTrans,*(HB[i]),kTrans,0.0f);
+    DC1[i]->CopyToMat(&Hca1);
+    DC2[i]->CopyToMat(&Hca2);
+    AssertEqual(*(HC1[i]),Hca1);
+    AssertEqual(*(HC2[i]),Hca2);
+    delete Ha[i]; delete Hb[i]; delete Hc1[i]; delete Hc2[i];
+    delete HA[i]; delete HB[i]; delete HC1[i]; delete HC2[i];
+    delete Da[i]; delete Db[i]; delete Dc1[i]; delete Dc2[i];
+    delete DA[i]; delete DB[i]; delete DC1[i]; delete DC2[i];
+  }
+}
+
+
 template<typename Real> 
 static void UnitTestCuMatrixAddToDiag() {
   for (int32 i = 0; i < 10; i++) {
@@ -2313,6 +2370,7 @@ template<typename Real> void CudaMatrixUnitTest() {
   UnitTestCuMatrixAddVecToRows<Real>();
   UnitTestCuMatrixAddMatMat<Real>();
   UnitTestCuMatrixSymAddMat2<Real>();
+  UnitTestCuMatrixAddMatMatBatched<Real>();
   UnitTestCuMatrixSymInvertPosDef<Real>();
   UnitTestCuMatrixCopyFromMat<Real>();
   UnitTestCuMatrixCopyFromTp<Real>();

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1284,32 +1284,42 @@ static void UnitTestCuMatrixAddMatMatBatched() {
   
   for (int32 i = 0; i < batchCount; i++) {
     // first create a Matrix intance and then creat a SubMatrix instance from that
-    Ha[i] = new Matrix<Real>(200,100);
-    Hb[i] = new Matrix<Real>(100,200);
-    Hc1[i] = new Matrix<Real>(200,200);
-    Hc2[i] = new Matrix<Real>(100,100);
+    Ha[i] = new Matrix<Real>(200, 100);
+    Hb[i] = new Matrix<Real>(100, 200);
+    Hc1[i] = new Matrix<Real>(200, 200);
+    Hc2[i] = new Matrix<Real>(100, 100);
     Ha[i]->SetRandn();
     Hb[i]->SetRandn();
-    HA.push_back(new SubMatrix<Real>(*(Ha[i]),0,Ha[i]->NumRows(),0,Ha[i]->NumCols()));
-    HB.push_back(new SubMatrix<Real>(*(Hb[i]),0,Hb[i]->NumRows(),0,Hb[i]->NumCols()));
-    HC1.push_back(new SubMatrix<Real>(*(Hc1[i]),0,Hc1[i]->NumRows(),0,Hc1[i]->NumCols()));
-    HC2.push_back(new SubMatrix<Real>(*(Hc2[i]),0,Hc2[i]->NumRows(),0,Hc2[i]->NumCols()));
+    HA.push_back(new SubMatrix<Real>(*(Ha[i]), 0, Ha[i]->NumRows(), 0, 
+			    Ha[i]->NumCols()));
+    HB.push_back(new SubMatrix<Real>(*(Hb[i]), 0, Hb[i]->NumRows(), 0, 
+			    Hb[i]->NumCols()));
+    HC1.push_back(new SubMatrix<Real>(*(Hc1[i]), 0, Hc1[i]->NumRows(), 0, 
+			    Hc1[i]->NumCols()));
+    HC2.push_back(new SubMatrix<Real>(*(Hc2[i]), 0, Hc2[i]->NumRows(), 0, 
+			    Hc2[i]->NumCols()));
 
     // first create a CuMatrix intance and then creat a CuSubMatrix instance from that
-    Da[i] = new CuMatrix<Real>(200,100);
-    Db[i] = new CuMatrix<Real>(100,200);
-    Dc1[i] = new CuMatrix<Real>(200,200);
-    Dc2[i] = new CuMatrix<Real>(100,100);
+    Da[i] = new CuMatrix<Real>(200, 100);
+    Db[i] = new CuMatrix<Real>(100, 200);
+    Dc1[i] = new CuMatrix<Real>(200, 200);
+    Dc2[i] = new CuMatrix<Real>(100, 100);
     Da[i]->CopyFromMat(*(Ha[i]));
     Db[i]->CopyFromMat(*(Hb[i]));
-    DA.push_back(new CuSubMatrix<Real>(*(Da[i]),0,Da[i]->NumRows(),0,Da[i]->NumCols()));
-    DB.push_back(new CuSubMatrix<Real>(*(Db[i]),0,Db[i]->NumRows(),0,Db[i]->NumCols()));
-    DC1.push_back(new CuSubMatrix<Real>(*(Dc1[i]),0,Dc1[i]->NumRows(),0,Dc1[i]->NumCols()));
-    DC2.push_back(new CuSubMatrix<Real>(*(Dc2[i]),0,Dc2[i]->NumRows(),0,Dc2[i]->NumCols()));
+    DA.push_back(new CuSubMatrix<Real>(*(Da[i]), 0, Da[i]->NumRows(), 0, 
+			    Da[i]->NumCols()));
+    DB.push_back(new CuSubMatrix<Real>(*(Db[i]), 0, Db[i]->NumRows(), 0, 
+			    Db[i]->NumCols()));
+    DC1.push_back(new CuSubMatrix<Real>(*(Dc1[i]), 0, Dc1[i]->NumRows(), 0, 
+			    Dc1[i]->NumCols()));
+    DC2.push_back(new CuSubMatrix<Real>(*(Dc2[i]), 0, Dc2[i]->NumRows(), 0, 
+			    Dc2[i]->NumCols()));
   }
 
-  AddMatMatBatched(static_cast<Real>(0.5f),DC1,DA,kNoTrans,DB,kNoTrans,static_cast<Real>(0.0f));
-  AddMatMatBatched(static_cast<Real>(0.5f),DC2,DA,kTrans,DB,kTrans,static_cast<Real>(0.0f));
+  AddMatMatBatched(static_cast<Real>(0.5f), DC1, DA, kNoTrans, DB, kNoTrans, 
+		  static_cast<Real>(0.0f));
+  AddMatMatBatched(static_cast<Real>(0.5f), DC2, DA, kTrans, DB, kTrans, 
+		  static_cast<Real>(0.0f));
 
   // used to store results from DC1 and DC2 for equality check
   Matrix<Real> Hca1(200,200);
@@ -1317,12 +1327,12 @@ static void UnitTestCuMatrixAddMatMatBatched() {
 
   // equality check
   for (int32 i = 0; i< batchCount; i++) {
-    (*HC1[i]).AddMatMat(0.5f, *(HA[i]),kNoTrans,*(HB[i]),kNoTrans,0.0f);
-    (*HC2[i]).AddMatMat(0.5f, *(HA[i]),kTrans,*(HB[i]),kTrans,0.0f);
+    (*HC1[i]).AddMatMat(0.5f, *(HA[i]), kNoTrans, *(HB[i]), kNoTrans, 0.0f);
+    (*HC2[i]).AddMatMat(0.5f, *(HA[i]), kTrans, *(HB[i]), kTrans, 0.0f);
     DC1[i]->CopyToMat(&Hca1);
     DC2[i]->CopyToMat(&Hca2);
-    AssertEqual(*(HC1[i]),Hca1);
-    AssertEqual(*(HC2[i]),Hca2);
+    AssertEqual(*(HC1[i]), Hca1);
+    AssertEqual(*(HC2[i]), Hca2);
     delete Ha[i]; delete Hb[i]; delete Hc1[i]; delete Hc2[i];
     delete HA[i]; delete HB[i]; delete HC1[i]; delete HC2[i];
     delete Da[i]; delete Db[i]; delete Dc1[i]; delete Dc2[i];

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1700,6 +1700,96 @@ double TraceMatMat(const CuMatrixBase<double> &A,
                    const CuMatrixBase<double> &B,
                    MatrixTransposeType trans);
 
+template<typename Real>
+void AddMatMatBatched(const Real alpha, std::vector<CuSubMatrix<Real>* > &C,
+		const std::vector<CuSubMatrix<Real>* > &A, MatrixTransposeType transA,
+		const std::vector<CuSubMatrix<Real>* > &B, MatrixTransposeType transB,
+		const Real beta) {
+    // the batch counts should be the same	
+    int32 batchCountA = static_cast<int32>(A.size()), batchCountB = static_cast<int32>(B.size()), batchCountC = static_cast<int32>(C.size());
+    KALDI_ASSERT((batchCountA == batchCountB) && (batchCountB == batchCountC));
+    int32 batchCount = batchCountA;
+
+    if (batchCount == 0) return;
+    
+    // all elements must have the same num-rows, num-cols and stride
+    for (int32 i = 0; i < batchCount-1; i++) {
+      KALDI_ASSERT(A[i]->NumRows() == A[i+1]->NumRows());
+      KALDI_ASSERT(A[i]->NumCols() == A[i+1]->NumCols());
+      KALDI_ASSERT(A[i]->Stride() == A[i+1]->Stride());
+      KALDI_ASSERT(B[i]->NumRows() == B[i+1]->NumRows());
+      KALDI_ASSERT(B[i]->NumCols() == B[i+1]->NumCols());
+      KALDI_ASSERT(B[i]->Stride() == B[i+1]->Stride());
+      KALDI_ASSERT(C[i]->NumRows() == C[i+1]->NumRows());
+      KALDI_ASSERT(C[i]->NumCols() == C[i+1]->NumCols());
+      KALDI_ASSERT(C[i]->Stride() == C[i+1]->Stride());
+    }
+    // CUBLAS is col-major, cudamatrix is row-major, how to do the mapping?
+    // keep trans..., just swap A&B matrices: A->B B->A
+    MatrixIndexT m = ((transB==kTrans)? B[0]->NumRows() : B[0]->NumCols()); 
+    MatrixIndexT n = ((transA==kTrans)? A[0]->NumCols() : A[0]->NumRows());
+    MatrixIndexT k = ((transB==kTrans)? B[0]->NumCols() : B[0]->NumRows());
+    MatrixIndexT k1 = ((transA==kTrans)? A[0]->NumRows() : A[0]->NumCols());
+
+    KALDI_ASSERT(m == C[0]->NumCols());
+    KALDI_ASSERT(n == C[0]->NumRows());
+    KALDI_ASSERT(k == k1);
+
+    if (m == 0) return;
+
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    // place all data (A[batchCount], B[batchCount], C[batchCount]) in memory together
+    // in order to make only one call of cudaMemcpy 	  
+    Real **device_abc_array = (Real**)CuDevice::Instantiate().Malloc(3*batchCount*sizeof(Real*));
+    const Real **device_a_array = const_cast<const Real**>(device_abc_array); 
+    const Real **device_b_array = const_cast<const Real**>(device_abc_array) + batchCount;
+    Real **device_c_array = device_abc_array + 2 * batchCount;
+    const Real **host_abc_array = new const Real*[3*batchCount];
+    const Real **host_a_array = host_abc_array; 
+    const Real **host_b_array = host_abc_array + batchCount; 
+    const Real **host_c_array = host_abc_array + 2 * batchCount; 
+    
+    for (int32 i = 0; i < batchCount; i++) {
+      host_a_array[i] = A[i]->data_;
+      host_b_array[i] = B[i]->data_;
+      host_c_array[i] = C[i]->data_;
+    }
+
+    CU_SAFE_CALL(cudaMemcpy(device_abc_array, host_abc_array, 3*batchCount*sizeof(Real*), cudaMemcpyHostToDevice));
+
+    Timer tim;
+    CU_SAFE_CALL(cublas_gemmBatched(GetCublasHandle(),
+			    (transB==kTrans? CUBLAS_OP_T:CUBLAS_OP_N),
+			    (transA==kTrans? CUBLAS_OP_T:CUBLAS_OP_N), 
+			    m, n, k, alpha, device_b_array, B[0]->Stride(), 
+			    device_a_array, A[0]->Stride(),beta, 
+			    device_c_array,C[0]->Stride(), batchCount));
+
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+
+    CuDevice::Instantiate().Free(device_abc_array);
+    delete[] host_abc_array;
+  } else
+#endif
+  {
+    for (int32 i = 0; i< batchCount; i++) {
+      C[i]->Mat().AddMatMat(alpha, A[i]->Mat(), transA, B[i]->Mat(), transB, beta);
+    }
+  }
+}
+
+template
+void AddMatMatBatched(const float alpha, std::vector<CuSubMatrix<float>* > &C,
+		const std::vector<CuSubMatrix<float>* > &A, MatrixTransposeType transA,
+		const std::vector<CuSubMatrix<float>* > &B, MatrixTransposeType transB,
+		const float beta);
+
+template
+void AddMatMatBatched(const double alpha, std::vector<CuSubMatrix<double>* > &C,
+		const std::vector<CuSubMatrix<double>* > &A, MatrixTransposeType transA,
+		const std::vector<CuSubMatrix<double>* > &B, MatrixTransposeType transB,
+		const double beta);
 
 template<typename Real>
 void CuMatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -27,6 +27,7 @@
 #define KALDI_CUDAMATRIX_CU_MATRIX_H_
 
 #include <sstream>
+#include <vector>
 
 #include "cudamatrix/cu-matrixdim.h"
 #include "cudamatrix/cu-common.h"
@@ -43,6 +44,13 @@ namespace kaldi {
 template<typename Real>
 Real TraceMatMat(const CuMatrixBase<Real> &A, const CuMatrixBase<Real> &B,
                  MatrixTransposeType trans = kNoTrans);
+
+template<typename Real>
+void AddMatMatBatched(const Real alpha, std::vector<CuSubMatrix<Real>* > &C,
+		const std::vector<CuSubMatrix<Real>* > &A, MatrixTransposeType transA,
+		const std::vector<CuSubMatrix<Real>* > &B, MatrixTransposeType transB,
+		const Real beta);
+
 /**
  * Matrix for CUDA computing.
  * Does the computation on the CUDA card when CUDA is compiled in and
@@ -170,6 +178,11 @@ class CuMatrixBase {
   friend Real TraceMatSmat<Real>(const CuMatrixBase<Real> &A,
                                  const CuSparseMatrix<Real> &B,
                                  MatrixTransposeType trans);
+
+  friend void AddMatMatBatched<Real>(const Real alpha, std::vector<CuSubMatrix<Real>* > &C,
+		const std::vector<CuSubMatrix<Real>* > &A, MatrixTransposeType transA,
+		const std::vector<CuSubMatrix<Real>* > &B, MatrixTransposeType transB,
+		const Real beta);
 
   /// Adds "value" to the diagonal elements of the matrix.  The matrix
   /// *this does not have to be square.

--- a/src/cudamatrix/cublas-wrappers.h
+++ b/src/cudamatrix/cublas-wrappers.h
@@ -27,15 +27,27 @@ namespace kaldi {
 
 inline cublasStatus_t cublas_gemm(cublasHandle_t handle, cublasOperation_t transa, 
 		cublasOperation_t transb, int m, int n,int k, float alpha, 
-		const float *A, int lda,const float *B, int ldb, float beta, 
+		const float *A, int lda, const float *B, int ldb, float beta, 
 		float *C, int ldc) {
   return cublasSgemm_v2(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc);
 }
 inline cublasStatus_t cublas_gemm(cublasHandle_t handle, cublasOperation_t transa,
 	       	cublasOperation_t transb, int m, int n,int k, double alpha, 
-		const double *A, int lda,const double *B, int ldb, double beta, 
+		const double *A, int lda, const double *B, int ldb, double beta, 
 		double *C, int ldc) {
   return cublasDgemm_v2(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc);
+}
+inline cublasStatus_t cublas_gemmBatched(cublasHandle_t handle, cublasOperation_t transa,
+	       	cublasOperation_t transb, int m, int n, int k, float alpha,
+		const float *A[], int lda, const float *B[], int ldb, float beta,
+		float *C[], int ldc, int batchCount) {
+  return cublasSgemmBatched(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc,batchCount); 
+}
+inline cublasStatus_t cublas_gemmBatched(cublasHandle_t handle, cublasOperation_t transa,
+	       	cublasOperation_t transb, int m, int n, int k, double alpha,
+		const double *A[], int lda, const double *B[], int ldb, double beta,
+		double *C[], int ldc, int batchCount) {
+  return cublasDgemmBatched(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc,batchCount); 
 }
 inline cublasStatus_t cublas_trsm(cublasHandle_t handle, int m, int n, float alpha,
 	       	const float* A, int lda, float* B, int ldb) {

--- a/src/cudamatrix/cublas-wrappers.h
+++ b/src/cudamatrix/cublas-wrappers.h
@@ -41,13 +41,13 @@ inline cublasStatus_t cublas_gemmBatched(cublasHandle_t handle, cublasOperation_
 	       	cublasOperation_t transb, int m, int n, int k, float alpha,
 		const float *A[], int lda, const float *B[], int ldb, float beta,
 		float *C[], int ldc, int batchCount) {
-  return cublasSgemmBatched(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc,batchCount); 
+  return cublasSgemmBatched(handle, transa, transb, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc, batchCount); 
 }
 inline cublasStatus_t cublas_gemmBatched(cublasHandle_t handle, cublasOperation_t transa,
 	       	cublasOperation_t transb, int m, int n, int k, double alpha,
 		const double *A[], int lda, const double *B[], int ldb, double beta,
 		double *C[], int ldc, int batchCount) {
-  return cublasDgemmBatched(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc,batchCount); 
+  return cublasDgemmBatched(handle, transa, transb, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc, batchCount); 
 }
 inline cublasStatus_t cublas_trsm(cublasHandle_t handle, int m, int n, float alpha,
 	       	const float* A, int lda, float* B, int ldb) {


### PR DESCRIPTION
The batched AddMatMat function passed my test code.
 
Issues possibly needed to investigate:
1. Real ** cannot been converted to const Real ** when calling cublas_gemmBatched(). Currently I use const_cast at line 1761 in cu-matix.cc.
2. 0.5f and 0.0f cannot be automatically casted to type double as its counterpart in UnitTestCuMatrixAddMatMat(). Currently I use static_cast at line 1311 in cu-matrix-test.cc

valgrind shows there is 0 definite losts on both cu-matrix-test and cu-matrix-speed-test

The speed test shows the speed boosting of using GPU over CPU:
for CPU:
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 16, batchSize = 10, speed was 0.017399 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 32, batchSize = 10, speed was 0.0493568 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 64, batchSize = 10, speed was 0.0557112 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 128, batchSize = 10, speed was 0.0564673 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 256, batchSize = 10, speed was 0.0572283 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 512, batchSize = 10, speed was 0.0598009 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 1024, batchSize = 10, speed was 0.0606233 gigaflops.
for GPU:
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 16, batchSize = 10, speed was 0.0190346 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 32, batchSize = 10, speed was 0.312882 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 64, batchSize = 10, speed was 2.31153 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 128, batchSize = 10, speed was 10.5593 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 256, batchSize = 10, speed was 3.10337 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 512, batchSize = 10, speed was 28.5466 gigaflops.
LOG (TestCuMatrixMatMatBatched():cu-matrix-speed-test.cc:89) For CuMatrix::AddMatMatBatched<double>, for dim = 1024, batchSize = 10, speed was 40.4558 gigaflops.