### PR TITLE
Fixed strict-aliasing issue using union in const ARPA related code; A…

### DIFF
--- a/src/lm/const-arpa-lm.h
+++ b/src/lm/const-arpa-lm.h
@@ -20,6 +20,9 @@
 #ifndef KALDI_LM_CONST_ARPA_LM_H_
 #define KALDI_LM_CONST_ARPA_LM_H_
 
+#include <string>
+#include <vector>
+
 #include "base/kaldi-common.h"
 #include "fstext/deterministic-fst.h"
 #include "util/common-utils.h"
@@ -28,6 +31,15 @@ namespace kaldi {
 
 // Forward declaration of Auxiliary struct ArpaLine.
 struct ArpaLine;
+
+union Int32AndFloat {
+  int32 i;
+  float f;
+
+  Int32AndFloat() {}
+  Int32AndFloat(int32 input_i) : i(input_i) {}
+  Int32AndFloat(float input_f) : f(input_f) {}
+};
 
 class ConstArpaLm {
  public:
@@ -199,14 +211,14 @@ class ConstArpaLm {
  This class wraps a ConstArpaLm format language model with the interface defined
  in DeterministicOnDemandFst.
  */
-class ConstArpaLmDeterministicFst :
-    public fst::DeterministicOnDemandFst<fst::StdArc> {
+class ConstArpaLmDeterministicFst
+  : public fst::DeterministicOnDemandFst<fst::StdArc> {
  public:
   typedef fst::StdArc::Weight Weight;
   typedef fst::StdArc::StateId StateId;
   typedef fst::StdArc::Label Label;
 
-  ConstArpaLmDeterministicFst(const ConstArpaLm& lm);
+  explicit ConstArpaLmDeterministicFst(const ConstArpaLm& lm);
 
   // We cannot use "const" because the pure virtual function in the interface is
   // not const.
@@ -235,6 +247,6 @@ bool BuildConstArpaLm(const bool natural_base, const int32 bos_symbol,
                       const std::string& arpa_rxfilename,
                       const std::string& const_arpa_wxfilename);
 
-} // namespace kaldi
+}  // namespace kaldi
 
 #endif  // KALDI_LM_CONST_ARPA_LM_H_

--- a/src/lmbin/arpa-to-const-arpa.cc
+++ b/src/lmbin/arpa-to-const-arpa.cc
@@ -69,7 +69,7 @@ int main(int argc, char *argv[]) {
 
     if (bos_symbol == -1 || eos_symbol == -1) {
       KALDI_ERR << "Please set --bos-symbol and --eos-symbol.";
-      exit (1);
+      exit(1);
     }
 
     std::string arpa_rxfilename = po.GetArg(1),


### PR DESCRIPTION
…lso fixed some style issue that I saw in the related code. Tested this on WSJ and I was able to generate the same binary G.carpa as before.