### PR TITLE
Avoid crash if wave remainer is not specified in caller

### DIFF
--- a/src/feat/feature-fbank.cc
+++ b/src/feat/feature-fbank.cc
@@ -111,7 +111,8 @@ void Fbank::ComputeInternal(const VectorBase<BaseFloat> &wave,
   int32 cols_out = opts_.mel_opts.num_bins + opts_.use_energy;
   if (rows_out == 0) {
     output->Resize(0, 0);
-    *wave_remainder = wave;
+    if (wave_remainder != NULL)
+      *wave_remainder = wave;
     return;
   }
   // Prepare the output buffer

--- a/src/feat/feature-mfcc.cc
+++ b/src/feat/feature-mfcc.cc
@@ -122,7 +122,8 @@ void Mfcc::ComputeInternal(const VectorBase<BaseFloat> &wave,
       cols_out = opts_.num_ceps;
   if (rows_out == 0) {
     output->Resize(0, 0);
-    *wave_remainder = wave;
+    if (wave_remainder != NULL)
+      *wave_remainder = wave;
     return;
   }
   output->Resize(rows_out, cols_out);

--- a/src/feat/feature-plp.cc
+++ b/src/feat/feature-plp.cc
@@ -167,7 +167,8 @@ void Plp::ComputeInternal(const VectorBase<BaseFloat> &wave,
       cols_out = opts_.num_ceps;
   if (rows_out == 0) {
     output->Resize(0, 0);
-    *wave_remainder = wave;
+    if (wave_remainder != NULL)
+      *wave_remainder = wave;
     return;
   }
   output->Resize(rows_out, cols_out);


### PR DESCRIPTION
API allows to skip wave_remainder parameter in the call, while on some cases it can cause crash.