### PR TITLE
Fix <unk> bug in TEDLIUM Cantab Research language model.

### DIFF
--- a/egs/tedlium/s5/RESULTS
+++ b/egs/tedlium/s5/RESULTS
@@ -7,6 +7,27 @@ for x in exp/*/decode*; do [ -d $x ] && grep WER $x/wer_* | utils/best_wer.sh; d
   for x in exp/{mono,tri,sgmm,nnet,dnn,lstm}*/decode*; do [ -d $x ] && grep Sum $x/score_*/*.sys | utils/best_wer.sh; done 2>/dev/null | grep $filter_regexp
 exit 0
 
+
+#---------------------------------(Post-<unk> fix for Cantab LM) Provided for reference---------------------------------
+# There was a problem with the language model preparation where Kaldi expected <UNK> to represent OOV words while
+# the language model used <unk> to represent them. See `git log tedlium-unk-fix` for details.
+# Fixing this causes a small increased in WER.
+
+# GMMs
+# DEV SPEAKERS:
+%WER 31.0 | 507 17792 | 73.5 20.2 6.3 4.5 31.0 97.2 | -0.032 | exp/tri1/decode_nosp_dev/score_11_0.0/ctm.filt.filt.sys
+%WER 26.4 | 507 17792 | 77.8 16.7 5.5 4.2 26.4 95.5 | -0.066 | exp/tri2/decode_nosp_dev/score_13_0.0/ctm.filt.filt.sys
+%WER 26.1 | 507 17792 | 77.2 16.3 6.5 3.4 26.1 95.5 | -0.106 | exp/tri2/decode_dev/score_14_1.0/ctm.filt.filt.sys
+%WER 22.0 | 507 17792 | 81.6 13.2 5.2 3.6 22.0 93.9 | -0.189 | exp/tri3/decode_dev/score_13_1.0/ctm.filt.filt.sys
+
+# TEST SPEAKERS:
+%WER 30.9 | 1155 27512 | 72.1 21.0 6.9 3.0 30.9 94.5 | 0.035 | exp/tri1/decode_nosp_test/score_12_0.5/ctm.filt.filt.sys
+%WER 25.5 | 1155 27512 | 78.0 17.4 4.6 3.6 25.5 92.8 | -0.034 | exp/tri2/decode_nosp_test/score_12_0.0/ctm.filt.filt.sys
+%WER 24.9 | 1155 27512 | 78.3 16.7 5.0 3.2 24.9 93.0 | -0.020 | exp/tri2/decode_test/score_14_0.5/ctm.filt.filt.sys
+%WER 20.3 | 1155 27512 | 82.7 13.4 3.9 3.0 20.3 90.0 | -0.063 | exp/tri3/decode_test/score_14_0.5/ctm.filt.filt.sys
+
+#---------------------------------(Pre-<unk> fix for Cantab LM) Provided for reference----------------------------------
+
 # Results from Nikolay, using kaldi scoring:
 # %WER 35.17 [ 9677 / 27512, 1267 ins, 1681 del, 6729 sub ] exp/tri1/decode/wer_13
 # %WER 30.03 [ 8262 / 27512, 1255 ins, 1367 del, 5640 sub ] exp/tri2/decode/wer_15

--- a/egs/tedlium/s5/local/prepare_dict.sh
+++ b/egs/tedlium/s5/local/prepare_dict.sh
@@ -2,6 +2,7 @@
 #
 # Copyright  2014 Nickolay V. Shmyrev
 #            2014 Brno University of Technology (Author: Karel Vesely)
+#            2016 Daniel Galvez
 # Apache 2.0
 #
 
@@ -13,7 +14,7 @@ srcdict=db/cantab-TEDLIUM/cantab-TEDLIUM.dct
 [ ! -r $srcdict ] && echo "Missing $srcdict" && exit 1
 
 # Join dicts and fix some troubles
-cat $srcdict | grep -v -w "<s>" | grep -v -w "</s>" | grep -v -w '<unk>' | \
+cat $srcdict | grep -v -w "<s>" | grep -v -w "</s>" | grep -v -w "<unk>" | \
   LANG= LC_ALL= sort | sed 's:([0-9])::g' > $dir/lexicon_words.txt
 
 cat $dir/lexicon_words.txt | awk '{ for(n=2;n<=NF;n++){ phones[$n] = 1; }} END{for (p in phones) print p;}' | \
@@ -28,9 +29,11 @@ echo SIL > $dir/optional_silence.txt
 echo -n >$dir/extra_questions.txt
 
 # Add to the lexicon the silences, noises etc.
+# Typically, you would use "<UNK> NSN" here, but the Cantab Research language models
+# use <unk> instead of <UNK> to represent out of vocabulary words.
 (echo '!SIL SIL'; echo '[BREATH] BRH'; echo '[NOISE] NSN'; echo '[COUGH] CGH';
  echo '[SMACK] SMK'; echo '[UM] UM'; echo '[UH] UHH'
- echo '<UNK> NSN' ) | \
+ echo '<unk> NSN' ) | \
  cat - $dir/lexicon_words.txt | sort | uniq > $dir/lexicon.txt
 
 # Check that the dict dir is okay!

--- a/egs/tedlium/s5/local/prepare_lm.sh
+++ b/egs/tedlium/s5/local/prepare_lm.sh
@@ -22,7 +22,6 @@ gunzip -c "$arpa_lm" | \
    grep -v '<s> <s>' | \
    grep -v '</s> <s>' | \
    grep -v '</s> </s>' | \
-   sed "s=<unk>=<UNK>=g" | \
    arpa2fst - | fstprint | \
    utils/remove_oovs.pl /dev/null | \
    utils/eps2disambig.pl | utils/s2eps.pl | fstcompile --isymbols=data/lang_nosp_test/words.txt \

--- a/egs/tedlium/s5/run.sh
+++ b/egs/tedlium/s5/run.sh
@@ -34,11 +34,12 @@ if [ $stage -le 0 ]; then
   local/prepare_dict.sh || exit 1
 
   utils/prepare_lang.sh data/local/dict_nosp \
-    "<UNK>" data/local/lang_nosp data/lang_nosp || exit 1
+    "<unk>" data/local/lang_nosp data/lang_nosp || exit 1
 
   local/prepare_lm.sh || exit 1
 
 fi
+
 # Feature extraction
 feat_dir=$pwd/data/mfcc_features
 if [ $stage -le 1 ]; then
@@ -101,7 +102,7 @@ if [ $stage -le 5 ]; then
     exp/tri2/sil_counts_nowb.txt \
     exp/tri2/pron_bigram_counts_nowb.txt data/local/dict
 
-  utils/prepare_lang.sh data/local/dict "<UNK>" data/local/lang data/lang
+  utils/prepare_lang.sh data/local/dict "<unk>" data/local/lang data/lang
   cp -rT data/lang data/lang_test
   cp -rT data/lang data/lang_rescore
   cp data/lang_nosp_test/G.fst data/lang_test


### PR DESCRIPTION
The Cantab LM used <unk> to represent out of vocabulary words.
However, the scripts supposed that <UNK> was used to represent
out of vocabulary words. For some strange reason, the Cantab LM gives
<unk> a pronunciation "AH NG K". The end result was that the models
considered unknown words to have the pronunciation "AH NG K" instead
of an unknown pronunciation, and never actually saw any unknown words,
degrading performance.

This bug was previously fixed for the pruned 3-gram language model,
but not for the unpruned 4-gram model used for rescoring.
The fix is to use <unk> as the OOV word entirely throughout the scripts.