### PR TITLE
[WIP] 3D-CNN; The convolution component is further generalized to sup…

### DIFF
--- a/egs/swbd/s5c/RESULTS
+++ b/egs/swbd/s5c/RESULTS
@@ -164,6 +164,14 @@ exit 0
 %WER 24.3 | 2628 21594 | 78.6 15.0 6.4 2.9 24.3 60.0 | exp/nnet3/tdnn_cnn_sp/decode_eval2000_hires_sw1_tg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
 %WER 18.9 | 4459 42989 | 83.2 11.5 5.3 2.2 18.9 55.6 | exp/nnet3/tdnn_cnn_sp/decode_eval2000_hires_sw1_tg/score_11_0.0/eval2000_hires.ctm.filt.sys
 
+# results with nnet3 3dcnn+tdnn: local/nnet3/run_tdnn_3dcnn.sh --use_cnn true (13.3.2016) (2 epoch training on speed-perturbed and volume perturbed data)
+%WER 11.7 | 1831 21395 | 89.5 6.9 3.5 1.3 11.7 47.0 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_fsh_fg/score_11_0.0/eval2000_hires.ctm.swbd.filt.sys
+%WER 22.1 | 2628 21594 | 80.5 13.4 6.1 2.6 22.1 58.1 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_fsh_fg/score_11_0.0/eval2000_hires.ctm.callhm.filt.sys
+%WER 16.9 | 4459 42989 | 85.0 10.2 4.8 2.0 16.9 53.5 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_fsh_fg/score_11_0.0/eval2000_hires.ctm.filt.sys
+%WER 13.0 | 1831 21395 | 88.4 7.9 3.7 1.5 13.0 49.9 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_tg/score_10_0.0/eval2000_hires.ctm.swbd.filt.sys
+%WER 23.9 | 2628 21594 | 78.9 14.8 6.2 2.9 23.9 60.6 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_tg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
+%WER 18.5 | 4459 42989 | 83.7 11.4 5.0 2.2 18.5 56.2 | exp/nnet3/tdnn_3dcnn_sp/decode_eval2000_hires_sw1_tg/score_10_0.0/eval2000_hires.ctm.filt.sys
+
 
 # current best 'chain' models with TDNNs (see local/chain/run_tdnn_2o.sh)
 %WER 11.3 | 1831 21395 | 90.0 6.8 3.2 1.3 11.3 46.6 | exp/chain/tdnn_2o_sp/decode_eval2000_sw1_fsh_fg/score_10_0.0/eval2000_hires.ctm.swbd.filt.sys

--- a/egs/swbd/s5c/local/nnet3/run_tdnn_3dcnn.sh
+++ b/egs/swbd/s5c/local/nnet3/run_tdnn_3dcnn.sh
@@ -58,6 +58,9 @@ if [ "$use_cnn" == "true" ]; then
   cnn_bottleneck_dim=  # remove this option if you don't want to add the bottleneck affine
   cepstral_lifter=  # have to fill this in if you are not using the default lifter value in the production of MFCC
                     # Here we assume your are using the default lifter value (22.0)
+
+  # When --filt-z-dim is not specified it will be equal to input-z-dim
+  # and when --filt-z-step is not specified it will be equal to --filt-z-dim
   cnn_layer="--filt-x-dim=4 --filt-y-dim=4 --num-filters=1024"
   cnn_opts+=(--cnn.layer "$cnn_layer")
   cnn_layer="--filt-x-dim=2 --filt-y-dim=4 --filt-z-dim=16 --num-filters=1"
@@ -75,7 +78,7 @@ if [ "$use_cnn" == "true" ]; then
   cmvn_opts="--norm-means=true --norm-vars=false"
 fi
 
-dir=exp/nnet3/tdnn_testminibatch
+dir=exp/nnet3/tdnn
 dir=$dir${affix:+_$affix}
 dir=${dir}$suffix
 train_set=train_nodup$suffix

