### PR TITLE
Add special case to SimpleComponent's InitFromConfig for easy

### DIFF
--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -576,18 +576,25 @@ class FixedAffineComponent: public Component {
   KALDI_DISALLOW_COPY_AND_ASSIGN(FixedAffineComponent);
 };
 
-// SumGroupComponent is used to sum up groups of posteriors.
-// It's used to introduce a kind of Gaussian-mixture-model-like
-// idea into neural nets.  This is basically a degenerate case of
-// MixtureProbComponent; we had to implement it separately to
-// be efficient for CUDA (we can use this one regardless whether
-// we have CUDA or not; it's the normal case we want anyway).
+/// SumGroupComponent is used to sum up groups of posteriors.
+/// It's used to introduce a kind of Gaussian-mixture-model-like
+/// idea into neural nets.  This is basically a degenerate case of
+/// MixtureProbComponent; we had to implement it separately to
+/// be efficient for CUDA (we can use this one regardless whether
+/// we have CUDA or not; it's the normal case we want anyway).
+///
+/// There are two forms of initialization in a config file: one
+/// where the number of elements are specified for each group
+/// individually as a vector, and one where only the total input
+/// dimension and the output dimension (number of groups) is specified.
+/// The second is used when all groups have the same size.
 class SumGroupComponent: public Component {
 public:
   virtual int32 InputDim() const { return input_dim_; }
   virtual int32 OutputDim() const { return output_dim_; }
   void Init(const std::vector<int32> &sizes); // the vector is of the input dim
                                               // (>= 1) for each output dim.
+  void Init(int32 input_dim, int32 output_dim);
   void GetSizes(std::vector<int32> *sizes) const; // Get a vector saying, for
                                                   // each output-dim, how many
                                                   // inputs were summed over.

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -807,7 +807,7 @@ void ComputeExampleComputationRequestSimple(
 
 static void GenerateRandomComponentConfig(std::string *component_type,
                                           std::string *config) {
-  int32 n = RandInt(0, 22);
+  int32 n = RandInt(0, 23);
   BaseFloat learning_rate = 0.001 * RandInt(1, 3);
 
   std::ostringstream os;
@@ -1014,6 +1014,13 @@ static void GenerateRandomComponentConfig(std::string *component_type,
       int32 output_dim = RandInt(1, 50), group_size = RandInt(1, 15),
           input_dim = output_dim * group_size;
       os << "input-dim=" << input_dim << " output-dim=" << output_dim;
+      break;
+    }
+    case 23: {
+      *component_type = "SumGroupComponent";
+      int32 num_groups = RandInt(1, 50),
+        input_dim = num_groups * RandInt(1, 15);
+      os << "input-dim=" << input_dim << " output-dim=" << num_groups;
       break;
     }
     default:


### PR DESCRIPTION
creation when all groups are of the same size.

Addresses issue #413.

I chose to implement the functionality by providing a new initialization to SumGroupComponent. As a result, serialization is not as efficient as it could be. If this is undesirable, I will redo this.