### PR TITLE
Removing null-pointer checks as mentioned in #89

### DIFF
--- a/src/feat/feature-fbank.cc
+++ b/src/feat/feature-fbank.cc
@@ -41,9 +41,10 @@ Fbank::Fbank(const FbankOptions &opts)
 Fbank::~Fbank() {
   for (std::map<BaseFloat, MelBanks*>::iterator iter = mel_banks_.begin();
       iter != mel_banks_.end();
-      ++iter)
+      ++iter) {
     delete iter->second;
-    delete srfft_;
+  }
+  delete srfft_;
 }
 
 const MelBanks *Fbank::GetMelBanks(BaseFloat vtln_warp) {
@@ -82,7 +83,7 @@ void Fbank::Compute(const VectorBase<BaseFloat> &wave,
                     Matrix<BaseFloat> *output,
                     Vector<BaseFloat> *wave_remainder) {
   const MelBanks *this_mel_banks = GetMelBanks(vtln_warp);
-  ComputeInternal(wave, *this_mel_banks, output, wave_remainder);  
+  ComputeInternal(wave, *this_mel_banks, output, wave_remainder);
 }
 
 void Fbank::Compute(const VectorBase<BaseFloat> &wave,
@@ -92,9 +93,9 @@ void Fbank::Compute(const VectorBase<BaseFloat> &wave,
   bool must_delete_mel_banks;
   const MelBanks *mel_banks = GetMelBanks(vtln_warp,
                                           &must_delete_mel_banks);
-  
+
   ComputeInternal(wave, *mel_banks, output, wave_remainder);
-  
+
   if (must_delete_mel_banks)
     delete mel_banks;
 }
@@ -125,7 +126,7 @@ void Fbank::ComputeInternal(const VectorBase<BaseFloat> &wave,
   // Buffers
   Vector<BaseFloat> window;  // windowed waveform.
   Vector<BaseFloat> mel_energies;
-  std::vector<BaseFloat> temp_buffer;  // used by srfft.  
+  std::vector<BaseFloat> temp_buffer;  // used by srfft.
   BaseFloat log_energy;
 
   // Compute all the freames, r is frame index..

--- a/src/lat/kaldi-lattice.h
+++ b/src/lat/kaldi-lattice.h
@@ -86,9 +86,9 @@ class CompactLatticeHolder {
   const T &Value() const {
     KALDI_ASSERT(t_ != NULL && "Called Value() on empty CompactLatticeHolder");
     return *t_;
-  } 
+  }
 
-  void Clear() { if (t_) { delete t_; t_ = NULL; } }
+  void Clear() { delete t_; t_ = NULL; }
 
   ~CompactLatticeHolder() { Clear(); }
 
@@ -116,9 +116,9 @@ class LatticeHolder {
   const T &Value() const {
     KALDI_ASSERT(t_ != NULL && "Called Value() on empty LatticeHolder");
     return *t_;
-  } 
+  }
 
-  void Clear() { if (t_) { delete t_; t_ = NULL; } }
+  void Clear() {  delete t_; t_ = NULL; }
 
   ~LatticeHolder() { Clear(); }
 

--- a/src/lm/kaldi-lm.h
+++ b/src/lm/kaldi-lm.h
@@ -62,7 +62,7 @@ class LangModelFst: public fst::VectorFst<fst::StdArc> {
  public:
   typedef fst::StdArc::Weight LmWeight;
   typedef fst::StdArc::StateId StateId;
-  
+
 
   LangModelFst() {
     pfst_ = new fst::VectorFst<fst::StdArc>;
@@ -83,7 +83,8 @@ class LangModelFst: public fst::VectorFst<fst::StdArc> {
             bool useNaturalLog = true,
             const string startSent = "<s>",
             const string endSent = "</s>") {
-    if (pfst_) delete pfst_;
+
+   delete pfst_;
     pfst_ = ReadStream(strm, sourcename,
                        gtype, pst,
                        useNaturalLog,
@@ -97,13 +98,14 @@ class LangModelFst: public fst::VectorFst<fst::StdArc> {
             bool useNaturalLog = true,
             const string startSent = "<s>",
             const string endSent = "</s>") {
-    if (pfst_) { delete pfst_; pfst_ = NULL; }
+
+    delete pfst_;
     if (rxfilename == "") {
       KALDI_ERR << "arpa2fst and similar programs no longer support empty filename "
                 << "for standard input; use '-'";
     }
     Input ki(rxfilename);
-    
+
     pfst_ = ReadStream(ki.Stream(),
                        PrintableRxfilename(rxfilename),
                        gtype, pst,


### PR DESCRIPTION
I used the following shell code to find the offenders

find .  \( -name "*.h" -o -name "*.cc" \) | xargs grep -P  ".*if *\((.*)\).*delete.*\1.*"

might not cover all cases (but this is a low-importance subject anyways, I believe)