### PR TITLE
featbin/extract-feature-segments.cc: float to int conversion fix and a new option

### DIFF
--- a/src/featbin/extract-feature-segments.cc
+++ b/src/featbin/extract-feature-segments.cc
@@ -2,7 +2,7 @@
 
 // Copyright 2009-2011  Microsoft Corporation;  Govivace Inc.
 //           2012-2013  Mirko Hannemann;  Arnab Ghoshal
-//           2015       Tanel Alumae  
+//           2015       Tanel Alumae
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -34,11 +34,14 @@
 int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
-    
+
     const char *usage =
         "Create feature files by segmenting input files.\n"
-        "Usage:  extract-feature-segments [options...] <feats-rspecifier> <segments-file> <feats-wspecifier>\n"
-        " (segments-file has lines like: output-utterance-id input-utterance-or-spk-id 1.10 2.36)\n";
+        "Usage:  "
+        "extract-feature-segments [options...] <feats-rspecifier> "
+        " <segments-file> <feats-wspecifier>\n"
+        " (segments-file has lines like: "
+        "output-utterance-id input-utterance-or-spk-id 1.10 2.36)\n";
 
     // construct all the global objects
     ParseOptions po(usage);
@@ -51,48 +54,49 @@ int main(int argc, char *argv[]) {
 
     // Register the options
     po.Register("min-segment-length", &min_segment_length,
-                "Minimum segment length in seconds (reject shorter segments)");
-    po.Register("frame-length", &frame_length,
-                "Frame length in milliseconds");
-    po.Register("frame-shift", &frame_shift,
-                "Frame shift in milliseconds");
+        "Minimum segment length in seconds (reject shorter segments)");
+    po.Register("frame-length", &frame_length, "Frame length in milliseconds");
+    po.Register("frame-shift", &frame_shift, "Frame shift in milliseconds");
     po.Register("max-overshoot", &max_overshoot,
-                "End segments overshooting by less (in seconds) are truncated,"
-                " else rejected.");
+        "End segments overshooting by less (in seconds) are truncated,"
+        " else rejected.");
     po.Register("snip-edges", &snip_edges,
-                "If true, n_frames frames will be snipped from the beginning of each extracted feature matrix, "
-                "where n_frames = ceil((frame_length - frame_shift) / frame_shift), "
-                "except for the segments at the beginning of a file, where "
-                "the snipping is done from the end. "
-                "This ensures that only the feature vectors that "
-                "completely fit in the segment are extracted. "
-                "This makes the extracted segment lengths match the lengths of the "
-                "features that have been extracted from already segmented audio.");
+        "If true, n_frames frames will be snipped from the beginning of each "
+        "extracted feature matrix, "
+        "where n_frames = ceil((frame_length - frame_shift) / frame_shift), "
+        "except for the segments at the beginning of a file, where "
+        "the snipping is done from the end. "
+        "This ensures that only the feature vectors that "
+        "completely fit in the segment are extracted. "
+        "This makes the extracted segment lengths match the lengths of the "
+        "features that have been extracted from already segmented audio.");
 
     // OPTION PARSING ...
     // parse options  (+filling the registered variables)
     po.Read(argc, argv);
-    // number of arguments should be 3(scriptfile,segments file and outputwav write mode)
+    // number of arguments should be 3
+    // (scriptfile, segments file and outputwav write mode)
     if (po.NumArgs() != 3) {
       po.PrintUsage();
       exit(1);
     }
 
-    std::string rspecifier = po.GetArg(1); // get script file/feature archive
-    std::string segments_rxfilename = po.GetArg(2);// get segment file
-    std::string wspecifier = po.GetArg(3); // get written archive name
+    std::string rspecifier = po.GetArg(1);  // get script file/feature archive
+    std::string segments_rxfilename = po.GetArg(2);  // get segment file
+    std::string wspecifier = po.GetArg(3);  // get written archive name
 
     BaseFloatMatrixWriter feat_writer(wspecifier);
 
-    RandomAccessBaseFloatMatrixReader feat_reader(rspecifier); 
+    RandomAccessBaseFloatMatrixReader feat_reader(rspecifier);
 
-    Input ki(segments_rxfilename); // no binary argment: never binary.
+    Input ki(segments_rxfilename);  // no binary argment: never binary.
 
     int32 num_lines = 0, num_success = 0;
 
     int32 snip_length = 0;
     if (snip_edges) {
-      snip_length =  static_cast<int32>(ceil(1.0 * (frame_length - frame_shift) / frame_shift));
+      snip_length = static_cast<int32>(ceil(
+          1.0 * (frame_length - frame_shift) / frame_shift));
     }
 
     std::string line;
