### PR TITLE
Consider user-defined environment variables

### DIFF
--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -13,7 +13,7 @@ $(error ATLASLIBS not defined.)
 endif
 
 
-CXXFLAGS = -msse -msse2 -Wall -I.. \
+KALDI_CXXFLAGS = -msse -msse2 -Wall -I.. \
 	   -pthread \
       -DKALDI_DOUBLEPRECISION=0 -DHAVE_POSIX_MEMALIGN \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
@@ -24,11 +24,12 @@ CXXFLAGS = -msse -msse2 -Wall -I.. \
       -g # -O0 -DKALDI_PARANOID 
 
 ifeq ($(KALDI_FLAVOR), dynamic)
-CXXFLAGS += -fPIC
+KALDI_CXXFLAGS += -fPIC
 endif
 
-LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
-LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl
+CXXFLAGS := $(KALDI_CXXFLAGS) $(CXXFLAGS)
+LDFLAGS := -rdynamic $(OPENFSTLDFLAGS) $(LDFLAGS)
+LDLIBS := $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl $(LDLIBS)
 CC = g++
 CXX = g++
 AR = ar

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -1,6 +1,6 @@
 # You have to make sure CLAPACKLIBS is set...
 
-CXXFLAGS = -msse -Wall -I.. -pthread \
+KALDI_CXXFLAGS = -msse -Wall -I.. -pthread \
       -DKALDI_DOUBLEPRECISION=0 -msse2 -DHAVE_POSIX_MEMALIGN \
       -Wno-sign-compare -Wno-unused-local-typedefs \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
@@ -10,11 +10,12 @@ CXXFLAGS = -msse -Wall -I.. -pthread \
       -g # -O0 -DKALDI_PARANOID 
 
 ifeq ($(KALDI_FLAVOR), dynamic)
-CXXFLAGS += -fPIC
+KALDI_CXXFLAGS += -fPIC
 endif
 
-LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
-LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl
+CXXFLAGS := $(KALDI_CXXFLAGS) $(CXXFLAGS)
+LDFLAGS := -rdynamic $(OPENFSTLDFLAGS) $(LDFLAGS)
+LDLIBS := $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl $(LDLIBS)
 CC = g++
 CXX = g++
 AR = ar

--- a/src/makefiles/linux_cuda.mk
+++ b/src/makefiles/linux_cuda.mk
@@ -2,7 +2,8 @@
 CUDA_INCLUDE= -I$(CUDATKDIR)/include
 CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 32 -DHAVE_CUDA
 
-CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include 
-LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath=$(CUDATKDIR)/lib
-LDLIBS += -lcublas -lcudart #LDLIBS : The libs are loaded later than static libs in implicit rule
+CXXFLAGS := -DHAVE_CUDA -I$(CUDATKDIR)/include $(CXXFLAGS)
+LDFLAGS := -L$(CUDATKDIR)/lib -Wl,-rpath=$(CUDATKDIR)/lib $(LDFLAGS)
+# LDLIBS : The libs are loaded later than static libs in implicit rule
+LDLIBS := -lcublas -lcudart $(LDLIBS)
 

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -13,7 +13,7 @@ $(error OPENBLASROOT not defined.)
 endif
 
 
-CXXFLAGS = -msse -msse2 -Wall -I.. \
+KALDI_CXXFLAGS = -msse -msse2 -Wall -I.. \
            -pthread \
       -DKALDI_DOUBLEPRECISION=0 -DHAVE_POSIX_MEMALIGN \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
@@ -24,11 +24,12 @@ CXXFLAGS = -msse -msse2 -Wall -I.. \
       -g # -O0 -DKALDI_PARANOID 
 
 ifeq ($(KALDI_FLAVOR), dynamic)
-CXXFLAGS += -fPIC
+KALDI_CXXFLAGS += -fPIC
 endif
 
-LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
-LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(OPENBLASLIBS) -lm -lpthread -ldl 
+CXXFLAGS := $(KALDI_CXXFLAGS) $(CXXFLAGS)
+LDFLAGS := -rdynamic $(OPENFSTLDFLAGS) $(LDFLAGS)
+LDLIBS := $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(OPENBLASLIBS) -lm -lpthread -ldl $(LDLIBS)
 CC = g++
 CXX = g++
 AR = ar

--- a/src/makefiles/linux_x86_64_cuda.mk
+++ b/src/makefiles/linux_x86_64_cuda.mk
@@ -2,7 +2,7 @@
 CUDA_INCLUDE= -I$(CUDATKDIR)/include
 CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA
 
-CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include 
+CXXFLAGS := -DHAVE_CUDA -I$(CUDATKDIR)/include $(CXXFLAGS)
 UNAME := $(shell uname)
 #aware of fact in cuda60 there is no lib64, just lib.
 ifeq ($(UNAME), Darwin)

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -19,7 +19,7 @@ endif
 
 MKLLIB ?= $(MKLROOT)/lib/em64t
 
-CXXFLAGS = -m64 -msse -msse2 -pthread -Wall -I.. \
+KALDI_CXXFLAGS = -m64 -msse -msse2 -pthread -Wall -I.. \
       -DKALDI_DOUBLEPRECISION=0 -DHAVE_POSIX_MEMALIGN \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
@@ -29,7 +29,7 @@ CXXFLAGS = -m64 -msse -msse2 -pthread -Wall -I.. \
       -g # -O0 -DKALDI_PARANOID
 
 ifeq ($(KALDI_FLAVOR), dynamic)
-CXXFLAGS += -fPIC
+KALDI_CXXFLAGS += -fPIC
 endif
 
 ## Use the following for STATIC LINKING of the SEQUENTIAL version of MKL
@@ -52,8 +52,9 @@ MKL_DYN_MUL = -L$(MKLLIB) -lmkl_solver_lp64 -Wl,--start-group -lmkl_intel_lp64 \
 
 # MKLFLAGS = $(MKL_DYN_MUL)
 
-LDFLAGS = -rdynamic -L$(FSTROOT)/lib -Wl,-R$(FSTROOT)/lib
-LDLIBS =  $(EXTRA_LDLIBS) -lfst -ldl $(MKLFLAGS) -lm -lpthread
+CXXFLAGS := $(KALDI_CXXFLAGS) $(CXXFLAGS)
+LDFLAGS := -rdynamic -L$(FSTROOT)/lib -Wl,-R$(FSTROOT)/lib $(LDFLAGS)
+LDLIBS :=  $(EXTRA_LDLIBS) -lfst -ldl $(MKLFLAGS) -lm -lpthread $(LDLIBS)
 CC = g++
 CXX = g++
 AR = ar


### PR DESCRIPTION
Put kaldi-defined compiler and linker flags before user-defined flags so the
former could be overriden.