### PR TITLE
Improved ARPA compilers diagnostics.

### DIFF
--- a/src/lm/arpa-file-parser-test.cc
+++ b/src/lm/arpa-file-parser-test.cc
@@ -44,7 +44,7 @@ struct NGramTestData {
   float backoff;
 };
 
-std::ostream& operator<<(std::ostream& os, const NGramTestData& data) {
+std::ostream& operator<<(std::ostream &os, const NGramTestData &data) {
   std::ios::fmtflags saved_state(os.flags());
   os << std::fixed << std::setprecision(6);
 
@@ -62,7 +62,7 @@ template <class T>
 struct CountedArray {
   template <size_t N>
   CountedArray(T(&array)[N]) : array(array), count(N) { }
-  const T* array;
+  const T *array;
   const size_t count;
 };
 
@@ -73,7 +73,7 @@ inline CountedArray<T> MakeCountedArray(T(&array)[N]) {
 
 class TestableArpaFileParser : public ArpaFileParser {
  public:
-  TestableArpaFileParser(ArpaParseOptions options, fst::SymbolTable* symbols)
+  TestableArpaFileParser(ArpaParseOptions options, fst::SymbolTable *symbols)
       : ArpaFileParser(options, symbols),
         header_available_(false),
         read_complete_(false),
@@ -121,8 +121,8 @@ void TestableArpaFileParser::ReadComplete() {
 }
 
 //
-bool CompareNgrams(const NGramTestData& actual,
-                   const NGramTestData& expected) {
+bool CompareNgrams(const NGramTestData &actual,
+                   const NGramTestData &expected) {
   if (actual.line_number != expected.line_number
       || !std::equal(actual.words, actual.words + kMaxOrder,
                      expected.words)
@@ -231,7 +231,6 @@ ngram 3=2\n\
 \\3-grams:\n\
 -0.3	<s> a \xCE\xB2\n\
 -0.2	<s> a </s>\n\
-\n\
 \\end\\";
 
 // Symbol table that is created with predefined test symbols, "a" but no "b".

--- a/src/lm/arpa-file-parser.cc
+++ b/src/lm/arpa-file-parser.cc
@@ -31,7 +31,8 @@ namespace kaldi {
 
 ArpaFileParser::ArpaFileParser(ArpaParseOptions options,
                                fst::SymbolTable* symbols)
-    : options_(options), symbols_(symbols), line_number_(0) {
+    : options_(options), symbols_(symbols),
+      line_number_(0), warning_count_(0) {
 }
 
 ArpaFileParser::~ArpaFileParser() {
@@ -70,49 +71,51 @@ void ArpaFileParser::Read(std::istream &is, bool binary) {
 
   ngram_counts_.clear();
   line_number_ = 0;
+  warning_count_ = 0;
+  current_line_.clear();
 
-#define PARSE_ERR (KALDI_ERR << "in line " << line_number_ << ": ")
+#define PARSE_ERR (KALDI_ERR << LineReference() << ": ")
 
   // Give derived class an opportunity to prepare its state.
   ReadStarted();
 
-  std::string line;
-
   // Processes "\data\" section.
   bool keyword_found = false;
-  while (++line_number_, getline(is, line) && !is.eof()) {
-    if (line.empty()) continue;
+  while (++line_number_, getline(is, current_line_) && !is.eof()) {
+    if (current_line_.empty()) continue;
 
     // Continue skipping lines until the \data\ marker alone on a line is found.
     if (!keyword_found) {
-      if (line == "\\data\\") {
+      if (current_line_ == "\\data\\") {
         KALDI_LOG << "Reading \\data\\ section.";
         keyword_found = true;
       }
       continue;
     }
 
-    if (line[0] == '\\') break;
+    if (current_line_[0] == '\\') break;
 
     // Enters "\data\" section, and looks for patterns like "ngram 1=1000",
     // which means there are 1000 unigrams.
-    std::size_t equal_symbol_pos = line.find("=");
+    std::size_t equal_symbol_pos = current_line_.find("=");
     if (equal_symbol_pos != std::string::npos)
-      line.replace(equal_symbol_pos, 1, " = ");  // Inserts spaces around "="
+      // Guaranteed spaces around the "=".
+      current_line_.replace(equal_symbol_pos, 1, " = ");
     std::vector<std::string> col;
-    SplitStringToVector(line, " \t", true, &col);
+    SplitStringToVector(current_line_, " \t", true, &col);
     if (col.size() == 4 && col[0] == "ngram" && col[2] == "=") {
       int32 order, ngram_count = 0;
       if (!ConvertStringToInteger(col[1], &order) ||
           !ConvertStringToInteger(col[3], &ngram_count)) {
-        PARSE_ERR << "Cannot parse ngram count '" << line << "'.";
+        PARSE_ERR << "cannot parse ngram count";
       }
       if (ngram_counts_.size() <= order) {
         ngram_counts_.resize(order);
       }
       ngram_counts_[order - 1] = ngram_count;
     } else {
-      KALDI_WARN << "Uninterpretable line in \\data\\ section: " << line;
+      KALDI_WARN << LineReference()
+                 << ": uninterpretable line in \\data\\ section";
     }
   }
 
@@ -138,35 +141,34 @@ void ArpaFileParser::Read(std::istream &is, bool binary) {
     // Must be looking at a \k-grams: directive at this point.
     std::ostringstream keyword;
     keyword << "\\" << cur_order << "-grams:";
-    if (line != keyword.str()) {
-      PARSE_ERR << "Invalid directive '" << line << "', "
-                << "expecting '" << keyword.str() << "'.";
+    if (current_line_ != keyword.str()) {
+      PARSE_ERR << "invalid directive, expecting '" << keyword.str() << "'";
     }
-    KALDI_LOG << "Reading " << line << " section.";
+    KALDI_LOG << "Reading " << current_line_ << " section.";
 
     int32 ngram_count = 0;
-    while (++line_number_, getline(is, line) && !is.eof()) {
-      if (line.empty()) continue;
-      if (line[0] == '\\') break;
+    while (++line_number_, getline(is, current_line_) && !is.eof()) {
+      if (current_line_.empty()) continue;
+      if (current_line_[0] == '\\') break;
 
       std::vector<std::string> col;
-      SplitStringToVector(line, " \t", true, &col);
+      SplitStringToVector(current_line_, " \t", true, &col);
 
       if (col.size() < 1 + cur_order ||
           col.size() > 2 + cur_order ||
           (cur_order == ngram_counts_.size() && col.size() != 1 + cur_order)) {
-        PARSE_ERR << "Invalid n-gram line '"  << line << "'";
+        PARSE_ERR << "Invalid n-gram data line";
       }
       ++ngram_count;
 
       // Parse out n-gram logprob and, if present, backoff weight.
       if (!ConvertStringToReal(col[0], &ngram.logprob)) {
-        PARSE_ERR << "Invalid n-gram logprob '" << col[0] << "'.";
+        PARSE_ERR << "invalid n-gram logprob '" << col[0] << "'";
       }
       ngram.backoff = 0.0;
       if (col.size() > cur_order + 1) {
         if (!ConvertStringToReal(col[cur_order + 1], &ngram.backoff))
-          PARSE_ERR << "Invalid backoff weight '" << col[cur_order + 1] << "'.";
+          PARSE_ERR << "invalid backoff weight '" << col[cur_order + 1] << "'";
       }
       // Convert to natural log unless the option is set not to.
       if (!options_.use_log10) {
@@ -190,11 +192,14 @@ void ArpaFileParser::Read(std::istream &is, bool binary) {
                   word = options_.unk_symbol;
                   break;
                 case ArpaParseOptions::kSkipNGram:
+                  if (ShouldWarn())
+                    KALDI_WARN << LineReference() << " skipped: word '"
+                               << col[1 + index] << "' not in symbol table";
                   skip_ngram = true;
                   break;
                 default:
-                  PARSE_ERR << "Word '"  << col[1 + index]
-                            << "' not in symbol table.";
+                  PARSE_ERR << "word '"  << col[1 + index]
+                            << "' not in symbol table";
               }
             }
           }
@@ -206,8 +211,8 @@ void ArpaFileParser::Read(std::istream &is, bool binary) {
         }
         // Whichever way we got it, an epsilon is invalid.
         if (word == 0) {
-          PARSE_ERR << "Epsilon symbol '" << col[1 + index]
-                    << "' is illegal in ARPA LM.";
+          PARSE_ERR << "epsilon symbol '" << col[1 + index]
+                    << "' is illegal in ARPA LM";
         }
         ngram.words[index] = word;
       }
@@ -216,20 +221,36 @@ void ArpaFileParser::Read(std::istream &is, bool binary) {
       }
     }
     if (ngram_count > ngram_counts_[cur_order - 1]) {
-      PARSE_ERR << "Header said there would be " << ngram_counts_[cur_order - 1]
-                << " n-grams of order " << cur_order << ", but we saw "
-                << ngram_count;
+      PARSE_ERR << "header said there would be " << ngram_counts_[cur_order - 1]
+                << " n-grams of order " << cur_order
+                << ", but we saw more already.";
     }
   }
 
-  if (line != "\\end\\") {
-    PARSE_ERR << "Invalid or unexpected directive line '" << line << "', "
-              << "expected \\end\\.";
+  if (current_line_ != "\\end\\") {
+    PARSE_ERR << "invalid or unexpected directive line, expecting \\end\\";
   }
 
+  if (warning_count_ > 0 && warning_count_ > (uint32)options_.max_warnings) {
+    KALDI_WARN << "Of " << warning_count_ << " parse warnings, "
+               << options_.max_warnings << " were reported. Run program with "
+               << "--max_warnings=-1 to see all warnings";
+  }
+
+  current_line_.empty();
   ReadComplete();
 
 #undef PARSE_ERR
+}
+
+std::string ArpaFileParser::LineReference() const {
+  std::stringstream ss;
+  ss << "line " << line_number_ << " [" << current_line_ << "]";
+  return ss.str();
+}
+
+bool ArpaFileParser::ShouldWarn() {
+ return ++warning_count_ <= (uint32)options_.max_warnings;
 }
 
 }  // namespace kaldi

--- a/src/lm/arpa-lm-compiler.cc
+++ b/src/lm/arpa-lm-compiler.cc
@@ -106,18 +106,21 @@ class OptimizedHistKey {
   uint64 data_;
 };
 
+}  // namespace
+
 template <class HistKey>
 class ArpaLmCompilerImpl : public ArpaLmCompilerImplInterface {
  public:
-  ArpaLmCompilerImpl(fst::StdVectorFst* fst, Symbol bos_symbol,
-                     Symbol eos_symbol, Symbol sub_eps);
+  ArpaLmCompilerImpl(ArpaLmCompiler* parent, fst::StdVectorFst* fst,
+                     Symbol sub_eps);
 
-  virtual void ConsumeNGram(const NGram& ngram, bool is_highest);
+  virtual void ConsumeNGram(const NGram &ngram, bool is_highest);
 
  private:
   StateId AddStateWithBackoff(HistKey key, float backoff);
   void CreateBackoff(HistKey key, StateId state, float weight);
 
+  ArpaLmCompiler *parent_;  // Not owned.
   fst::StdVectorFst* fst_;  // Not owned.
   Symbol bos_symbol_;
   Symbol eos_symbol_;
@@ -131,10 +134,9 @@ class ArpaLmCompilerImpl : public ArpaLmCompilerImplInterface {
 
 template <class HistKey>
 ArpaLmCompilerImpl<HistKey>::ArpaLmCompilerImpl(
-    fst::StdVectorFst* fst, Symbol bos_symbol,
-    Symbol eos_symbol, Symbol sub_eps) : fst_(fst), bos_symbol_(bos_symbol),
-                                         eos_symbol_(eos_symbol),
-                                         sub_eps_(sub_eps) {
+    ArpaLmCompiler* parent, fst::StdVectorFst* fst, Symbol sub_eps)
+    : parent_(parent), fst_(fst), bos_symbol_(parent->Options().bos_symbol),
+      eos_symbol_(parent->Options().eos_symbol), sub_eps_(sub_eps) {
   // The algorithm maintains state per history. The 0-gram is a special state
   // for emptry history. All unigrams (including BOS) backoff into this state.
   StateId zerogram = fst_->AddState();
@@ -150,8 +152,8 @@ ArpaLmCompilerImpl<HistKey>::ArpaLmCompilerImpl(
 }
 
 template <class HistKey>
-void ArpaLmCompilerImpl<HistKey>::ConsumeNGram(
-    const NGram& ngram, bool is_highest) {
+void ArpaLmCompilerImpl<HistKey>::ConsumeNGram(const NGram &ngram,
+                                               bool is_highest) {
   // Generally, we do the following. Suppose we are adding an n-gram "A B
   // C". Then find the node for "A B", add a new node for "A B C", and connect
   // them with the arc accepting "C" with the specified weight. Also, add a
@@ -181,7 +183,9 @@ void ArpaLmCompilerImpl<HistKey>::ConsumeNGram(
   if (source_it == history_.end()) {
     // There was no "A B", therefore the probability of "A B C" is zero.
     // Print a warning and discard current n-gram.
-    KALDI_WARN << "No parent gram, skipping";
+    if (parent_->ShouldWarn())
+      KALDI_WARN << parent_->LineReference()
+                 << " skipped: no parent (n-1)-gram exists";
     return;
   }
 
@@ -225,6 +229,7 @@ void ArpaLmCompilerImpl<HistKey>::ConsumeNGram(
 
   // Add arc from source to dest, whichever way it was found.
   fst_->AddArc(source, fst::StdArc(sym, sym, weight, dest));
+  return;
 }
 
 // Find or create a new state for n-gram defined by key, and ensure it has a
@@ -266,8 +271,6 @@ inline void ArpaLmCompilerImpl<HistKey>::CreateBackoff(
   fst_->AddArc(state, fst::StdArc(sub_eps_, 0, weight, dest_it->second));
 }
 
-}  // namespace
-
 ArpaLmCompiler::~ArpaLmCompiler() {
   if (impl_ != NULL)
     delete impl_;
@@ -286,25 +289,23 @@ void ArpaLmCompiler::HeaderAvailable() {
     max_symbol += NgramCounts()[0];
 
   if (NgramCounts().size() <= 4 && max_symbol < OptimizedHistKey::kMaxData) {
-    impl_ = new ArpaLmCompilerImpl<OptimizedHistKey>(
-        &fst_, Options().bos_symbol, Options().eos_symbol, sub_eps_);
+    impl_ = new ArpaLmCompilerImpl<OptimizedHistKey>(this, &fst_, sub_eps_);
   } else {
-    impl_ = new ArpaLmCompilerImpl<GeneralHistKey>(
-        &fst_, Options().bos_symbol, Options().eos_symbol, sub_eps_);
+    impl_ = new ArpaLmCompilerImpl<GeneralHistKey>(this, &fst_, sub_eps_);
     KALDI_LOG << "Reverting to slower state tracking because model is large: "
               << NgramCounts().size() << "-gram with symbols up to "
               << max_symbol;
   }
 }
 
-void ArpaLmCompiler::ConsumeNGram(const NGram& ngram) {
+void ArpaLmCompiler::ConsumeNGram(const NGram &ngram) {
   // <s> is invalid in tails, </s> in heads of an n-gram.
   for (int i = 0; i < ngram.words.size(); ++i) {
     if ((i > 0 && ngram.words[i] == Options().bos_symbol) ||
         (i + 1 < ngram.words.size()
          && ngram.words[i] == Options().eos_symbol)) {
-      KALDI_WARN << "In line " << LineNumber()
-                 << ": Skipping n-gram with invalid BOS/EOS placement";
+      KALDI_WARN << LineReference()
+                 << " skipped: n-gram has invalid BOS/EOS placement";
       return;
     }
   }

--- a/src/lm/arpa-lm-compiler.h
+++ b/src/lm/arpa-lm-compiler.h
@@ -50,6 +50,7 @@ class ArpaLmCompiler : public ArpaFileParser {
   int sub_eps_;
   ArpaLmCompilerImplInterface* impl_;  // Owned.
   fst::StdVectorFst fst_;
+  template <class HistKey> friend class ArpaLmCompilerImpl;
 };
 
 }  // namespace kaldi

--- a/src/lm/const-arpa-lm.cc
+++ b/src/lm/const-arpa-lm.cc
@@ -268,7 +268,7 @@ void ConstArpaLmBuilder::HeaderAvailable() {
   ngram_order_ = NgramCounts().size();
 }
 
-void ConstArpaLmBuilder::ConsumeNGram(const NGram& ngram) {
+void ConstArpaLmBuilder::ConsumeNGram(const NGram &ngram) {
   int32 cur_order = ngram.words.size();
   // If <ngram_order_> is larger than 1, then we do not create LmState for
   // the final order entry. We only keep the log probability for it.
@@ -1062,15 +1062,9 @@ bool ConstArpaLmDeterministicFst::GetArc(StateId s,
   return true;
 }
 
-bool BuildConstArpaLm(const int32 bos_symbol, const int32 eos_symbol,
-                      const int32 unk_symbol,
+bool BuildConstArpaLm(const ArpaParseOptions& options,
                       const std::string& arpa_rxfilename,
                       const std::string& const_arpa_wxfilename) {
-  ArpaParseOptions options;
-  options.bos_symbol = bos_symbol;
-  options.eos_symbol = eos_symbol;
-  options.unk_symbol = unk_symbol;
-
   ConstArpaLmBuilder lm_builder(options);
   KALDI_LOG << "Reading " << arpa_rxfilename;
   ReadKaldiObject(arpa_rxfilename, &lm_builder);

--- a/src/lm/const-arpa-lm.h
+++ b/src/lm/const-arpa-lm.h
@@ -25,6 +25,7 @@
 
 #include "base/kaldi-common.h"
 #include "fstext/deterministic-fst.h"
+#include "lm/arpa-file-parser.h"
 #include "util/common-utils.h"
 
 namespace kaldi {
@@ -418,8 +419,7 @@ class ConstArpaLmDeterministicFst
 // Reads in an Arpa format language model and converts it into ConstArpaLm
 // format. We assume that the words in the input Arpa format language model have
 // been converted into integers.
-bool BuildConstArpaLm(const int32 bos_symbol, const int32 eos_symbol,
-                      const int32 unk_symbol,
+bool BuildConstArpaLm(const ArpaParseOptions& options,
                       const std::string& arpa_rxfilename,
                       const std::string& const_arpa_wxfilename);
 

--- a/src/lmbin/arpa-to-const-arpa.cc
+++ b/src/lmbin/arpa-to-const-arpa.cc
@@ -13,7 +13,7 @@
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
 // WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-// MERCHANTABLITY OR NON-INFRINGEMENT.
+// MERCHANTABILITY OR NON-INFRINGEMENT.
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
         "that wants to rescore lattices. We assume that the words in the\n"
         "input arpa language model has been converted to integers.\n"
         "\n"
-        "The program is used joinly with utils/map_arpa_lm.pl to build\n"
+        "The program is used jointly with utils/map_arpa_lm.pl to build\n"
         "ConstArpaLm format language model. We first map the words in an Arpa\n"
         "format language model to integers using utils/map_arpa_m.pl, and\n"
         "then use this program to build a ConstArpaLm format language model.\n"
@@ -44,16 +44,19 @@ int main(int argc, char *argv[]) {
 
     kaldi::ParseOptions po(usage);
 
-    int32 unk_symbol = -1;
-    int32 bos_symbol = -1;
-    int32 eos_symbol = -1;
-    po.Register("unk-symbol", &unk_symbol,
+    ArpaParseOptions options;
+    options.Register(&po);
+
+    // Ideally, these registrations would be in ArpaParseOptions, but some
+    // programs want integers and other want symbols, so we register them
+    // outside instead.
+    po.Register("unk-symbol", &options.unk_symbol,
                 "Integer corresponds to unknown-word in language model. -1 if "
                 "no such word is provided.");
-    po.Register("bos-symbol", &bos_symbol,
+    po.Register("bos-symbol", &options.bos_symbol,
                 "Integer corresponds to <s>. You must set this to your actual "
                 "BOS integer.");
-    po.Register("eos-symbol", &eos_symbol,
+    po.Register("eos-symbol", &options.eos_symbol,
                 "Integer corresponds to </s>. You must set this to your actual "
                 "EOS integer.");
 
@@ -64,7 +67,7 @@ int main(int argc, char *argv[]) {
       exit(1);
     }
 
-    if (bos_symbol == -1 || eos_symbol == -1) {
+    if (options.bos_symbol == -1 || options.eos_symbol == -1) {
       KALDI_ERR << "Please set --bos-symbol and --eos-symbol.";
       exit(1);
     }
@@ -72,8 +75,8 @@ int main(int argc, char *argv[]) {
     std::string arpa_rxfilename = po.GetArg(1),
         const_arpa_wxfilename = po.GetOptArg(2);
 
-    bool ans = BuildConstArpaLm(bos_symbol, eos_symbol, unk_symbol,
-                                arpa_rxfilename, const_arpa_wxfilename);
+    bool ans = BuildConstArpaLm(options, arpa_rxfilename,
+                                const_arpa_wxfilename);
     if (ans)
       return 0;
     else

--- a/src/lmbin/arpa2fst.cc
+++ b/src/lmbin/arpa2fst.cc
@@ -34,6 +34,9 @@ int main(int argc, char *argv[]) {
         "data/lang/words.txt lm/input.arpa G.fst\n";
     ParseOptions po(usage);
 
+    ArpaParseOptions options;
+    options.Register(&po);
+
     // Option flags.
     std::string bos_symbol = "<s>";
     std::string eos_symbol = "</s>";
@@ -66,7 +69,6 @@ int main(int argc, char *argv[]) {
     std::string arpa_rxfilename = po.GetArg(1),
         fst_wxfilename = po.GetOptArg(2);
 
-    ArpaParseOptions options;
     int64 disambig_symbol_id = 0;
 
     fst::SymbolTable* symbols;


### PR DESCRIPTION
- Option `--max-arpa-warnings` to control number of warnings, default 30.
- Much improved error message with both source line number and the line itself.

This addresses the warning flood from arpa2fst noted in https://github.com/kaldi-asr/kaldi/pull/634#issuecomment-204861154

This does not remove the log10 option per #640, to keep the PR smaller. That's coming next.