### PR TITLE
If compiling with MSVS 2015, dont redefine snprintf

### DIFF
--- a/src/base/kaldi-utils.cc
+++ b/src/base/kaldi-utils.cc
@@ -20,7 +20,9 @@
 #include <Synchapi.h>
 #elif defined(_WIN32) || defined(_MSC_VER) || defined(MINGW)
 #include <Windows.h>
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif /* _MSC_VER < 1900 */
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
As of Windows 10 and MSVS 2015, `snprintf` is no longer identical to `_snprintf`

This PR checks for MSVS 2015 or greater, will not redefine `snprintf` if so