### PR TITLE
Fix compilation issues with gcc4.4.7

### DIFF
--- a/src/nnet/nnet-component-test.cc
+++ b/src/nnet/nnet-component-test.cc
@@ -347,7 +347,7 @@ int main() {
   using namespace kaldi;
   using namespace kaldi::nnet1;
 
-  for (int32 loop = 0; loop < 2; loop++) {
+  for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // use no GPU

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -351,7 +351,7 @@ int main() {
   using namespace kaldi;
   using namespace kaldi::nnet3;
 
-  for (int32 loop = 0; loop < 2; loop++) {
+  for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");

--- a/src/nnet3/nnet-compute-test.cc
+++ b/src/nnet3/nnet-compute-test.cc
@@ -117,7 +117,7 @@ int main() {
   //SetVerboseLevel(2);
 
 
-  for (int32 loop = 0; loop < 2; loop++) {
+  for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");

--- a/src/nnet3/nnet-derivative-test.cc
+++ b/src/nnet3/nnet-derivative-test.cc
@@ -428,7 +428,7 @@ int main() {
   //SetVerboseLevel(2);
 
 
-  for (int32 loop = 0; loop < 2; loop++) {
+  for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");


### PR DESCRIPTION
When I try to compile and run the tests with gcc4.4.7 on CentOS I get this error:
```
nnet-component-test.cc: In function ‘int main()’:  
nnet-component-test.cc:350: error: reference to ‘int32’ is ambiguous  
kaldi/tools/openfst/include/fst/types.h:30: error: candidates are: typedef int32_t int32  
../base/kaldi-types.h:47: error:                 typedef int32_t kaldi::int32
nnet-component-test.cc:350: error: reference to ‘int32’ is ambiguous
kaldi/tools/openfst/include/fst/types.h:30: error: candidates are: typedef int32_t int32
../base/kaldi-types.h:47: error:                 typedef int32_t kaldi::int32
nnet-component-test.cc:350: error: expected ‘;’ before ‘loop’
nnet-component-test.cc:350: error: ‘loop’ was not declared in this scope
```
This patch fixes it.