### PR TITLE
SRE10 example: Various improvements, mostly cosmetic, to the DNN-based speaker recognition system

### DIFF
--- a/egs/sre10/README.txt
+++ b/egs/sre10/README.txt
@@ -10,8 +10,9 @@
  are required by the subdirectories. See the corresponding README.txt files 
  in the subdirectories for more details.
 
- The subdirectories "v1" and so on are different versions of the recipe;
- we don't call them "s1" etc., because they don't really correspond to
- the speech recognition recipes.
-
+ The subdirectories "v1" and so on are different iVector-based speaker 
+ recognition recipes. The recipe in v1 demonstrates a standard approach 
+ using a full-covariance GMM-UBM, iVectors, and a PLDA backend. The example 
+ in v2 replaces the GMM of the v1 recipe with a time-delay deep neural 
+ network.
 

--- a/egs/sre10/v1/local/dnn/train_dnn.sh
+++ b/egs/sre10/v1/local/dnn/train_dnn.sh
@@ -15,7 +15,7 @@ set -e
 local/dnn/fisher_data_prep.sh /export/corpora3/LDC/LDC2004T19 /export/corpora3/LDC/LDC2005T19 \
    /export/corpora3/LDC/LDC2004S13 /export/corpora3/LDC/LDC2005S13
 # You could also try specifying the --calldata argument to this command as below.
-# If specified, the script will use actual speaker personal identification 
+# If specified, the script will use actual speaker personal identification
 # numbers released with the dataset, i.e. real speaker IDs. Note: --calldata has
 # to be the first argument of this script.
 # local/fisher_data_prep.sh --calldata /export/corpora3/LDC/LDC2004T19 /export/corpora3/LDC/LDC2005T19 \
@@ -28,7 +28,7 @@ local/dnn/fisher_prepare_dict.sh
 
 utils/prepare_lang.sh data/local/dict "<unk>" data/local/lang data/lang
 
-local/dnn/fisher_train_lms.sh 
+local/dnn/fisher_train_lms.sh
 local/dnn/fisher_create_test_lang.sh
 
 # Use the first 4k sentences as dev set.  Note: when we trained the LM, we used
@@ -55,12 +55,12 @@ utils/subset_data_dir.sh --first data/dev_and_test_asr 5000 data/dev_asr
 utils/subset_data_dir.sh --last data/dev_and_test_asr 5000 data/test_asr
 rm -r data/dev_and_test_asr
 
-steps/compute_cmvn_stats.sh data/dev_asr exp/make_mfcc/dev_asr $mfccdir 
-steps/compute_cmvn_stats.sh data/test_asr exp/make_mfcc/test_asr $mfccdir 
+steps/compute_cmvn_stats.sh data/dev_asr exp/make_mfcc/dev_asr $mfccdir
+steps/compute_cmvn_stats.sh data/test_asr exp/make_mfcc/test_asr $mfccdir
 
 n=$[`cat data/train_all_asr/segments | wc -l` - 10000]
 utils/subset_data_dir.sh --last data/train_all_asr $n data/train_asr
-steps/compute_cmvn_stats.sh data/train_asr exp/make_mfcc/train_asr $mfccdir 
+steps/compute_cmvn_stats.sh data/train_asr exp/make_mfcc/train_asr $mfccdir
 
 
 # Now-- there are 1.6 million utterances, and we want to start the monophone training
@@ -75,30 +75,30 @@ utils/subset_data_dir.sh --speakers data/train_asr 30000 data/train_asr_30k
 utils/subset_data_dir.sh --speakers data/train_asr 100000 data/train_asr_100k
 
 
-# The next commands are not necessary for the scripts to run, but increase 
-# efficiency of data access by putting the mfcc's of the subset 
+# The next commands are not necessary for the scripts to run, but increase
+# efficiency of data access by putting the mfcc's of the subset
 # in a contiguous place in a file.