@@ -128,15 +132,16 @@ int main(int argc, char *argv[]) {
       // start time must not be negative; start time must not be greater than
       // end time, except if end time is -1
       if (start < 0 || end <= 0 || start >= end) {
-        KALDI_WARN << "Invalid line in segments file [empty or invalid segment]: "
+        KALDI_WARN << "Invalid line in segments file "
+            "[empty or invalid segment]: "
                    << line;
         continue;
       }
       int32 channel = -1;  // means channel info is unspecified.
       // if each line has 5 elements then 5th element must be channel identifier
-      if(split_line.size() == 5) {
+      if (split_line.size() == 5) {
         if (!ConvertStringToInteger(split_line[4], &channel) || channel < 0) {
-          KALDI_WARN << "Invalid line in segments file [bad channel]: " << line;
+          KALDI_WARN<< "Invalid line in segments file [bad channel]: " << line;
           continue;
         }
       }
@@ -150,11 +155,14 @@ int main(int argc, char *argv[]) {
         continue;
       }
       const Matrix<BaseFloat> &feats = feat_reader.Value(utterance);
-      int32 num_samp = feats.NumRows(), // total number of samples present in wav data
-          num_chan = feats.NumCols(); // total number of channels present in wav file
+      // total number of samples present in wav data
+      int32 num_samp = feats.NumRows();
+      // total number of channels present in wav file
+      int32 num_chan = feats.NumCols();
       // Convert start & end times of the segment to corresponding sample number
-      int32 start_samp = static_cast<int32>(round((start * 1000.0/frame_shift)));
-      int32 end_samp = static_cast<int32>(round(end * 1000.0/frame_shift));
+      int32 start_samp = static_cast<int32>(round(
+          (start * 1000.0 / frame_shift)));
+      int32 end_samp = static_cast<int32>(round(end * 1000.0 / frame_shift));
 
       if (start_samp > 0) {
         start_samp += snip_length;
@@ -167,8 +175,9 @@ int main(int argc, char *argv[]) {
        * otherwise skip the segment
        */
       if (start_samp < 0 || start_samp >= num_samp) {
-        KALDI_WARN << "Start sample out of range " << start_samp << " [length:] "
-                   << num_samp << "x" << num_chan << ", skipping segment " << segment;
+        KALDI_WARN << "Start sample out of range " << start_samp
+            << " [length:] " << num_samp << "x" << num_chan
+            << ", skipping segment " << segment;
         continue;
       }
 
@@ -176,28 +185,34 @@ int main(int argc, char *argv[]) {
        * otherwise skip the segment
        */
       if (end_samp > num_samp) {
-        if (end_samp >=
-            num_samp + static_cast<int32>(round(max_overshoot * 1000.0/frame_shift))) {
-          KALDI_WARN << "End sample too far out of range " << end_samp
-                     << " [length:] " << num_samp << "x" << num_chan << ", skipping segment "
-                     << segment;
+        if (end_samp >= num_samp
+                + static_cast<int32>(
+                    round(max_overshoot * 1000.0 / frame_shift))) {
+          KALDI_WARN<< "End sample too far out of range " << end_samp
+              << " [length:] " << num_samp << "x" << num_chan
+              << ", skipping segment "
+              << segment;
           continue;
         }
-        end_samp = num_samp; // for small differences, just truncate.
+        end_samp = num_samp;  // for small differences, just truncate.
       }
 
       /* check whether the segment size is less than minimum segment length(default 0.1 sec)
        * if yes, skip the segment
        */
-      if (end_samp <=
-          start_samp + static_cast<int32>(round((min_segment_length * 1000.0/frame_shift)))) {
-        KALDI_WARN << "Segment " << segment << " too short, skipping it.";
+      if (end_samp
+          <= start_samp
+              + static_cast<int32>(round(
+                  (min_segment_length * 1000.0 / frame_shift)))) {
+        KALDI_WARN<< "Segment " << segment << " too short, skipping it.";
         continue;
       }
 
-      SubMatrix<BaseFloat> segment_matrix(feats, start_samp, end_samp-start_samp, 0, num_chan);
+      SubMatrix<BaseFloat> segment_matrix(feats, start_samp,
+          end_samp-start_samp, 0, num_chan);
       Matrix<BaseFloat> outmatrix(segment_matrix);
-      feat_writer.Write(segment, outmatrix);  // write segment in feature archive.
+      // write segment in feature archive.
+      feat_writer.Write(segment, outmatrix);
       num_success++;
     }
     KALDI_LOG << "Successfully processed " << num_success << " lines out of "


### PR DESCRIPTION
Fixing float to int32 conversion, and adding an option to trim start times by window_length-window_period.

This allows the lengths of extracted feature segments to match with the lengths of feature vectors that are calculated from already segmented audio.