### PR TITLE
fix a minor bug, avoiding ambiguous reference

### DIFF
--- a/src/nnet3bin/nnet3-compute.cc
+++ b/src/nnet3bin/nnet3-compute.cc
@@ -31,6 +31,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     using namespace kaldi::nnet3;
     typedef kaldi::int32 int32;
+    typedef kaldi::int64 int64;
 
     const char *usage =
         "Propagate the features through raw neural network model "


### PR DESCRIPTION
ambiguous reference "int64" between base/kaldi-types.h and ../tools/openfst/include/fst/types.h