-( . path.sh; 
+( . path.sh;
   # make sure mfccdir is defined as above..
-  cp data/train_asr_10k_nodup/feats.scp{,.bak} 
+  cp data/train_asr_10k_nodup/feats.scp{,.bak}
   copy-feats scp:data/train_asr_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_10k_nodup.ark,$mfccdir/kaldi_fish_10k_nodup.scp \
   && cp $mfccdir/kaldi_fish_10k_nodup.scp data/train_asr_10k_nodup/feats.scp
 )
-( . path.sh; 
+( . path.sh;
   # make sure mfccdir is defined as above..
-  cp data/train_asr_30k/feats.scp{,.bak} 
+  cp data/train_asr_30k/feats.scp{,.bak}
   copy-feats scp:data/train_asr_30k/feats.scp  ark,scp:$mfccdir/kaldi_fish_30k.ark,$mfccdir/kaldi_fish_30k.scp \
   && cp $mfccdir/kaldi_fish_30k.scp data/train_asr_30k/feats.scp
 )
-( . path.sh; 
+( . path.sh;
   # make sure mfccdir is defined as above..
-  cp data/train_asr_100k/feats.scp{,.bak} 
+  cp data/train_asr_100k/feats.scp{,.bak}
   copy-feats scp:data/train_asr_100k/feats.scp  ark,scp:$mfccdir/kaldi_fish_100k.ark,$mfccdir/kaldi_fish_100k.scp \
   && cp $mfccdir/kaldi_fish_100k.scp data/train_asr_100k/feats.scp
 )
 
 steps/train_mono.sh --nj 10 --cmd "$train_cmd" \
-  data/train_asr_10k_nodup data/lang exp/mono0a 
+  data/train_asr_10k_nodup data/lang exp/mono0a
 
 steps/align_si.sh --nj 30 --cmd "$train_cmd" \
    data/train_asr_30k data/lang exp/mono0a exp/mono0a_ali || exit 1;
@@ -109,7 +109,7 @@ steps/train_deltas.sh --cmd "$train_cmd" \
 
 (utils/mkgraph.sh data/lang_test exp/tri1 exp/tri1/graph
  steps/decode.sh --nj 25 --cmd "$decode_cmd" --config conf/decode.config \
-   exp/tri1/graph data/dev exp/tri1/decode_dev)&
+   exp/tri1/graph data/dev_asr exp/tri1/decode_dev)&
 
 steps/align_si.sh --nj 30 --cmd "$train_cmd" \
    data/train_asr_30k data/lang exp/tri1 exp/tri1_ali || exit 1;
@@ -120,7 +120,7 @@ steps/train_deltas.sh --cmd "$train_cmd" \
 (
   utils/mkgraph.sh data/lang_test exp/tri2 exp/tri2/graph || exit 1;
   steps/decode.sh --nj 25 --cmd "$decode_cmd" --config conf/decode.config \
-   exp/tri2/graph data/dev exp/tri2/decode_dev || exit 1;
+   exp/tri2/graph data/dev_asr exp/tri2/decode_dev || exit 1;
 )&
 
 
@@ -134,11 +134,11 @@ steps/train_lda_mllt.sh --cmd "$train_cmd" \
 (
   utils/mkgraph.sh data/lang_test exp/tri3a exp/tri3a/graph || exit 1;
   steps/decode.sh --nj 25 --cmd "$decode_cmd" --config conf/decode.config \
-   exp/tri3a/graph data/dev exp/tri3a/decode_dev || exit 1;
+   exp/tri3a/graph data/dev_asr exp/tri3a/decode_dev || exit 1;
 )&
 
 
-# Next we'll use fMLLR and train with SAT (i.e. on 
+# Next we'll use fMLLR and train with SAT (i.e. on
 # fMLLR features)
 
 steps/align_fmllr.sh --nj 30 --cmd "$train_cmd" \
@@ -150,9 +150,8 @@ steps/train_sat.sh  --cmd "$train_cmd" \
 (
   utils/mkgraph.sh data/lang_test exp/tri4a exp/tri4a/graph
   steps/decode_fmllr.sh --nj 25 --cmd "$decode_cmd" --config conf/decode.config \
-   exp/tri4a/graph data/dev exp/tri4a/decode_dev
+   exp/tri4a/graph data/dev_asr exp/tri4a/decode_dev
 )&
-
 
 steps/align_fmllr.sh --nj 30 --cmd "$train_cmd" \
   data/train_asr data/lang exp/tri4a exp/tri4a_ali || exit 1;
@@ -164,7 +163,7 @@ steps/train_sat.sh  --cmd "$train_cmd" \
 (
   utils/mkgraph.sh data/lang_test exp/tri5a exp/tri5a/graph
   steps/decode_fmllr.sh --nj 25 --cmd "$decode_cmd" --config conf/decode.config \
-    exp/tri5a/graph data/dev exp/tri5a/decode_dev
+    exp/tri5a/graph data/dev_asr exp/tri5a/decode_dev
 )&
 
 # this will help find issues with the lexicon.

--- a/egs/sre10/v2/README.txt
+++ b/egs/sre10/v2/README.txt
@@ -1,0 +1,20 @@
+ Data required for system development (on top of the data for testing described
+ in ../README.txt).  We use SWBD and the older (prior to 2010) SREs to train the
+ supervised-GMM and iVector extractor. To create an in-domain system, the SREs
+ are needed to train the PLDA backend.  The TDNN is trained on Fisher English.
+ 
+     Corpus              LDC Catalog No.
+     SWBD2 Phase 2       LDC99S79
+     SWBD2 Phase 3       LDC2002S06
+     SWBD Cellular 1     LDC2001S13
+     SWBD Ceullar 2      LDC2004S07
+     SRE2004             LDC2006S44
+     SRE2005 Train       LDC2011S01
+     SRE2005 Test        LDC2011S04
+     SRE2006 Train       LDC2011S09
+     SRE2006 Test 1      LDC2011S10
+     SRE2006 Test 2      LDC2012S01
+     SRE2008 Train       LDC2011S05
+     SRE2008 Test        LDC2011S08
+     Fisher speech       LDC2004S13, LDC2005S13 
+     Fisher test         LDC2004T19, LDC2005T19        

--- a/src/fgmmbin/fgmm-global-init-from-accs.cc
+++ b/src/fgmmbin/fgmm-global-init-from-accs.cc
@@ -60,8 +60,9 @@ int main(int argc, char *argv[]) {
       gmm_accs.Read(ki.Stream(), binary, true /* add accs. */);
     }
 
-    int32 num_gauss = gmm_accs.NumGauss(),
-          dim = gmm_accs.Dim();
+    int32 num_gauss = gmm_accs.NumGauss(), dim = gmm_accs.Dim(),
+          tot_floored = 0, gauss_floored = 0;
+
     FullGmm fgmm(num_components, dim);
 
     Vector<BaseFloat> weights(num_gauss);
@@ -85,14 +86,25 @@ int main(int argc, char *argv[]) {
       SpMatrix<BaseFloat> covar(gmm_accs.covariance_accumulator()[i]);
       covar.Scale(1.0 / occ);
       covar.AddVec2(-1.0, means.Row(i));  // subtract squared means.
-      covar.Invert();
+      // Floor variance Eigenvalues.
+      BaseFloat floored = std::max(
+          static_cast<BaseFloat>(gmm_opts.variance_floor),
+          static_cast<BaseFloat>(covar.MaxAbsEig() / gmm_opts.max_condition));
+      if (floored) {
+        tot_floored += floored;
+        gauss_floored++;
+      }
+      covar.InvertDouble();
       invcovars.push_back(covar);
     }
     fgmm.SetWeights(weights);
     fgmm.SetInvCovarsAndMeans(invcovars, means);
     int32 num_bad = fgmm.ComputeGconsts();
     KALDI_LOG << "FullGmm has " << num_bad << " bad GConsts";
-
+    if (tot_floored > 0) {
+      KALDI_WARN << tot_floored << " variances floored in " << gauss_floored
+                 << " Gaussians.";
+    }
     WriteKaldiObject(fgmm, model_out_filename, binary_write);
 
     KALDI_LOG << "Written model to " << model_out_filename;


### PR DESCRIPTION
* Removed the requirement that --num_components (of the DNN) be passed to sid/init_full_ubm_from_dnn.sh. It is now parsed from nnet-am-info.

*  Modified src/fgmmbin/fgmm-global-init-from-accs.cc to first floor the covariance eigenvalues prior to inverting. 

* Fixed bugs in optional parts of DNN training recipe.

* Added a README to egs/sre10/v2/