### PR TITLE
Fix compilation issues when using KALDI_DOUBLEPRECISION=1

### DIFF
--- a/src/feat/signal.cc
+++ b/src/feat/signal.cc
@@ -34,7 +34,7 @@ void ElementwiseProductOfFft(const Vector<BaseFloat> &a, Vector<BaseFloat> *b) {
 void ConvolveSignals(const Vector<BaseFloat> &filter, Vector<BaseFloat> *signal) {
   int32 signal_length = signal->Dim();
   int32 filter_length = filter.Dim();
-  Vector<float> signal_padded(signal_length + filter_length - 1);
+  Vector<BaseFloat> signal_padded(signal_length + filter_length - 1);
   signal_padded.SetZero();
   for (int32 i = 0; i < signal_length; i++) {
     for (int32 j = 0; j < filter_length; j++) {
@@ -54,11 +54,11 @@ void FFTbasedConvolveSignals(const Vector<BaseFloat> &filter, Vector<BaseFloat> 
 
   SplitRadixRealFft<BaseFloat> srfft(fft_length);
 
-  Vector<float> filter_padded(fft_length);
+  Vector<BaseFloat> filter_padded(fft_length);
   filter_padded.Range(0, filter_length).CopyFromVec(filter);
   srfft.Compute(filter_padded.Data(), true);
 
-  Vector<float> signal_padded(fft_length);
+  Vector<BaseFloat> signal_padded(fft_length);
   signal_padded.Range(0, signal_length).CopyFromVec(*signal);
   srfft.Compute(signal_padded.Data(), true);
 
@@ -83,13 +83,13 @@ void FFTbasedBlockConvolveSignals(const Vector<BaseFloat> &filter, Vector<BaseFl
   KALDI_VLOG(1) << "Block size is " << block_length;
   SplitRadixRealFft<BaseFloat> srfft(fft_length);
 
-  Vector<float> filter_padded(fft_length);
+  Vector<BaseFloat> filter_padded(fft_length);
   filter_padded.Range(0, filter_length).CopyFromVec(filter);
   srfft.Compute(filter_padded.Data(), true);
 
-  Vector<float> temp_pad(filter_length - 1);
+  Vector<BaseFloat> temp_pad(filter_length - 1);
   temp_pad.SetZero();
-  Vector<float> signal_block_padded(fft_length);
+  Vector<BaseFloat> signal_block_padded(fft_length);
 
   for (int32 po = 0; po < signal_length; po += block_length) {
     // get a block of the signal

--- a/src/lm/kaldi-rnnlm.cc
+++ b/src/lm/kaldi-rnnlm.cc
@@ -58,8 +58,8 @@ KaldiRnnlmWrapper::KaldiRnnlmWrapper(
 
 BaseFloat KaldiRnnlmWrapper::GetLogProb(
     int32 word, const std::vector<int32> &wseq,
-    const std::vector<BaseFloat> &context_in,
-    std::vector<BaseFloat> *context_out) {
+    const std::vector<float> &context_in,
+    std::vector<float> *context_out) {
 
   std::vector<std::string> wseq_symbols(wseq.size());
   for (int32 i = 0; i < wseq_symbols.size(); ++i) {
@@ -79,7 +79,7 @@ RnnlmDeterministicFst::RnnlmDeterministicFst(int32 max_ngram_order,
 
   // Uses empty history for <s>.
   std::vector<Label> bos;
-  std::vector<BaseFloat> bos_context(rnnlm->GetHiddenLayerSize(), 1.0f);
+  std::vector<float> bos_context(rnnlm->GetHiddenLayerSize(), 1.0f);
   state_to_wseq_.push_back(bos);
   state_to_context_.push_back(bos_context);
   wseq_to_state_[bos] = 0;
@@ -101,7 +101,7 @@ bool RnnlmDeterministicFst::GetArc(StateId s, Label ilabel, fst::StdArc *oarc) {
   KALDI_ASSERT(static_cast<size_t>(s) < state_to_wseq_.size());
 
   std::vector<Label> wseq = state_to_wseq_[s];
-  std::vector<BaseFloat> new_context(rnnlm_->GetHiddenLayerSize());
+  std::vector<float> new_context(rnnlm_->GetHiddenLayerSize());
   BaseFloat logprob = rnnlm_->GetLogProb(ilabel, wseq,
                                          state_to_context_[s], &new_context);
 

--- a/src/lm/kaldi-rnnlm.cc
+++ b/src/lm/kaldi-rnnlm.cc
@@ -79,7 +79,7 @@ RnnlmDeterministicFst::RnnlmDeterministicFst(int32 max_ngram_order,
 
   // Uses empty history for <s>.
   std::vector<Label> bos;
-  std::vector<float> bos_context(rnnlm->GetHiddenLayerSize(), 1.0f);
+  std::vector<float> bos_context(rnnlm->GetHiddenLayerSize(), 1.0);
   state_to_wseq_.push_back(bos);
   state_to_context_.push_back(bos_context);
   wseq_to_state_[bos] = 0;

--- a/src/lm/kaldi-rnnlm.h
+++ b/src/lm/kaldi-rnnlm.h
@@ -56,8 +56,8 @@ class KaldiRnnlmWrapper {
   int32 GetEos() const { return eos_; }
 
   BaseFloat GetLogProb(int32 word, const std::vector<int32> &wseq,
-                       const std::vector<BaseFloat> &context_in,
-                       std::vector<BaseFloat> *context_out);
+                       const std::vector<float> &context_in,
+                       std::vector<float> *context_out);
 
  private:
   rnnlm::CRnnLM rnnlm_;
@@ -96,7 +96,7 @@ class RnnlmDeterministicFst
 
   KaldiRnnlmWrapper *rnnlm_;
   int32 max_ngram_order_;
-  std::vector<std::vector<BaseFloat> > state_to_context_;
+  std::vector<std::vector<float> > state_to_context_;
 };
 
 }  // namespace kaldi

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -3933,7 +3933,7 @@ void Convolutional1dComponent::Propagate(const ChunkInfo &in_info,
   }
   
   // apply all filters
-  AddMatMatBatched(1.0f, tgt_batch, patch_batch, kNoTrans, filter_params_batch,
+  AddMatMatBatched<BaseFloat>(1.0f, tgt_batch, patch_batch, kNoTrans, filter_params_batch,
 		  kTrans, 1.0f);
 
   // release memory
@@ -4060,7 +4060,7 @@ void Convolutional1dComponent::Backprop(const ChunkInfo &in_info,
 				    p * num_filters, num_filters)));
     filter_params_batch.push_back(filter_params_elem);  
   }
-  AddMatMatBatched(1.0f, patch_deriv_batch, out_deriv_batch, kNoTrans, 
+  AddMatMatBatched<BaseFloat>(1.0f, patch_deriv_batch, out_deriv_batch, kNoTrans, 
 		  filter_params_batch, kNoTrans, 0.0f);
 
   // release memory
@@ -4275,7 +4275,7 @@ void Convolutional1dComponent::Update(const CuMatrixBase<BaseFloat> &in_value,
 				    p * filter_dim, filter_dim)));
   }
 
-  AddMatMatBatched(1.0f, filters_grad_batch, diff_patch_batch, kTrans, patch_batch,
+  AddMatMatBatched<BaseFloat>(1.0f, filters_grad_batch, diff_patch_batch, kTrans, patch_batch,
 		  kNoTrans, 1.0f);
 
   // add the row blocks together to filters_grad

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -3933,8 +3933,8 @@ void Convolutional1dComponent::Propagate(const ChunkInfo &in_info,
   }
   
   // apply all filters
-  AddMatMatBatched<BaseFloat>(1.0f, tgt_batch, patch_batch, kNoTrans, filter_params_batch,
-		  kTrans, 1.0f);
+  AddMatMatBatched<BaseFloat>(1.0, tgt_batch, patch_batch, kNoTrans, filter_params_batch,
+		  kTrans, 1.0);
 
   // release memory
   delete filter_params_elem;
@@ -4060,8 +4060,8 @@ void Convolutional1dComponent::Backprop(const ChunkInfo &in_info,
 				    p * num_filters, num_filters)));
     filter_params_batch.push_back(filter_params_elem);  
   }
-  AddMatMatBatched<BaseFloat>(1.0f, patch_deriv_batch, out_deriv_batch, kNoTrans, 
-		  filter_params_batch, kNoTrans, 0.0f);
+  AddMatMatBatched<BaseFloat>(1.0, patch_deriv_batch, out_deriv_batch, kNoTrans, 
+		  filter_params_batch, kNoTrans, 0.0);
 
   // release memory
   delete filter_params_elem;
@@ -4275,8 +4275,8 @@ void Convolutional1dComponent::Update(const CuMatrixBase<BaseFloat> &in_value,
 				    p * filter_dim, filter_dim)));
   }
 
-  AddMatMatBatched<BaseFloat>(1.0f, filters_grad_batch, diff_patch_batch, kTrans, patch_batch,
-		  kNoTrans, 1.0f);
+  AddMatMatBatched<BaseFloat>(1.0, filters_grad_batch, diff_patch_batch, kTrans, patch_batch,
+		  kNoTrans, 1.0);
 
   // add the row blocks together to filters_grad
   filters_grad.AddMatBlocks(1.0, filters_grad_blocks_batch);

--- a/src/nnet2/nnet-precondition-online-test.cc
+++ b/src/nnet2/nnet-precondition-online-test.cc
@@ -307,7 +307,7 @@ void UnitTestPreconditionDirectionsOnline() {
     AssertEqual(trace1, trace2 * gamma2 * gamma2, 1.0e-02);
 
     AssertEqual(Mcopy1, Mcopy2);
-    AssertEqual(row_prod1, row_prod2, 1.0e-02f);
+    AssertEqual<BaseFloat>(row_prod1, row_prod2, 1.0e-02);
     AssertEqual(gamma1, gamma2, 1.0e-02);
 
     // make sure positive definite

--- a/src/nnet3/natural-gradient-online-test.cc
+++ b/src/nnet3/natural-gradient-online-test.cc
@@ -307,7 +307,7 @@ void UnitTestPreconditionDirectionsOnline() {
     AssertEqual(trace1, trace2 * gamma2 * gamma2, 1.0e-02);
 
     AssertEqual(Mcopy1, Mcopy2);
-    AssertEqual(row_prod1, row_prod2, 1.0e-02f);
+    AssertEqual<BaseFloat>(row_prod1, row_prod2, 1.0e-02);
     AssertEqual(gamma1, gamma2, 1.0e-02);
 
     // make sure positive definite


### PR DESCRIPTION
Fix some compilation issues by specifying templates instead of letting the compiler guess and replacing hardcoded floats in signal processing by BaseFloat typedef

When dealing with rnnlm, floats are used everywhere, no matter what the precision of the rest of Kaldi is (it was already like that in most of the rnnlm code, with a few exceptions)