### PR TITLE
Fix a lattice determinization bug.

### DIFF
--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -538,6 +538,7 @@ template<class Weight, class IntType> class LatticeDeterminizerPruned {
                    << forward_cost << ", "
                    << state.forward_cost;
       }
+      return state_id;
     }
     OutputStateId state_id = static_cast<OutputStateId>(output_states_.size());
     OutputState *new_state = new OutputState(subset, forward_cost);


### PR DESCRIPTION
I'm not that familiar with this code yet, but this seems like an obvious omission..
I've only performed a toy test on 2 utterances, and the (non-compressed) lattice sizes are as follows:
>   old lat.ark: 323482
>   new lat.ark: 209510

The run time for a debug(-O0 -g) version of the nnet3-latgen-faster didn't change noticeably- there was a 2-3% difference, but that could be due to e.g. slightly different load on my laptop, while testing.