### PR TITLE
WIP: Proposed: path.sh to automatically add src/*bin directories to PATH

### DIFF
--- a/src/path.sh
+++ b/src/path.sh
@@ -1,25 +1,9 @@
-# we are using BASH_SOURCE[0], because its set correctly even when the file
+# We are using BASH_SOURCE[0], because its set correctly even when the file
 # is sourced.
-# The formatting of the path export command is intentionally weird, because
-# this allows for easy diff'ing
-this_script_path=$(readlink -f "${BASH_SOURCE[0]}") 
-my_kaldi_src=$(dirname $this_script_path)
-export PATH=\
-$my_kaldi_src/bin:\
-$my_kaldi_src/chainbin:\
-$my_kaldi_src/featbin:\
-$my_kaldi_src/fgmmbin:\
-$my_kaldi_src/fstbin:\
-$my_kaldi_src/gmmbin:\
-$my_kaldi_src/ivectorbin:\
-$my_kaldi_src/kwsbin:\
-$my_kaldi_src/latbin:\
-$my_kaldi_src/lmbin:\
-$my_kaldi_src/nnet2bin:\
-$my_kaldi_src/nnet3bin:\
-$my_kaldi_src/nnetbin:\
-$my_kaldi_src/online2bin:\
-$my_kaldi_src/onlinebin:\
-$my_kaldi_src/sgmm2bin:\
-$my_kaldi_src/sgmmbin:\
-$PATH
+this_script_path="$(readlink -f "${BASH_SOURCE[0]}")"
+my_kaldi_src="$(dirname "$this_script_path")"
+add_to_path="$(shopt -s failglob
+               echo "$my_kaldi_src/"*bin/ |
+                 (read -ra a; IFS=:; echo "${a[*]}"))" \
+  && PATH="$add_to_path:$PATH"
+unset -v this_script_path my_kaldi_src add_to_path


### PR DESCRIPTION
Since the new `src/path.sh` is bash-only anyway, I modified it like this to add all `src/*bin` directories to the path automatically. This is not the prettiest code out there, but does the job. This uses only bash built-ins.

Thoughts?

[setting to WIP as it interferes with the ongoing changes #631]