### PR TITLE
compute-wer : cleaning the tool, integer vectors are loaded as stings,

### DIFF
--- a/egs/timit/s5/local/score_basic.sh
+++ b/egs/timit/s5/local/score_basic.sh
@@ -55,6 +55,6 @@ $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring/log/score_basic.LMWT.log \
     utils/int2sym.pl -f 2- $symtab \| \
     local/timit_norm_trans.pl -i - -m $phonemap -from 48 -to 39 \| \
     compute-wer --text --mode=all \
-     ark:$dir/scoring/test_filt.txt ark,p:- $dir/scoring/wer_stats_LMWT ">&" $dir/wer_LMWT || exit 1;
+     ark:$dir/scoring/test_filt.txt ark,p:- ">&" $dir/wer_LMWT || exit 1;
 
 exit 0;

--- a/egs/wsj/s5/utils/scoring/wer_per_spk_details.pl
+++ b/egs/wsj/s5/utils/scoring/wer_per_spk_details.pl
@@ -96,6 +96,8 @@ while(<UTT2SPK>) {
   my @F=split;
   die "Incompatible format of the utt2spk file: $_" if @F != 2; 
   $UTTMAP{$F[0]} = $F[1];
+  # Set width of speaker column by its longest label,
+  if($SPK_WIDTH < length($F[1])) { $SPK_WIDTH = length($F[1]) }
 }
 close(UTT2SPK);
 

