### PR TITLE
some updates for SparseLinearComponent

### DIFF
--- a/src/cudamatrix/cu-sparse-matrix.cc
+++ b/src/cudamatrix/cu-sparse-matrix.cc
@@ -191,6 +191,23 @@ void CuRowSparseMatrix<Real>::SetRandn(BaseFloat zero_prob) {
 }
 
 template <typename Real>
+Real CuRowSparseMatrix<Real>::FrobeniusNorm() const {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    std::vector<RowElement<Real> > cpu_data;
+    data_.CopyToVec(&cpu_data);
+    Real squared_sum = 0;
+    for (int32 i = 0; i < cpu_data.size(); ++i)
+      squared_sum += cpu_data[i].weight * cpu_data[i].weight;
+    return std::sqrt(squared_sum);
+  } else
+#endif
+    {
+      return this->Mat().FrobeniusNorm();
+    }
+}
+
+template <typename Real>
 void CuRowSparseMatrix<Real>::Write(std::ostream &os, bool binary) const {
   SparseMatrix<Real> tmp;
   CopyToSmat(&tmp);

--- a/src/cudamatrix/cu-sparse-matrix.h
+++ b/src/cudamatrix/cu-sparse-matrix.h
@@ -56,6 +56,8 @@ class CuRowSparseMatrix {
   // const version. This should only be called when CUDA is enabled.
   const MatrixIndexT* NumElementsPerRow() const;
 
+  Real FrobeniusNorm() const;
+
   // returns pointer to element data, or NULL if empty (use with NumElements()).
   // This should only be called when CUDA is enabled.
   RowElement<Real> *Data();

--- a/src/matrix/sparse-matrix-test.cc
+++ b/src/matrix/sparse-matrix-test.cc
@@ -183,6 +183,33 @@ void UnitTestSparseMatrixAddToMat() {
 }
 
 template <typename Real>
+void UnitTestSparseMatrixCopyToFromMat() {
+  for (int32 i = 0; i < 10; i++) {
+    MatrixIndexT row = 10 + Rand() % 40;
+    MatrixIndexT col = 10 + Rand() % 50;
+
+    SparseMatrix<Real> smat(row, col);
+    smat.SetRandn(0.8);
+
+    Matrix<Real> mat(row, col);
+ 
+    Real norm = smat.FrobeniusNorm();
+
+    smat.CopyToMat(&mat);
+    Matrix<Real> mat1(mat);
+    smat.CopyFromMat(mat);
+    AssertEqual(mat1, mat, 0.00001);
+    AssertEqual(norm, smat.FrobeniusNorm());
+
+    smat.Transpose();
+    mat.Resize(smat.NumRows(), smat.NumCols(), kUndefined);
+    smat.CopyToMat(&mat);
+    mat.Transpose();
+    AssertEqual(mat1, mat, 0.00001);
+  }
+}
+
+template <typename Real>
 void UnitTestSparseMatrixTraceMatSmat() {
   for (int32 i = 0; i < 10; i++) {
     MatrixIndexT row = 10 + Rand() % 40;
@@ -226,6 +253,7 @@ void SparseMatrixUnitTest() {
   UnitTestSparseMatrixFrobeniusNorm<Real>();
   UnitTestSparseMatrixAddToMat<Real>();
   UnitTestSparseMatrixTraceMatSmat<Real>();
+  UnitTestSparseMatrixCopyToFromMat<Real>();
 }
 
 }  // namespace kaldi

--- a/src/matrix/sparse-matrix.cc
+++ b/src/matrix/sparse-matrix.cc
@@ -340,16 +340,17 @@ template<typename Real>
 void SparseMatrix<Real>::Transpose() {
   if(rows_.empty())
     return;
-  std::vector<SparseVector<Real> > trows(NumCols(), SparseVector<Real>(NumRows()));
+  std::vector<SparseVector<Real> > trans_rows
+    (NumCols(), SparseVector<Real>(NumRows()));
   for (int32 i = 0; i < rows_.size(); ++i) {
     const std::pair<MatrixIndexT, Real> *row_data = rows_[i].Data();
     for (int32 j = 0; j < rows_[i].NumElements(); ++j) {
-      trows[row_data[j].first].pairs_.push_back(std::make_pair(
-				      i,
-				      row_data[j].second));
+      trans_rows[row_data[j].first].pairs_.push_back(std::make_pair(
+							  i,
+							  row_data[j].second));
     }
   }
-  rows_.swap(trows);
+  rows_.swap(trans_rows);
 }
 
 template <typename Real>
@@ -400,10 +401,10 @@ void SparseMatrix<Real>::CopyFromMat(const MatrixBase<OtherReal> &other) {
   if (rows_.size() == 0) return;
   for (int32 r = 0; r < rows_.size(); r++) {
     SparseVector<Real> row(other.NumCols());
-    for(int32 c = 0; c < other.NumCols(); c++)
-      row.pairs_.push_back(std::make_pair(c, other(r, c)));
+    for (int32 c = 0; c < other.NumCols(); c++)
+      if (other(r, c) != 0.0)      
+	row.pairs_.push_back(std::make_pair(c, other(r, c)));
     rows_[r].Swap(&row);
-    //    rows_[r].CopyFromSvec(row);
   }
 }
 template void SparseMatrix<float>::CopyFromMat(const MatrixBase<float> &other);

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -45,13 +45,15 @@ void TestNnetComponentCopy(Component *c) {
 }
 
 void TestNnetComponentAddScale(Component *c) {
-  Component *c2 = c->Copy();
-  Component *c3 = c2->Copy();
-  c3->Add(0.5, *c2);
-  c2->Scale(1.5);
-  KALDI_ASSERT(c2->Info() == c3->Info());
-  delete c2;
-  delete c3;
+  if (c->Properties() & kUpdatableComponent) {
+    Component *c2 = c->Copy();
+    Component *c3 = c2->Copy();
+    c3->Add(0.5, *c2);
+    c2->Scale(1.5);
+    KALDI_ASSERT(c2->Info() == c3->Info());
+    delete c2;
+    delete c3;
+  }
 }
 
 void TestNnetComponentVectorizeUnVectorize(Component *c) {
@@ -78,16 +80,9 @@ void TestNnetComponentUpdatableFlag(Component *c) {
   UpdatableComponent *uc = dynamic_cast<UpdatableComponent*>(c);
   if(uc==NULL)
     return;
-  if(!(uc->Properties() & kUpdatableComponent) || (uc->NumParameters() == 0)){
+  if(!(uc->Properties() & kUpdatableComponent)){
     KALDI_ASSERT(uc->NumParameters() == 0);
     KALDI_ASSERT(uc->DotProduct(*uc) == 0);
-    UpdatableComponent *uc2 = dynamic_cast<UpdatableComponent*>(uc->Copy());
-    uc2->Scale(7.0);
-    uc2->Add(3.0, *uc);
-    KALDI_ASSERT(uc2->Info() == uc->Info());
-    uc->SetZero(false);
-    KALDI_ASSERT(uc2->Info() == uc->Info());
-    delete uc2;
   }
 }
 


### PR DESCRIPTION
1. Minor fixes regarding assertions in non-updatable mode and keeping transposed version in sync.
2. Fix a bug in SparseMatrix::CopyFromMat from previous commit. 
3. Add FrobeniusNorm() for CuRowSparseMatrix and add uncentered-variance to SparseLinearComponent's Info().