### PR TITLE
some fixes related to SparseLinearComponent

### DIFF
--- a/src/matrix/sparse-matrix-test.cc
+++ b/src/matrix/sparse-matrix-test.cc
@@ -173,6 +173,12 @@ void UnitTestSparseMatrixAddToMat() {
     smat.CopyFromMat(other_mat1);
     smat.CopyToMat(&mat);
     AssertEqual(other_mat1, mat, 0.00001);
+
+    smat.Transpose();
+    mat.Resize(smat.NumRows(), smat.NumCols(), kUndefined);
+    smat.CopyToMat(&mat);
+    mat.Transpose();
+    AssertEqual(other_mat1, mat, 0.00001);
   }
 }
 

--- a/src/matrix/sparse-matrix.h
+++ b/src/matrix/sparse-matrix.h
@@ -37,6 +37,7 @@ namespace kaldi {
 
 template <typename Real>
 class SparseVector {
+  friend class SparseMatrix<Real>;
  public:
   MatrixIndexT Dim() const { return dim_; }
 
@@ -148,6 +149,8 @@ class SparseMatrix {
   /// later when it is necessary.
   template <class OtherReal>
   void CopyFromSmat(const SparseMatrix<OtherReal> &other);
+  
+  void CopyFromPosterior(MatrixIndexT dim, const std::vector<std::vector<std::pair<MatrixIndexT, Real> > > &pairs);
 
   /// Does *other = *other + alpha * *this.
   void AddToMat(BaseFloat alpha, MatrixBase<Real> *other,
@@ -156,7 +159,9 @@ class SparseMatrix {
   SparseMatrix<Real> &operator = (const SparseMatrix<Real> &other);
 
   SparseMatrix(const SparseMatrix<Real> &other) { *this = other; }
-
+  
+  void Transpose();
+  
   void Swap(SparseMatrix<Real> *other);
 
   // returns pointer to element data, or NULL if empty (use with NumElements()).

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -970,7 +970,7 @@ void SparseLinearComponent::InitFromConfig(ConfigLine *cfl) {
 void SparseLinearComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                 const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
-  out->AddMatSmat(1.0, in, kNoTrans, linear_params_, kTrans, 0.0);
+  out->AddMatSmat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
 }
 
 void SparseLinearComponent::Backprop(const std::string &debug_info,

--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -345,8 +345,9 @@ class SparseLinearComponent: public UpdatableComponent {
   virtual std::string Type() const { return "SparseLinearComponent"; }
 
   virtual int32 Properties() const {
-    return kSimpleComponent|kUpdatableComponent|kLinearInParameters|
-        kLinearInInput|kBackpropNeedsInput|kBackpropAdds;
+    int32 extra_bits = is_updatable_ ? kBackpropNeedsInput|kUpdatableComponent : 0;
+    return kSimpleComponent|extra_bits|kLinearInParameters|
+        kLinearInInput|kBackpropAdds|kPropagateAdds;
   }
 
   virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
@@ -382,10 +383,10 @@ class SparseLinearComponent: public UpdatableComponent {
             std::string matrix_filename, bool updatable = false);
 
   void ComputeLinearParamsTransposedVersion() {
-    Matrix<BaseFloat> tmp(linear_params_.NumRows(), linear_params_.NumCols());
-    linear_params_.CopyToMat(&tmp);
+    SparseMatrix<BaseFloat> tmp(linear_params_.NumRows(), linear_params_.NumCols());
+    linear_params_.CopyToSmat(&tmp);
     tmp.Transpose();
-    linear_params_transposed_.CopyFromMat(tmp);
+    linear_params_transposed_.CopyFromSmat(tmp);
   }
 
  private:


### PR DESCRIPTION
Add Transpose() for SparseMatrix
More efficient CopyFromMat for SparseMatrix
Fix kUpdatableComponent and kBackpropNeedsInput bug
Set kPropagateAdds flag and modify Propagate(): out->AddMatSmat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0); 

I'll prepare the rest of the fixes in the next commit. Also I'll implement transpose for GPU ASAP.