### PR TITLE
Fixes to unit tests under Windows

### DIFF
--- a/src/hmm/posterior-test.cc
+++ b/src/hmm/posterior-test.cc
@@ -77,7 +77,7 @@ void TestPosteriorIo() {
       KALDI_ASSERT(post[i].size() == post2[i].size());
       for (int32 j = 0; j < post[i].size(); j++) {
         KALDI_ASSERT(post[i][j].first == post2[i][j].first &&
-                     fabs(post[i][j].second - post2[i][j].second < 0.01));
+                     fabs(post[i][j].second - post2[i][j].second) < 0.01);
       }
     }
   }


### PR DESCRIPTION
Looks like I hit the same issue as the recent PR #335 (got a rebase conflict with it!), only with the  VS 2013 compiler. I think my fix is more correct (I avoid running tests twice when CUDA is not compiled), but I can drop this part if there any objections. The parenthesis in `posterior-test.cc` is a real deal though.