### PR TITLE
SetLogHandler() to redirect Kaldi loggigng to custom function

### DIFF
--- a/src/base/kaldi-error-test.cc
+++ b/src/base/kaldi-error-test.cc
@@ -46,6 +46,7 @@ int main() {
   try {
     kaldi::UnitTestError();
     KALDI_ASSERT(0);  // should not happen.
+    exit(1);
   } catch(std::runtime_error &r) {
     std::cout << "UnitTestError: the error we generated was: " << r.what();
   }


### PR DESCRIPTION
Toolkits with libraries generating log messages often implement a way to intercept these messages by allowing the client to register a function to be called when a log message is produced. See examples in [gRPC](https://github.com/grpc/grpc/blob/02f5f8de36924b9fe55ccda800fa465b94bd181d/include/grpc/impl/codegen/log.h#L90) and [protobuf](https://github.com/google/protobuf/blob/b0f661181d10bddc08e380992590a1cdd92be92b/src/google/protobuf/stubs/logging.h#L206). This is a feature sorely missing in Kaldi when it is used as a library in customized clients.

Here's my hack to introduce the mechanism, `SetLogHandler()` API.

WIP because the feature is still lacking unit tests, but otherwise feature-complete, and feedback is welcome. I combined all KaldiLog*Message helper classes into a single class `MessageLogger` with an additional constructor argument for message severity. I also expressed `KaldiAssertFailure_()` via it. I think this is the Right Thing, since Kaldi programs relying on `IsKaldiError()` would not previously count assertion failures as errors; now they do.