### PR TITLE
Make CWD check less strict

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -52,7 +52,7 @@ function is_set {
 
 ##   First do some checks.  These verify that all the things are
 ##   here that should be here.
-if [ "`basename $PWD`" != "src" ]; then
+if ! [ -x "$PWD/configure" ]; then
   echo 'You must run "configure" from the src/ directory.'
   exit 1
 fi


### PR DESCRIPTION
It might be that `configure` is still invoked from 'src' directory, yet the
directory name itself isn't 'src'. While a real procedure of comparing two
filesystem paths to be equal is quite complex, this small trick does exactly
what we want to do - check that `configure` is invoked from the same directory
where it is.