### PR TITLE
Add chain library to nnet3bin dependencies

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -147,7 +147,7 @@ $(EXT_SUBDIRS) : mklibdir
 
 bin fstbin gmmbin fgmmbin sgmmbin sgmm2bin featbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin lmbin kwsbin online2bin: \
  base matrix util feat tree optimization thread gmm transform sgmm sgmm2 fstext hmm \
- lm decoder lat cudamatrix nnet nnet2 nnet3 ivector
+ lm decoder lat cudamatrix nnet nnet2 nnet3 ivector chain
 
 #2)The libraries have inter-dependencies
 base:

--- a/src/nnet3bin/Makefile
+++ b/src/nnet3bin/Makefile
@@ -21,7 +21,7 @@ cuda-compiled.o: ../kaldi.mk
 
 TESTFILES =
 
-ADDLIBS = ../nnet3/kaldi-nnet3.a ../gmm/kaldi-gmm.a \
+ADDLIBS = ../chain/kaldi-chain.a ../nnet3/kaldi-nnet3.a ../gmm/kaldi-gmm.a \
          ../decoder/kaldi-decoder.a ../lat/kaldi-lat.a ../hmm/kaldi-hmm.a  \
          ../transform/kaldi-transform.a ../tree/kaldi-tree.a \
          ../thread/kaldi-thread.a ../cudamatrix/kaldi-cudamatrix.a \


### PR DESCRIPTION
I also added `chain` to all tools' dependencies in main Makefile. Though it is not required (`nnet3` pools it anyway), looks like it should be there.