### PR TITLE
Added support for nnet3 raw computation without acoustic model

### DIFF
--- a/src/nnet3/Makefile
+++ b/src/nnet3/Makefile
@@ -23,7 +23,7 @@ OBJFILES = nnet-common.o nnet-compile.o nnet-component-itf.o \
   nnet-utils.o nnet-compute.o nnet-test-utils.o nnet-analyze.o \
   nnet-example-utils.o nnet-training.o \
   nnet-diagnostics.o nnet-combine.o nnet-am-decodable-simple.o \
-  nnet-optimize-utils.o
+  nnet-optimize-utils.o nnet-simple-computer.o
 
 LIBNAME = kaldi-nnet3
 

--- a/src/nnet3/nnet-am-decodable-simple.cc
+++ b/src/nnet3/nnet-am-decodable-simple.cc
@@ -18,6 +18,7 @@
 // limitations under the License.
 
 #include "nnet3/nnet-am-decodable-simple.h"
+#include "nnet3/nnet-simple-computer.h"
 
 namespace kaldi {
 namespace nnet3 {
@@ -31,20 +32,12 @@ DecodableAmNnetSimple::DecodableAmNnetSimple(
     const VectorBase<BaseFloat> *ivector,
     const MatrixBase<BaseFloat> *online_ivectors,
     int32 online_ivector_period):
+    NnetSimpleComputer(opts.simple_computer_opts, am_nnet.GetNnet(), feats, am_nnet.LeftContext(), am_nnet.RightContext(), ivector, online_ivectors, online_ivector_period),
     opts_(opts),
     trans_model_(trans_model),
     am_nnet_(am_nnet),
-    priors_(am_nnet_.Priors()),
-    feats_(feats),
-    ivector_(ivector), online_ivector_feats_(online_ivectors),
-    online_ivector_period_(online_ivector_period),
-    compiler_(am_nnet_.GetNnet(), opts_.optimize_config),
-    current_log_post_offset_(0) {
-  KALDI_ASSERT(!(ivector != NULL && online_ivectors != NULL));
-  KALDI_ASSERT(!(online_ivectors != NULL && online_ivector_period <= 0 &&
-                 "You need to set the --online-ivector-period option!"));
+    priors_(am_nnet.Priors()) {
   priors_.ApplyLog();
-  PossiblyWarnForFramesPerChunk();
 }
 
 DecodableAmNnetSimple::DecodableAmNnetSimple(
@@ -54,18 +47,12 @@ DecodableAmNnetSimple::DecodableAmNnetSimple(
     const MatrixBase<BaseFloat> &feats,
     const MatrixBase<BaseFloat> &ivectors,
     int32 online_ivector_period):
+    NnetSimpleComputer(opts.simple_computer_opts, am_nnet.GetNnet(), feats, am_nnet.LeftContext(), am_nnet.RightContext(), NULL, &ivectors, online_ivector_period),
     opts_(opts),
     trans_model_(trans_model),
     am_nnet_(am_nnet),
-    priors_(am_nnet_.Priors()),
-    feats_(feats),
-    ivector_(NULL),
-    online_ivector_feats_(&ivectors),
-    online_ivector_period_(online_ivector_period),
-    compiler_(am_nnet_.GetNnet(), opts_.optimize_config),
-    current_log_post_offset_(0) {
+    priors_(am_nnet.Priors()) {
   priors_.ApplyLog();
-  PossiblyWarnForFramesPerChunk();
 }
 
 DecodableAmNnetSimple::DecodableAmNnetSimple(
@@ -74,20 +61,13 @@ DecodableAmNnetSimple::DecodableAmNnetSimple(
     const AmNnetSimple &am_nnet,
     const MatrixBase<BaseFloat> &feats,
     const VectorBase<BaseFloat> &ivector):
+    NnetSimpleComputer(opts.simple_computer_opts, am_nnet.GetNnet(), feats, am_nnet.LeftContext(), am_nnet.RightContext(), &ivector, NULL, 0), 
     opts_(opts),
     trans_model_(trans_model),
     am_nnet_(am_nnet),
-    priors_(am_nnet_.Priors()),
-    feats_(feats),
-    ivector_(&ivector),
-    online_ivector_feats_(NULL),
-    online_ivector_period_(0),
-    compiler_(am_nnet_.GetNnet(), opts_.optimize_config),
-    current_log_post_offset_(0) {
+    priors_(am_nnet.Priors()) {
   priors_.ApplyLog();
-  PossiblyWarnForFramesPerChunk();
 }
-
 
 BaseFloat DecodableAmNnetSimple::LogLikelihood(int32 frame,
                                                int32 transition_id) {
@@ -99,149 +79,15 @@ BaseFloat DecodableAmNnetSimple::LogLikelihood(int32 frame,
                            pdf_id);
 }
 
-int32 DecodableAmNnetSimple::GetIvectorDim() const {
-  if (ivector_ != NULL)
-    return ivector_->Dim();
-  else if (online_ivector_feats_ != NULL)
-    return online_ivector_feats_->NumCols();
-  else
-    return 0;
-}
-
-void DecodableAmNnetSimple::EnsureFrameIsComputed(int32 frame) {
-  KALDI_ASSERT(frame >= 0 && frame  < feats_.NumRows());
-
-  const Nnet &nnet = am_nnet_.GetNnet();
-  int32 feature_dim = feats_.NumCols(),
-      ivector_dim = GetIvectorDim(),
-      nnet_input_dim = nnet.InputDim("input"),
-      nnet_ivector_dim = std::max<int32>(0, nnet.InputDim("ivector"));
-  if (feature_dim != nnet_input_dim)
-    KALDI_ERR << "Neural net expects 'input' features with dimension "
-              << nnet_input_dim << " but you provided "
-              << feature_dim;
-  if (ivector_dim != std::max<int32>(0, nnet.InputDim("ivector")))
-    KALDI_ERR << "Neural net expects 'ivector' features with dimension "
-              << nnet_ivector_dim << " but you provided " << ivector_dim;
-
-  int32 current_frames_computed = current_log_post_.NumRows(),
-      current_offset = current_log_post_offset_;
-  KALDI_ASSERT(frame < current_offset ||
-               frame >= current_offset + current_frames_computed);
-  // allow the output to be computed for frame 0 ... num_input_frames - 1.
-  int32 start_output_frame = frame,
-      num_output_frames = std::min<int32>(feats_.NumRows() - start_output_frame,
-                                          opts_.frames_per_chunk);
-  KALDI_ASSERT(num_output_frames > 0);
-  KALDI_ASSERT(opts_.extra_left_context >= 0);
-  int32 left_context = am_nnet_.LeftContext() + opts_.extra_left_context;
-  int32 first_input_frame = start_output_frame - left_context,
-      num_input_frames = left_context + num_output_frames +
-                         am_nnet_.RightContext();
-  Vector<BaseFloat> ivector;
-  GetCurrentIvector(start_output_frame, num_output_frames, &ivector);
-
-  Matrix<BaseFloat> input_feats;
-  if (first_input_frame >= 0 &&
-      first_input_frame + num_input_frames <= feats_.NumRows()) {
-    SubMatrix<BaseFloat> input_feats(feats_.RowRange(first_input_frame,
-                                                     num_input_frames));
-    DoNnetComputation(first_input_frame, input_feats, ivector,
-                      start_output_frame, num_output_frames);
-  } else {
-    Matrix<BaseFloat> feats_block(num_input_frames, feats_.NumCols());
-    int32 tot_input_feats = feats_.NumRows();
-    for (int32 i = 0; i < num_input_frames; i++) {
-      SubVector<BaseFloat> dest(feats_block, i);
-      int32 t = i + first_input_frame;
-      if (t < 0) t = 0;
-      if (t >= tot_input_feats) t = tot_input_feats - 1;
-      const SubVector<BaseFloat> src(feats_, t);
-      dest.CopyFromVec(src);
-    }
-    DoNnetComputation(first_input_frame, feats_block, ivector,
-                      start_output_frame, num_output_frames);
-  }
-}
-
-void DecodableAmNnetSimple::GetCurrentIvector(int32 output_t_start,
-                                              int32 num_output_frames,
-                                              Vector<BaseFloat> *ivector) {
-  if (ivector_ != NULL) {
-    *ivector = *ivector_;
-    return;
-  } else if (online_ivector_feats_ == NULL) {
-    return;
-  }
-  KALDI_ASSERT(online_ivector_period_ > 0);
-  // frame_to_search is the frame that we want to get the most recent iVector
-  // for.  We choose a point near the middle of the current window, the concept
-  // being that this is the fairest comparison to nnet2.   Obviously we could do
-  // better by always taking the last frame's iVector, but decoding with
-  // 'online' ivectors is only really a mechanism to simulate online operation.
-  int32 frame_to_search = output_t_start + num_output_frames / 2;
-  int32 ivector_frame = frame_to_search / online_ivector_period_;
-  KALDI_ASSERT(ivector_frame >= 0);
-  if (ivector_frame >= online_ivector_feats_->NumRows()) {
-    int32 margin = ivector_frame - (online_ivector_feats_->NumRows() - 1);
-    if (margin * online_ivector_period_ > 50) {
-      // Half a second seems like too long to be explainable as edge effects.
-      KALDI_ERR << "Could not get iVector for frame " << frame_to_search
-                << ", only available till frame "
-                << online_ivector_feats_->NumRows()
-                << " * ivector-period=" << online_ivector_period_
-                << " (mismatched --ivector-period?)";
-    }
-    ivector_frame = online_ivector_feats_->NumRows() - 1;
-  }
-  *ivector = online_ivector_feats_->Row(ivector_frame);
-}
-
-
 void DecodableAmNnetSimple::DoNnetComputation(
     int32 input_t_start,
     const MatrixBase<BaseFloat> &input_feats,
     const VectorBase<BaseFloat> &ivector,
     int32 output_t_start,
     int32 num_output_frames) {
-  ComputationRequest request;
-  request.need_model_derivative = false;
-  request.store_component_stats = false;
-
-  bool shift_time = true; // shift the 'input' and 'output' to a consistent
-                          // time, to take advantage of caching in the compiler.
-                          // An optimization.
-  int32 time_offset = (shift_time ? -output_t_start : 0);
-
-  // First add the regular features-- named "input".
-  request.inputs.reserve(2);
-  request.inputs.push_back(
-      IoSpecification("input", time_offset + input_t_start,
-                      time_offset + input_t_start + input_feats.NumRows()));
-  if (ivector.Dim() != 0) {
-    std::vector<Index> indexes;
-    indexes.push_back(Index(0, 0, 0));
-    request.inputs.push_back(IoSpecification("ivector", indexes));
-  }
-  request.outputs.push_back(
-      IoSpecification("output", time_offset + output_t_start,
-                      time_offset + output_t_start + num_output_frames));
-  const NnetComputation *computation = compiler_.Compile(request);
-  Nnet *nnet_to_update = NULL;  // we're not doing any update.
-  NnetComputer computer(opts_.compute_config, *computation,
-                        am_nnet_.GetNnet(), nnet_to_update);
-
-  CuMatrix<BaseFloat> input_feats_cu(input_feats);
-  computer.AcceptInput("input", &input_feats_cu);
-  CuMatrix<BaseFloat> ivector_feats_cu;
-  if (ivector.Dim() > 0) {
-    ivector_feats_cu.Resize(1, ivector.Dim());
-    ivector_feats_cu.Row(0).CopyFromVec(ivector);
-    computer.AcceptInput("ivector", &ivector_feats_cu);
-  }
-  computer.Forward();
   CuMatrix<BaseFloat> cu_output;
-  computer.GetOutputDestructive("output", &cu_output);
+  DoNnetComputationInternal(input_t_start, input_feats, ivector, 
+                            output_t_start, num_output_frames, &cu_output);
   // subtract log-prior (divide by prior)
   cu_output.AddVecToRows(-1.0, priors_);
   // apply the acoustic scale
@@ -250,18 +96,6 @@ void DecodableAmNnetSimple::DoNnetComputation(
   // the following statement just swaps the pointers if we're not using a GPU.
   cu_output.Swap(&current_log_post_);
   current_log_post_offset_ = output_t_start;
-}
-
-void DecodableAmNnetSimple::PossiblyWarnForFramesPerChunk() const {
-  static bool warned = false;
-  int32 nnet_modulus = am_nnet_.GetNnet().Modulus();
-  if (opts_.frames_per_chunk % nnet_modulus != 0 && !warned) {
-    warned = true;
-    KALDI_WARN << "It may be more efficient to set the --frames-per-chunk "
-               << "(currently " << opts_.frames_per_chunk << " to a "
-               << "multiple of the network's shift-invariance modulus "
-               << nnet_modulus;
-  }
 }
 
 } // namespace nnet3

--- a/src/nnet3/nnet-am-decodable-simple.h
+++ b/src/nnet3/nnet-am-decodable-simple.h
@@ -20,67 +20,44 @@
 #ifndef KALDI_NNET3_NNET_AM_DECODABLE_SIMPLE_H_
 #define KALDI_NNET3_NNET_AM_DECODABLE_SIMPLE_H_
 
-#include <vector>
 #include "base/kaldi-common.h"
 #include "gmm/am-diag-gmm.h"
 #include "hmm/transition-model.h"
 #include "itf/decodable-itf.h"
-#include "nnet3/nnet-optimize.h"
-#include "nnet3/nnet-compute.h"
-#include "nnet3/am-nnet-simple.h"
+#include "nnet3/nnet-simple-computer.h"
 
 namespace kaldi {
 namespace nnet3 {
 
 
-struct DecodableAmNnetSimpleOptions {
-  int32 extra_left_context;
-  int32 frames_per_chunk;
+struct DecodableAmNnetSimpleOptions : public NnetSimpleComputerOptions {
   BaseFloat acoustic_scale;
-  bool debug_computation;
-  NnetOptimizeOptions optimize_config;
-  NnetComputeOptions compute_config;
+  NnetSimpleComputerOptions simple_computer_opts;
 
   DecodableAmNnetSimpleOptions():
-      extra_left_context(0),
-      frames_per_chunk(50),
-      acoustic_scale(0.1),
-      debug_computation(false) { }
+      acoustic_scale(0.1) {}
 
   void Register(OptionsItf *opts) {
-    opts->Register("extra-left-context", &extra_left_context,
-                   "Number of frames of additional left-context to add on top "
-                   "of the neural net's inherent left context (may be useful in "
-                   "recurrent setups");
-    opts->Register("frames-per-chunk", &frames_per_chunk,
-                   "Number of frames in each chunk that is separately evaluated "
-                   "by the neural net.");
     opts->Register("acoustic-scale", &acoustic_scale,
                    "Scaling factor for acoustic log-likelihoods");
-    opts->Register("debug-computation", &debug_computation, "If true, turn on "
-                   "debug for the actual computation (very verbose!)");
+  
+    simple_computer_opts.Register(opts);
 
-    // register the optimization options with the prefix "optimization".
-    ParseOptions optimization_opts("optimization", opts);
-    optimize_config.Register(&optimization_opts);
-
-    // register the compute options with the prefix "computation".
-    ParseOptions compute_opts("computation", opts);
-    compute_config.Register(&compute_opts);
   }
 };
 
 /* DecodableAmNnetSimple is a decodable object that decodes with a neural net
    acoustic model of type AmNnetSimple.  It can accept just input features, or
    input features plus iVectors.
+   It inherits from the NnetSimpleComputer class, which does the 
+   neural network computation.
 */
-class DecodableAmNnetSimple: public DecodableInterface {
+class DecodableAmNnetSimple: public DecodableInterface, public NnetSimpleComputer {
  public:
   /// Constructor that just takes the features as input, but can also optionally
   /// take batch-mode or online iVectors.  Note: it stores references to all
   /// arguments to the constructor, so don't delete them till this goes out of
   /// scope.
-
   DecodableAmNnetSimple(const DecodableAmNnetSimpleOptions &opts,
                         const TransitionModel &trans_model,
                         const AmNnetSimple &am_nnet,
@@ -105,7 +82,6 @@ class DecodableAmNnetSimple: public DecodableInterface {
                         const MatrixBase<BaseFloat> &feats,
                         const VectorBase<BaseFloat> &ivector);
 
-
   // Note, frames are numbered from zero.  But transition_id is numbered
   // from one (this routine is called by FSTs).
   virtual BaseFloat LogLikelihood(int32 frame, int32 transition_id);
@@ -120,58 +96,18 @@ class DecodableAmNnetSimple: public DecodableInterface {
     return (frame == NumFramesReady() - 1);
   }
 
+ private: 
 
-
- private:
-  // This call is made to ensure that we have the log-probs for this frame
-  // cached in current_log_post_.
-  void EnsureFrameIsComputed(int32 frame);
-
-  // This function does the actual nnet computation; it is called from
-  // EnsureFrameIsComputed.  Any padding at file start/end is done by
-  // the caller of this function (so the input should exceed the output
-  // by a suitable amount of context).  It puts its output in current_log_post_.
   void DoNnetComputation(int32 input_t_start,
                          const MatrixBase<BaseFloat> &input_feats,
                          const VectorBase<BaseFloat> &ivector,
                          int32 output_t_start,
                          int32 num_output_frames);
 
-  // Gets the iVector that will be used for this chunk of frames, if
-  // we are using iVectors (else does nothing).
-  void GetCurrentIvector(int32 output_t_start, int32 num_output_frames,
-                         Vector<BaseFloat> *ivector);
-
-  void PossiblyWarnForFramesPerChunk() const;
-
-  // returns dimension of the provided iVectors if supplied, or 0 otherwise.
-  int32 GetIvectorDim() const;
-
   const DecodableAmNnetSimpleOptions &opts_;
   const TransitionModel &trans_model_;
   const AmNnetSimple &am_nnet_;
   CuVector<BaseFloat> priors_;
-  const MatrixBase<BaseFloat> &feats_;
-
-  // ivector_ is the iVector if we're using iVectors that are estimated in batch
-  // mode.
-  const VectorBase<BaseFloat> *ivector_;
-
-  // online_ivector_feats_ is the iVectors if we're using online-estimated ones.
-  const MatrixBase<BaseFloat> *online_ivector_feats_;
-  // online_ivector_period_ helps us interpret online_ivector_feats_; it's the
-  // number of frames the rows of ivector_feats are separated by.
-  int32 online_ivector_period_;
-
-  CachingOptimizingCompiler compiler_;
-
-
-  // The current log-posteriors that we got from the last time we
-  // ran the computation.
-  Matrix<BaseFloat> current_log_post_;
-  // The time-offset of the current log-posteriors.
-  int32 current_log_post_offset_;
-
 
 };
 

--- a/src/nnet3/nnet-simple-computer.cc
+++ b/src/nnet3/nnet-simple-computer.cc
@@ -1,0 +1,289 @@
+// nnet3/nnet-simple-computer.cc
+
+// Copyright      2015  Johns Hopkins University (author: Daniel Povey)
+//                2015  Vimal Manohar
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nnet3/nnet-simple-computer.h"
+#include "nnet3/nnet-utils.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+ NnetSimpleComputer::NnetSimpleComputer(
+  const NnetSimpleComputerOptions &opts,
+  const Nnet &nnet,
+  const MatrixBase<BaseFloat> &feats,
+  int32 left_context, int32 right_context,
+  const VectorBase<BaseFloat> *ivector,
+  const MatrixBase<BaseFloat> *online_ivectors,
+  int32 online_ivector_period): 
+ opts_(opts),
+ nnet_(nnet),
+ feats_(feats),
+ ivector_(ivector), online_ivector_feats_(online_ivectors),
+ online_ivector_period_(online_ivector_period),
+ compiler_(nnet_, opts_.optimize_config),
+ current_log_post_offset_(0), 
+ left_context_(left_context), right_context_(right_context) {
+ KALDI_ASSERT(!(ivector != NULL && online_ivectors != NULL));
+ KALDI_ASSERT(!(online_ivectors != NULL && online_ivector_period <= 0 &&
+    "You need to set the --online-ivector-period option!"));
+ PossiblyWarnForFramesPerChunk();
+}
+
+NnetSimpleComputer::NnetSimpleComputer(
+  const NnetSimpleComputerOptions &opts,
+  const Nnet &nnet,
+  const MatrixBase<BaseFloat> &feats,
+  const VectorBase<BaseFloat> *ivector,
+  const MatrixBase<BaseFloat> *online_ivectors,
+  int32 online_ivector_period):
+ opts_(opts),
+ nnet_(nnet),
+ feats_(feats),
+ ivector_(ivector), online_ivector_feats_(online_ivectors),
+ online_ivector_period_(online_ivector_period),
+ compiler_(nnet_, opts_.optimize_config),
+ current_log_post_offset_(0) {
+ KALDI_ASSERT(!(ivector != NULL && online_ivectors != NULL));
+ KALDI_ASSERT(!(online_ivectors != NULL && online_ivector_period <= 0 &&
+    "You need to set the --online-ivector-period option!"));
+ PossiblyWarnForFramesPerChunk();
+ ComputeSimpleNnetContext(nnet_, &left_context_, &right_context_);
+}
+
+NnetSimpleComputer::NnetSimpleComputer(
+  const NnetSimpleComputerOptions &opts,
+  const Nnet &nnet,
+  const MatrixBase<BaseFloat> &feats,
+  const MatrixBase<BaseFloat> &ivectors,
+  int32 online_ivector_period):
+ opts_(opts),
+ nnet_(nnet),
+ feats_(feats),
+ ivector_(NULL),
+ online_ivector_feats_(&ivectors),
+ online_ivector_period_(online_ivector_period),
+ compiler_(nnet, opts_.optimize_config),
+ current_log_post_offset_(0) {
+ PossiblyWarnForFramesPerChunk();
+ ComputeSimpleNnetContext(nnet_, &left_context_, &right_context_);
+}  
+
+NnetSimpleComputer::NnetSimpleComputer(
+  const NnetSimpleComputerOptions &opts,
+  const Nnet &nnet,
+  const MatrixBase<BaseFloat> &feats,
+  const VectorBase<BaseFloat> &ivector):
+ opts_(opts),
+ nnet_(nnet),
+ feats_(feats),
+ ivector_(&ivector),
+ online_ivector_feats_(NULL),
+ online_ivector_period_(0),
+ compiler_(nnet, opts_.optimize_config),
+ current_log_post_offset_(0) {
+ PossiblyWarnForFramesPerChunk();
+ ComputeSimpleNnetContext(nnet_, &left_context_, &right_context_);
+}      
+
+int32 NnetSimpleComputer::GetIvectorDim() const {
+  if (ivector_ != NULL)
+    return ivector_->Dim();
+  else if (online_ivector_feats_ != NULL)
+    return online_ivector_feats_->NumCols();
+  else
+    return 0;
+}
+
+void NnetSimpleComputer::EnsureFrameIsComputed(int32 frame) {
+  KALDI_ASSERT(frame >= 0 && frame  < feats_.NumRows());
+
+  int32 feature_dim = feats_.NumCols(),
+      ivector_dim = GetIvectorDim(),
+      nnet_input_dim = nnet_.InputDim("input"),
+      nnet_ivector_dim = std::max<int32>(0, nnet_.InputDim("ivector"));
+  if (feature_dim != nnet_input_dim)
+    KALDI_ERR << "Neural net expects 'input' features with dimension "
+              << nnet_input_dim << " but you provided "
+              << feature_dim;
+  if (ivector_dim != std::max<int32>(0, nnet_.InputDim("ivector")))
+    KALDI_ERR << "Neural net expects 'ivector' features with dimension "
+              << nnet_ivector_dim << " but you provided " << ivector_dim;
+
+  int32 current_frames_computed = current_log_post_.NumRows(),
+      current_offset = current_log_post_offset_;
+  KALDI_ASSERT(frame < current_offset ||
+               frame >= current_offset + current_frames_computed);
+  // allow the output to be computed for frame 0 ... num_input_frames - 1.
+  int32 start_output_frame = frame,
+      num_output_frames = std::min<int32>(feats_.NumRows() - start_output_frame,
+                                          opts_.frames_per_chunk);
+  KALDI_ASSERT(num_output_frames > 0);
+  KALDI_ASSERT(opts_.extra_left_context >= 0);
+  int32 left_context = LeftContext() + opts_.extra_left_context;
+  int32 first_input_frame = start_output_frame - left_context,
+      num_input_frames = left_context + num_output_frames +
+                         RightContext();
+  Vector<BaseFloat> ivector;
+  GetCurrentIvector(start_output_frame, num_output_frames, &ivector);
+  
+  Matrix<BaseFloat> input_feats;
+  if (first_input_frame >= 0 &&
+      first_input_frame + num_input_frames <= feats_.NumRows()) {
+    SubMatrix<BaseFloat> input_feats(feats_.RowRange(first_input_frame,
+                                                     num_input_frames));
+    DoNnetComputation(first_input_frame, input_feats, ivector,
+                      start_output_frame, num_output_frames);
+  } else {
+    Matrix<BaseFloat> feats_block(num_input_frames, feats_.NumCols());
+    int32 tot_input_feats = feats_.NumRows();
+    for (int32 i = 0; i < num_input_frames; i++) {
+      SubVector<BaseFloat> dest(feats_block, i);
+      int32 t = i + first_input_frame;
+      if (t < 0) t = 0;
+      if (t >= tot_input_feats) t = tot_input_feats - 1;
+      const SubVector<BaseFloat> src(feats_, t);
+      dest.CopyFromVec(src);
+    }
+    DoNnetComputation(first_input_frame, feats_block, ivector,
+                      start_output_frame, num_output_frames);
+  }  
+}
+
+void NnetSimpleComputer::GetCurrentIvector(int32 output_t_start,
+                                              int32 num_output_frames,
+                                              Vector<BaseFloat> *ivector) {
+  if (ivector_ != NULL) {
+    *ivector = *ivector_;
+    return;
+  } else if (online_ivector_feats_ == NULL) {
+    return;
+  }
+  KALDI_ASSERT(online_ivector_period_ > 0);
+  // frame_to_search is the frame that we want to get the most recent iVector
+  // for.  We choose a point near the middle of the current window, the concept
+  // being that this is the fairest comparison to nnet2.   Obviously we could do
+  // better by always taking the last frame's iVector, but decoding with
+  // 'online' ivectors is only really a mechanism to simulate online operation.
+  int32 frame_to_search = output_t_start + num_output_frames / 2;
+  int32 ivector_frame = frame_to_search / online_ivector_period_;
+  KALDI_ASSERT(ivector_frame >= 0);
+  if (ivector_frame >= online_ivector_feats_->NumRows()) {
+    int32 margin = ivector_frame - (online_ivector_feats_->NumRows() - 1);
+    if (margin * online_ivector_period_ > 50) {
+      // Half a second seems like too long to be explainable as edge effects.
+      KALDI_ERR << "Could not get iVector for frame " << frame_to_search
+                << ", only available till frame "
+                << online_ivector_feats_->NumRows()
+                << " * ivector-period=" << online_ivector_period_
+                << " (mismatched --ivector-period?)";
+    }
+    ivector_frame = online_ivector_feats_->NumRows() - 1;
+  }
+  *ivector = online_ivector_feats_->Row(ivector_frame);
+}
+  
+
+void NnetSimpleComputer::DoNnetComputation(
+    int32 input_t_start,
+    const MatrixBase<BaseFloat> &input_feats,
+    const VectorBase<BaseFloat> &ivector,
+    int32 output_t_start,
+    int32 num_output_frames) {
+  CuMatrix<BaseFloat> cu_output;
+  DoNnetComputationInternal(input_t_start, input_feats, ivector, 
+                            output_t_start, num_output_frames, &cu_output);
+  current_log_post_.Resize(0, 0);
+  // the following statement just swaps the pointers if we're not using a GPU.
+  cu_output.Swap(&current_log_post_);
+  current_log_post_offset_ = output_t_start;
+}
+
+void NnetSimpleComputer::DoNnetComputationInternal(
+    int32 input_t_start,
+    const MatrixBase<BaseFloat> &input_feats,
+    const VectorBase<BaseFloat> &ivector,
+    int32 output_t_start,
+    int32 num_output_frames,
+    CuMatrix<BaseFloat> *cu_output) {
+  KALDI_ASSERT(cu_output != NULL);
+
+  ComputationRequest request;
+  request.need_model_derivative = false;
+  request.store_component_stats = false;
+
+  bool shift_time = true; // shift the 'input' and 'output' to a consistent
+                          // time, to take advantage of caching in the compiler.
+                          // An optimization.
+  int32 time_offset = (shift_time ? -output_t_start : 0);
+  
+  // First add the regular features-- named "input".
+  request.inputs.reserve(2);
+  request.inputs.push_back(
+      IoSpecification("input", time_offset + input_t_start,
+                      time_offset + input_t_start + input_feats.NumRows()));
+  if (ivector.Dim() != 0) {
+    std::vector<Index> indexes;
+    indexes.push_back(Index(0, 0, 0));
+    request.inputs.push_back(IoSpecification("ivector", indexes));
+  }
+  request.outputs.push_back(
+      IoSpecification("output", time_offset + output_t_start,
+                      time_offset + output_t_start + num_output_frames));
+  const NnetComputation *computation = compiler_.Compile(request);
+  Nnet *nnet_to_update = NULL;  // we're not doing any update.
+  NnetComputer computer(opts_.compute_config, *computation,
+                        nnet_, nnet_to_update);
+
+  CuMatrix<BaseFloat> input_feats_cu(input_feats);
+  computer.AcceptInput("input", &input_feats_cu);
+  CuMatrix<BaseFloat> ivector_feats_cu;
+  if (ivector.Dim() > 0) {
+    ivector_feats_cu.Resize(1, ivector.Dim());
+    ivector_feats_cu.Row(0).CopyFromVec(ivector);
+    computer.AcceptInput("ivector", &ivector_feats_cu);
+  }
+  computer.Forward();
+  computer.GetOutputDestructive("output", cu_output);
+}
+
+void NnetSimpleComputer::PossiblyWarnForFramesPerChunk() const {
+  static bool warned = false;
+  int32 nnet_modulus = nnet_.Modulus();  
+  if (opts_.frames_per_chunk % nnet_modulus != 0 && !warned) {
+    warned = true;
+    KALDI_WARN << "It may be more efficient to set the --frames-per-chunk "
+               << "(currently " << opts_.frames_per_chunk << " to a "
+               << "multiple of the network's shift-invariance modulus "
+               << nnet_modulus;
+  }
+}
+
+void NnetSimpleComputer::GetOutput(Matrix<BaseFloat> *output) {
+  for (size_t frame = 0; frame < feats_.NumRows(); frame += opts_.frames_per_chunk) {
+   EnsureFrameIsComputed(frame);
+   if (frame == 0)
+    output->Resize(feats_.NumRows(), current_log_post_.NumCols());
+   SubMatrix<BaseFloat> this_output(*output, current_log_post_offset_, current_log_post_.NumRows(), 0, current_log_post_.NumCols());
+   this_output.CopyFromMat(current_log_post_);
+  }
+}
+
+}
+}

--- a/src/nnet3/nnet-simple-computer.h
+++ b/src/nnet3/nnet-simple-computer.h
@@ -1,0 +1,190 @@
+// nnet3/nnet-simple-computer.h
+
+// Copyright 2012-2015  Johns Hopkins University (author: Daniel Povey)
+//                2015  Vimal Manohar
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_NNET3_NNET_SIMPLE_COMPUTER_H
+#define KALDI_NNET3_NNET_SIMPLE_COMPUTER_H
+
+#include "base/kaldi-common.h"
+#include "nnet3/nnet-optimize.h"
+#include "nnet3/nnet-compute.h"
+#include "nnet3/am-nnet-simple.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+struct NnetSimpleComputerOptions {
+  int32 extra_left_context;
+  int32 frames_per_chunk;
+  bool debug_computation;
+  
+  NnetOptimizeOptions optimize_config;
+  NnetComputeOptions compute_config;
+
+  NnetSimpleComputerOptions():
+      extra_left_context(0),
+      frames_per_chunk(50),
+      debug_computation(false) { }
+
+  void Register(OptionsItf *opts) {
+    opts->Register("extra-left-context", &extra_left_context,
+                   "Number of frames of additional left-context to add on top "
+                   "of the neural net's inherent left context (may be useful in "
+                   "recurrent setups");
+    opts->Register("frames-per-chunk", &frames_per_chunk,
+                   "Number of frames in each chunk that is separately evaluated "
+                   "by the neural net.");
+    opts->Register("debug-computation", &debug_computation, "If true, turn on "
+                   "debug for the actual computation (very verbose!)");
+
+    // register the optimization options with the prefix "optimization".
+    ParseOptions optimization_opts("optimization", opts);
+    optimize_config.Register(&optimization_opts);
+
+    // register the compute options with the prefix "computation".
+    ParseOptions compute_opts("computation", opts);
+    compute_config.Register(&compute_opts);
+  }
+};
+
+class NnetSimpleComputer {
+ public:
+  
+  /// Constructor that just takes the features, and the left and right
+  /// contexts as input, but can also optionally
+  /// take batch-mode or online iVectors.  Note: it stores references to all
+  /// arguments to the constructor, so don't delete them till this goes out of
+  /// scope.
+  /// This is mainly when the raw neural network is used without the 
+  /// acoustic model.
+  NnetSimpleComputer(const NnetSimpleComputerOptions &opts,
+                     const Nnet &nnet,
+                     const MatrixBase<BaseFloat> &feats,
+                     int32 left_context,
+                     int32 right_context,
+                     const VectorBase<BaseFloat> *ivector = NULL,
+                     const MatrixBase<BaseFloat> *online_ivectors = NULL,
+                     int32 online_ivector_period = 1);
+
+  /// Constructor that just takes the features as input, but can also optionally
+  /// take batch-mode or online iVectors.  Note: it stores references to all
+  /// arguments to the constructor, so don't delete them till this goes out of
+  /// scope.
+  NnetSimpleComputer(const NnetSimpleComputerOptions &opts,
+                     const Nnet &nnet,
+                     const MatrixBase<BaseFloat> &feats,
+                     const VectorBase<BaseFloat> *ivector = NULL,
+                     const MatrixBase<BaseFloat> *online_ivectors = NULL,
+                     int32 online_ivector_period = 1);
+
+  /// Constructor that also accepts iVectors estimated online;
+  /// online_ivector_period is the time spacing between rows of the matrix.
+  NnetSimpleComputer(const NnetSimpleComputerOptions &opts, 
+                     const Nnet &nnet,
+                     const MatrixBase<BaseFloat> &feats,
+                     const MatrixBase<BaseFloat> &online_ivectors,
+                     int32 online_ivector_period);
+
+  /// Constructor that accepts iVectors estimated in batch mode
+  NnetSimpleComputer(const NnetSimpleComputerOptions &opts,
+                     const Nnet &nnet,
+                     const MatrixBase<BaseFloat> &feats,
+                     const VectorBase<BaseFloat> &ivector);
+
+  /// This function does the forward pass through the neural network
+  /// and returns the result to the output matrix
+  void GetOutput(Matrix<BaseFloat> *output);
+
+ protected:
+  // This call is made to ensure that we have the log-probs for this frame
+  // cached in current_log_post_.
+  void EnsureFrameIsComputed(int32 frame);
+
+  // This function does the actual nnet computation; it is called from
+  // EnsureFrameIsComputed. It puts its output in current_log_post_.
+  // This is just a wrapper to the DoNnetComputationInternal function.
+  // This is virtual because its implementation in DecodableAmNnetSimple 
+  // class must also add in acoustic scale and priors.
+  virtual void DoNnetComputation(int32 input_t_start,
+    const MatrixBase<BaseFloat> &input_feats,
+    const VectorBase<BaseFloat> &ivector,
+    int32 output_t_start,
+    int32 num_output_frames);
+  
+  // This function does the internal computations in the 
+  // actual nnet computation; it is called from
+  // DoNnetComputation. Any padding at file start/end is done by
+  // the caller of this function (so the input should exceed the output
+  // by a suitable amount of context).  
+  // It returns the output as a CuMatrix
+  void DoNnetComputationInternal(int32 input_t_start,
+    const MatrixBase<BaseFloat> &input_feats,
+    const VectorBase<BaseFloat> &ivector,
+    int32 output_t_start,
+    int32 num_output_frames,
+    CuMatrix<BaseFloat> *cu_output);
+
+  // Gets the iVector that will be used for this chunk of frames, if
+  // we are using iVectors (else does nothing).
+  void GetCurrentIvector(int32 output_t_start, int32 num_output_frames,
+    Vector<BaseFloat> *ivector);
+
+  void PossiblyWarnForFramesPerChunk() const;
+
+  // returns dimension of the provided iVectors if supplied, or 0 otherwise.
+  int32 GetIvectorDim() const;
+
+  int32 LeftContext() const { return left_context_; }
+  int32 RightContext() const { return right_context_; }
+
+  const NnetSimpleComputerOptions &opts_;
+
+  const Nnet &nnet_;
+
+  const MatrixBase<BaseFloat> &feats_;
+
+  // ivector_ is the iVector if we're using iVectors that are estimated in batch
+  // mode.
+  const VectorBase<BaseFloat> *ivector_;
+
+  // online_ivector_feats_ is the iVectors if we're using online-estimated ones.
+  const MatrixBase<BaseFloat> *online_ivector_feats_;
+  // online_ivector_period_ helps us interpret online_ivector_feats_; it's the
+  // number of frames the rows of ivector_feats are separated by.
+  int32 online_ivector_period_;
+
+  CachingOptimizingCompiler compiler_;
+
+  // The current log-posteriors that we got from the last time we
+  // ran the computation. 
+  // NOTE: This is just the output of the neural network, not necessarily the 
+  // log-posteriors
+  Matrix<BaseFloat> current_log_post_;
+  // The time-offset of the current log-posteriors. 
+  int32 current_log_post_offset_;
+ 
+  // The left and right contexts that are needed for per-frame computation
+  int32 left_context_;
+  int32 right_context_;
+};
+
+} // namespace nnet3
+} // namespace kaldi
+
+#endif  // KALDI_NNET3_NNET_SIMPLE_COMPUTER_H

--- a/src/nnet3bin/Makefile
+++ b/src/nnet3bin/Makefile
@@ -11,7 +11,8 @@ BINFILES = nnet3-init nnet3-info nnet3-get-egs nnet3-copy-egs nnet3-subset-egs \
    nnet3-compute-from-egs nnet3-train nnet3-am-init nnet3-am-train-transitions \
    nnet3-am-adjust-priors nnet3-am-copy nnet3-compute-prob \
    nnet3-average nnet3-am-info nnet3-combine nnet3-latgen-faster \
-   nnet3-copy nnet3-show-progress nnet3-align-compiled
+   nnet3-copy nnet3-show-progress nnet3-align-compiled \
+   nnet3-get-egs-dense-targets
 
 OBJFILES =
 

--- a/src/nnet3bin/Makefile
+++ b/src/nnet3bin/Makefile
@@ -12,7 +12,7 @@ BINFILES = nnet3-init nnet3-info nnet3-get-egs nnet3-copy-egs nnet3-subset-egs \
    nnet3-am-adjust-priors nnet3-am-copy nnet3-compute-prob \
    nnet3-average nnet3-am-info nnet3-combine nnet3-latgen-faster \
    nnet3-copy nnet3-show-progress nnet3-align-compiled \
-   nnet3-get-egs-dense-targets
+   nnet3-get-egs-dense-targets nnet3-compute
 
 OBJFILES =
 

--- a/src/nnet3bin/nnet3-compute.cc
+++ b/src/nnet3bin/nnet3-compute.cc
@@ -1,0 +1,166 @@
+// nnet3bin/nnet3-compute.cc
+
+// Copyright 2012-2015   Johns Hopkins University (author: Daniel Povey)
+//                2015   Vimal Manohar
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "nnet3/nnet-simple-computer.h"
+#include "base/timer.h"
+#include "nnet3/nnet-utils.h"
+
+
+int main(int argc, char *argv[]) {
+  // note: making this program work with GPUs is as simple as initializing the
+  // device, but it probably won't make a huge difference in speed for typical
+  // setups.
+  try {
+    using namespace kaldi;
+    using namespace kaldi::nnet3;
+    typedef kaldi::int32 int32;
+
+    const char *usage =
+        "Propagate through neural network model\n"
+        "Usage: nnet3-compute [options] <nnet-in> <features-rspecifier> <matrix-wspecifier>\n";
+    ParseOptions po(usage);
+    Timer timer;
+    
+    NnetSimpleComputerOptions opts;
+        
+    bool apply_exp = false;
+    std::string use_gpu = "yes";
+    
+    std::string word_syms_filename;
+    std::string ivector_rspecifier,
+                online_ivector_rspecifier,
+                utt2spk_rspecifier;
+    int32 online_ivector_period = 0;
+    opts.Register(&po);
+    
+    po.Register("ivectors", &ivector_rspecifier, "Rspecifier for "
+                "iVectors as vectors (i.e. not estimated online); per utterance "
+                "by default, or per speaker if you provide the --utt2spk option.");
+    po.Register("utt2spk", &utt2spk_rspecifier, "Rspecifier for "
+                "utt2spk option used to get ivectors per speaker");
+    po.Register("online-ivectors", &online_ivector_rspecifier, "Rspecifier for "
+                "iVectors estimated online, as matrices.  If you supply this,"
+                " you must set the --online-ivector-period option.");
+    po.Register("online-ivector-period", &online_ivector_period, "Number of frames "
+                "between iVectors in matrices supplied to the --online-ivectors "
+                "option");
+    po.Register("apply-exp", &apply_exp, "If true, apply exp function to "
+                "output");
+    po.Register("use-gpu", &use_gpu,
+                "yes|no|optional|wait, only has effect if compiled with CUDA");
+    
+    po.Read(argc, argv);
+    
+    if (po.NumArgs() != 3) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().SelectGpuId(use_gpu);
+#endif
+
+    std::string nnet_rxfilename = po.GetArg(1),
+                feature_rspecifier = po.GetArg(2),
+                matrix_wspecifier = po.GetArg(3);
+ 
+    Nnet nnet;
+    ReadKaldiObject(nnet_rxfilename, &nnet);
+
+    RandomAccessBaseFloatMatrixReader online_ivector_reader(
+        online_ivector_rspecifier);
+    RandomAccessBaseFloatVectorReaderMapped ivector_reader(
+        ivector_rspecifier, utt2spk_rspecifier);
+    
+    BaseFloatMatrixWriter matrix_writer(matrix_wspecifier);
+
+    int32 num_success = 0, num_fail = 0;
+    int64 frame_count = 0;
+
+    SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
+      
+    int32 left_context = 0, right_context = 0;
+    ComputeSimpleNnetContext(nnet, &left_context, &right_context);
+
+    for (; !feature_reader.Done(); feature_reader.Next()) {
+      std::string utt = feature_reader.Key();
+      const Matrix<BaseFloat> &features (feature_reader.Value());
+      if (features.NumRows() == 0) {
+        KALDI_WARN << "Zero-length utterance: " << utt;
+        num_fail++;
+        continue;
+      }
+      const Matrix<BaseFloat> *online_ivectors = NULL;
+      const Vector<BaseFloat> *ivector = NULL;
+      if (!ivector_rspecifier.empty()) {
+        if (!ivector_reader.HasKey(utt)) {
+          KALDI_WARN << "No iVector available for utterance " << utt;
+          num_fail++;
+          continue;
+        } else {
+          ivector = &ivector_reader.Value(utt);
+        }
+      }
+      if (!online_ivector_rspecifier.empty()) {
+        if (!online_ivector_reader.HasKey(utt)) {
+          KALDI_WARN << "No online iVector available for utterance " << utt;
+          num_fail++;
+          continue;
+        } else {
+          online_ivectors = &online_ivector_reader.Value(utt);
+        }
+      }
+          
+      NnetSimpleComputer nnet_computer(
+          opts, nnet,
+          features, 
+          left_context, right_context,
+          ivector, online_ivectors,
+          online_ivector_period);
+
+      Matrix<BaseFloat> matrix;
+      nnet_computer.GetOutput(&matrix);
+
+      if (apply_exp)
+        matrix.ApplyExp();
+
+      matrix_writer.Write(utt, matrix);
+
+      frame_count += features.NumRows();
+      num_success++;
+    }
+      
+    double elapsed = timer.Elapsed();
+    KALDI_LOG << "Time taken "<< elapsed 
+              << "s: real-time factor assuming 100 frames/sec is "
+              << (elapsed*100.0/frame_count);
+    KALDI_LOG << "Done " << num_success << " utterances, failed for "
+              << num_fail;
+    
+    if (num_success != 0) return 0;
+    else return 1;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}

--- a/src/nnet3bin/nnet3-get-egs-dense-targets.cc
+++ b/src/nnet3bin/nnet3-get-egs-dense-targets.cc
@@ -1,0 +1,256 @@
+// nnet3bin/nnet3-get-egs-dense-targets.cc
+
+// Copyright 2012-2015  Johns Hopkins University (author:  Daniel Povey)
+//                2014  Vimal Manohar
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "hmm/transition-model.h"
+#include "hmm/posterior.h"
+#include "nnet3/nnet-example.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+
+static void ProcessFile(const MatrixBase<BaseFloat> &feats,
+                        const MatrixBase<BaseFloat> *ivector_feats,
+                        const MatrixBase<BaseFloat> &targets,
+                        const std::string &utt_id,
+                        bool compress,
+                        int32 num_targets,
+                        int32 left_context,
+                        int32 right_context,
+                        int32 frames_per_eg,
+                        int64 *num_frames_written,
+                        int64 *num_egs_written,
+                        NnetExampleWriter *example_writer) {
+  KALDI_ASSERT(feats.NumRows() == static_cast<int32>(targets.NumRows()));
+  
+  for (int32 t = 0; t < feats.NumRows(); t += frames_per_eg) {
+
+    // actual_frames_per_eg is the number of frames with actual targets.
+    // At the end of the file, we pad with the last frame repeated
+    // so that all examples have the same structure (prevents the need
+    // for recompilations).
+    // TODO: We might need to ignore the end of the file.
+    int32 actual_frames_per_eg = std::min(frames_per_eg,
+                                          feats.NumRows() - t);
+
+
+    int32 tot_frames = left_context + frames_per_eg + right_context;
+
+    Matrix<BaseFloat> input_frames(tot_frames, feats.NumCols());
+    
+    // Set up "input_frames".
+    for (int32 j = -left_context; j < frames_per_eg + right_context; j++) {
+      int32 t2 = j + t;
+      if (t2 < 0) t2 = 0;
+      if (t2 >= feats.NumRows()) t2 = feats.NumRows() - 1;
+      SubVector<BaseFloat> src(feats, t2),
+          dest(input_frames, j + left_context);
+      dest.CopyFromVec(src);
+    }
+
+    NnetExample eg;
+    
+    // call the regular input "input".
+    eg.io.push_back(NnetIo("input", - left_context,
+                           input_frames));
+
+    // if applicable, add the iVector feature.
+    if (ivector_feats != NULL) {
+      // try to get closest frame to middle of window to get
+      // a representative iVector.
+      int32 closest_frame = t + (actual_frames_per_eg / 2);
+      KALDI_ASSERT(ivector_feats->NumRows() > 0);
+      if (closest_frame >= ivector_feats->NumRows())
+        closest_frame = ivector_feats->NumRows() - 1;
+      Matrix<BaseFloat> ivector(1, ivector_feats->NumCols());
+      ivector.Row(0).CopyFromVec(ivector_feats->Row(closest_frame));
+      eg.io.push_back(NnetIo("ivector", 0, ivector));
+    }
+
+    // add the labels.
+    Matrix<BaseFloat> targets_dest(frames_per_eg, targets.NumCols());
+    for (int32 i = 0; i < actual_frames_per_eg; i++) {
+      // Copy the i^th row of the target matrix from the (t+i)^th row of the
+      // input targets matrix
+      SubVector<BaseFloat> this_target_dest(targets_dest, i);
+      SubVector<BaseFloat> this_target_src(targets, t+i);
+      this_target_dest.CopyFromVec(this_target_src);
+    } 
+    
+    // Copy the last frame's target to the padded frames
+    for (int32 i = actual_frames_per_eg; i < frames_per_eg; i++) {
+      // Copy the i^th row of the target matrix from the last row of the 
+      // input targets matrix
+      KALDI_ASSERT(t + actual_frames_per_eg - 1 == feats.NumRows() - 1);
+      SubVector<BaseFloat> this_target_dest(targets_dest, i);
+      SubVector<BaseFloat> this_target_src(targets, t+actual_frames_per_eg-1);
+      this_target_dest.CopyFromVec(this_target_src);
+    } 
+
+    // push this created targets matrix into the eg
+    eg.io.push_back(NnetIo("output", 0, targets_dest));
+    
+    if (compress)
+      eg.Compress();
+      
+    std::ostringstream os;
+    os << utt_id << "-" << t;
+
+    std::string key = os.str(); // key is <utt_id>-<frame_id>
+
+    *num_frames_written += actual_frames_per_eg;
+    *num_egs_written += 1;
+
+    example_writer->Write(key, eg);
+  }
+}
+
+
+} // namespace nnet2
+} // namespace kaldi
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::nnet3;
+    typedef kaldi::int32 int32;
+    typedef kaldi::int64 int64;
+
+    const char *usage =
+        "Get frame-by-frame examples of data for nnet3 neural network training.\n"
+        "This program is similar to nnet3-get-egs, but the targets here are "
+        "dense matrices instead of posteriors (sparse matrices).\n"
+        "This is useful when you want the targets to be continuous real-valued "
+        "with the neural network possibly trained with a quadratic objective\n"
+        "\n"
+        "Usage:  nnet3-get-egs-dense-targets --num-targets=<n> [options] "
+        "<features-rspecifier> <targets-rspecifier> <egs-out>\n"
+        "\n"
+        "An example [where $feats expands to the actual features]:\n"
+        "nnet-get-egs-dense-targets --num-targets=26 --left-context=12 --right-context=9 --num-frames=8 \"$feats\"\\\n"
+        "\"ark:copy-matrix ark:exp/snrs/snr.1.ark ark:- |\"\n"
+        "   ark:- \n";
+        
+
+    bool compress = true;
+    int32 num_targets = -1, left_context = 0, right_context = 0,
+        num_frames = 1, length_tolerance = 100;
+        
+    std::string ivector_rspecifier;
+    
+    ParseOptions po(usage);
+    po.Register("compress", &compress, "If true, write egs in "
+                "compressed format.");
+    po.Register("num-targets", &num_targets, "Number of targets for the neural network");
+    po.Register("left-context", &left_context, "Number of frames of left "
+                "context the neural net requires.");
+    po.Register("right-context", &right_context, "Number of frames of right "
+                "context the neural net requires.");
+    po.Register("num-frames", &num_frames, "Number of frames with labels "
+                "that each example contains.");
+    po.Register("ivectors", &ivector_rspecifier, "Rspecifier of ivector "
+                "features, as matrix.");
+    po.Register("length-tolerance", &length_tolerance, "Tolerance for "
+                "difference in num-frames between feat and ivector matrices");
+    
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 3) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    if (num_targets <= 0)
+      KALDI_ERR << "--num-targets options is required.";
+
+    std::string feature_rspecifier = po.GetArg(1),
+        matrix_rspecifier = po.GetArg(2),
+        examples_wspecifier = po.GetArg(3);
+
+    // Read in all the training files.
+    SequentialBaseFloatMatrixReader feat_reader(feature_rspecifier);
+    RandomAccessBaseFloatMatrixReader matrix_reader(matrix_rspecifier);
+    NnetExampleWriter example_writer(examples_wspecifier);
+    RandomAccessBaseFloatMatrixReader ivector_reader(ivector_rspecifier);
+    
+    int32 num_done = 0, num_err = 0;
+    int64 num_frames_written = 0, num_egs_written = 0;
+    
+    for (; !feat_reader.Done(); feat_reader.Next()) {
+      std::string key = feat_reader.Key();
+      const Matrix<BaseFloat> &feats = feat_reader.Value();
+      if (!matrix_reader.HasKey(key)) {
+        KALDI_WARN << "No target matrix for key " << key;
+        num_err++;
+      } else {
+        const Matrix<BaseFloat> &target_matrix = matrix_reader.Value(key);
+        if (target_matrix.NumRows() != feats.NumRows()) {
+          KALDI_WARN << "Target matrix has wrong size " << target_matrix.NumRows()
+                     << " versus " << feats.NumRows();
+          num_err++;
+          continue;
+        }
+        const Matrix<BaseFloat> *ivector_feats = NULL;
+        if (!ivector_rspecifier.empty()) {
+          if (!ivector_reader.HasKey(key)) {
+            KALDI_WARN << "No iVectors for utterance " << key;
+            num_err++;
+            continue;
+          } else {
+            // this address will be valid until we call HasKey() or Value()
+            // again.
+            ivector_feats = &(ivector_reader.Value(key));
+          }
+        }
+
+        if (ivector_feats != NULL &&
+            (abs(feats.NumRows() - ivector_feats->NumRows()) > length_tolerance
+             || ivector_feats->NumRows() == 0)) {
+          KALDI_WARN << "Length difference between feats " << feats.NumRows()
+                     << " and iVectors " << ivector_feats->NumRows()
+                     << "exceeds tolerance " << length_tolerance;
+          num_err++;
+          continue;
+        }
+          
+        ProcessFile(feats, ivector_feats, target_matrix, key, compress,
+                    num_targets, left_context, right_context, num_frames,
+                    &num_frames_written, &num_egs_written,
+                    &example_writer);
+        num_done++;
+      }
+    }
+
+    KALDI_LOG << "Finished generating examples, "
+              << "successfully processed " << num_done
+              << " feature files, wrote " << num_egs_written << " examples, "
+              << " with " << num_frames_written << " egs in total; "
+              << num_err << " files had errors.";
+    return (num_egs_written == 0 || num_err > num_done ? 1 : 0);
+  } catch(const std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return -1;
+  }
+}
+


### PR DESCRIPTION
1) Created nnet3-get-egs-dense-targets to create egs that continuous valued targets.
2) Separated the nnet computation part from the DecodableAmNnetSimple class to create NnetSimpleComputer, and DecodableAmNnetSimple is made a child of NnetSimpleComputer -- Not sure if this part follows the code standards