### PR TITLE
Overrides the Read method for FmllrDiagGmmAccs to init SingleFrameStats

### DIFF
--- a/src/transform/fmllr-diag-gmm.h
+++ b/src/transform/fmllr-diag-gmm.h
@@ -81,7 +81,10 @@ class FmllrDiagGmmAccs: public AffineXformStats {
   void Init(size_t dim) {
     AffineXformStats::Init(dim, dim); single_frame_stats_.Init(dim);
   }
-
+  void Read(std::istream &in, bool binary, bool add) {
+      AffineXformStats::Read(in, binary, add);
+      single_frame_stats_.Init(Dim());
+  }
   /// Accumulate stats for a single GMM in the model; returns log likelihood.
   BaseFloat AccumulateForGmm(const DiagGmm &gmm,
                              const VectorBase<BaseFloat> &data,


### PR DESCRIPTION

The default Read method (inherited from AffineXformStats) will not initialize single_frame_stats_ which causes a runtime error after Reading adaptation data (using OnlineGmmAdaptationState::Read) and then estimating fmllr. To be precise the error happens in FmllrDiagGmmAccs::AccumulateFromPosteriors --> FmllrDiagGmmAccs::DataHasChanged which finds a dimension mismatch 0 vs 40.