### PR TITLE
Implement --convert-repeated-to-block option in nnet3-am-copy.

### DIFF
--- a/src/nnet3/nnet-nnet.cc
+++ b/src/nnet3/nnet-nnet.cc
@@ -1,7 +1,7 @@
 // nnet3/nnet-nnet.cc
 
 // Copyright      2015  Johns Hopkins University (author: Daniel Povey)
-
+//                2016  Daniel Galvez
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -137,6 +137,12 @@ const Component *Nnet::GetComponent(int32 c) const {
 Component *Nnet::GetComponent(int32 c) {
   KALDI_ASSERT(static_cast<size_t>(c) < components_.size());
   return components_[c];
+}
+
+void Nnet::SetComponent(int32 c, Component *component) {
+  KALDI_ASSERT(static_cast<size_t>(c) < components_.size());
+  delete components_[c];
+  components_[c] = component;
 }
 
 /// Returns true if this is component-input node, i.e. a node of type kDescriptor

--- a/src/nnet3/nnet-nnet.h
+++ b/src/nnet3/nnet-nnet.h
@@ -1,7 +1,7 @@
 // nnet3/nnet-nnet.h
 
 // Copyright   2012-2015  Johns Hopkins University (author: Daniel Povey)
-
+//             2016  Daniel Galvez
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,6 +130,12 @@ class Nnet {
   /// caller.
   const Component *GetComponent(int32 c) const;
 
+  /// Replace the component indexed by c with a new component.
+  /// Frees previous component indexed by c.
+  /// Changing the identity of a component is dangerous; this was made
+  /// only to replaced RepeatedAffine components with BlockAffine components,
+  /// which will still have the same inputDim() and OutputDim() values.
+  void SetComponent(int32 c, Component *component);
 
   /// returns const reference to a particular numbered network node.
   const NetworkNode &GetNode(int32 node) const {

--- a/src/nnet3/nnet-nnet.h
+++ b/src/nnet3/nnet-nnet.h
@@ -132,9 +132,6 @@ class Nnet {
 
   /// Replace the component indexed by c with a new component.
   /// Frees previous component indexed by c.
-  /// Changing the identity of a component is dangerous; this was made
-  /// only to replaced RepeatedAffine components with BlockAffine components,
-  /// which will still have the same inputDim() and OutputDim() values.
   void SetComponent(int32 c, Component *component);
 
   /// returns const reference to a particular numbered network node.

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -1369,6 +1369,26 @@ BlockAffineComponent::BlockAffineComponent(const BlockAffineComponent &other) :
   bias_params_(other.bias_params_),
   num_blocks_(other.num_blocks_) {}
 
+BlockAffineComponent::BlockAffineComponent(const RepeatedAffineComponent &rac) :
+  UpdatableComponent(rac),
+  linear_params_(rac.num_repeats_ * rac.linear_params_.NumRows(), 
+                 rac.linear_params_.NumCols(), kUndefined),
+  bias_params_(rac.num_repeats_ * rac.linear_params_.NumRows(), kUndefined),
+  num_blocks_(rac.num_repeats_)
+{
+  // copy rac's linear_params_ and bias_params_ to this.
+  int32 num_rows_in_block = rac.linear_params_.NumRows();
+  for(int32 block_counter = 0; block_counter < num_blocks_; block_counter++) {
+    int32 row_offset = block_counter * num_rows_in_block;
+    CuSubMatrix<BaseFloat> block = this->linear_params_.RowRange(row_offset,
+                                                                 num_rows_in_block);
+    block.CopyFromMat(rac.linear_params_);
+    CuSubVector<BaseFloat> block_bias = this->bias_params_.Range(row_offset,
+                                                                 num_rows_in_block);
+    block_bias.CopyFromVec(rac.bias_params_);
+  }
+}
+
 Component* BlockAffineComponent::Copy() const {
   BlockAffineComponent *ans = new BlockAffineComponent(*this);
   return ans;
@@ -4826,6 +4846,15 @@ void CompositeComponent::InitFromConfig(ConfigLine *cfl) {
                 << "(or undefined or bad component type [type=xxx]), in "
                 << "CompositeComponent config line '" << cfl->WholeLine() << "'";
     }
+    if(this_component->Type() == "CompositeComponent") {
+      DeletePointers(&components);
+      delete this_component;
+      KALDI_ERR << "Found CompositeComponent nested within CompositeComponent."
+                << "Try decreasing max-rows-process instead."
+                << "Nested line: '" << nested_line.WholeLine() << "'\n"
+                << "Toplevel CompositeComponent line '" << cfl->WholeLine()
+                << "'";
+    }
     this_component->InitFromConfig(&nested_line);
     components.push_back(this_component);
   }
@@ -4835,7 +4864,16 @@ void CompositeComponent::InitFromConfig(ConfigLine *cfl) {
   this->Init(components, max_rows_process);
 }
 
+const Component* CompositeComponent::GetComponent(int32 i) const {
+  KALDI_ASSERT(static_cast<size_t>(i) < components_.size());
+  return components_[i];
+}
 
+void CompositeComponent::SetComponent(int32 i, Component *component) {
+  KALDI_ASSERT(static_cast<size_t>(i) < components_.size());
+  delete components_[i];
+  components_[i] = component;
+}
 
 } // namespace nnet3
 } // namespace kaldi

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -1371,11 +1371,10 @@ BlockAffineComponent::BlockAffineComponent(const BlockAffineComponent &other) :
 
 BlockAffineComponent::BlockAffineComponent(const RepeatedAffineComponent &rac) :
   UpdatableComponent(rac),
-  linear_params_(rac.num_repeats_ * rac.linear_params_.NumRows(), 
+  linear_params_(rac.num_repeats_ * rac.linear_params_.NumRows(),
                  rac.linear_params_.NumCols(), kUndefined),
   bias_params_(rac.num_repeats_ * rac.linear_params_.NumRows(), kUndefined),
-  num_blocks_(rac.num_repeats_)
-{
+  num_blocks_(rac.num_repeats_) {
   // copy rac's linear_params_ and bias_params_ to this.
   int32 num_rows_in_block = rac.linear_params_.NumRows();
   for(int32 block_counter = 0; block_counter < num_blocks_; block_counter++) {

--- a/src/nnet3/nnet-test-utils.h
+++ b/src/nnet3/nnet-test-utils.h
@@ -1,7 +1,7 @@
 // nnet3/nnet-test-utils.h
 
 // Copyright   2015  Johns Hopkins University (author: Daniel Povey)
-
+// Copyright   2016  Daniel Galvez
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,6 +59,11 @@ struct NnetGenerationOptions {
 void GenerateConfigSequence(const NnetGenerationOptions &opts,
                             std::vector<std::string> *configs);
 
+/// Generate a config string with a composite component composed only
+/// of block affine, repeated affine, and natural gradient repeated affine
+/// components.
+void GenerateConfigSequenceCompositeBlock(const NnetGenerationOptions &opts,
+                                          std::vector<std::string> *configs);
 
 /**  This function computes an example computation request, for testing purposes.
      The "Simple" in the name means that it currently only supports neural nets

--- a/src/nnet3/nnet-utils-test.cc
+++ b/src/nnet3/nnet-utils-test.cc
@@ -1,6 +1,7 @@
 // nnet3/nnet-utils-test.cc
 
 // Copyright 2015  Johns Hopkins University (author: Daniel Povey)
+//           2016  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -18,6 +19,7 @@
 // limitations under the License.
 
 #include "nnet3/nnet-nnet.h"
+#include "nnet3/nnet-simple-component.h"
 #include "nnet3/nnet-test-utils.h"
 
 namespace kaldi {
@@ -45,6 +47,59 @@ void UnitTestNnetContext() {
   }
 }
 
+void UnitTestConvertRepeatedToBlockAffine() {
+  // a test without a composite component.
+  std::string config =
+    "component name=repeated-affine1 type=RepeatedAffineComponent "
+    "input-dim=100 output-dim=200 num-repeats=20\n"
+    "component name=relu1 type=RectifiedLinearComponent dim=200\n"
+    "component name=block-affine1 type=BlockAffineComponent "
+    "input-dim=200 output-dim=100 num-blocks=10\n"
+    "component name=relu2 type=RectifiedLinearComponent dim=100\n"
+    "component name=repeated-affine2 type=NaturalGradientRepeatedAffineComponent "
+    "input-dim=100 output-dim=200 num-repeats=10\n"
+    "\n"
+    "input-node name=input dim=100\n"
+    "component-node name=repeated-affine1 component=repeated-affine1 input=input\n"
+    "component-node name=relu1 component=relu1 input=repeated-affine1\n"
+    "component-node name=block-affine1 component=block-affine1 input=relu1\n"
+    "component-node name=relu2 component=relu2 component=relu2 input=block-affine1\n"
+    "component-node name=repeated-affine2 component=repeated-affine2 input=relu2\n"
+    "output-node name=output input=repeated-affine2\n";
+
+  Nnet nnet;
+  std::istringstream is(config);
+  nnet.ReadConfig(is);
+  ConvertRepeatedToBlockAffine(&nnet);
+
+  for(int i = 0; i < nnet.NumComponents(); i++) {
+    Component *c = nnet.GetComponent(i);
+    KALDI_ASSERT(c->Type() != "RepeatedAffineComponent"
+                 && c->Type() != "NaturalGradientRepeatedAffineComponent");
+  }
+}
+
+void UnitTestConvertRepeatedToBlockAffineComposite() {
+  // test that repeated affine components nested within a CompositeComponent
+  // are converted.
+  struct NnetGenerationOptions gen_config;
+  gen_config.output_dim = 0;
+  std::vector<std::string> configs;
+  // this function generates a neural net with one component:
+  // a composite component.
+  GenerateConfigSequenceCompositeBlock(gen_config, &configs);
+  Nnet nnet;
+  std::istringstream is(configs[0]);
+  nnet.ReadConfig(is);
+  KALDI_ASSERT(nnet.NumComponents() == 1);
+  ConvertRepeatedToBlockAffine(&nnet);
+  CompositeComponent *cc = dynamic_cast<CompositeComponent*>(nnet.GetComponent(0));
+  for(int i = 0; i < cc->NumComponents(); i++) {
+    const Component *c = cc->GetComponent(i);
+    KALDI_ASSERT(c->Type() == "BlockAffineComponent");
+  }
+}
+
 } // namespace nnet3
 } // namespace kaldi
 
@@ -54,6 +109,8 @@ int main() {
   SetVerboseLevel(2);
 
   UnitTestNnetContext();
+  UnitTestConvertRepeatedToBlockAffine();
+  UnitTestConvertRepeatedToBlockAffineComposite();
 
   KALDI_LOG << "Nnet tests succeeded.";
 

--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -1,7 +1,8 @@
 // nnet3/nnet-utils.cc
 
 // Copyright      2015  Johns Hopkins University (author: Daniel Povey)
-
+//                2016  Daniel Galvez
+//
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +19,7 @@
 // limitations under the License.
 
 #include "nnet3/nnet-utils.h"
+#include "nnet3/nnet-simple-component.h"
 
 namespace kaldi {
 namespace nnet3 {
@@ -357,6 +359,51 @@ int32 NumUpdatableComponents(const Nnet &dest) {
       ans++;
   }
   return ans;
+}
+
+void ConvertRepeatedToBlockAffine(CompositeComponent *c_component) {
+  for(int32 i = 0; i < c_component->NumComponents(); i++) {
+    const Component *c = c_component->GetComponent(i);
+    KALDI_ASSERT(c->Type() != "CompositeComponent" &&
+                 "Nesting CompositeComponent within CompositeComponent is not allowed.\n"
+                 "(We may change this as more complicated components are introduced.)");
+
+    if(c->Type() == "RepeatedAffineComponent" ||
+       c->Type() == "NaturalGradientRepeatedAffineComponent") {
+      // N.B.: NaturalGradientRepeatedAffineComponent is a subclass of
+      // RepeatedAffineComponent.
+      const RepeatedAffineComponent *rac =
+        dynamic_cast<const RepeatedAffineComponent*>(c);
+      KALDI_ASSERT(rac != NULL);
+      BlockAffineComponent *bac = new BlockAffineComponent(*rac);
+      // following call deletes rac
+      c_component->SetComponent(i, bac);
+    }
+  }
+}
+
+void ConvertRepeatedToBlockAffine(Nnet *nnet) {
+  for(int32 i = 0; i < nnet->NumComponents(); i++) {
+    const Component *const_c = nnet->GetComponent(i);
+    if(const_c->Type() == "RepeatedAffineComponent" ||
+       const_c->Type() == "NaturalGradientRepeatedAffineComponent") {
+      // N.B.: NaturalGradientRepeatedAffineComponent is a subclass of
+      // RepeatedAffineComponent.
+      const RepeatedAffineComponent *rac =
+        dynamic_cast<const RepeatedAffineComponent*>(const_c);
+      KALDI_ASSERT(rac != NULL);
+      BlockAffineComponent *bac = new BlockAffineComponent(*rac);
+      // following call deletes rac
+      nnet->SetComponent(i, bac);
+    } else if (const_c->Type() == "CompositeComponent") {
+      // We must modify the composite component, so we use the
+      // non-const GetComponent() call here.
+      Component *c = nnet->GetComponent(i);
+      CompositeComponent *cc = dynamic_cast<CompositeComponent*>(c);
+      KALDI_ASSERT(cc != NULL);
+      ConvertRepeatedToBlockAffine(cc);
+    }
+  }
 }
 
 std::string NnetInfo(const Nnet &nnet) {

--- a/src/nnet3/nnet-utils.h
+++ b/src/nnet3/nnet-utils.h
@@ -1,7 +1,7 @@
 // nnet3/nnet-utils.h
 
 // Copyright   2015  Johns Hopkins University (author: Daniel Povey)
-
+//             2016  Daniel Galvez
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -138,6 +138,9 @@ void UnVectorizeNnet(const VectorBase<BaseFloat> &params,
 /// Returns the number of updatable components in the nnet.
 int32 NumUpdatableComponents(const Nnet &dest);
 
+/// Convert all components of type RepeatedAffineComponent or
+/// NaturalGradientRepeatedAffineComponent to BlockAffineComponent in nnet.
+void ConvertRepeatedToBlockAffine(Nnet *nnet);
 
 /// This function returns various info about the neural net.
 /// If the nnet satisfied IsSimpleNnet(nnet), the info includes "left-context=5\nright-context=3\n...".  The info includes

--- a/src/nnet3bin/nnet3-am-copy.cc
+++ b/src/nnet3bin/nnet3-am-copy.cc
@@ -1,6 +1,7 @@
 // nnet3bin/nnet3-am-copy.cc
 
 // Copyright 2012-2015  Johns Hopkins University (author:  Daniel Povey)
+//           2016 Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -47,6 +48,7 @@ int main(int argc, char *argv[]) {
         raw = false;
     BaseFloat learning_rate = -1;
     std::string set_raw_nnet = "";
+    bool convert_repeated_to_block = false;
     BaseFloat scale = 1.0;
 
     ParseOptions po(usage);
@@ -57,6 +59,10 @@ int main(int argc, char *argv[]) {
                 "Set the raw nnet inside the model to the one provided in "
                 "the option string (interpreted as an rxfilename).  Done "
                 "before the learning-rate is changed.");
+    po.Register("convert-repeated-to-block", &convert_repeated_to_block,
+                "Convert all RepeatedAffineComponents and "
+                "NaturalGradientRepeatedAffineComponents to "
+                "BlockAffineComponents in the model. Done after set-raw-nnet.");
     po.Register("learning-rate", &learning_rate,
                 "If supplied, all the learning rates of updatable components"
                 " are set to this value.");
@@ -87,6 +93,10 @@ int main(int argc, char *argv[]) {
       Nnet nnet;
       ReadKaldiObject(set_raw_nnet, &nnet);
       am_nnet.SetNnet(nnet);
+    }
+
+    if(convert_repeated_to_block) {
+      ConvertRepeatedToBlockAffine(&(am_nnet.GetNnet()));
     }
 
     if (learning_rate >= 0)

--- a/src/nnet3bin/nnet3-am-copy.cc
+++ b/src/nnet3bin/nnet3-am-copy.cc
@@ -95,9 +95,8 @@ int main(int argc, char *argv[]) {
       am_nnet.SetNnet(nnet);
     }
 
-    if(convert_repeated_to_block) {
+    if(convert_repeated_to_block)
       ConvertRepeatedToBlockAffine(&(am_nnet.GetNnet()));
-    }
 
     if (learning_rate >= 0)
       SetLearningRate(learning_rate, &(am_nnet.GetNnet()));


### PR DESCRIPTION
Addresses #440.

In addition to the unit tests provided, I ran nnet3-am-copy --repeated-to-block on one of my own models, and check all the components were successfully converted.
