### PR TITLE
Saving the aligned ctm, with the wav id.

### DIFF
--- a/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
+++ b/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
@@ -325,7 +325,7 @@ sub ProcessWav {
   # Save the aligned CTM if needed
   if(defined($ACT)){
     for (my $i=0; $i<=$#aligned_ctm; $i++) {
-      print $ACT "$aligned_ctm[$i][0] $aligned_ctm[$i][1] ";
+      print $ACT "$wav_id $aligned_ctm[$i][0] $aligned_ctm[$i][1] ";
       print $ACT "$aligned_ctm[$i][2] $aligned_ctm[$i][3]\n";
     }
   }

--- a/egs/wsj/s5/steps/cleanup/make_segmentation_data_dir.sh
+++ b/egs/wsj/s5/steps/cleanup/make_segmentation_data_dir.sh
@@ -164,6 +164,7 @@ steps/cleanup/create_segments_from_ctm.pl \
   --min-sil-length $min_sil_length \
   --separator $separator --special-symbol $special_symbol \
   --wer-cutoff $wer_cutoff \
+  --aligned-ctm-filename $new_data_dir/tmp/aligned_ctm \
   $new_data_dir/tmp/ctm $new_data_dir/tmp/aligned.txt \
   $new_data_dir/segments $new_data_dir/text
 


### PR DESCRIPTION
Write the wav id into the aligned CTM, because otherwise there isn't an easy way to know which part is related to which file. 
Save the aligned CTM in the tmp folder of the new data dir, when making the segmentation data dir.