### PR TITLE
Fixed index reference in silence test in make_lexicon_fst.pl

### DIFF
--- a/egs/wsj/s5/utils/make_lexicon_fst.pl
+++ b/egs/wsj/s5/utils/make_lexicon_fst.pl
@@ -135,7 +135,7 @@ if ( $silprob == 0.0 ) { # No optional silences: just have one (loop+final) stat
         $word_or_eps = "<eps>";
         $pron_cost_string = ""; $pron_cost = 0.0; # so we only print it the 1st time.
         $s = $ns;
-      } elsif ($p ne $silphone) {
+      } elsif (!defined($silphone) || $p ne $silphone) {
         # This is non-deterministic but relatively compact,
         # and avoids epsilons.
         $local_nosilcost = $nosilcost + $pron_cost;

--- a/egs/wsj/s5/utils/make_lexicon_fst.pl
+++ b/egs/wsj/s5/utils/make_lexicon_fst.pl
@@ -29,7 +29,7 @@ if ($ARGV[0] eq "--pron-probs") {
 if (@ARGV != 1 && @ARGV != 3 && @ARGV != 4) {
   print STDERR
     "Usage: make_lexicon_fst.pl [--pron-probs] lexicon.txt [silprob silphone [sil_disambig_sym]] >lexiconfst.txt
-Creates a lexicon FST that transduces phones to words, and may allow optional silence. 
+Creates a lexicon FST that transduces phones to words, and may allow optional silence.
 Note: ordinarily, each line of lexicon.txt is: word phone1 phone2 ... phoneN; if the --pron-probs option is
 used, each line is: word pronunciation-probability phone1 phone2 ... phoneN.  The probability 'prob' will
 typically be between zero and one, and note that it's generally helpful to normalize so the largest one
@@ -42,7 +42,7 @@ introduced to fix a particular case of non-determinism of decoding graphs.\n";
 $lexfn = shift @ARGV;
 if (@ARGV == 0) {
   $silprob = 0.0;
-} elsif (@ARGV == 2) { 
+} elsif (@ARGV == 2) {
   ($silprob,$silphone) = @ARGV;
 } else {
   ($silprob,$silphone,$sildisambig) = @ARGV;
@@ -56,19 +56,6 @@ if ($silprob != 0.0) {
 
 open(L, "<$lexfn") || die "Error opening lexicon $lexfn";
 
-
-sub is_sil {
-  # Return true (1) if provided with a phone-sequence
-  # that means silence.
-  # @_ is the parameters of the function
-  # This function returns true if @_ equals ( $silphone )
-  # or something of the form ( "#0", $silphone, "#1" )
-  # where the "#0" and "#1" are disambiguation symbols.
-  return ( @_ == 1 && $_[0] eq $silphone ||
-           (@_ == 3 && $_[1] eq $silphone &&
-            $_[0] =~ m/^\#\d+$/ &&
-            $_[0] =~ m/^\#\d+$/));
-}
 
 if ( $silprob == 0.0 ) { # No optional silences: just have one (loop+final) state which is numbered zero.
   $loopstate = 0;
@@ -92,7 +79,7 @@ if ( $silprob == 0.0 ) { # No optional silences: just have one (loop+final) stat
       $pron_cost = -log($pron_prob);
     }
     if ($pron_cost != 0.0) { $pron_cost_string = "\t$pron_cost"; } else { $pron_cost_string = ""; }
-    
+
     $s = $loopstate;
     $word_or_eps = $w;
     while (@A > 0) {
@@ -148,18 +135,16 @@ if ( $silprob == 0.0 ) { # No optional silences: just have one (loop+final) stat
         $word_or_eps = "<eps>";
         $pron_cost_string = ""; $pron_cost = 0.0; # so we only print it the 1st time.
         $s = $ns;
+      } elsif ($p ne $silphone) {
+        # This is non-deterministic but relatively compact,
+        # and avoids epsilons.
+        $local_nosilcost = $nosilcost + $pron_cost;
+        $local_silcost = $silcost + $pron_cost;
+        print "$s\t$loopstate\t$p\t$word_or_eps\t$local_nosilcost\n";
+        print "$s\t$silstate\t$p\t$word_or_eps\t$local_silcost\n";
       } else {
-        if (!is_sil($p)) {
-          # This is non-deterministic but relatively compact,
-          # and avoids epsilons.
-          $local_nosilcost = $nosilcost + $pron_cost;
-          $local_silcost = $silcost + $pron_cost;
-          print "$s\t$loopstate\t$p\t$word_or_eps\t$local_nosilcost\n";
-          print "$s\t$silstate\t$p\t$word_or_eps\t$local_silcost\n";
-        } else {
-          # no point putting opt-sil after silence word.
-          print "$s\t$loopstate\t$p\t$word_or_eps$pron_cost_string\n";
-        }
+        # no point putting opt-sil after silence word.
+        print "$s\t$loopstate\t$p\t$word_or_eps$pron_cost_string\n";
       }
     }
   }


### PR DESCRIPTION
This looks worrisome. `is_sil` was overdetecting silence phones [from inception](https://github.com/kaldi-asr/kaldi/commit/ff22b92d04a045b5150caf04bebb60fe8daa4ed0#diff-7dd4dca3302824cb2d3f9559d61af3b0R53)