### PR TITLE
throw GPU usage information (nvidia-smi) when no more unused GPUS

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -41,6 +41,7 @@
 #include "base/kaldi-error.h"
 #include "base/kaldi-utils.h"
 #include "util/common-utils.h"
+#include "util/kaldi-io.h"
 
 namespace kaldi {
 
@@ -131,6 +132,10 @@ void CuDevice::SelectGpuId(std::string use_gpu) {
       Sleep(sec_sleep);
       if (!GetCudaContext(num_gpus)) {
         if (use_gpu == "yes") {
+          {
+            Input input;
+            input.Open("nvidia-smi 1>&2 |");
+          }
           KALDI_ERR << "Failed to create CUDA context, no more unused GPUs?";
         }
         if (use_gpu == "optional") {


### PR DESCRIPTION
./cu-vector-test
LOG (cu-vector-test:SelectGpuId():cu-device.cc:104) Manually selected to compute on CPU.
2.474e+09 2.474e+09
5.69062e+07 5.69062e+07
LOG (cu-vector-test:main():cu-vector-test.cc:765) Tests without GPU use succeeded.
WARNING (cu-vector-test:SelectGpuId():cu-device.cc:130) Will try again to get a GPU after 20 seconds.
ERROR (cu-vector-test:SelectGpuId():cu-device.cc:136) Failed to create CUDA context, no more unused GPUs?
terminate called after throwing an instance of 'std::runtime_error'
  what():  ERROR (cu-vector-test:SelectGpuId():cu-device.cc:136) Failed to create CUDA context, no more unused GPUs?

[stack trace: ]
kaldi::KaldiGetStackTrace()
kaldi::KaldiErrorMessage::~KaldiErrorMessage()
kaldi::CuDevice::SelectGpuId(std::string)
./cu-vector-test(main+0x21b) [0x4b50aa]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xfd) [0x2b586c80bead]
./cu-vector-test() [0x4b4c89]


Mon Dec  7 22:17:50 2015
+------------------------------------------------------+
| NVIDIA-SMI 346.46     Driver Version: 346.46         |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  Tesla K10.G2.8GB    Off  | 0000:07:00.0     Off |                    0 |
| N/A   44C    P0    62W / 117W |    574MiB /  3583MiB |     29%    E. Thread |
+-------------------------------+----------------------+----------------------+
|   1  Tesla K10.G2.8GB    Off  | 0000:08:00.0     Off |                    0 |
| N/A   44C    P0    48W / 117W |    574MiB /  3583MiB |     18%    E. Thread |
+-------------------------------+----------------------+----------------------+
|   2  Tesla K10.G2.8GB    Off  | 0000:44:00.0     Off |                    0 |
| N/A   48C    P0    58W / 117W |    574MiB /  3583MiB |     24%    E. Thread |
+-------------------------------+----------------------+----------------------+
|   3  Tesla K10.G2.8GB    Off  | 0000:45:00.0     Off |                    0 |
| N/A   52C    P0    48W / 117W |    574MiB /  3583MiB |     12%    E. Thread |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID  Type  Process name                               Usage      |
|=============================================================================|
|    0      8424    C   nnet3-train                                    561MiB |
|    1      8833    C   nnet3-train                                    561MiB |
|    2      8915    C   nnet3-train                                    561MiB |
|    3      8922    C   nnet3-train                                    561MiB |
+-----------------------------------------------------------------------------+