### PR TITLE
Make the cstr scripts for wsj use dict suffix

### DIFF
--- a/egs/wsj/s5/local/cstr_wsj_extend_dict.sh
+++ b/egs/wsj/s5/local/cstr_wsj_extend_dict.sh
@@ -12,6 +12,11 @@
 # way.
 # It makes use of scripts in local/dict/
 
+dict_suffix=
+
+echo "$0 $@"  # Print the command line for logging
+. utils/parse_options.sh || exit 1;
+
 if [ $# -ne 1 ]; then
   echo "Usage: local/cstr_wsj_train_lms.sh WSJ1_doc_dir"
   exit 1
@@ -25,19 +30,20 @@ if [ ! -d $srcdir/lng_modl ]; then
   exit 1
 fi
 
-mkdir -p data/local/dict_larger
-dir=data/local/dict_larger
-cp data/local/dict/* data/local/dict_larger # Various files describing phones etc.
+mkdir -p data/local/dict${dict_suffix}_larger
+dir=data/local/dict${dict_suffix}_larger
+cp data/local/dict${dict_suffix}/* data/local/dict${dict_suffix}_larger # Various files describing phones etc.
   # are there; we just want to copy them as the phoneset is the same.
-rm data/local/dict_larger/lexicon.txt # we don't want this.
+rm data/local/dict${dict_suffix}_larger/lexicon.txt # we don't want this.
+rm data/local/dict${dict_suffix}_larger/lexiconp.txt # we don't want this either.
 mincount=2 # Minimum count of an OOV we will try to generate a pron for.
 
-[ ! -f data/local/dict/cmudict/cmudict.0.7a ] && echo "CMU dict not in expected place" && exit 1;
+[ ! -f data/local/dict${dict_suffix}/cmudict/cmudict.0.7a ] && echo "CMU dict not in expected place" && exit 1;
 
 # Remove comments from cmudict; print first field; remove
 # words like FOO(1) which are alternate prons: our dict format won't
 # include these markers.
-grep -v ';;;' data/local/dict/cmudict/cmudict.0.7a | 
+grep -v ';;;' data/local/dict${dict_suffix}/cmudict/cmudict.0.7a | 
  perl -ane 's/^(\S+)\(\d+\)/$1/; print; ' | sort | uniq > $dir/dict.cmu
 
 cat $dir/dict.cmu | awk '{print $1}' | sort | uniq > $dir/wordlist.cmu

--- a/egs/wsj/s5/run.sh
+++ b/egs/wsj/s5/run.sh
@@ -47,7 +47,7 @@ local/wsj_format_data.sh --lang-suffix "_nosp" || exit 1;
  # Caution: the commands below will only work if $decode_cmd 
  # is setup to use qsub.  Else, just remove the --cmd option.
  # NOTE: If you have a setup corresponding to the cstr_wsj_data_prep.sh style,
- # use local/cstr_wsj_extend_dict.sh $corpus/wsj1/doc/ instead.
+ # use local/cstr_wsj_extend_dict.sh --dict-suffix "_nosp" $corpus/wsj1/doc/ instead.
   (
    local/wsj_extend_dict.sh --dict-suffix "_nosp" $wsj1/13-32.1  && \
    utils/prepare_lang.sh data/local/dict_nosp_larger \


### PR DESCRIPTION
The scripts for the cstr style wsj directory layout did not take in
account the dict_suffix. The script is now brought up-to-date with
wsj_extend_dict.sh

(this is my first PR here. Please let me know if I have forgotten something or should do something different)