--- a/egs/swbd/s5c/local/nnet3/run_tdnn_3dcnn.sh
+++ b/egs/swbd/s5c/local/nnet3/run_tdnn_3dcnn.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# this is the standard "tdnn" system, built in nnet3; it's what we use to
+# call multi-splice.
+
+. cmd.sh
+
+
+# At this script level we don't support not running on GPU, as it would be painfully slow.
+# If you want to run without GPU you'd have to call train_tdnn.sh with --gpu false,
+# --num-threads 16 and --minibatch-size 128.
+
+stage=9
+affix=
+train_stage=-10
+has_fisher=true
+speed_perturb=true
+use_cnn=true
+cmvn_opts="--norm-means=false --norm-vars=false"
+common_egs_dir=
+reporting_email=
+remove_egs=true
+
+. cmd.sh
+. ./path.sh
+. ./utils/parse_options.sh
+
+
+if ! cuda-compiled; then
+  cat <<EOF && exit 1
+This script is intended to be used with GPUs but you have not compiled Kaldi with CUDA
+If you want to use GPUs (and have them), go to src/, and configure and make on a machine
+where "nvcc" is installed.
+EOF
+fi
+
+suffix=
+if [ "$speed_perturb" == "true" ]; then
+  suffix=_sp
+fi
+
+cnn_opts=()
+if [ "$use_cnn" == "true" ]; then
+# When the cnn option is on, the LDA is replaced by
+# an CNN layer at the front of the network
+# and the recipe uses fbank features as the CNN input
+# As the dimension of the CNN output is usually large, we place
+# a linear layer at the output of CNN for dimension reduction
+# The ivectors are processed through a fully connected affine layer,
+# then concatenated with the CNN bottleneck output and
+# passed to the deeper part of the network.
+# Due to the data compression issue, it is better to convert MFCC
+# to FBANK in the network instead of directly using FBANK features
+# from the storage. This script uses MFCC features as its input
+# and were converted to FBANK features with an inverse of DCT matrix
+# at the first layer of the network.
+
+  cnn_bottleneck_dim=  # remove this option if you don't want to add the bottleneck affine
+  cepstral_lifter=  # have to fill this in if you are not using the default lifter value in the production of MFCC
+                    # Here we assume your are using the default lifter value (22.0)
+  cnn_layer="--filt-x-dim=4 --filt-y-dim=4 --num-filters=1024"
+  cnn_opts+=(--cnn.layer "$cnn_layer")
+  cnn_layer="--filt-x-dim=2 --filt-y-dim=4 --filt-z-dim=16 --num-filters=1"
+  cnn_opts+=(--cnn.layer "$cnn_layer")
+
+  cnn_layer="--filt-x-dim=1 --filt-y-dim=4 --num-filters=1024"
+  cnn_opts+=(--cnn.layer "$cnn_layer")
+  cnn_layer="--filt-x-dim=1 --filt-y-dim=4 --filt-z-dim=32 --num-filters=1"
+  cnn_opts+=(--cnn.layer "$cnn_layer")
+
+  [ ! -z "$cnn_bottleneck_dim" ] && cnn_opts+=(--cnn.bottleneck-dim $cnn_bottleneck_dim)
+  [ ! -z "$cepstral_lifter" ] && cnn_opts+=(--cnn.cepstral-lifter $cepstral_lifter)
+  affix=3dcnn
+  # We found that using CNN with mean-normalized features obtains better results
+  cmvn_opts="--norm-means=true --norm-vars=false"
+fi
+
+dir=exp/nnet3/tdnn_testminibatch
+dir=$dir${affix:+_$affix}
+dir=${dir}$suffix
+train_set=train_nodup$suffix
+ali_dir=exp/tri4_ali_nodup$suffix
+
+local/nnet3/run_ivector_common.sh --stage $stage \
+	--speed-perturb $speed_perturb || exit 1;
+
+if [ $stage -le 9 ]; then
+  echo "$0: creating neural net configs";
+
+  # create the config files for nnet initialization
+  python steps/nnet3/tdnn/make_configs.py  \
+    "${cnn_opts[@]}" \
+    --feat-dir data/${train_set}_hires \
+    --ivector-dir exp/nnet3/ivectors_${train_set} \
+    --ali-dir $ali_dir \
+    --relu-dim 1024 \
+    --splice-indexes "-2,-1,0,1,2 -1,2 -3,3 -7,2 0"  \
+    --use-presoftmax-prior-scale true \
+   $dir/configs || exit 1;
+fi
+
+
+if [ $stage -le 10 ]; then
+  if [[ $(hostname -f) == *.clsp.jhu.edu ]] && [ ! -d $dir/egs/storage ]; then
+    utils/create_split_dir.pl \
+     /export/b0{3,4,5,6}/$USER/kaldi-data/egs/swbd-$(date +'%m_%d_%H_%M')/s5/$dir/egs/storage $dir/egs/storage
+  fi
+
+  steps/nnet3/train_dnn.py --stage=$train_stage \
+    --cmd="$decode_cmd" \
+    --feat.online-ivector-dir exp/nnet3/ivectors_${train_set} \
+    --feat.cmvn-opts="$cmvn_opts" \
+    --trainer.num-epochs 2 \
+    --trainer.optimization.minibatch-size 512 \
+    --trainer.optimization.num-jobs-initial 3 \
+    --trainer.optimization.num-jobs-final 16 \
+    --trainer.optimization.initial-effective-lrate 0.0017 \
+    --trainer.optimization.final-effective-lrate 0.00017 \
+    --egs.dir "$common_egs_dir" \
+    --cleanup.remove-egs $remove_egs \
+    --cleanup.preserve-model-interval 100 \
+    --use-gpu true \
+    --feat-dir=data/${train_set}_hires \
+    --ali-dir $ali_dir \
+    --lang data/lang \
+    --reporting.email="$reporting_email" \
+    --dir=$dir  || exit 1;
+
+fi
+
+graph_dir=exp/tri4/graph_sw1_tg
+if [ $stage -le 11 ]; then
+  for decode_set in train_dev eval2000; do
+    (
+    num_jobs=`cat data/${decode_set}_hires/utt2spk|cut -d' ' -f2|sort -u|wc -l`
+    steps/nnet3/decode.sh --nj $num_jobs --cmd "$decode_cmd" \
+        --online-ivector-dir exp/nnet3/ivectors_${decode_set} \
+       $graph_dir data/${decode_set}_hires $dir/decode_${decode_set}_hires_sw1_tg || exit 1;
+    if $has_fisher; then
+	steps/lmrescore_const_arpa.sh --cmd "$decode_cmd" \
+          data/lang_sw1_{tg,fsh_fg} data/${decode_set}_hires \
+	  $dir/decode_${decode_set}_hires_sw1_{tg,fsh_fg} || exit 1;
+    fi
+    ) &
+  done
+fi
+wait;
+exit 0;
+

