### PR TITLE
Minor cosmetic changes in lattice determinization code

### DIFF
--- a/src/decoder/Makefile
+++ b/src/decoder/Makefile
@@ -1,6 +1,6 @@
 all:
 
-EXTRA_CXXFLAGS = -Wno-sign-compare -O3
+EXTRA_CXXFLAGS = -Wno-sign-compare
 include ../kaldi.mk
 
 TESTFILES = 

--- a/src/fstext/determinize-lattice-inl.h
+++ b/src/fstext/determinize-lattice-inl.h
@@ -764,29 +764,18 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     // be so at output].  This function follows input-epsilons, and augments the
     // subset accordingly.
     
-    unordered_map<InputStateId, Element> cur_subset;
-    typedef typename unordered_map<InputStateId, Element>::iterator MapIter;    
-
-    {
-      MapIter iter = cur_subset.end();
-      for (size_t i = 0;i < subset->size();i++) {
-        std::pair<const InputStateId, Element> pr((*subset)[i].state, (*subset)[i]);
-#if __GNUC__ == 4 && __GNUC_MINOR__ == 0
-        iter = cur_subset.insert(iter, pr).first;
-#else
-        iter = cur_subset.insert(iter, pr);
-#endif
-        // By providing iterator where we inserted last one, we make insertion more efficient since
-        // input subset was already in sorted order.
-      }
-    }
-    // find whether input fst is known to be sorted on input label. 
-    bool sorted = ((ifst_->Properties(kILabelSorted, false) & kILabelSorted) != 0);
-
     std::deque<Element> queue;
-    for (typename vector<Element>::const_iterator iter = subset->begin();
-         iter != subset->end();
-         ++iter) queue.push_back(*iter);
+    unordered_map<InputStateId, Element> cur_subset;
+    typedef typename unordered_map<InputStateId, Element>::iterator MapIter;
+    typedef typename vector<Element>::const_iterator VecIter;
+
+    for (VecIter iter = subset->begin(); iter != subset->end(); ++iter) {
+      queue.push_back(*iter);
+      cur_subset[iter->state] = *iter;
+    }
+
+    // find whether input fst is known to be sorted on input label.
+    bool sorted = ((ifst_->Properties(kILabelSorted, false) & kILabelSorted) != 0);
     bool replaced_elems = false; // relates to an optimization, see below.
     int counter = 0; // stops infinite loops here for non-lattice-determinizable input;
     // useful in testing.
@@ -823,8 +812,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
           else
             next_elem.string = repository_.Successor(elem.string, arc.olabel);
           
-          typename unordered_map<InputStateId, Element>::iterator
-              iter = cur_subset.find(next_elem.state);
+          MapIter iter = cur_subset.find(next_elem.state);
           if (iter == cur_subset.end()) {
             // was no such StateId: insert and add to queue.
             cur_subset[next_elem.state] = next_elem;

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -646,29 +646,18 @@ template<class Weight, class IntType> class LatticeDeterminizerPruned {
     // be so at output].  This function follows input-epsilons, and augments the
     // subset accordingly.
     
-    unordered_map<InputStateId, Element> cur_subset;
-    typedef typename unordered_map<InputStateId, Element>::iterator MapIter;    
-
-    {
-      MapIter iter = cur_subset.end();
-      for (size_t i = 0; i < subset->size(); i++) {
-        std::pair<const InputStateId, Element> pr((*subset)[i].state, (*subset)[i]);
-#if __GNUC__ == 4 && __GNUC_MINOR__ == 0
-        iter = cur_subset.insert(iter, pr).first;
-#else
-        iter = cur_subset.insert(iter, pr);
-#endif
-        // By providing iterator where we inserted last one, we make insertion more efficient since
-        // input subset was already in sorted order.
-      }
-    }
-    // find whether input fst is known to be sorted on input label. 
-    bool sorted = ((ifst_->Properties(kILabelSorted, false) & kILabelSorted) != 0);
-
     std::priority_queue<Element, vector<Element>, greater<Element> > queue;
-    for (typename vector<Element>::const_iterator iter = subset->begin();
-         iter != subset->end();
-         ++iter) queue.push(*iter);
+    unordered_map<InputStateId, Element> cur_subset;
+    typedef typename unordered_map<InputStateId, Element>::iterator MapIter;
+    typedef typename vector<Element>::const_iterator VecIter;
+
+    for (VecIter iter = subset->begin(); iter != subset->end(); ++iter) {
+      queue.push(*iter);
+      cur_subset[iter->state] = *iter;
+    }
+
+    // find whether input fst is known to be sorted on input label.
+    bool sorted = ((ifst_->Properties(kILabelSorted, false) & kILabelSorted) != 0);
     bool replaced_elems = false; // relates to an optimization, see below.
     int counter = 0; // stops infinite loops here for non-lattice-determinizable input
     // (e.g. input with negative-cost epsilon loops); useful in testing.
@@ -702,8 +691,7 @@ template<class Weight, class IntType> class LatticeDeterminizerPruned {
           // next_elem.string is not set up yet... create it only
           // when we know we need it (this is an optimization) 
           
-          typename unordered_map<InputStateId, Element>::iterator
-              iter = cur_subset.find(next_elem.state);
+          MapIter iter = cur_subset.find(next_elem.state);
           if (iter == cur_subset.end()) {
             // was no such StateId: insert and add to queue.
             next_elem.string = (arc.olabel == 0 ? elem.string :


### PR DESCRIPTION
Change a few lines in EpsilonClosure(), that look a bit more hairier, than they need to be (likely related to the change from std::map to std::unordered_map, mentioned by Dan in #382).