### PR TITLE
Limit deriv times

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -213,8 +213,6 @@ void CuDevice::FinalizeActiveGpu() {
     KALDI_LOG << "The active GPU is [" << act_gpu_id << "]: " << name << "\t"
               << GetFreeMemory(&free_memory_at_startup_, NULL) << " version "
               << properties_.major << "." << properties_.minor;
-
-    if (verbose_) PrintMemoryUsage();
   }
   return;
 }

--- a/src/nnet3/nnet-analyze.cc
+++ b/src/nnet3/nnet-analyze.cc
@@ -643,7 +643,7 @@ void ComputationChecker::CheckComputationMatrixAccesses() const {
         KALDI_ERR << "Input matrix is initialized.";
     } else {
       if (accesses.allocate_command == -1)
-        KALDI_ERR << "Matrix is not initialized.";
+        KALDI_ERR << "Matrix m" << matrix_index << "is not initialized.";
       if (accesses.accesses.empty()) {
         KALDI_ERR << "Matrix m" << matrix_index << " is never accessed.";
       } else if (accesses.accesses.front().command_index <
@@ -657,7 +657,7 @@ void ComputationChecker::CheckComputationMatrixAccesses() const {
         KALDI_ERR << "Output matrix is destroyed.";
     } else {
       if (accesses.deallocate_command == -1)
-        KALDI_ERR << "Matrix is not destroyed.";
+        KALDI_ERR << "Matrix m" << matrix_index << " is not destroyed.";
       if (accesses.accesses.empty()) {
         if (accesses.is_input) {
           // we allow there to be no accesses if it is an input, e.g. if an

--- a/src/nnet3/nnet-analyze.cc
+++ b/src/nnet3/nnet-analyze.cc
@@ -42,11 +42,17 @@ void ComputationVariables::ComputeSplitPoints(
     column_split_points_[s.matrix_index].push_back(s.col_offset + s.num_cols);
   }
   for (int32 matrix_index = 1; matrix_index < num_matrices; matrix_index++) {
+    // Because it's possible for matrices not to have any submatrices (after
+    // pruning), we need to make sure that the beginning and end dimensions are
+    // in the split points.
+    column_split_points_[matrix_index].push_back(0);
+    column_split_points_[matrix_index].push_back(
+        computation.matrices[matrix_index].num_cols);
+    row_split_points_[matrix_index].push_back(0);
+    row_split_points_[matrix_index].push_back(
+        computation.matrices[matrix_index].num_rows);
     SortAndUniq(&(column_split_points_[matrix_index]));
     SortAndUniq(&(row_split_points_[matrix_index]));
-    // should have at least 0 and num_rows included, so size >= 2.
-    KALDI_ASSERT(column_split_points_[matrix_index].size() >= 2 &&
-                 row_split_points_[matrix_index].size() >= 2);
   }
   // note: the last split point of each matrix doesn't get its own variable index.
   matrix_to_variable_index_.resize(num_matrices + 1);

--- a/src/nnet3/nnet-analyze.h
+++ b/src/nnet3/nnet-analyze.h
@@ -139,13 +139,13 @@ class ComputationVariables {
       AccessType access_type,
       CommandAttributes *ca) const;
 
-  /// Appends to variables_indexes the list of variables corresponding to a
-  /// matrix index.
+  /// Appends to variables_indexes the sorted list of variables corresponding to
+  /// a matrix index.
   void AppendVariablesForMatrix(
       int32 matrix_index,
       std::vector<int32> *variable_indexes) const;
 
-  // Appends to variable_indexes the list of variables corresponding to a
+  // Appends to variable_indexes the sorted list of variables corresponding to a
   // submatrix index.
   void AppendVariablesForSubmatrix(
       int32 submatrix_index,
@@ -155,6 +155,10 @@ class ComputationVariables {
   int32 NumVariables() const { return num_variables_; }
 
   int32 GetMatrixForVariable(int32 variable) const;
+
+  // returns a string that describes a variable in Matlab-like format (but with
+  // zero indexing): something like "m1" or "m1(0:99,:)" or "m1(0:19,10:49)"
+  std::string DescribeVariable(int32 variable) const;
 
  private:
   // sets up split_points_, matrix_to_variable_index_, and num_variables_.
@@ -211,8 +215,8 @@ class ComputationVariables {
 };
 
 
-// This struct records an access to a variable (i.e. a row range of a matrix) or
-// to a matrix.
+// This struct records an access to a variable (i.e. a row and column range of a
+// matrix).
 struct Access {
   int32 command_index;
   AccessType access_type;
@@ -252,7 +256,8 @@ struct MatrixAccesses {
   /// (read, read/write, write).  It will be sorted on command index with only
   /// one record per command.  Note: a write to only a part of the matrix
   /// (i.e. a submatrix that isn't the whole thing) will be recorded as an
-  /// access of type read/write.
+  /// access of type read/write.  An allocation with zeroing is recorded
+  /// as a write access.
   std::vector<Access> accesses;
   /// true if this matrix is an input to the computation (i.e. either an
   /// input-value or an output-deriv).
@@ -401,17 +406,8 @@ class ComputationChecker {
 };
 
 
-
-
-
-
-
-
-
-
 } // namespace nnet3
 } // namespace kaldi
 
 
 #endif
-

--- a/src/nnet3/nnet-analyze.h
+++ b/src/nnet3/nnet-analyze.h
@@ -254,9 +254,11 @@ struct MatrixAccesses {
   /// (i.e. a submatrix that isn't the whole thing) will be recorded as an
   /// access of type read/write.
   std::vector<Access> accesses;
-  /// true if this matrix is an input to the computation.
+  /// true if this matrix is an input to the computation (i.e. either an
+  /// input-value or an output-deriv).
   bool is_input;
-  /// true if this matrix is an output of the computation.
+  /// true if this matrix is an output of the computation (i.e. either an
+  /// output-value or an input-deriv).
   bool is_output;
   MatrixAccesses(): allocate_command(-1), deallocate_command(-1),
                     is_input(false), is_output(false) { }

--- a/src/nnet3/nnet-common.h
+++ b/src/nnet3/nnet-common.h
@@ -39,7 +39,7 @@ namespace nnet3 {
    of the member of the minibatch, 't', used for the frame index in speech
    recognition, and 'x', which is a catch-all extra index which we might use in
    convolutional setups or for other reasons.  It is possible to extend this by
-   adding new indexes if needed. 
+   adding new indexes if needed.
 */
 struct Index {
   int32 n;  // member-index of minibatch, or zero.
@@ -48,15 +48,15 @@ struct Index {
   // ... it is possible to add extra index here, if needed.
   Index(): n(0), t(0), x(0) { }
   Index(int32 n, int32 t, int32 x = 0): n(n), t(t), x(x) { }
-  
+
   bool operator == (const Index &a) const {
     return n == a.n && t == a.t && x == a.x;
   }
   bool operator < (const Index &a) const {
-    if (n < a.n) { return true; }
-    else if (n > a.n) { return false; }
-    else if (t < a.t) { return true; }
+    if (t < a.t) { return true; }
     else if (t > a.t) { return false; }
+    else if (n < a.n) { return true; }
+    else if (n > a.n) { return false; }
     else return (x < a.x);
   }
   Index operator + (const Index &other) const {

--- a/src/nnet3/nnet-computation.h
+++ b/src/nnet3/nnet-computation.h
@@ -157,25 +157,25 @@ struct ComputationRequest {
      from matrix indexed arg2 (using shallow swap), then zero the matrix
      we just allocated.
    - kPropagate: Forward computation of neural net, see Component::Propagate()
-   - arg1 is is component-index in neural net
-   - arg2 is index into ComponentPrecomputedIndexes (0 if NULL; always 0
-   for simple Components)
-   - arg3 is sub-matrix index of input
-   - arg4 is sub-matrix index of output
+     - arg1 is is component-index in neural net
+     - arg2 is index into ComponentPrecomputedIndexes (0 if NULL; always 0
+       for simple Components)
+     - arg3 is sub-matrix index of input
+     - arg4 is sub-matrix index of output
    - kStoreStats: Call Component::StoreStats() (used for computing diagnostics
-   such as average activations; called after Propagate).
-   - arg1 is component-index in neural net
-   - arg2 is sub-matrix index of the output of the Propagate function
+      such as average activations; called after Propagate).
+     - arg1 is component-index in neural net
+     - arg2 is sub-matrix index of the output of the Propagate function
    - kBackprop: Do the back-propagation operation, see Component::Backprop()
-   - arg1 is index of component in neural net
-   - arg2 is index into ComponentPrecomputedIndexes (0 if NULL; always 0
-   for simple Components)
-   - arg3 is submatrix-index of input value (input to Propagate()); 0 if unused
-   - arg4 is submatrix-index of output value (output of Propagate()); 0 if unused
-   - arg5 is submatrix-index of output derivative
-   - arg6 is submatrix-index of input derivative; 0 if unused.
+     - arg1 is index of component in neural net
+     - arg2 is index into ComponentPrecomputedIndexes (0 if NULL; always 0
+       for simple Components)
+     - arg3 is submatrix-index of input value (input to Propagate()); 0 if unused
+     - arg4 is submatrix-index of output value (output of Propagate()); 0 if unused
+     - arg5 is submatrix-index of output derivative
+     - arg6 is submatrix-index of input derivative; 0 if unused.
    - kBackpropNoModelUpdate: as kBackprop, but does not set the
-    'to_update' argument to the Backprop call, even if the model  is updatable,
+     'to_update' argument to the Backprop call, even if the model  is updatable,
      so it skips the model-update phase of backprop.
    - kMatrixCopy: Copy contents of sub-matrix arg2 to sub-matrix arg1
    - kMatrixAdd: Add contents of sub-matrix arg2 to sub-matrix arg1
@@ -184,18 +184,18 @@ struct ComputationRequest {
    - kAddRows: call \ref CuMatrix::AddRows() "AddRows()" on sub-matrix arg1
      with sub-matrix arg2 and indexes[arg3] as arguments.
    - kAddRowsMulti, kAddToRowsMulti, kCopyRowsMulti, kCopyToRowsMulti:
-   Call the corresponding function in class CuMatrix.
-   - arg1 is sub-matrix index of *this matrix in operation
-   - arg2 is index into "indexes_multi", of which each pair is
-   (sub-matrix index, row index) (or (-1,-1) for NULL marker), which
-   is turned into a vector of BaseFloat* (pointers to matrix rows)
-   before being given as the argument to the function.
+     Call the corresponding function in class CuMatrix.
+     - arg1 is sub-matrix index of *this matrix in operation
+     - arg2 is index into "indexes_multi", of which each pair is
+     (sub-matrix index, row index) (or (-1,-1) for NULL marker), which
+     is turned into a vector of BaseFloat* (pointers to matrix rows)
+     before being given as the argument to the function.
    - kAddRowRanges: call \ref CuMatrix::AddRowRanges() "AddRowRanges()"
-   on sub-matrix arg1, with arg2 as source matrix, and indexes given
-   indexes_ranges[arg3].
+     on sub-matrix arg1, with arg2 as source sub-matrix, and indexes given
+     indexes_ranges[arg3].
    - kNoOperation: does nothing (sometimes useful during optimization)
    - kNoOperationMarker: does nothing, but used to mark end of forward commands
-   (sometimes useful during optimization).
+     (sometimes useful during optimization).
 */
 enum CommandType {
   kAllocMatrixUndefined, kAllocMatrixZeroed,
@@ -321,7 +321,8 @@ struct NnetComputation {
   /// the submatrix of which we want a column and/or row range.  As a
   /// convenience, -1 for the 'num_rows' or the 'num_cols' will be interpreted
   /// as 'as much as possible'.  Returns the new sub-matrix index.  Writes to
-  /// 'this->submatrices'.
+  /// 'this->submatrices'.  There is no mechanism to stop duplicates from being
+  /// created, but calling RenumberComputation() will remove such duplicates.
   int32 NewSubMatrix(int32 base_submatrix,
                      int32 row_offset, int32 num_rows,
                      int32 col_offset, int32 num_cols);

--- a/src/nnet3/nnet-computation.h
+++ b/src/nnet3/nnet-computation.h
@@ -180,9 +180,9 @@ struct ComputationRequest {
    - kMatrixCopy: Copy contents of sub-matrix arg2 to sub-matrix arg1
    - kMatrixAdd: Add contents of sub-matrix arg2 to sub-matrix arg1
    - kCopyRows: call \ref CuMatrix::CopyRows() "CopyRows()" on sub-matrix arg1
-   with sub-matrix arg2 and indexes[arg3] as arguments.
+     with sub-matrix arg2 and indexes[arg3] as arguments.
    - kAddRows: call \ref CuMatrix::AddRows() "AddRows()" on sub-matrix arg1
-   with sub-matrix arg2 and indexes[arg3] as arguments.
+     with sub-matrix arg2 and indexes[arg3] as arguments.
    - kAddRowsMulti, kAddToRowsMulti, kCopyRowsMulti, kCopyToRowsMulti:
    Call the corresponding function in class CuMatrix.
    - arg1 is sub-matrix index of *this matrix in operation

--- a/src/nnet3/nnet-derivative-test.cc
+++ b/src/nnet3/nnet-derivative-test.cc
@@ -68,6 +68,13 @@ void SetDerivTimesOptions(const ComputationRequest &request,
     t_length = max_t + 1 - min_t;
     KALDI_ASSERT(t_length > 0);
   }
+  if (RandInt(0, 4) == 0) {
+    // ensure that all derivs will be pruned away;
+    // this tests more code.
+    min_t = orig_min_t - 10;
+    max_t = min_t + 1;
+  }
+
   int32 output_min_t, output_max_t;
   KALDI_ASSERT(request.outputs[0].name == "output");
   ComputeMinAndMaxTimes(request.outputs[0].indexes,

--- a/src/nnet3/nnet-derivative-test.cc
+++ b/src/nnet3/nnet-derivative-test.cc
@@ -28,16 +28,69 @@ namespace kaldi {
 namespace nnet3 {
 
 
+void ComputeMinAndMaxTimes(const std::vector<Index> &indexes,
+                           int32 *min_t,
+                           int32 *max_t) {
+  KALDI_ASSERT(!indexes.empty());
+  *min_t = indexes[0].t;
+  *max_t = *min_t;
+  for (int32 n = 1; n < static_cast<int32>(indexes.size()); n++) {
+    *min_t = std::min(*min_t, indexes[n].t);
+    *max_t = std::max(*max_t, indexes[n].t);
+  }
+}
+
+
+// This function is called if you want to set min_deriv_time and max_deriv_time.
+// It works out some meaningful values to set, based on the config.
+void SetDerivTimesOptions(const ComputationRequest &request,
+                          NnetOptimizeOptions *opt_config) {
+  int32 min_t, max_t;
+  KALDI_ASSERT(request.inputs[0].name == "input");
+  const std::vector<Index> &input_indexes = request.inputs[0].indexes;
+  ComputeMinAndMaxTimes(input_indexes, &min_t, &max_t);
+
+  int32 orig_min_t = min_t, orig_max_t = max_t;
+  int t_length = max_t + 1 - min_t;
+  KALDI_ASSERT(t_length > 0);
+  if (t_length == 1)
+    return;
+  if (RandInt(0, 2) == 0) {
+    // remove as much as 4 frames from the left (but don't remove everything).
+    min_t += std::min(4, RandInt(0, t_length - 1));
+    opt_config->min_deriv_time = min_t;
+    t_length = max_t + 1 - min_t;
+    KALDI_ASSERT(t_length > 0);
+  }
+  if (RandInt(0, 2) == 0) {
+    max_t -= std::min(4, RandInt(0, t_length - 1));
+    opt_config->max_deriv_time = max_t;
+    t_length = max_t + 1 - min_t;
+    KALDI_ASSERT(t_length > 0);
+  }
+  int32 output_min_t, output_max_t;
+  KALDI_ASSERT(request.outputs[0].name == "output");
+  ComputeMinAndMaxTimes(request.outputs[0].indexes,
+                        &output_min_t, &output_max_t);
+
+  KALDI_LOG << "ComputationRequest has output (min,max) = (" << output_min_t
+            << ',' << output_max_t << "), input (min,max) = (" << orig_min_t
+            << ',' << orig_max_t << "), limiting deriv times to ("
+            << opt_config->min_deriv_time << ','
+            << opt_config->max_deriv_time;
+}
+
 // This test makes sure that the model-derivatives are correct.
 void UnitTestNnetModelDerivatives() {
-  int32 num_tries = 20, num_success = 0;
+  int32 num_tries = 20, num_success = 0, num_fail = 0;
   for (int32 n = 0; n < num_tries; n++) {
     struct NnetGenerationOptions gen_config;
     //gen_config.allow_nonlinearity = false;
     //gen_config.allow_recursion = false;
     //gen_config.allow_final_nonlinearity = true;
     bool allow_optimization = true;
-    
+    bool limit_deriv_times = (RandInt(0, 2) == 0);
+
     std::vector<std::string> configs;
     GenerateConfigSequence(gen_config, &configs);
     Nnet nnet;
@@ -57,7 +110,7 @@ void UnitTestNnetModelDerivatives() {
     request.outputs[0].has_deriv = true;
     // whether input-derivatives are required or not does not matter,
     // so leave it as it is in that regard.
-    
+
     NnetComputation computation;
     Compiler compiler(request, nnet);
 
@@ -70,16 +123,22 @@ void UnitTestNnetModelDerivatives() {
     }
     CheckComputationOptions check_config;
     // we can do the rewrite check since it's before optimization.
-    check_config.check_rewrite = true;  
+    check_config.check_rewrite = true;
     ComputationChecker checker(check_config, nnet, request, computation);
     checker.Check();
-    
+
     if (RandInt(0, 3) != 0 && allow_optimization) {
       NnetOptimizeOptions opt_config;
+      if (limit_deriv_times)
+        SetDerivTimesOptions(request, &opt_config);
+
       Optimize(opt_config, nnet, request, &computation);
       std::ostringstream os;
       computation.Print(os, nnet);
       KALDI_LOG << "Optimized computation is: " << os.str();
+      check_config.check_rewrite = false;
+      ComputationChecker checker_opt(check_config, nnet, request, computation);
+      checker_opt.Check();
     }
 
     NnetComputeOptions compute_opts;
@@ -92,7 +151,7 @@ void UnitTestNnetModelDerivatives() {
     bool is_gradient = true;
     SetZero(is_gradient, &nnet_deriv);  // forces "simple" update and unit
                                         // learning rate.
-    
+
     int32 num_directions = 4;  // must be >= 1.  Best if it's >1, will reduce
                                // the probability of random failures.
 
@@ -130,10 +189,10 @@ void UnitTestNnetModelDerivatives() {
         CuMatrix<BaseFloat> temp(inputs[i]);
         computer.AcceptInput(request.inputs[i].name, &temp);
       }
-      
+
       KALDI_LOG << "Running forward computation";
       computer.Forward();
-      
+
       const CuMatrixBase<BaseFloat> &output(computer.GetOutput("output"));
       KALDI_LOG << "Output sum for pass " << pass << " is " << output.Sum();
       BaseFloat objf = TraceMatMat(output, output_deriv, kTrans);
@@ -153,7 +212,7 @@ void UnitTestNnetModelDerivatives() {
                                       DotProduct(nnet, nnet_deriv);
       }
     }
-    
+
     Vector<BaseFloat> predicted_objf_change_vec(num_directions),
         measured_objf_change_vec(num_directions);
     for (int32 d = 0; d < num_directions; d++) {
@@ -167,16 +226,23 @@ void UnitTestNnetModelDerivatives() {
     KALDI_LOG << "Vector of measured objf-change is: "
               << measured_objf_change_vec;
     BaseFloat delta_thresh = 0.05;
-    if (!ApproxEqual(predicted_objf_change_vec,
-                     measured_objf_change_vec, delta_thresh)) {
-      KALDI_WARN << "Predicted and measured objf-changes differ too much.";
+    if (limit_deriv_times) {
+      KALDI_LOG << "Not checking that predicted/measured changes matched "
+                << "because we limited times of derivatives.";
     } else {
-      num_success++;
+      if (!ApproxEqual(predicted_objf_change_vec,
+                       measured_objf_change_vec, delta_thresh)) {
+        KALDI_WARN << "Predicted and measured objf-changes differ too much.";
+        num_fail++;
+      } else {
+        num_success++;
+      }
     }
   }
   KALDI_LOG << "Model-derivative check succeeded for " << num_success << " out of "
-            << num_tries << " tries.";
-  if (num_success < num_tries - (2 + num_tries / 5))
+            << (num_fail + num_success) << " tries.";
+  int32 num_checked = num_fail + num_success;
+  if (num_success < num_checked - (2 + num_checked / 5))
     KALDI_ERR << "Failed too many times.";
 }
 
@@ -190,7 +256,7 @@ void UnitTestNnetInputDerivatives() {
     //gen_config.allow_recursion = false;
     //gen_config.allow_final_nonlinearity = true;
     bool allow_optimization = true;
-    
+
     std::vector<std::string> configs;
     GenerateConfigSequence(gen_config, &configs);
     Nnet nnet;
@@ -210,7 +276,7 @@ void UnitTestNnetInputDerivatives() {
     for (int32 i = 0; i < request.inputs.size(); i++)
       request.inputs[i].has_deriv = true;
     request.outputs[0].has_deriv = true;
-    
+
     NnetComputation computation;
     Compiler compiler(request, nnet);
 
@@ -223,12 +289,13 @@ void UnitTestNnetInputDerivatives() {
     }
     CheckComputationOptions check_config;
     // we can do the rewrite check since it's before optimization.
-    check_config.check_rewrite = true;  
+    check_config.check_rewrite = true;
     ComputationChecker checker(check_config, nnet, request, computation);
     checker.Check();
-    
+
     if (RandInt(0, 3) != 0 && allow_optimization) {
       NnetOptimizeOptions opt_config;
+      // opt_config.initialize_undefined = false;  // temp
       Optimize(opt_config, nnet, request, &computation);
       std::ostringstream os;
       computation.Print(os, nnet);
@@ -274,7 +341,7 @@ void UnitTestNnetInputDerivatives() {
     // pass num_directions + 1.
     // Other passes are with various differently-perturbed versions of
     // the features.
-    for (int32 pass = 0; pass <= num_directions + 1; pass++) {  
+    for (int32 pass = 0; pass <= num_directions + 1; pass++) {
       // provide the input to the computations.
       for (size_t i = 0; i < request.inputs.size(); i++) {
         CuMatrix<BaseFloat> temp(inputs[i]);
@@ -296,7 +363,7 @@ void UnitTestNnetInputDerivatives() {
 
       KALDI_LOG << "Running forward computation";
       computer.Forward();
-      
+
       const CuMatrixBase<BaseFloat> &output(computer.GetOutput("output"));
       KALDI_LOG << "Output sum for pass " << pass << " is " << output.Sum();
       BaseFloat objf = TraceMatMat(output, output_deriv, kTrans);
@@ -317,7 +384,7 @@ void UnitTestNnetInputDerivatives() {
     }
     KALDI_ASSERT(ApproxEqual(measured_objf[0],
                              measured_objf[num_directions + 1]));
-    
+
     Vector<BaseFloat> predicted_objf_change_vec(num_directions),
         measured_objf_change_vec(num_directions);
     for (int32 d = 0; d < num_directions; d++) {

--- a/src/nnet3/nnet-optimize-test.cc
+++ b/src/nnet3/nnet-optimize-test.cc
@@ -172,6 +172,12 @@ static bool UnitTestNnetOptimizeWithOptions(NnetOptimizeOptions opt_config) {
 // the outputs are the same.
 static void UnitTestNnetOptimize() {
   NnetOptimizeOptions optimize_all;
+  // randomly sometimes set min_deriv and max_deriv to small/large values,
+  // which will cause some of the LimitDerivativeTimes() code to be called
+  // (without really changing anything).
+  if (RandInt(0, 3) == 0) optimize_all.min_deriv_time = -200;
+  if (RandInt(0, 3) == 0) optimize_all.max_deriv_time = 1000;
+
   // this is useful for debugging as it removes nans:
   // optimize_all.initialize_undefined = false;
   bool success = UnitTestNnetOptimizeWithOptions(optimize_all);

--- a/src/nnet3/nnet-optimize-utils.h
+++ b/src/nnet3/nnet-optimize-utils.h
@@ -347,7 +347,7 @@ class ComputationRenumberer {
   /// number of elements of 'used' that were true.
   static int32 CreateRenumbering(const std::vector<bool> &used,
                                  std::vector<int32> *renumbering);
-  
+
   // vector of bool indexed by original submatrix-index, that is true if a
   // submatrix-index is used somewhere in the computation (always true for
   // the zeroth element).
@@ -385,14 +385,14 @@ class DerivativeTimeLimiter {
                         NnetComputation *computation);
 
   void LimitDerivTimes();
-  
+
  private:
 
   // This command ensures that for each matrix m there is a corresponding
   // submatrix that spans the entire matrix, and stores its index in
   // entire_submatrix_[m].
   void EnsureMatricesHaveEntireSubmatrices();
-  
+
   // sets up matrix_prune_info_.
   void ComputeMatrixPruneInfo();
 
@@ -409,7 +409,7 @@ class DerivativeTimeLimiter {
   // we can actually limit their extent in time, and changes the way the
   // matrices are allocated (it may remove some matrices entirely).
   void PruneMatrices();
-  
+
   // called from PruneMatrices only for matrices that are derivatives,
   // not inputs or outputs of the computation, and which are partly
   // inside the time range, this function returns true if we can
@@ -417,12 +417,12 @@ class DerivativeTimeLimiter {
   // desired range are never accessed), and false otherwise.
   inline bool CanLimitMatrix(const Analyzer &analyzer,
                              int32 matrix_index) const;
-  
+
   // called from PruneMatrices after it has figured out which matrices we need
   // to limit to a row-range, this function changes computation->submatrices and
   // computation->matrices in the way required to do that.
   inline void LimitMatrices(const std::vector<bool> &will_limit);
-   
+
   // does the processing for a command of type kMatrixCopy or kMatrixAdd.
   void MapSimpleMatrixCommand(NnetComputation::Command *c);
 
@@ -436,7 +436,7 @@ class DerivativeTimeLimiter {
   // command is called with, and 2nd arg is 'indexes_multi' index (which
   // contains pairs (source-submatrix, source-row).
   void MapIndexesMultiCommand(NnetComputation::Command *c);
-  
+
   // does the processing for a command of type kAddRowRanges.
   void MapAddRowRangesCommand(NnetComputation::Command *c);
 
@@ -448,7 +448,7 @@ class DerivativeTimeLimiter {
   // Note: this calls computation_->NewSubMatrix, and will generate duplicates
   // of the same submatrix which we'll later remove in RemoveOrphanMatrices.
   void ModifyCommand(NnetComputation::Command *command);
-  
+
   // this will detect which matrices we can reduce the allocated size of,
   // and reduce their size.
   void ResizeMatrices();
@@ -476,12 +476,12 @@ class DerivativeTimeLimiter {
                       // the time range.
   };
 
-  
+
   const Nnet &nnet_;
 
   int32 min_deriv_time_;
   int32 max_deriv_time_;
-  
+
   // the computation; we require it to have debug info set up
   // (otherwise you shouldn't be instantiating this class).
   NnetComputation *computation_;
@@ -491,7 +491,7 @@ class DerivativeTimeLimiter {
   std::vector<int32> entire_submatrix_;
 
   std::vector<MatrixPruneInfo> matrix_prune_info_;
-  
+
   // for each submatrix in the original range of computation_->submatrices,
   // submatrix_map_ maps it to itself if the submatrix is completely inside the
   // time-range, or to zero if it's completely outside the time-range, or to a
@@ -504,8 +504,8 @@ class DerivativeTimeLimiter {
   // debug info) represents a derivative.
   // this comes up so frequently that storing it separately seemed like a good idea.
   std::vector<int32> submatrix_map_if_deriv_;
-  
-  std::vector<MatrixPruneInfo> prune_info_;   
+
+  std::vector<MatrixPruneInfo> prune_info_;
 };
 
 // This is the top-level interface to limit the times on which derivatives are
@@ -585,10 +585,13 @@ void IdentifyMatrixArgs(std::vector<NnetComputation::Command> *command,
 
 /// This function outputs to "matrix_args" the addresses of indexes inside
 /// 'computation' that correspond to matrices.  These live inside
-/// computation->commands, computation->submatrices, and
-/// computation->input_output_info.  Zeros may be present if there were optional
-/// arguments; we do include pointers to them, but you can just ignore them.
-void IdentifyMatrixArgsInComputation(NnetComputation *computation,
+/// computation->commands and computation->input_output_info; and if
+/// 'include_from_submatrices' is true, then the matrix-indexes present in
+/// computation->submatrices[*].matrix_index will be included too.  Zeros may be
+/// present if there were optional arguments; we do include pointers to them,
+/// but you can just ignore them.
+void IdentifyMatrixArgsInComputation(bool include_from_submatrices,
+                                     NnetComputation *computation,
                                      std::vector<int32*> *matrix_args);
 
 

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -258,7 +258,7 @@ void GenerateConfigSequenceRnnClockwork(
         "input=Sum(affine1_node, IfDefined(recurrent_affine1))\n";
   os << "component-node name=final_affine_0 component=final_affine_0 input=nonlin1\n";
   os << "component-node name=final_affine_1 component=final_affine_1 input=Offset(nonlin1, -1)\n";
-  os << "component-node name=final_affine_2 component=final_affine_1 input=Offset(nonlin1, 1)\n";
+  os << "component-node name=final_affine_2 component=final_affine_2 input=Offset(nonlin1, 1)\n";
   os << "component-node name=output_nonlin component=logsoftmax input=Switch(final_affine_0, final_affine_1, final_affine_2)\n";
   os << "output-node name=output input=output_nonlin\n";
   configs->push_back(os.str());

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -37,11 +37,11 @@ void GenerateConfigSequenceSimplest(
   int32 input_dim = 10 + Rand() % 20,
        output_dim = 100 + Rand() % 200;
 
-  
+
   os << "component name=affine1 type=AffineComponent input-dim="
      << input_dim << " output-dim=" << output_dim << std::endl;
 
-  os << "input-node name=input dim=" << input_dim << std::endl;  
+  os << "input-node name=input dim=" << input_dim << std::endl;
   os << "component-node name=affine1_node component=affine1 input=input\n";
   os << "output-node name=output input=affine1_node\n";
   configs->push_back(os.str());
@@ -59,7 +59,7 @@ void GenerateConfigSequenceSimpleContext(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
        output_dim = 100 + Rand() % 200;
@@ -97,7 +97,7 @@ void GenerateConfigSequenceSimple(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
       output_dim = 100 + Rand() % 200,
@@ -118,9 +118,9 @@ void GenerateConfigSequenceSimple(
       os << "component name=logsoftmax type=LogSoftmaxComponent dim="
          << output_dim << std::endl;
     }
-  }      
+  }
   os << "input-node name=input dim=" << input_dim << std::endl;
-  
+
   os << "component-node name=affine1_node component=affine1 input=Append(";
   for (size_t i = 0; i < splice_context.size(); i++) {
     int32 offset = splice_context[i];
@@ -168,15 +168,20 @@ void GenerateConfigSequenceRnn(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
       output_dim = 100 + Rand() % 200,
       hidden_dim = 40 + Rand() % 50;
   os << "component name=affine1 type=NaturalGradientAffineComponent input-dim="
      << spliced_dim << " output-dim=" << hidden_dim << std::endl;
-  os << "component name=nonlin1 type=RectifiedLinearComponent dim="
-     << hidden_dim << std::endl;
+  if (RandInt(0, 1) == 0) {
+    os << "component name=nonlin1 type=RectifiedLinearComponent dim="
+       << hidden_dim << std::endl;
+  } else {
+    os << "component name=nonlin1 type=TanhComponent dim="
+       << hidden_dim << std::endl;
+  }
   os << "component name=recurrent_affine1 type=NaturalGradientAffineComponent input-dim="
      << hidden_dim << " output-dim=" << hidden_dim << std::endl;
   os << "component name=affine2 type=NaturalGradientAffineComponent input-dim="
@@ -184,7 +189,7 @@ void GenerateConfigSequenceRnn(
   os << "component name=logsoftmax type=LogSoftmaxComponent dim="
      << output_dim << std::endl;
   os << "input-node name=input dim=" << input_dim << std::endl;
-  
+
   os << "component-node name=affine1_node component=affine1 input=Append(";
   for (size_t i = 0; i < splice_context.size(); i++) {
     int32 offset = splice_context[i];
@@ -220,7 +225,7 @@ void GenerateConfigSequenceRnnClockwork(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
       output_dim = 100 + Rand() % 200,
@@ -243,7 +248,7 @@ void GenerateConfigSequenceRnnClockwork(
   os << "component name=logsoftmax type=LogSoftmaxComponent dim="
      << output_dim << std::endl;
   os << "input-node name=input dim=" << input_dim << std::endl;
-  
+
   os << "component-node name=affine1_node component=affine1 input=Append(";
   for (size_t i = 0; i < splice_context.size(); i++) {
     int32 offset = splice_context[i];
@@ -267,11 +272,11 @@ void GenerateConfigSequenceRnnClockwork(
 
 
 // This generates a single config corresponding to an LSTM.
-// based on the equations in 
+// based on the equations in
 // Sak et. al. "LSTM based RNN architectures for LVCSR", 2014
 // We name the components based on the following equations (Eqs 7-15 in paper)
 //      i(t) = S(Wix * x(t) + Wir * r(t-1) + Wic * c(t-1) + bi)
-//      f(t) = S(Wfx * x(t) + Wfr * r(t-1) + Wfc * c(t-1) + bf) 
+//      f(t) = S(Wfx * x(t) + Wfr * r(t-1) + Wfc * c(t-1) + bf)
 //      c(t) = {f(t) .* c(t-1)} + {i(t) .* g(Wcx * x(t) + Wcr * r(t-1) + bc)}
 //      o(t) = S(Wox * x(t) + Wor * r(t-1) + Woc * c(t) + bo)
 //      m(t) = o(t) .* h(c(t))
@@ -281,18 +286,18 @@ void GenerateConfigSequenceRnnClockwork(
 // where S : sigmoid
 // matrix with feed-forward connections
 // from the input x(t)
-// W*x = [Wix^T, Wfx^T, Wcx^T, Wox^T]^T 
+// W*x = [Wix^T, Wfx^T, Wcx^T, Wox^T]^T
 
 // matrix with recurrent (feed-back) connections
 // from the output projection
 // W*r = [Wir^T, Wfr^T, Wcr^T, Wor^T]^T
 
 // matrix to generate r(t) and p(t)
-// m(t) 
+// m(t)
 // W*m = [Wrm^T, Wpm^T]^T
 // matrix to generate y(t)
-// Wy* = [Wyr^T, Wyp^T] 
- 
+// Wy* = [Wyr^T, Wyp^T]
+
 // Diagonal matrices with recurrent connections and feed-forward connections
 // from the cell output c(t) since these can be both recurrent and
 // feed-forward we dont combine the matrices
@@ -310,7 +315,7 @@ void GenerateConfigSequenceLstm(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
       output_dim = 100 + Rand() % 200,
@@ -329,7 +334,7 @@ void GenerateConfigSequenceLstm(
 
   // Forget gate control : Wf* matrices
   os << "component name=Wf-xr type=NaturalGradientAffineComponent"
-     << " input-dim=" << spliced_dim + projection_dim 
+     << " input-dim=" << spliced_dim + projection_dim
      << " output-dim=" << cell_dim << std::endl;
   os << "component name=Wfc type=PerElementScaleComponent "
      << " dim=" << cell_dim << std::endl;
@@ -359,8 +364,8 @@ void GenerateConfigSequenceLstm(
      << " output-dim=" << cell_dim << std::endl;
 
   // Defining the diagonal matrices
-  // Defining the final affine transform 
-  os << "component name=final_affine type=NaturalGradientAffineComponent " 
+  // Defining the final affine transform
+  os << "component name=final_affine type=NaturalGradientAffineComponent "
      << "input-dim=" << cell_dim << " output-dim=" << output_dim << std::endl;
   os << "component name=logsoftmax type=LogSoftmaxComponent dim="
      << output_dim << std::endl;
@@ -379,17 +384,17 @@ void GenerateConfigSequenceLstm(
   os << "component name=h type=TanhComponent dim="
      << cell_dim << std::endl;
   os << "component name=c1 type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
   os << "component name=c2 type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
   os << "component name=m type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
 
   // Defining the computations
-  std::ostringstream temp_string_stream; 
+  std::ostringstream temp_string_stream;
   for (size_t i = 0; i < splice_context.size(); i++) {
     int32 offset = splice_context[i];
     temp_string_stream << "Offset(input, " << offset << ")";
@@ -397,7 +402,7 @@ void GenerateConfigSequenceLstm(
       temp_string_stream << ", ";
   }
   std::string spliced_input = temp_string_stream.str();
-  
+
   std::string c_tminus1 = "Sum(IfDefined(Offset(c1_t, -1)), IfDefined(Offset( c2_t, -1)))";
 
   // i_t
@@ -422,18 +427,18 @@ void GenerateConfigSequenceLstm(
 
   // h_t
   os << "component-node name=h_t component=h input=Sum(c1_t, c2_t)\n";
-  
+
   // g_t
   os << "component-node name=g1 component=Wc-xr input=Append("
      << spliced_input << ", IfDefined(Offset(r_t, -1)))\n";
   os << "component-node name=g_t component=g input=g1\n";
- 
+
   // parts of c_t
   os << "component-node name=c1_t component=c1 "
      << " input=Append(f_t, " << c_tminus1 << ")\n";
   os << "component-node name=c2_t component=c2 input=Append(i_t, g_t)\n";
 
-  // m_t 
+  // m_t
   os << "component-node name=m_t component=m input=Append(o_t, h_t)\n";
 
   // r_t and p_t
@@ -441,7 +446,7 @@ void GenerateConfigSequenceLstm(
   // Splitting outputs of Wy- node
   os << "dim-range-node name=r_t input-node=rp_t dim-offset=0 "
      << "dim=" << projection_dim << std::endl;
-  
+
   // y_t
   os << "component-node name=y_t component=Wy- input=rp_t\n";
 
@@ -466,7 +471,7 @@ void GenerateConfigSequenceLstmType2(
       splice_context.push_back(i);
   if (splice_context.empty())
     splice_context.push_back(0);
-  
+
   int32 input_dim = 10 + Rand() % 20,
       spliced_dim = input_dim * splice_context.size(),
       output_dim = 100 + Rand() % 200,
@@ -492,8 +497,8 @@ void GenerateConfigSequenceLstmType2(
      << " dim=" << cell_dim << std::endl;
   os << "component name=Woc type=PerElementScaleComponent "
      << " dim=" << cell_dim << std::endl;
-  // Defining the final affine transform 
-  os << "component name=final_affine type=NaturalGradientAffineComponent " 
+  // Defining the final affine transform
+  os << "component name=final_affine type=NaturalGradientAffineComponent "
      << "input-dim=" << cell_dim << " output-dim=" << output_dim << std::endl;
   os << "component name=logsoftmax type=LogSoftmaxComponent dim="
      << output_dim << std::endl;
@@ -514,15 +519,15 @@ void GenerateConfigSequenceLstmType2(
   os << "component name=h type=TanhComponent dim="
      << cell_dim << std::endl;
   os << "component name=f_t-c_tminus1 type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
   os << "component name=i_t-g type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
   os << "component name=m_t type=ElementwiseProductComponent "
-     << " input-dim=" << 2 * cell_dim 
+     << " input-dim=" << 2 * cell_dim
      << " output-dim=" << cell_dim << std::endl;
-    
+
 
   // Defining the computations
   os << "component-node name=W-x component=W-x input=Append(";
@@ -545,7 +550,7 @@ void GenerateConfigSequenceLstmType2(
      << "dim=" << projection_dim << std::endl;
   os << "dim-range-node name=p_t input-node=W-m dim-offset=" << projection_dim
      << " dim=" << projection_dim << std::endl;
-  
+
   // Splitting outputs of W*x node
   os << "dim-range-node name=W_ix-x_t input-node=W-x dim-offset=0 "
      << "dim=" << cell_dim << std::endl;
@@ -555,7 +560,7 @@ void GenerateConfigSequenceLstmType2(
      << "dim-offset=" << 2 * cell_dim << " dim="<<cell_dim << std::endl;
   os << "dim-range-node name=W_ox-x_t input-node=W-x "
      << "dim-offset=" << 3 * cell_dim << " dim="<<cell_dim << std::endl;
-  
+
   // Splitting outputs of W*r node
   os << "dim-range-node name=W_ir-r_tminus1 input-node=W-r dim-offset=0 "
      << "dim=" << cell_dim << std::endl;
@@ -575,21 +580,21 @@ void GenerateConfigSequenceLstmType2(
   os << "component-node name=f_t-c_tminus1 component=f_t-c_tminus1 input=Append(f_t, Offset(c_t, -1))\n";
   os << "component-node name=i_t-g component=i_t-g input=Append(i_t, g)\n";
   os << "component-node name=m_t component=m_t input=Append(o_t, h)\n";
-  
+
   os << "component-node name=g component=g input=Sum(W_cx-x_t, W_cr-r_tminus1)\n";
-  
+
   // Final affine transform
   os << "component-node name=Wyr component=Wyr input=r_t\n";
   os << "component-node name=Wyp component=Wyp input=p_t\n";
 
   os << "component-node name=final_affine component=final_affine input=Sum(Wyr, Wyp)\n";
-  
+
   os << "component-node name=posteriors component=logsoftmax input=final_affine\n";
   os << "output-node name=output input=posteriors\n";
-  
+
   configs->push_back(os.str());
 }
- 
+
 void GenerateConfigSequence(
     const NnetGenerationOptions &opts,
     std::vector<std::string> *configs) {
@@ -606,7 +611,7 @@ start:
       break;
     case 2:
       if (!opts.allow_context || !opts.allow_nonlinearity)
-        goto start;        
+        goto start;
       GenerateConfigSequenceSimple(opts, configs);
       break;
     case 3:
@@ -655,11 +660,11 @@ void ComputeExampleComputationRequestSimple(
       input_end_frame = output_end_frame + right_context + (Rand() % 3),
       n_offset = Rand() % 2;
   bool need_deriv = (Rand() % 2 == 0);
-  
+
   request->inputs.clear();
   request->outputs.clear();
   inputs->clear();
-  
+
   std::vector<Index> input_indexes, ivector_indexes, output_indexes;
   for (int32 n = n_offset; n < n_offset + num_examples; n++) {
     for (int32 t = input_start_frame; t < input_end_frame; t++)
@@ -812,7 +817,7 @@ Component *GenerateRandomSimpleComponent() {
   ConfigLine config_line;
   if (!config_line.ParseLine(config))
     KALDI_ERR << "Bad config line " << config;
-  
+
   Component *c = Component::NewComponentOfType(component_type);
   if (c == NULL)
     KALDI_ERR << "Invalid component type " << component_type;
@@ -862,7 +867,7 @@ void GenerateSimpleNnetTrainingExample(
                right_context >= 0 && output_dim > 0 && input_dim > 0
                && example != NULL);
   example->io.clear();
-  
+
   int32 feature_t_begin = RandInt(0, 2);
   int32 num_feat_frames = left_context + right_context + num_supervised_frames;
   Matrix<BaseFloat> input_mat(num_feat_frames, input_dim);


### PR DESCRIPTION
This is a pull request for my changes to limit the times for which derivatives are computed in BPTT.  (It's not as simple as you might think, since the framework itself does the derivative computation for you).  I plan to merge once the checks finish, e.g. in 1 hour.
I have now debugged and tested this on Pegah's setup, and it's both faster (e.g. 1 minute 15 seconds -> 1 minute) and seems to give better objective function values.
The option that I added when testing this is --optimization.min-deriv-time=-7.  You may in general want to set this to the negative of the left-context of the network, or a bit more negative than that.  But the left-context of the network is a reasonable default.  You'll have to change the scripts to work with this.  Basically, any derivative quantities computed on times before that will be considered to be zero by the framework and won't be computed, and hence the model won't be updated for those times.
If you don't add any extra command line options the code behaves basically as before.
@vijayaditya  and @pegahgh please take note!  Also of course @naxingyu and @nichongjia.