### PR TITLE
Avoid ValueError by splitting on any number of spaces

### DIFF
--- a/egs/wsj/s5/steps/nnet3/make_tdnn_configs.py
+++ b/egs/wsj/s5/steps/nnet3/make_tdnn_configs.py
@@ -70,7 +70,7 @@ else:
 splice_array = []
 left_context = 0
 right_context = 0
-split1 = args.splice_indexes.split(" ");  # we already checked the string is nonempty.
+split1 = args.splice_indexes.split();  # we already checked the string is nonempty.
 if len(split1) < 1:
     sys.exit("invalid --splice-indexes argument, too short: "
              + args.splice_indexes)


### PR DESCRIPTION
Removing the argument from split() ensures that we get the desired result also when the input splice_indexes has multiple spaces separating the fields instead of a single space. E.g.:
`splice_indexes="-4,-3,-2,-1,0,1,2,3,4`  0  -2,2  0  -4,4 0"
`splice_indexes.split()`
`['-4,-3,-2,-1,0,1,2,3,4',` '0', '-2,2', '0', '-4,4', '0']
`splice_indexes.split("` ")
`['-4,-3,-2,-1,0,1,2,3,4',` '', '0', '', '-2,2', '', '0', '', '-4,4', '0']
Where the latter gives me a ValueError (and is the default in train_tdnn.sh).