### PR TITLE
CUDA memory leak via cu-device.cc ?

### DIFF
--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -76,6 +76,13 @@ class CuDevice {
     return active_gpu_id_;
   }
 
+  void DeviceReset() {
+   if ( Enabled() ) {
+     cudaSetDevice( ActiveGpuId() );
+     cudaDeviceReset();
+    }
+  }
+
   /// Returns true if either we have no GPU, or we have a GPU
   /// and it supports double precision.
   bool DoublePrecisionSupported();

--- a/src/nnet2bin/nnet-train-simple.cc
+++ b/src/nnet2bin/nnet-train-simple.cc
@@ -102,6 +102,7 @@ int main(int argc, char *argv[]) {
     }
 #if HAVE_CUDA==1
     CuDevice::Instantiate().PrintProfile();
+    CuDevice::Instantiate().DeviceReset();
 #endif
     
     KALDI_LOG << "Finished training, processed " << num_examples


### PR DESCRIPTION
Hello,

We've come across a memory leak when using nnet-train-simple, we have tracked it down to not calling cudaDevieReset() on exit.

The affects of this bug are quite severe, during our training stage we see around 30MB of memory lost for each nnet iteration.

Over the number of iterations in our training scripts we consume all memory on the machine (32GB) and cannot complete training.

The very strange thing is that this memory is never reclaimed at program exit and requires a machine reboot to retrieve. I am separately trying to isolate this and report to nvidia if applicable.

The attached pull request is our 'fix' for the issue. It's perhaps not ideal but I couldn't find a better place to call deviceReset from, tried the CuDevice destructor but that didn't seem to work.

I have full steps to reproduce the bug in this repo: 

https://github.com/matth/kaldi-cuda-leak-example

Some of the environmental info is outlined below:

        $ uname -a

        Linux 3.19.0-47-generic #53~14.04.1-Ubuntu SMP Mon Jan 18 16:09:14 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux

        $ cat /proc/driver/nvidia/version

        NVRM version: NVIDIA UNIX x86_64 Kernel Module  358.16  Mon Nov 16 19:25:55 PST 2015
        GCC version:  gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)

        $ nvidia-smi --query-gpu=index,name --format=csv

        index, name
        0, GeForce GTX TITAN X
        1, GeForce GTX TITAN X

        $ nvcc --version

        nvcc: NVIDIA (R) Cuda compiler driver
        Copyright (c) 2005-2015 NVIDIA Corporation
        Built on Mon_Feb_16_22:59:02_CST_2015
        Cuda compilation tools, release 7.0, V7.0.27`