### PR TITLE
WARNING: this commit may change decoding results slightly due to diff…

### DIFF
--- a/egs/wsj/s5/utils/mkgraph.sh
+++ b/egs/wsj/s5/utils/mkgraph.sh
@@ -62,7 +62,8 @@ mkdir -p $lang/tmp
 if [[ ! -s $lang/tmp/LG.fst || $lang/tmp/LG.fst -ot $lang/G.fst || \
       $lang/tmp/LG.fst -ot $lang/L_disambig.fst ]]; then
   fsttablecompose $lang/L_disambig.fst $lang/G.fst | fstdeterminizestar --use-log=true | \
-    fstminimizeencoded | fstarcsort --sort_type=ilabel > $lang/tmp/LG.fst || exit 1;
+    fstminimizeencoded | fstpushspecial | \
+    fstarcsort --sort_type=ilabel > $lang/tmp/LG.fst || exit 1;
   fstisstochastic $lang/tmp/LG.fst || echo "[info]: LG not stochastic."
 fi
 


### PR DESCRIPTION
…erent pruning effects. Added fstpushspecial to LG stage of graph building to make LG.fst more stochastic. Tested on WSJ, it increased the graph building time slightly, but reduced decoding time. Impact to WER was very small. Also tested that adding fstpushspecial to the HCLG stage was not helpful.