--- a/egs/wsj/s5/steps/nnet3/components.py
+++ b/egs/wsj/s5/steps/nnet3/components.py
@@ -142,10 +142,10 @@ def AddConvolutionLayer(config_lines, name, input,
     components = config_lines['components']
     component_nodes = config_lines['component-nodes']
 
-    # if filt_z_dim is zero we assume it equals to the input
-    if filt_z_dim == 0:
+    # if filt_z_dim is None we assume it equals to the input
+    if filt_z_dim is None:
       filt_z_dim = input_z_dim
-    if filt_z_step == 0:
+    if filt_z_step is None:
       filt_z_step = filt_z_dim
 
     conv_init_string = ("component name={0}_conv type=ConvolutionComponent "
@@ -166,6 +166,7 @@ def AddConvolutionLayer(config_lines, name, input,
     num_x_steps = (1 + (input_x_dim - filt_x_dim) / filt_x_step)
     num_y_steps = (1 + (input_y_dim - filt_y_dim) / filt_y_step)
     num_z_steps = (1 + (input_z_dim - filt_z_dim) / filt_z_step)
+    # The output is actually a vectorized 4d-tensor but we ignore the 4th dimension and fold it into the 3rd dimension
     output_dim = num_x_steps * num_y_steps * num_z_steps * num_filters;
     return {'descriptor':  '{0}_conv_t'.format(name),
             'dimension': output_dim,

--- a/egs/wsj/s5/steps/nnet3/tdnn/make_configs.py
+++ b/egs/wsj/s5/steps/nnet3/tdnn/make_configs.py
@@ -268,15 +268,17 @@ def AddLpFilter(config_lines, name, input, rate, num_lpfilter_taps, lpfilt_filen
     input_z_dim = 1
     filt_x_dim = len(filter_input_splice_indexes)
     filt_y_dim = 1
+    filt_z_dim = 1
     filt_x_step = 1
     filt_y_step = 1
+    filt_z_step = 1
     input_vectorization = 'zyx'
 
     tdnn_input_descriptor = nodes.AddConvolutionLayer(config_lines, name,
                                                      filter_input_descriptor,
                                                      input_x_dim, input_y_dim, input_z_dim,
-                                                     filt_x_dim, filt_y_dim,
-                                                     filt_x_step, filt_y_step,
+                                                     filt_x_dim, filt_y_dim, filt_z_dim,
+                                                     filt_x_step, filt_y_step, filt_z_step,
                                                      1, input_vectorization,
                                                      filter_bias_file = lpfilt_filename,
                                                      is_updatable = is_updatable)
@@ -290,8 +292,8 @@ def AddConvMaxpLayer(config_lines, name, input, args):
 
     input = nodes.AddConvolutionLayer(config_lines, name, input,
                               input['3d-dim'][0], input['3d-dim'][1], input['3d-dim'][2],
-                              args.filt_x_dim, args.filt_y_dim,
-                              args.filt_x_step, args.filt_y_step,
+                              args.filt_x_dim, args.filt_y_dim, args.filt_z_dim,
+                              args.filt_x_step, args.filt_y_step, args.filt_z_step,
                               args.num_filters, input['vectorization'])
 
     if args.pool_x_size > 1 or args.pool_y_size > 1 or args.pool_z_size > 1:
@@ -299,6 +301,9 @@ def AddConvMaxpLayer(config_lines, name, input, args):
                                 input['3d-dim'][0], input['3d-dim'][1], input['3d-dim'][2],
                                 args.pool_x_size, args.pool_y_size, args.pool_z_size,
                                 args.pool_x_step, args.pool_y_step, args.pool_z_step)
+    else:
+      output = nodes.AddRelNormLayer(config_lines, name, input, norm_target_rms = 1.0)
+      input['descriptor'] = output['descriptor']
 
     return input
 
@@ -348,8 +353,10 @@ def ParseCnnString(cnn_param_string_list):
 
     cnn_parser.add_argument("--filt-x-dim", required=True, type=int)
     cnn_parser.add_argument("--filt-y-dim", required=True, type=int)
+    cnn_parser.add_argument("--filt-z-dim", type=int, default = 0)
     cnn_parser.add_argument("--filt-x-step", type=int, default = 1)
     cnn_parser.add_argument("--filt-y-step", type=int, default = 1)
+    cnn_parser.add_argument("--filt-z-step", type=int, default = 0)
     cnn_parser.add_argument("--num-filters", required=True, type=int)
     cnn_parser.add_argument("--pool-x-size", type=int, default = 1)
     cnn_parser.add_argument("--pool-y-size", type=int, default = 1)

--- a/egs/wsj/s5/steps/nnet3/tdnn/make_configs.py
+++ b/egs/wsj/s5/steps/nnet3/tdnn/make_configs.py
@@ -353,10 +353,10 @@ def ParseCnnString(cnn_param_string_list):
 
     cnn_parser.add_argument("--filt-x-dim", required=True, type=int)
     cnn_parser.add_argument("--filt-y-dim", required=True, type=int)
-    cnn_parser.add_argument("--filt-z-dim", type=int, default = 0)
+    cnn_parser.add_argument("--filt-z-dim", type=int, default = None)
     cnn_parser.add_argument("--filt-x-step", type=int, default = 1)
     cnn_parser.add_argument("--filt-y-step", type=int, default = 1)
-    cnn_parser.add_argument("--filt-z-step", type=int, default = 0)
+    cnn_parser.add_argument("--filt-z-step", type=int, default = None)
     cnn_parser.add_argument("--num-filters", required=True, type=int)
     cnn_parser.add_argument("--pool-x-size", type=int, default = 1)
     cnn_parser.add_argument("--pool-y-size", type=int, default = 1)

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -3173,12 +3173,13 @@ void NaturalGradientPerElementScaleComponent::Update(
   scales_.AddVec(1.0, delta_scales);
 }
 
+
 // Constructors for the convolution component
 ConvolutionComponent::ConvolutionComponent():
     UpdatableComponent(),
     input_x_dim_(0), input_y_dim_(0), input_z_dim_(0),
-    filt_x_dim_(0), filt_y_dim_(0),
-    filt_x_step_(0), filt_y_step_(0),
+    filt_x_dim_(0), filt_y_dim_(0), filt_z_dim_(0),
+    filt_x_step_(0), filt_y_step_(0), filt_z_step_(0),
     input_vectorization_(kZyx),
     is_gradient_(false) {}
 
@@ -3190,8 +3191,10 @@ ConvolutionComponent::ConvolutionComponent(
     input_z_dim_(component.input_z_dim_),
     filt_x_dim_(component.filt_x_dim_),
     filt_y_dim_(component.filt_y_dim_),
+    filt_z_dim_(component.filt_z_dim_),
     filt_x_step_(component.filt_x_step_),
     filt_y_step_(component.filt_y_step_),
+    filt_z_step_(component.filt_z_step_),
     input_vectorization_(component.input_vectorization_),
     filter_params_(component.filter_params_),
     bias_params_(component.bias_params_),
@@ -3201,8 +3204,8 @@ ConvolutionComponent::ConvolutionComponent(
     const CuMatrixBase<BaseFloat> &filter_params,
     const CuVectorBase<BaseFloat> &bias_params,
     int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-    int32 filt_x_dim, int32 filt_y_dim,
-    int32 filt_x_step, int32 filt_y_step,
+    int32 filt_x_dim, int32 filt_y_dim, int32 filt_z_dim,
+    int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
     TensorVectorizationType input_vectorization,
     BaseFloat learning_rate):
     input_x_dim_(input_x_dim),
@@ -3210,14 +3213,16 @@ ConvolutionComponent::ConvolutionComponent(
     input_z_dim_(input_z_dim),
     filt_x_dim_(filt_x_dim),
     filt_y_dim_(filt_y_dim),
+    filt_z_dim_(filt_z_dim),
     filt_x_step_(filt_x_step),
     filt_y_step_(filt_y_step),
+    filt_z_step_(filt_z_step),
     input_vectorization_(input_vectorization),
     filter_params_(filter_params),
     bias_params_(bias_params){
   KALDI_ASSERT(filter_params.NumRows() == bias_params.Dim() &&
                bias_params.Dim() != 0);
-  KALDI_ASSERT(filter_params.NumCols() == filt_x_dim * filt_y_dim * input_z_dim);
+  KALDI_ASSERT(filter_params.NumCols() == filt_x_dim * filt_y_dim * filt_z_dim);
   SetUnderlyingLearningRate(learning_rate);
   is_gradient_ = false;
 }
@@ -3231,15 +3236,17 @@ int32 ConvolutionComponent::InputDim() const {
 int32 ConvolutionComponent::OutputDim() const {
   int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_);
   int32 num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_);
+  int32 num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_);
   int32 num_filters = filter_params_.NumRows();
-  return num_x_steps * num_y_steps * num_filters;
+  return num_x_steps * num_y_steps * num_z_steps * num_filters;
 }
 
 // initialize the component using hyperparameters
 void ConvolutionComponent::Init(
     int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-    int32 filt_x_dim, int32 filt_y_dim,
-    int32 filt_x_step, int32 filt_y_step, int32 num_filters,
+    int32 filt_x_dim, int32 filt_y_dim, int32 filt_z_dim,
+    int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
+    int32 num_filters,
     TensorVectorizationType input_vectorization,
     BaseFloat param_stddev, BaseFloat bias_stddev) {
   input_x_dim_ = input_x_dim;
@@ -3247,12 +3254,15 @@ void ConvolutionComponent::Init(
   input_z_dim_ = input_z_dim;
   filt_x_dim_ = filt_x_dim;
   filt_y_dim_ = filt_y_dim;
+  filt_z_dim_ = filt_z_dim;
   filt_x_step_ = filt_x_step;
   filt_y_step_ = filt_y_step;
+  filt_z_step_ = filt_z_step;
   input_vectorization_ = input_vectorization;
   KALDI_ASSERT((input_x_dim_ - filt_x_dim_) % filt_x_step_ == 0);
   KALDI_ASSERT((input_y_dim_ - filt_y_dim_) % filt_y_step_ == 0);
-  int32 filter_dim = filt_x_dim_ * filt_y_dim_ * input_z_dim_;
+  KALDI_ASSERT((input_z_dim_ - filt_z_dim_) % filt_z_step_ == 0);
+  int32 filter_dim = filt_x_dim_ * filt_y_dim_ * filt_z_dim_;
   filter_params_.Resize(num_filters, filter_dim);
   bias_params_.Resize(num_filters);
   KALDI_ASSERT(param_stddev >= 0.0 && bias_stddev >= 0.0);
@@ -3265,8 +3275,8 @@ void ConvolutionComponent::Init(
 // initialize the component using predefined matrix file
 void ConvolutionComponent::Init(
     int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-    int32 filt_x_dim, int32 filt_y_dim,
-    int32 filt_x_step, int32 filt_y_step,
+    int32 filt_x_dim, int32 filt_y_dim,int32 filt_z_dim,
+    int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
     TensorVectorizationType input_vectorization,
     std::string matrix_filename) {
   input_x_dim_ = input_x_dim;
@@ -3274,12 +3284,14 @@ void ConvolutionComponent::Init(
   input_z_dim_ = input_z_dim;
   filt_x_dim_ = filt_x_dim;
   filt_y_dim_ = filt_y_dim;
+  filt_z_dim_ = filt_z_dim;
   filt_x_step_ = filt_x_step;
   filt_y_step_ = filt_y_step;
+  filt_z_step_ = filt_z_step;
   input_vectorization_ = input_vectorization;
   CuMatrix<BaseFloat> mat;
   ReadKaldiObject(matrix_filename, &mat);
-  int32 filter_dim = (filt_x_dim_ * filt_y_dim_ * input_z_dim_);
+  int32 filter_dim = (filt_x_dim_ * filt_y_dim_ * filt_z_dim_);
   int32 num_filters = mat.NumRows();
   KALDI_ASSERT(mat.NumCols() == (filter_dim + 1));
   filter_params_.Resize(num_filters, filter_dim);
@@ -3297,12 +3309,14 @@ std::string ConvolutionComponent::Info() const {
          << ", input-z-dim=" << input_z_dim_
          << ", filt-x-dim=" << filt_x_dim_
          << ", filt-y-dim=" << filt_y_dim_
+         << ", filt-z-dim=" << filt_z_dim_
          << ", filt-x-step=" << filt_x_step_
          << ", filt-y-step=" << filt_y_step_
+         << ", filt-z-step=" << filt_z_step_
          << ", input-vectorization=" << input_vectorization_
          << ", num-filters=" << filter_params_.NumRows();
   PrintParameterStats(stream, "filter-params", filter_params_);
-  PrintParameterStats(stream, "bias-params", bias_params_, true);
+  PrintParameterStats(stream, "bias-params", bias_params_, true);  
   return stream.str();
 }
 
@@ -3311,8 +3325,8 @@ void ConvolutionComponent::InitFromConfig(ConfigLine *cfl) {
   bool ok = true;
   std::string matrix_filename;
   int32 input_x_dim = -1, input_y_dim = -1, input_z_dim = -1,
-        filt_x_dim = -1, filt_y_dim = -1,
-        filt_x_step = -1, filt_y_step = -1,
+        filt_x_dim = -1, filt_y_dim = -1, filt_z_dim = -1,
+        filt_x_step = -1, filt_y_step = -1, filt_z_step = -1,
         num_filters = -1;
   std::string input_vectorization_order = "zyx";
   InitLearningRatesFromConfig(cfl);
@@ -3321,8 +3335,10 @@ void ConvolutionComponent::InitFromConfig(ConfigLine *cfl) {
   ok = ok && cfl->GetValue("input-z-dim", &input_z_dim);
   ok = ok && cfl->GetValue("filt-x-dim", &filt_x_dim);
   ok = ok && cfl->GetValue("filt-y-dim", &filt_y_dim);
+  ok = ok && cfl->GetValue("filt-z-dim", &filt_z_dim);
   ok = ok && cfl->GetValue("filt-x-step", &filt_x_step);
   ok = ok && cfl->GetValue("filt-y-step", &filt_y_step);
+  ok = ok && cfl->GetValue("filt-z-step", &filt_z_step);
 
   if (!ok)
     KALDI_ERR << "Bad initializer " << cfl->WholeLine();
@@ -3342,8 +3358,8 @@ void ConvolutionComponent::InitFromConfig(ConfigLine *cfl) {
   if (cfl->GetValue("matrix", &matrix_filename)) {
     // initialize from prefined parameter matrix
     Init(input_x_dim, input_y_dim, input_z_dim,
-         filt_x_dim, filt_y_dim,
-         filt_x_step, filt_y_step,
+         filt_x_dim, filt_y_dim, filt_z_dim,
+         filt_x_step, filt_y_step, filt_z_step,
          input_vectorization,
          matrix_filename);
   } else {
@@ -3356,7 +3372,8 @@ void ConvolutionComponent::InitFromConfig(ConfigLine *cfl) {
     cfl->GetValue("param-stddev", &param_stddev);
     cfl->GetValue("bias-stddev", &bias_stddev);
     Init(input_x_dim, input_y_dim, input_z_dim,
-         filt_x_dim, filt_y_dim, filt_x_step, filt_y_step, num_filters,
+         filt_x_dim, filt_y_dim, filt_z_dim,
+         filt_x_step, filt_y_step, filt_z_step, num_filters,
          input_vectorization, param_stddev, bias_stddev);
   }
   if (cfl->HasUnusedValues())
@@ -3392,10 +3409,13 @@ void ConvolutionComponent::InputToInputPatches(
     CuMatrix<BaseFloat> *patches) const{
   int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_);
   int32 num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_);
+  int32 num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_);
   const int32 filt_x_step = filt_x_step_,
               filt_y_step = filt_y_step_,
+              filt_z_step = filt_z_step_,
               filt_x_dim = filt_x_dim_,
               filt_y_dim = filt_y_dim_,
+              filt_z_dim = filt_z_dim_,
               input_x_dim = input_x_dim_,
               input_y_dim = input_y_dim_,
               input_z_dim = input_z_dim_,
@@ -3405,22 +3425,27 @@ void ConvolutionComponent::InputToInputPatches(
   int32 column_map_size = column_map.size();
   for (int32 x_step = 0; x_step < num_x_steps; x_step++) {
     for (int32 y_step = 0; y_step < num_y_steps; y_step++)  {
-      int32 patch_number = x_step * num_y_steps + y_step;
-      int32 patch_start_index = patch_number * filter_dim;
-      for (int32 x = 0, index = patch_start_index; x < filt_x_dim; x++)  {
-        for (int32 y = 0; y < filt_y_dim; y++)  {
-          for (int32 z = 0; z < input_z_dim; z++, index++)  {
-            KALDI_ASSERT(index < column_map_size);
-            if (input_vectorization_ == kZyx)  {
-              column_map[index] = ZyxVectorIndex(x_step * filt_x_step + x,
-                                                 y_step * filt_y_step + y, z,
-                                                 input_x_dim, input_y_dim,
-                                                 input_z_dim);
-            } else if (input_vectorization_ == kYzx)  {
-              column_map[index] = YzxVectorIndex(x_step * filt_x_step + x,
-                                                  y_step * filt_y_step + y, z,
-                                                  input_x_dim, input_y_dim,
-                                                  input_z_dim);
+      for (int32 z_step = 0; z_step < num_z_steps; z_step++)  {
+        int32 patch_number = x_step * num_y_steps * num_z_steps 
+                           + y_step * num_z_steps + z_step;
+        int32 patch_start_index = patch_number * filter_dim;
+        for (int32 x = 0, index = patch_start_index; x < filt_x_dim; x++)  {
+          for (int32 y = 0; y < filt_y_dim; y++)  {
+            for (int32 z = 0; z < filt_z_dim; z++, index++)  {
+              KALDI_ASSERT(index < column_map_size);
+              if (input_vectorization_ == kZyx)  {
+                column_map[index] = ZyxVectorIndex(x_step * filt_x_step + x,
+                                                   y_step * filt_y_step + y,
+                                                   z_step * filt_z_step + z,
+                                                   input_x_dim, input_y_dim,
+                                                   input_z_dim);
+              } else if (input_vectorization_ == kYzx)  {
+                column_map[index] = YzxVectorIndex(x_step * filt_x_step + x,
+                                                   y_step * filt_y_step + y,
+                                                   z_step * filt_z_step + z,
+                                                   input_x_dim, input_y_dim,
+                                                   input_z_dim);
+              }
             }
           }
         }
@@ -3439,14 +3464,15 @@ void ConvolutionComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                          CuMatrixBase<BaseFloat> *out) const {
   const int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_),
               num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_),
+              num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_),
               num_filters = filter_params_.NumRows(),
               num_frames = in.NumRows(),
               filter_dim = filter_params_.NumCols();
   KALDI_ASSERT((*out).NumRows() == num_frames &&
-               (*out).NumCols() == (num_filters * num_x_steps * num_y_steps));
+               (*out).NumCols() == (num_filters * num_x_steps * num_y_steps * num_z_steps));
 
   CuMatrix<BaseFloat> patches(num_frames,
-                              num_x_steps * num_y_steps * filter_dim,
+                              num_x_steps * num_y_steps * num_z_steps * filter_dim,
                               kUndefined);
   InputToInputPatches(in, &patches);
   CuSubMatrix<BaseFloat>* filter_params_elem = new CuSubMatrix<BaseFloat>(
@@ -3457,13 +3483,16 @@ void ConvolutionComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
 
   for (int32 x_step = 0; x_step < num_x_steps; x_step++)  {
     for (int32 y_step = 0; y_step < num_y_steps; y_step++)  {
-      int32 patch_number = x_step * num_y_steps + y_step;
-      tgt_batch.push_back(new CuSubMatrix<BaseFloat>(
-              out->ColRange(patch_number * num_filters, num_filters)));
-      patch_batch.push_back(new CuSubMatrix<BaseFloat>(
-              patches.ColRange(patch_number * filter_dim, filter_dim)));
-      filter_params_batch.push_back(filter_params_elem);
-      tgt_batch[patch_number]->AddVecToRows(1.0, bias_params_, 1.0); // add bias
+      for (int32 z_step = 0; z_step < num_z_steps; z_step++)  {
+        int32 patch_number = x_step * num_y_steps * num_z_steps 
+                           + y_step * num_z_steps + z_step;
+        tgt_batch.push_back(new CuSubMatrix<BaseFloat>(
+                out->ColRange(patch_number * num_filters, num_filters)));
+        patch_batch.push_back(new CuSubMatrix<BaseFloat>(
+                patches.ColRange(patch_number * filter_dim, filter_dim)));
+        filter_params_batch.push_back(filter_params_elem);
+        tgt_batch[patch_number]->AddVecToRows(1.0, bias_params_, 1.0); // add bias
+      }
     }
   }
   // apply all filters
@@ -3530,10 +3559,13 @@ void ConvolutionComponent::InderivPatchesToInderiv(
 
   const int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_),
               num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_),
+              num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_),
               filt_x_step = filt_x_step_,
               filt_y_step = filt_y_step_,
+              filt_z_step = filt_z_step_,
               filt_x_dim = filt_x_dim_,
               filt_y_dim = filt_y_dim_,
+              filt_z_dim = filt_z_dim_,
               input_x_dim = input_x_dim_,
               input_y_dim = input_y_dim_,
               input_z_dim = input_z_dim_,
@@ -3545,26 +3577,31 @@ void ConvolutionComponent::InderivPatchesToInderiv(
   int32 rev_col_map_size = reverse_column_map.size();
   for (int32 x_step = 0; x_step < num_x_steps; x_step++) {
     for (int32 y_step = 0; y_step < num_y_steps; y_step++)  {
-      int32 patch_number = x_step * num_y_steps + y_step;
-      int32 patch_start_index = patch_number * filter_dim;
-      for (int32 x = 0, index = patch_start_index; x < filt_x_dim; x++)  {
-        for (int32 y = 0; y < filt_y_dim; y++)  {
-          for (int32 z = 0; z < input_z_dim; z++, index++)  {
-            int32 vector_index;
-            if (input_vectorization_ == kZyx)  {
-              vector_index = ZyxVectorIndex(x_step * filt_x_step + x,
-                                            y_step * filt_y_step + y, z,
-                                            input_x_dim, input_y_dim,
-                                            input_z_dim);
-            } else {
-              KALDI_ASSERT(input_vectorization_ == kYzx);
-              vector_index = YzxVectorIndex(x_step * filt_x_step + x,
-                                            y_step * filt_y_step + y, z,
-                                            input_x_dim, input_y_dim,
-                                            input_z_dim);
+      for (int32 z_step = 0; z_step < num_z_steps; z_step++)  {
+        int32 patch_number = x_step * num_y_steps * num_z_steps 
+                           + y_step * num_z_steps + z_step;
+        int32 patch_start_index = patch_number * filter_dim;
+        for (int32 x = 0, index = patch_start_index; x < filt_x_dim; x++)  {
+          for (int32 y = 0; y < filt_y_dim; y++)  {
+            for (int32 z = 0; z < filt_z_dim; z++, index++)  {
+              int32 vector_index;
+              if (input_vectorization_ == kZyx)  {
+                vector_index = ZyxVectorIndex(x_step * filt_x_step + x,
+                                              y_step * filt_y_step + y,
+                                              z_step * filt_z_step + z,
+                                              input_x_dim, input_y_dim,
+                                              input_z_dim);
+              } else {
+                KALDI_ASSERT(input_vectorization_ == kYzx);
+                vector_index = YzxVectorIndex(x_step * filt_x_step + x,
+                                              y_step * filt_y_step + y,
+                                              z_step * filt_z_step + z,
+                                              input_x_dim, input_y_dim,
+                                              input_z_dim);
+              }
+              KALDI_ASSERT(vector_index < rev_col_map_size);
+              reverse_column_map[vector_index].push_back(index);
             }
-            KALDI_ASSERT(vector_index < rev_col_map_size);
-            reverse_column_map[vector_index].push_back(index);
           }
         }
       }
@@ -3591,17 +3628,18 @@ void ConvolutionComponent::Backprop(const std::string &debug_info,
       dynamic_cast<ConvolutionComponent*>(to_update_in);
   const int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_),
               num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_),
+              num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_),
               num_filters = filter_params_.NumRows(),
               num_frames = out_deriv.NumRows(),
               filter_dim = filter_params_.NumCols();
 
   KALDI_ASSERT(out_deriv.NumRows() == num_frames &&
                out_deriv.NumCols() ==
-               (num_filters * num_x_steps * num_y_steps));
+               (num_filters * num_x_steps * num_y_steps * num_z_steps));
 
   // Compute inderiv patches
   CuMatrix<BaseFloat> in_deriv_patches(num_frames,
-                                       num_x_steps * num_y_steps * filter_dim,
+                                       num_x_steps * num_y_steps * num_z_steps * filter_dim,
                                        kSetZero);
 
   std::vector<CuSubMatrix<BaseFloat>* > patch_deriv_batch, out_deriv_batch,
@@ -3612,14 +3650,17 @@ void ConvolutionComponent::Backprop(const std::string &debug_info,
 
   for (int32 x_step = 0; x_step < num_x_steps; x_step++)  {
     for (int32 y_step = 0; y_step < num_y_steps; y_step++)  {
-      int32 patch_number = x_step * num_y_steps + y_step;
+      for (int32 z_step = 0; z_step < num_z_steps; z_step++)  {
+        int32 patch_number = x_step * num_y_steps * num_z_steps 
+                           + y_step * num_z_steps + z_step;
 
-      patch_deriv_batch.push_back(new CuSubMatrix<BaseFloat>(
-              in_deriv_patches.ColRange(
-              patch_number * filter_dim, filter_dim)));
-      out_deriv_batch.push_back(new CuSubMatrix<BaseFloat>(out_deriv.ColRange(
-              patch_number * num_filters, num_filters)));
-      filter_params_batch.push_back(filter_params_elem);
+        patch_deriv_batch.push_back(new CuSubMatrix<BaseFloat>(
+                in_deriv_patches.ColRange(
+                patch_number * filter_dim, filter_dim)));
+        out_deriv_batch.push_back(new CuSubMatrix<BaseFloat>(out_deriv.ColRange(
+                patch_number * num_filters, num_filters)));
+        filter_params_batch.push_back(filter_params_elem);
+      }
     }
   }
   AddMatMatBatched<BaseFloat>(1.0, patch_deriv_batch,
@@ -3654,19 +3695,20 @@ void ConvolutionComponent::Update(const std::string &debug_info,
   // useful dims
   const int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_),
               num_y_steps = (1 + (input_y_dim_ - filt_y_dim_) / filt_y_step_),
+              num_z_steps = (1 + (input_z_dim_ - filt_z_dim_) / filt_z_step_),
               num_filters = filter_params_.NumRows(),
               num_frames = out_deriv.NumRows(),
               filter_dim = filter_params_.NumCols();
   KALDI_ASSERT(out_deriv.NumRows() == num_frames &&
                out_deriv.NumCols() ==
-               (num_filters * num_x_steps * num_y_steps));
+               (num_filters * num_x_steps * num_y_steps * num_z_steps));
 
 
   CuMatrix<BaseFloat> filters_grad;
   CuVector<BaseFloat> bias_grad;
 
   CuMatrix<BaseFloat> input_patches(num_frames,
-                                    filter_dim * num_x_steps * num_y_steps,
+                                    filter_dim * num_x_steps * num_y_steps * num_z_steps,
                                     kUndefined);
   InputToInputPatches(in_value, &input_patches);
 
@@ -3676,21 +3718,24 @@ void ConvolutionComponent::Update(const std::string &debug_info,
   // create a single large matrix holding the smaller matrices
   // from the vector container filters_grad_batch along the rows
   CuMatrix<BaseFloat> filters_grad_blocks_batch(
-      num_x_steps * num_y_steps * filters_grad.NumRows(),
+      num_x_steps * num_y_steps * num_z_steps *filters_grad.NumRows(),
       filters_grad.NumCols());
 
   std::vector<CuSubMatrix<BaseFloat>* > filters_grad_batch, input_patch_batch;
 
   for (int32 x_step = 0; x_step < num_x_steps; x_step++)  {
     for (int32 y_step = 0; y_step < num_y_steps; y_step++)  {
-      int32 patch_number = x_step * num_y_steps + y_step;
-      filters_grad_batch.push_back(new CuSubMatrix<BaseFloat>(
-              filters_grad_blocks_batch.RowRange(
-				      patch_number * filters_grad.NumRows(),
+      for (int32 z_step = 0; z_step < num_z_steps; z_step++)  {
+        int32 patch_number = x_step * num_y_steps * num_z_steps 
+                           + y_step * num_z_steps + z_step;
+        filters_grad_batch.push_back(new CuSubMatrix<BaseFloat>(
+                filters_grad_blocks_batch.RowRange(
+  				      patch_number * filters_grad.NumRows(),
 				    filters_grad.NumRows())));
 
-      input_patch_batch.push_back(new CuSubMatrix<BaseFloat>(
-              input_patches.ColRange(patch_number * filter_dim, filter_dim)));
+        input_patch_batch.push_back(new CuSubMatrix<BaseFloat>(
+                input_patches.ColRange(patch_number * filter_dim, filter_dim)));
+      }
     }
   }
 
@@ -3724,7 +3769,8 @@ void ConvolutionComponent::Update(const std::string &debug_info,
 
 void ConvolutionComponent::SetZero(bool treat_as_gradient) {
   if (treat_as_gradient) {
-    SetActualLearningRate(1.0);
+    learning_rate_ = 1.0;  // don't call SetLearningRate, that would apply the
+                           // learning rate factor.
     is_gradient_ = true;
   }
   filter_params_.SetZero();
@@ -3743,10 +3789,14 @@ void ConvolutionComponent::Read(std::istream &is, bool binary) {
   ReadBasicType(is, binary, &filt_x_dim_);
   ExpectToken(is, binary, "<FiltYDim>");
   ReadBasicType(is, binary, &filt_y_dim_);
+  ExpectToken(is, binary, "<FiltZDim>");
+  ReadBasicType(is, binary, &filt_z_dim_);
   ExpectToken(is, binary, "<FiltXStep>");
   ReadBasicType(is, binary, &filt_x_step_);
   ExpectToken(is, binary, "<FiltYStep>");
   ReadBasicType(is, binary, &filt_y_step_);
+  ExpectToken(is, binary, "<FiltZStep>");
+  ReadBasicType(is, binary, &filt_z_step_);
   ExpectToken(is, binary, "<InputVectorization>");
   int32 input_vectorization;
   ReadBasicType(is, binary, &input_vectorization);
@@ -3778,10 +3828,14 @@ void ConvolutionComponent::Write(std::ostream &os, bool binary) const {
   WriteBasicType(os, binary, filt_x_dim_);
   WriteToken(os, binary, "<FiltYDim>");
   WriteBasicType(os, binary, filt_y_dim_);
+  WriteToken(os, binary, "<FiltZDim>");
+  WriteBasicType(os, binary, filt_z_dim_);
   WriteToken(os, binary, "<FiltXStep>");
   WriteBasicType(os, binary, filt_x_step_);
   WriteToken(os, binary, "<FiltYStep>");
   WriteBasicType(os, binary, filt_y_step_);
+  WriteToken(os, binary, "<FiltZStep>");
+  WriteBasicType(os, binary, filt_z_step_);
   WriteToken(os, binary, "<InputVectorization>");
   WriteBasicType(os, binary, static_cast<int32>(input_vectorization_));
   WriteToken(os, binary, "<FilterParams>");

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -3769,8 +3769,7 @@ void ConvolutionComponent::Update(const std::string &debug_info,
 
 void ConvolutionComponent::SetZero(bool treat_as_gradient) {
   if (treat_as_gradient) {
-    learning_rate_ = 1.0;  // don't call SetLearningRate, that would apply the
-                           // learning rate factor.
+    SetActualLearningRate(1.0);
     is_gradient_ = true;
   }
   filter_params_.SetZero();

--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -1501,9 +1501,6 @@ class ConvolutionComponent: public UpdatableComponent {
 
   int32 filt_z_dim_;    // size of the filter along z-axis
 
-  // there is no filt_z_dim_ as it is always assumed to be
-  // the same as input_z_dim_
-
   int32 filt_x_step_;   // the number of steps taken along x-axis of input
                         //  before computing the next dot-product
                         //  of filter and input
@@ -1515,8 +1512,6 @@ class ConvolutionComponent: public UpdatableComponent {
   int32 filt_z_step_;   // the number of steps taken along z-axis of input
                         // before computing the next dot-product of the filter
                         // and input
-
-  // there is no filt_z_step_ as only dot product is possible along this axis
 
   TensorVectorizationType input_vectorization_; // type of vectorization of the
   // input 3D tensor. Accepts zyx and yzx formats

--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -1408,8 +1408,8 @@ class ConvolutionComponent: public UpdatableComponent {
     const CuMatrixBase<BaseFloat> &filter_params,
     const CuVectorBase<BaseFloat> &bias_params,
     int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-    int32 filt_x_dim, int32 filt_y_dim,
-    int32 filt_x_step, int32 filt_y_step,
+    int32 filt_x_dim, int32 filt_y_dim, int32 filt_z_dim,
+    int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
     TensorVectorizationType input_vectorization,
     BaseFloat learning_rate);
 
@@ -1462,15 +1462,16 @@ class ConvolutionComponent: public UpdatableComponent {
   const CuVector<BaseFloat> &BiasParams() { return bias_params_; }
   const CuMatrix<BaseFloat> &LinearParams() { return filter_params_; }
   void Init(int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-            int32 filt_x_dim, int32 filt_y_dim,
-            int32 filt_x_step, int32 filt_y_step, int32 num_filters,
+            int32 filt_x_dim, int32 filt_y_dim, int32 filt_z_dim,
+            int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
+            int32 num_filters,
             TensorVectorizationType input_vectorization,
             BaseFloat param_stddev, BaseFloat bias_stddev);
   // there is no filt_z_dim parameter as the length of the filter along
   // z-dimension is same as the input
   void Init(int32 input_x_dim, int32 input_y_dim, int32 input_z_dim,
-            int32 filt_x_dim, int32 filt_y_dim,
-            int32 filt_x_step, int32 filt_y_step,
+            int32 filt_x_dim, int32 filt_y_dim, int32 filt_z_dim,
+            int32 filt_x_step, int32 filt_y_step, int32 filt_z_step,
             TensorVectorizationType input_vectorization,
             std::string matrix_filename);
 
@@ -1498,6 +1499,8 @@ class ConvolutionComponent: public UpdatableComponent {
 
   int32 filt_y_dim_;    // size of the filter along y-axis
 
+  int32 filt_z_dim_;    // size of the filter along z-axis
+
   // there is no filt_z_dim_ as it is always assumed to be
   // the same as input_z_dim_
 
@@ -1506,6 +1509,10 @@ class ConvolutionComponent: public UpdatableComponent {
                         //  of filter and input
 
   int32 filt_y_step_;   // the number of steps taken along y-axis of input
+                        // before computing the next dot-product of the filter
+                        // and input
+
+  int32 filt_z_step_;   // the number of steps taken along z-axis of input
                         // before computing the next dot-product of the filter
                         // and input
 

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -661,18 +661,23 @@ void GenerateConfigSequenceCnn(
 
   int32 input_x_dim = 10 + Rand() % 20,
         input_y_dim = 10 + Rand() % 20,
-        input_z_dim = 3 + Rand() % 10,
+        input_z_dim = 10 + Rand() % 20,
         filt_x_dim = 1 + Rand() % input_x_dim,
         filt_y_dim = 1 + Rand() % input_y_dim,
+        filt_z_dim = 1 + Rand() % input_z_dim,
         num_filters = 10 + Rand() % 20,
         filt_x_step = (1 + Rand() % filt_x_dim),
-        filt_y_step = (1 + Rand() % filt_y_dim);
+        filt_y_step = (1 + Rand() % filt_y_dim),
+        filt_z_step = (1 + Rand() % filt_z_dim);
   int32 remainder = (input_x_dim - filt_x_dim) % filt_x_step;
   // adjusting input_x_dim to ensure divisibility
   input_x_dim = input_x_dim - remainder;
   remainder = (input_y_dim - filt_y_dim) % filt_y_step;
   // adjusting input_x_dim to ensure divisibility
   input_y_dim = input_y_dim - remainder;
+  remainder = (input_z_dim - filt_z_dim) % filt_z_step;
+  // adjusting input_z_dim to ensure divisibility
+  input_z_dim = input_z_dim - remainder;
 
   int32 input_vectorization = Rand() % 2;
   std::string vectorization;
@@ -688,15 +693,17 @@ void GenerateConfigSequenceCnn(
      << " input-z-dim=" << input_z_dim
      << " filt-x-dim=" << filt_x_dim
      << " filt-y-dim=" << filt_y_dim
+     << " filt-z-dim=" << filt_z_dim
      << " filt-x-step=" << filt_x_step
      << " filt-y-step=" << filt_y_step
+     << " filt-z-step=" << filt_z_step
      << " num-filters=" << num_filters
      << " input-vectorization-order=" << vectorization
      << std::endl;
 
   int32 conv_output_x_dim = (1 + (input_x_dim - filt_x_dim) / filt_x_step);
   int32 conv_output_y_dim = (1 + (input_y_dim - filt_y_dim) / filt_y_step);
-  int32 conv_output_z_dim = num_filters;
+  int32 conv_output_z_dim = num_filters * (1 + (input_z_dim - filt_z_dim) / filt_z_step);
   int32 pool_x_size = 1 + Rand() % conv_output_x_dim;
   int32 pool_y_size = 1 + Rand() % conv_output_y_dim;
   int32 pool_z_size = 1 + Rand() % conv_output_z_dim;
@@ -1054,23 +1061,30 @@ static void GenerateRandomComponentConfig(std::string *component_type,
             input_z_dim = 3 + Rand() % 10,
             filt_x_dim = 1 + Rand() % input_x_dim,
             filt_y_dim = 1 + Rand() % input_y_dim,
+            filt_z_dim = 1 + Rand() % input_z_dim,
             num_filters = 1 + Rand() % 10,
             filt_x_step = (1 + Rand() % filt_x_dim),
-            filt_y_step = (1 + Rand() % filt_y_dim);
+            filt_y_step = (1 + Rand() % filt_y_dim),
+            filt_z_step = (1 + Rand() % filt_z_dim);
       int32 remainder = (input_x_dim - filt_x_dim) % filt_x_step;
       // adjusting input_x_dim to ensure divisibility
       input_x_dim = input_x_dim - remainder;
       remainder = (input_y_dim - filt_y_dim) % filt_y_step;
       // adjusting input_x_dim to ensure divisibility
       input_y_dim = input_y_dim - remainder;
+      remainder = (input_z_dim - filt_z_dim) % filt_z_step;
+      // adjusting input_z_dim to ensure divisibility
+      input_z_dim = input_z_dim - remainder;
 
       os << "input-x-dim=" << input_x_dim
          << " input-y-dim=" << input_y_dim
          << " input-z-dim=" << input_z_dim
          << " filt-x-dim=" << filt_x_dim
          << " filt-y-dim=" << filt_y_dim
+         << " filt-z-dim=" << filt_z_dim
          << " filt-x-step=" << filt_x_step
          << " filt-y-step=" << filt_y_step
+         << " filt-z-step=" << filt_z_step
          << " num-filters=" << num_filters
          << " input-vectorization-order=" << vectorization
          << " learning-rate=" << learning_rate;


### PR DESCRIPTION
…port  actual 3D convolution. The CNN input/output is a tensor with 3 axes (time, frequency and feature-map). In normal CNNs we do "3-D" convolution, but always ensure that the 3-D filter has length equal to input 3-D tensor along feature map axis. However we could perform actual 3-D convolution by using a 3-D filter which has length less than input along feature map axis.
The problem now is that the training become very slow when we are using 4 convolution layers.
From the log we saw that it spend a lot of time on AddMatMatBatched() :100: 
[cudevice profile]
AddMatVec       28.8452s
MulElements     39.1796s
MulRowsVec      52.0823s
AddMatBlocks    52.1977s
ApplyHeaviside  52.4034s
AddDiagVecMat   53.8776s
AddDiagMatMat   64.9836s
CuMatrix::SetZero       73.9582s
CuMatrixBase::CopyFromMat(from other CuMatrixBase)      77.5472s
AddMatMat       112.539s
CuMatrix::Resize        127.168s
AddCols 161.896s
AddVecToRows    203.794s
CopyCols        230.77s
AddMatMatBatched        999.96s
Total GPU time: 2424.14s (may involve some double-counting)

We would like to see if there is any way to speed up the training of the convolution component.