### PR TITLE
Add options for score.sh to rescoring script.

### DIFF
--- a/egs/wsj/s5/steps/lmrescore_const_arpa.sh
+++ b/egs/wsj/s5/steps/lmrescore_const_arpa.sh
@@ -9,6 +9,7 @@
 cmd=run.pl
 skip_scoring=false
 stage=1
+scoring_opts=
 # End configuration section.
 
 echo "$0 $@"  # Print the command line for logging
@@ -57,7 +58,7 @@ fi
 if ! $skip_scoring && [ $stage -le 2 ]; then
   err_msg="Not scoring because local/score.sh does not exist or not executable."
   [ ! -x local/score.sh ] && echo $err_msg && exit 1;
-  local/score.sh --cmd "$cmd" $data $newlang $outdir
+  local/score.sh --cmd "$cmd" $scoring_opts $data $newlang $outdir
 else
   echo "Not scoring because requested so..."
 fi


### PR DESCRIPTION
We want to specify the language model weight range for decoding in
chain models, but previously lmrescore_const_arpa.sh did not allow
passing in arguments to score.sh. This is also necessary to specify
--decode-mbr false to score.sh for chain scoring in TEDLIUM.