--- a/src/bin/align-text.cc
+++ b/src/bin/align-text.cc
@@ -47,7 +47,9 @@ int main(int argc, char *argv[]) {
         "\n"
         "Usage: align-text [options] <text1-rspecifier> <text2-rspecifier> \\\n"
         "                              <alignment-wspecifier>\n"
-        " e.g.: align-text ark:text1.txt ark:text2.txt ark,t:alignment.txt\n";
+        " e.g.: align-text ark:text1.txt ark:text2.txt ark,t:alignment.txt\n"
+        "See also: compute-wer,\n"
+        "Example scoring script: egs/wsj/s5/steps/score_kaldi.sh\n";
 
     ParseOptions po(usage);
 

--- a/src/bin/compute-wer.cc
+++ b/src/bin/compute-wer.cc
@@ -36,8 +36,9 @@ int main(int argc, char *argv[]) {
         "and outputs overall WER statistics to standard output.\n"
         "\n"
         "Usage: compute-wer [options] <ref-rspecifier> <hyp-rspecifier>\n"
-        "\n"
-        "E.g.: compute-wer --text --mode=present ark:data/train/text ark:hyp_text\n";
+        "E.g.: compute-wer --text --mode=present ark:data/train/text ark:hyp_text\n"
+        "See also: align-text,\n"
+        "Example scoring script: egs/wsj/s5/steps/score_kaldi.sh\n";
 
     ParseOptions po(usage);
 
@@ -49,7 +50,7 @@ int main(int argc, char *argv[]) {
                 "  \"strict\" means die if all in ref not also in hyp");
     
     bool dummy = false;
-    po.Register("text", &dummy, "Deprecatad option! Keeping for compatibility reasons.");
+    po.Register("text", &dummy, "Deprecated option! Keeping for compatibility reasons.");
 
     po.Read(argc, argv);
 

--- a/src/bin/compute-wer.cc
+++ b/src/bin/compute-wer.cc
@@ -2,6 +2,7 @@
 
 // Copyright 2009-2011  Microsoft Corporation
 //                2014  Johns Hopkins University (authors: Jan Trmal, Daniel Povey)
+//                2015  Brno Universiry of technology (author: Karel Vesely)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -24,42 +25,6 @@
 #include "tree/context-dep.h"
 #include "util/edit-distance.h"
 
-
-namespace kaldi {
-
-
-template<typename T>
-void PrintAlignmentStats(const std::vector<T> &ref,
-                         const std::vector<T> &hyp,
-                         T eps,
-                         std::ostream &os) {
-  // Make sure the eps symbol is not in the sentences we're aligning; this would
-  // not make sense.
-  KALDI_ASSERT(std::find(ref.begin(), ref.end(), eps) == ref.end());
-  KALDI_ASSERT(std::find(hyp.begin(), hyp.end(), eps) == hyp.end());
-
-  std::vector<std::pair<T, T> > aligned;
-  typedef typename std::vector<std::pair<T, T> >::const_iterator  aligned_iterator;
-
-  LevenshteinAlignment(ref, hyp, eps, &aligned);
-  for (aligned_iterator it = aligned.begin();
-       it != aligned.end(); ++it) {
-    KALDI_ASSERT(!(it->first == eps && it->second == eps));
-    if (it->first == eps) {
-      os << "insertion " << it->second << std::endl;
-    } else if (it->second == eps) {
-      os << "deletion " << it->first << std::endl;
-    } else if (it->first != it->second) {
-      os << "substitution " << it->first << ' ' << it->second << std::endl;
-    } else {
-      os << "correct " << it->first << std::endl;
-    }
-  }
-}
-
-}
-
-
 int main(int argc, char *argv[]) {
   using namespace kaldi;
   typedef kaldi::int32 int32;
@@ -69,29 +34,26 @@ int main(int argc, char *argv[]) {
         "Compute WER by comparing different transcriptions\n"
         "Takes two transcription files, in integer or text format,\n"
         "and outputs overall WER statistics to standard output.\n"
-        "Optionally, the third argument can be used to obtain detailed statistics\n"
         "\n"
-        "Usage: compute-wer [options] <ref-rspecifier> <hyp-rspecifier> [<stats-out>]\n"
+        "Usage: compute-wer [options] <ref-rspecifier> <hyp-rspecifier>\n"
         "\n"
-        "E.g.: compute-wer --text --mode=present ark:data/train/text ark:hyp_text\n"
-        "or: compute-wer --text --mode=present ark:data/train/text ark:hyp_text - | \\\n"
-        "   sort | uniq -c\n";
+        "E.g.: compute-wer --text --mode=present ark:data/train/text ark:hyp_text\n";
 
     ParseOptions po(usage);
 
     std::string mode = "strict";
-    bool text_input = false;  //  if this is true, we expect symbols as strings,
-
     po.Register("mode", &mode,
                 "Scoring mode: \"present\"|\"all\"|\"strict\":\n"
                 "  \"present\" means score those we have transcriptions for\n"
                 "  \"all\" means treat absent transcriptions as empty\n"
                 "  \"strict\" means die if all in ref not also in hyp");
-    po.Register("text", &text_input, "Expect strings, not integers, as input.");
+    
+    bool dummy = false;
+    po.Register("text", &dummy, "Deprecatad option! Keeping for compatibility reasons.");
 
     po.Read(argc, argv);
 
-    if (po.NumArgs() < 2 || po.NumArgs() > 3) {
+    if (po.NumArgs() != 2) {
       po.PrintUsage();
       exit(1);
     }
@@ -99,103 +61,62 @@ int main(int argc, char *argv[]) {
     std::string ref_rspecifier = po.GetArg(1);
     std::string hyp_rspecifier = po.GetArg(2);
 
-    Output stats_output;
-    bool detailed_stats = (po.NumArgs() == 3);
-    if (detailed_stats)
-      stats_output.Open(po.GetOptArg(3), false, false);  // non-binary output
-    
     if (mode != "strict" && mode != "present" && mode != "all") {
       KALDI_ERR << "--mode option invalid: expected \"present\"|\"all\"|\"strict\", got "
                 << mode;
     }
 
-
-
     int32 num_words = 0, word_errs = 0, num_sent = 0, sent_errs = 0,
         num_ins = 0, num_del = 0, num_sub = 0, num_absent_sents = 0;
 
-    if (!text_input) {
-      SequentialInt32VectorReader ref_reader(ref_rspecifier);
-      RandomAccessInt32VectorReader hyp_reader(hyp_rspecifier);
-
-      for (; !ref_reader.Done(); ref_reader.Next()) {
-        std::string key = ref_reader.Key();
-        const std::vector<int32> &ref_sent = ref_reader.Value();
-        std::vector<int32> hyp_sent;
-        if (!hyp_reader.HasKey(key)) {
-          if (mode == "strict")
-            KALDI_ERR << "No hypothesis for key " << key << " and strict "
-                "mode specifier.";
-          num_absent_sents++;
-          if (mode == "present")  // do not score this one.
-            continue;
-        } else {
-          hyp_sent = hyp_reader.Value(key);
-        }
-        num_words += ref_sent.size();
-        int32 ins, del, sub;
-        word_errs += LevenshteinEditDistance(ref_sent, hyp_sent,
-                                             &ins, &del, &sub);
-        num_ins += ins;
-        num_del += del;
-        num_sub += sub;
-
-        if (detailed_stats) {
-          const int32 eps = -1;
-          PrintAlignmentStats(ref_sent, hyp_sent, eps, stats_output.Stream());
-        }
-        num_sent++;
-        sent_errs += (ref_sent != hyp_sent);
+    // Both text and integers are loaded as vector of strings,
+    SequentialTokenVectorReader ref_reader(ref_rspecifier);
+    RandomAccessTokenVectorReader hyp_reader(hyp_rspecifier);
+    
+    // Main loop, accumulate WER stats,
+    for (; !ref_reader.Done(); ref_reader.Next()) {
+      std::string key = ref_reader.Key();
+      const std::vector<std::string> &ref_sent = ref_reader.Value();
+      std::vector<std::string> hyp_sent;
+      if (!hyp_reader.HasKey(key)) {
+        if (mode == "strict")
+          KALDI_ERR << "No hypothesis for key " << key << " and strict "
+              "mode specifier.";
+        num_absent_sents++;
+        if (mode == "present")  // do not score this one.
+          continue;
+      } else {
+        hyp_sent = hyp_reader.Value(key);
       }
-    } else {
-      SequentialTokenVectorReader ref_reader(ref_rspecifier);
-      RandomAccessTokenVectorReader hyp_reader(hyp_rspecifier);
+      num_words += ref_sent.size();
+      int32 ins, del, sub;
+      word_errs += LevenshteinEditDistance(ref_sent, hyp_sent, &ins, &del, &sub);
+      num_ins += ins;
+      num_del += del;
+      num_sub += sub;
 
-      for (; !ref_reader.Done(); ref_reader.Next()) {
-        std::string key = ref_reader.Key();
-        const std::vector<std::string> &ref_sent = ref_reader.Value();
-        std::vector<std::string> hyp_sent;
-        if (!hyp_reader.HasKey(key)) {
-          if (mode == "strict")
-            KALDI_ERR << "No hypothesis for key " << key << " and strict "
-                "mode specifier.";
-          num_absent_sents++;
-          if (mode == "present")  // do not score this one.
-            continue;
-        } else {
-          hyp_sent = hyp_reader.Value(key);
-        }
-        num_words += ref_sent.size();
-        int32 ins, del, sub;
-        word_errs += LevenshteinEditDistance(ref_sent, hyp_sent,
-                                             &ins, &del, &sub);
-        num_ins += ins;
-        num_del += del;
-        num_sub += sub;
-
-        if (detailed_stats) {
-          const std::string eps = "";
-          PrintAlignmentStats(ref_sent, hyp_sent, eps, stats_output.Stream());
-        }
-        num_sent++;
-        sent_errs += (ref_sent != hyp_sent);
-      }
+      num_sent++;
+      sent_errs += (ref_sent != hyp_sent);
     }
 
+    // Compute WER, SER,
     BaseFloat percent_wer = 100.0 * static_cast<BaseFloat>(word_errs)
         / static_cast<BaseFloat>(num_words);
+    BaseFloat percent_ser = 100.0 * static_cast<BaseFloat>(sent_errs)
+        / static_cast<BaseFloat>(num_sent);
+
+    // Print the ouptut,
     std::cout.precision(2);
     std::cerr.precision(2);
     std::cout << "%WER " << std::fixed << percent_wer << " [ " << word_errs
               << " / " << num_words << ", " << num_ins << " ins, "
               << num_del << " del, " << num_sub << " sub ]"
               << (num_absent_sents != 0 ? " [PARTIAL]" : "") << '\n';
-    BaseFloat percent_ser = 100.0 * static_cast<BaseFloat>(sent_errs)
-        / static_cast<BaseFloat>(num_sent);
     std::cout << "%SER " << std::fixed << percent_ser <<  " [ "
                << sent_errs << " / " << num_sent << " ]\n";
     std::cout << "Scored " << num_sent << " sentences, "
               << num_absent_sents << " not present in hyp.\n";
+
     return 0;
   } catch(const std::exception &e) {
     std::cerr << e.what();


### PR DESCRIPTION
- follow-up of discussion #254
- simplifying the 'compute-wer' tool (removing stats printing, removing int-vector comparing),
- TODO : update 'babel/s5b/local/generate_confusion_matrix.sh' 'babel/s5c/local/generate_confusion_matrix.sh', where the stats are used... (already sent email to @jtrmal)