### PR TITLE
Make join_suffix.py python3 compatible

### DIFF
--- a/egs/tedlium/s5/local/join_suffix.py
+++ b/egs/tedlium/s5/local/join_suffix.py
@@ -5,9 +5,10 @@
 
 
 import sys
+from codecs import open
 
 words = set()
-for line in open(sys.argv[1]):
+for line in open(sys.argv[1], encoding='utf8'):
     items = line.split()
     words.add(items[0])
 
@@ -16,12 +17,10 @@ for line in sys.stdin:
     new_items = []
     i = 1
     while i < len(items):
-	if i < len(items) - 1 and items[i+1][0] == '\'' and items[i] + items[i+1] in words:
-	    new_items.append(items[i] + items[i+1])
-	    i = i + 1
-	else:
-	    new_items.append(items[i])
-	i = i + 1
-	
-    print items[0], " ".join(new_items)
-    
+        if i < len(items) - 1 and items[i+1][0] == '\'' and items[i] + items[i+1] in words:
+            new_items.append(items[i] + items[i+1])
+            i = i + 1
+        else:
+            new_items.append(items[i])
+        i = i + 1
+    print(items[0] + ' ' + ' '.join(new_items))


### PR DESCRIPTION
join_suffix.py works only with python2, this change makes it compatible with both python2 and python3

(tested with python 2.7.10 and 3.5)