### PR TITLE
A few very minor fixes to Karel's confidence calibration scripts.

### DIFF
--- a/egs/wsj/s5/steps/conf/append_eval_to_ctm.py
+++ b/egs/wsj/s5/steps/conf/append_eval_to_ctm.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0

--- a/egs/wsj/s5/steps/conf/append_prf_to_ctm.py
+++ b/egs/wsj/s5/steps/conf/append_prf_to_ctm.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0

--- a/egs/wsj/s5/steps/conf/convert_ctm_to_tra.py
+++ b/egs/wsj/s5/steps/conf/convert_ctm_to_tra.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0

--- a/egs/wsj/s5/steps/conf/parse_arpa_unigrams.py
+++ b/egs/wsj/s5/steps/conf/parse_arpa_unigrams.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0
@@ -31,7 +31,7 @@ with gzip.open(arpa_gz,'r') as f:
 # Create list, 'wrd id log_p_unigram',
 words_unigram = [[wrd, id, (wrd_log10[wrd] if wrd in wrd_log10 else -99)] for wrd,id in words ]
 
-print words_unigram[0]
+print >>sys.stderr, words_unigram[0]
 # Store,
 with open(unigrams_out,'w') as f:
   f.writelines(['%s %s %g\n' % (w,i,p) for (w,i,p) in words_unigram])

--- a/egs/wsj/s5/steps/conf/prepare_calibration_data.py
+++ b/egs/wsj/s5/steps/conf/prepare_calibration_data.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0

--- a/egs/wsj/s5/steps/conf/prepare_word_categories.py
+++ b/egs/wsj/s5/steps/conf/prepare_word_categories.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2015  Brno University of Technology (author: Karel Vesely)
 # Apache 2.0
@@ -16,7 +16,7 @@ parser.add_option("--min-count", help="Minimum word-count to have a single word 
 (o, args) = parser.parse_args()
 
 if len(args) != 3:
-  parset.print_help()
+  parser.print_help()
   sys.exit(1)
 words_file, text_file, category_mapping_file = args
 


### PR DESCRIPTION
Mostly, we make sure that the calls to the Python scripts are changed to
"python \<script.py>", because the scripts start with "#!/bin/env"
(instead "#!/usr/bin/env") which doesn't work in e.g. Ubuntu.
Also a couple of typos corrected in the Python scripts themselves.

@vesis84 : Karel I hope you don't mind the changes. I believe
they should work in your environment too.

Just FYI, the mean NCE value for the LibriSpeech's "dev-other"
subset(I've split it in two, and used the first half for training and the
second one for testing) is 0.302.
Looking at the Karel's numbers, that @danpovey forwarded to the
mailing list it looks like it's about the same as AMI and somewhat
lower than the value for TED-LIUM. That sounds about right to me, 
given that the "other" subsets tend to contain heavily accented speech. 