### PR TITLE
Adds gmm-sum-hlda command line tool.

### DIFF
--- a/src/gmmbin/Makefile
+++ b/src/gmmbin/Makefile
@@ -9,7 +9,7 @@ BINFILES = gmm-init-mono gmm-est gmm-acc-stats-ali gmm-align \
            gmm-sum-accs gmm-init-trans gmm-est-regtree-fmllr gmm-acc-stats-twofeats \
            gmm-acc-stats gmm-init-lvtln gmm-est-lvtln-trans gmm-train-lvtln-special \
            gmm-acc-mllt gmm-mixup gmm-init-model \
-           gmm-acc-hlda gmm-est-hlda gmm-transform-means \
+           gmm-acc-hlda gmm-est-hlda gmm-transform-means gmm-sum-hlda\
            gmm-make-regtree gmm-decode-faster-regtree-fmllr gmm-post-to-gpost \
            gmm-est-fmllr-gpost gmm-est-fmllr gmm-est-regtree-fmllr-ali \
            gmm-est-regtree-mllr gmm-compute-likes \

--- a/src/gmmbin/gmm-sum-hlda.cc
+++ b/src/gmmbin/gmm-sum-hlda.cc
@@ -1,0 +1,61 @@
+// gmmbin/gmm-sum-hlda.cc
+
+// Copyright 2016 LINSE/UFSC (author: Augusto Henrique Hentz)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/common-utils.h"
+#include "gmm/mle-am-diag-gmm.h"
+#include "transform/hlda.h"
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    typedef kaldi::int32 int32;
+
+    const char *usage =
+        "Sum HLDA statistics obtained with gmm-acc-hlda.\n"
+        "Usage: gmm-sum-hlda [options] out.hacc in1.hacc in2.hlda ...\n";
+
+    bool binary = true;
+    ParseOptions po(usage);
+    po.Register("binary", &binary, "Write accumulators in binary mode.");
+    po.Read(argc, argv);
+
+    if (po.NumArgs() < 2) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    HldaAccsDiagGmm hlda_accs;
+    std::string acc_out_filename = po.GetArg(1);
+
+    for (int32 i = 2; i <= po.NumArgs(); i++) {
+      bool binary_in, add = true;
+      Input ki(po.GetArg(i), &binary_in);
+      hlda_accs.Read(ki.Stream(), binary_in, add);
+    }
+
+    Output ko(acc_out_filename, binary);
+    hlda_accs.Write(ko.Stream(), binary);
+    return 0;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}
+
+


### PR DESCRIPTION
The gmm-sum-hlda command line tool is used to combine HLDA accumulators
to another accumulator. It is useful in training using a compute
cluster, to avoid copying num_nodes * cpus_per_node by combining the
node's accumulators locally. This way, only num_nodes accumulators need
to be copied.