### PR TITLE
revise OpenBLAS git clone to more general HTTPS protocol

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -161,7 +161,7 @@ fortran_opt = $(shell gcc -v 2>&1 | perl -e '$$x = join(" ", <STDIN>); if($$x =~
 # option.
 openblas_compiled:
 	echo "Note: see tools/Makefile for options regarding OpenBLAS compilation"
-	-git clone git://github.com/xianyi/OpenBLAS
+	-git clone https://github.com/xianyi/OpenBLAS.git
 	-cd OpenBLAS; git pull
 	cd OpenBLAS; sed 's:# FCOMMON_OPT = -frecursive:FCOMMON_OPT = -frecursive:' < Makefile.rule >tmp && mv tmp Makefile.rule
 	# $(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=1 NUM_THREADS=64 -C OpenBLAS all install


### PR DESCRIPTION
Using HTTPS protocol to clone the OpenBLAS repository works for the computer behind a ssh firewall. Here is the reference https://help.github.com/articles/which-remote-url-should-i-use/
