### PR TITLE
Handle multiple pronunciations in lexicon. 

### DIFF
--- a/egs/fisher_callhome_spanish/s5/local/fsp_prepare_dict.sh
+++ b/egs/fisher_callhome_spanish/s5/local/fsp_prepare_dict.sh
@@ -70,6 +70,7 @@ if [ $stage -le 2 ]; then
   # representation
   cat $tmpdir/uniquewords | $local/spron.pl $lexicon/callhome_spanish_lexicon_970908/preferences $lexicon/callhome_spanish_lexicon_970908/basic_rules \
     | cut -f1 | sed -r 's:#\S+\s\S+\s\S+\s\S+\s(\S+):\1:g' \
+    | awk -F '[/][/]' '{print $1}' \
     > $tmpdir/lexicon_raw
 fi
 


### PR DESCRIPTION
Simple change to take care of multiple pronunciations. This is a very rare occurrence (once in 64k words) and hence we use the first pronunciation available instead of both. Fixes #506

There's a lot of additional work possible here. The lexicon contains quite a few special symbols that make an appearance in the Spanish Gigaword dataset. Obviously there is no acoustic evidence for these symbols when we train on the Fisher train set. This leads to warnings about no statistics for certain PDF-ids. These can be removed to make the lexicon smaller. This is not a change in the recipe but is rather an additional pre-processing step for the large external word list (derived from Spanish Gigaword). I'll make this change later. 