### PR TITLE
fix nnet2 convnet input spec

### DIFF
--- a/egs/hkust/s5/RESULTS
+++ b/egs/hkust/s5/RESULTS
@@ -20,7 +20,7 @@ exp/lstm5e/decode/cer_10:%WER 37.61 [ 21121 / 56154, 1829 ins, 3941 del, 15351 s
 # nnet2 results
 exp/nnet2_5d/decode/cer_10:%WER 38.59 [ 21669 / 56154, 2498 ins, 3581 del, 15590 sub ]
 # ConvNet with 2 convolutional layers and 2 ReLU layers
-exp/nnet2_convnet/decode/cer_10:%WER 40.73 [ 22873 / 56154, 2609 ins, 3712 del, 16552 sub ]
+exp/nnet2_convnet/decode/cer_10:%WER 41.19 [ 23129 / 56154, 2599 ins, 3782 del, 16748 sub ]
 
 # nnet3 results (using speed perturbed data)
 exp/nnet3/tdnn_sp/decode_dev/cer_10:%WER 33.79 [ 18977 / 56154, 2027 ins, 3485 del, 13465 sub ]

--- a/egs/hkust/s5/local/nnet2/run_convnet.sh
+++ b/egs/hkust/s5/local/nnet2/run_convnet.sh
@@ -49,7 +49,7 @@ fi
       --num-threads 1 --minibatch-size 512 \
       --mix-up 20000 --samples-per-iter 300000 \
       --num-epochs 15 --delta-order 2 \
-      --initial-effective-lrate 0.0005 --final-effective-lrate 0.000025 \
+      --initial-effective-lrate 0.0001 --final-effective-lrate 0.00001 \
       --num-jobs-initial 3 --num-jobs-final 8 --splice-width 5 \
       --hidden-dim 2000 --num-filters1 128 --patch-dim1 7 --pool-size 3 \
       --num-filters2 256 --patch-dim2 4 \

--- a/egs/wsj/s5/steps/nnet2/train_convnet_accel2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_convnet_accel2.sh
@@ -284,7 +284,7 @@ SoftmaxComponent dim=$num_leaves
 EOF
   
   cat >$dir/replace.1.config <<EOF
-Convolutional1dComponent input-dim=$pool_out_dim output-dim=$conv_out_dim2 learning-rate=$initial_lrate param-stddev=$stddev bias-stddev=$bias_stddev patch-dim=$patch_dim2 patch-step=$patch_step2 patch-stride=$patch_stride2 rearrange-input=true
+Convolutional1dComponent input-dim=$pool_out_dim output-dim=$conv_out_dim2 learning-rate=$initial_lrate param-stddev=$stddev bias-stddev=$bias_stddev patch-dim=$patch_dim2 patch-step=$patch_step2 patch-stride=$patch_stride2 appended-conv=true
 NormalizeComponent dim=$conv_out_dim2
 AffineComponentPreconditionedOnline input-dim=$conv_out_dim2 output-dim=$num_leaves $online_preconditioning_opts learning-rate=$initial_lrate param-stddev=0 bias-stddev=0
 SoftmaxComponent dim=$num_leaves

--- a/src/nnet2/nnet-component-test.cc
+++ b/src/nnet2/nnet-component-test.cc
@@ -376,25 +376,27 @@ void UnitTestConvolutional1dComponent() {
     if (Rand() % 2 == 0) {
       component.Init(learning_rate, input_dim, output_dim,
                      patch_dim, patch_step, patch_stride,
-                     param_stddev, bias_stddev);
+                     param_stddev, bias_stddev, true);
     } else {
-      // initialize the hyper-parameters
-      component.Init(learning_rate, input_dim, output_dim,
-                     patch_dim, patch_step, patch_stride,
-                     param_stddev, bias_stddev);
       Matrix<BaseFloat> mat(num_filters, filter_dim + 1);
       mat.SetRandn();
       mat.Scale(param_stddev);
       WriteKaldiObject(mat, "tmpf", true);
       Sleep(0.5);
       component.Init(learning_rate, patch_dim,
-                     patch_step, patch_stride, "tmpf");
+                     patch_step, patch_stride, "tmpf", false);
       unlink("tmpf");
     }
     UnitTestGenericComponentInternal(component);
   }
   {
-    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10";
+    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10 rearrange-input=false";
+    Convolutional1dComponent component;
+    component.InitFromString(str);
+    UnitTestGenericComponentInternal(component);
+  }
+  {
+    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10 rearrange-input=true";
     Convolutional1dComponent component;
     component.InitFromString(str);
     UnitTestGenericComponentInternal(component);

--- a/src/nnet2/nnet-component-test.cc
+++ b/src/nnet2/nnet-component-test.cc
@@ -390,13 +390,14 @@ void UnitTestConvolutional1dComponent() {
     UnitTestGenericComponentInternal(component);
   }
   {
-    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10 rearrange-input=false";
+    // appended-conv is false by default
+    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10";
     Convolutional1dComponent component;
     component.InitFromString(str);
     UnitTestGenericComponentInternal(component);
   }
   {
-    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10 rearrange-input=true";
+    const char *str = "learning-rate=0.01 input-dim=100 output-dim=70 param-stddev=0.1 patch-dim=4 patch-step=1 patch-stride=10 appended-conv=true";
     Convolutional1dComponent component;
     component.InitFromString(str);
     UnitTestGenericComponentInternal(component);

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -3721,9 +3721,9 @@ int32 Convolutional1dComponent::OutputDim() const {
 // initialize the component using hyperparameters
 void Convolutional1dComponent::Init(BaseFloat learning_rate,
                                     int32 input_dim, int32 output_dim,
-                                    int32 patch_dim, int32 patch_step, int32 patch_stride,
-                                    BaseFloat param_stddev, BaseFloat bias_stddev,
-                                    bool appended_conv) {
+                                    int32 patch_dim, int32 patch_step,
+                                    int32 patch_stride, BaseFloat param_stddev,
+                                    BaseFloat bias_stddev, bool appended_conv) {
   UpdatableComponent::Init(learning_rate);
   patch_dim_ = patch_dim;
   patch_step_ = patch_step;
@@ -3747,9 +3747,10 @@ void Convolutional1dComponent::Init(BaseFloat learning_rate,
 }
 
 // initialize the component using predefined matrix file
-void Convolutional1dComponent::Init(BaseFloat learning_rate,
-                                    int32 patch_dim, int32 patch_step, int32 patch_stride,
-                                    std::string matrix_filename, bool appended_conv) {
+void Convolutional1dComponent::Init(BaseFloat learning_rate, int32 patch_dim,
+                                    int32 patch_step, int32 patch_stride,
+                                    std::string matrix_filename,
+                                    bool appended_conv) {
   UpdatableComponent::Init(learning_rate);
   patch_dim_ = patch_dim;
   patch_step_ = patch_step;

--- a/src/nnet2/nnet-component.h
+++ b/src/nnet2/nnet-component.h
@@ -1729,10 +1729,10 @@ class Convolutional1dComponent: public UpdatableComponent {
   int32 OutputDim() const;
   void Init(BaseFloat learning_rate, int32 input_dim, int32 output_dim,
             int32 patch_dim, int32 patch_step, int32 patch_stride,
-            BaseFloat param_stddev, BaseFloat bias_stddev, bool rearrange_input);
+            BaseFloat param_stddev, BaseFloat bias_stddev, bool appended_conv);
   void Init(BaseFloat learning_rate,
             int32 patch_dim, int32 patch_step, int32 patch_stride,
-            std::string matrix_filename, bool rearrange_input);
+            std::string matrix_filename, bool appended_conv);
 
   // resize the component, setting the parameters to zero, while
   // leaving any other configuration values the same
@@ -1784,7 +1784,7 @@ class Convolutional1dComponent: public UpdatableComponent {
   const Convolutional1dComponent &operator = (const Convolutional1dComponent &other); // Disallow.
   CuMatrix<BaseFloat> filter_params_;
   CuVector<BaseFloat> bias_params_;
-  bool rearrange_input_;
+  bool appended_conv_;
   bool is_gradient_;
 };
 

--- a/src/nnet2/nnet-component.h
+++ b/src/nnet2/nnet-component.h
@@ -1784,6 +1784,8 @@ class Convolutional1dComponent: public UpdatableComponent {
   const Convolutional1dComponent &operator = (const Convolutional1dComponent &other); // Disallow.
   CuMatrix<BaseFloat> filter_params_;
   CuVector<BaseFloat> bias_params_;
+  // When appending convolutional1dcomponents, appended_conv_ should be
+  // set ture for the appended convolutional1dcomponents.
   bool appended_conv_;
   bool is_gradient_;
 };

--- a/src/nnet2/nnet-component.h
+++ b/src/nnet2/nnet-component.h
@@ -1729,10 +1729,10 @@ class Convolutional1dComponent: public UpdatableComponent {
   int32 OutputDim() const;
   void Init(BaseFloat learning_rate, int32 input_dim, int32 output_dim,
             int32 patch_dim, int32 patch_step, int32 patch_stride,
-            BaseFloat param_stddev, BaseFloat bias_stddev);
+            BaseFloat param_stddev, BaseFloat bias_stddev, bool rearrange_input);
   void Init(BaseFloat learning_rate,
             int32 patch_dim, int32 patch_step, int32 patch_stride,
-            std::string matrix_filename);
+            std::string matrix_filename, bool rearrange_input);
 
   // resize the component, setting the parameters to zero, while
   // leaving any other configuration values the same
@@ -1784,6 +1784,7 @@ class Convolutional1dComponent: public UpdatableComponent {
   const Convolutional1dComponent &operator = (const Convolutional1dComponent &other); // Disallow.
   CuMatrix<BaseFloat> filter_params_;
   CuVector<BaseFloat> bias_params_;
+  bool rearrange_input_;
   bool is_gradient_;
 };
 


### PR DESCRIPTION
Input of convolutional1dcomponent can be rearranged if rearrange_input_ is set true. It is required when appending multiple convolutional1dcomponent, as pointed out by @vijayaditya in [this discussion](https://groups.google.com/d/msgid/kaldi-developers/CANdDGsHqJBKkn%2BjFqwJDLTmBVDoAK3c3XH67jQ3HpR5Z1MmJSg%40mail.gmail.com?utm_medium=email&utm_source=footer).
Documents are updated.