### PR TITLE
fixed uninitialized variable warnings in steps/cleanup/create_segments_from_ctm.pl

### DIFF
--- a/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
+++ b/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
@@ -27,7 +27,7 @@ If you are going to use --wer-cutoff to filter out segments with high WER, make
 sure you set it to a reasonable value. If the value you set is higher than the
 WER from your alignment file, then most of the segments will be filtered out.
 
-    Usage: steps/cleanup/create_segments_from_ctm.pl [options] \
+Usage: steps/cleanup/create_segments_from_ctm.pl [options] \
                               <ctm> <aligned.txt> <segments> <text>
  e.g.: steps/cleanup/create_segments_from_ctm.pl \
           train_si284_split.ctm train_si284_split.aligned.txt \
@@ -50,7 +50,7 @@ Allowed options:
                       is saved to this file
 EOU
 
-    my $max_seg_length = 10.0;
+my $max_seg_length = 10.0;
 my $min_seg_length = 2.0;
 my $min_sil_length = 0.5;
 my $separator = ";";
@@ -68,10 +68,10 @@ GetOptions(
   'force-correct-boundary-words=f' => \$force_correct_boundary_words,
   'aligned-ctm-filename=s' => \$aligned_ctm_filename,
   'separator=s'      => \$separator,
-    'special-symbol=s' => \$special_symbol);
+  'special-symbol=s' => \$special_symbol);
 
 if (@ARGV != 4) {
-    die $Usage;
+  die $Usage;
 }
 
 my ($ctm_in, $align_in, $segments_out, $text_out) = @ARGV;
@@ -90,40 +90,41 @@ sub PrintSegment {
       $seg_start_index, $seg_end_index, $seg_count, $SO, $TO) = @_;
 
   if ($seg_start_index > $seg_end_index) {
-      return -1;
+    return -1;
   }
+
   # Removes the surrounding silence.
   while ($seg_start_index < scalar(@{$aligned_ctm}) &&
          $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
-      $seg_start_index += 1;
+    $seg_start_index += 1;
   }
   while ($seg_end_index >= 0 &&
          $aligned_ctm->[$seg_end_index]->[0] eq "<eps>") {
-      $seg_end_index -= 1;
+    $seg_end_index -= 1;
   }
   if ($seg_start_index > $seg_end_index) {
-      return -1;
+    return -1;
   }
 
   # Filters out segments with high WER.
   if ($wer_cutoff != -1) {
-      my $num_errors = 0; my $num_words = 0;
-      for (my $i = $seg_start_index; $i <= $seg_end_index; $i += 1) {
-	  if ($aligned_ctm->[$i]->[0] ne "<eps>") {
-	      $num_words += 1;
-	  }
-	  $num_errors += $aligned_ctm->[$i]->[3];
+    my $num_errors = 0; my $num_words = 0;
+    for (my $i = $seg_start_index; $i <= $seg_end_index; $i += 1) {
+      if ($aligned_ctm->[$i]->[0] ne "<eps>") {
+        $num_words += 1;
       }
-      if ($num_errors / $num_words > $wer_cutoff || $num_words < 1) {
-	  return -1;
-      }
+      $num_errors += $aligned_ctm->[$i]->[3];
+    }
+    if ($num_errors / $num_words > $wer_cutoff || $num_words < 1) {
+      return -1;
+    }
   }
 
   # Works out the surrounding silence.
   my $index = $seg_start_index - 1;
   while ($index >= 0 && $aligned_ctm->[$index]->[0] eq
          "<eps>" && $aligned_ctm->[$index]->[3] == 0) {
-      $index -= 1;
+    $index -= 1;
   }
   my $left_of_segment_has_deletion = "false";
   $left_of_segment_has_deletion = "true"
@@ -142,7 +143,7 @@ sub PrintSegment {
   while ($index < scalar(@{$aligned_ctm}) &&
          $aligned_ctm->[$index]->[0] eq "<eps>" &&
          $aligned_ctm->[$index]->[3] == 0) {
-      $index += 1;
+    $index += 1;
   }
   $right_of_segment_has_deletion = "true"
       if ($index < scalar(@{$aligned_ctm})-1 && $aligned_ctm->[$index+1]->[0] ne
@@ -159,7 +160,7 @@ sub PrintSegment {
 
   my $seg_start = $aligned_ctm->[$seg_start_index]->[1] - $pad_start_sil;
   my $seg_end = $aligned_ctm->[$seg_end_index]->[1] +
-      $aligned_ctm->[$seg_end_index]->[2] + $pad_end_sil;
+                $aligned_ctm->[$seg_end_index]->[2] + $pad_end_sil;
   if ($seg_end - $seg_start < $min_seg_length) {
       return -1;
   }
@@ -171,9 +172,9 @@ sub PrintSegment {
 
   print $TO "$seg_id ";
   for (my $x = $seg_start_index; $x <= $seg_end_index; $x += 1) {
-      if ($aligned_ctm->[$x]->[0] ne "<eps>") {
-	  print $TO "$aligned_ctm->[$x]->[0] ";
-      }
+    if ($aligned_ctm->[$x]->[0] ne "<eps>") {
+      print $TO "$aligned_ctm->[$x]->[0] ";
+    }
   }
   print $TO "\n";
   return 0;
@@ -181,40 +182,40 @@ sub PrintSegment {
 
 # Computes split point.
 sub GetSplitPoint {
-    my ($aligned_ctm, $seg_start_index, $seg_end_index, $max_seg_length) = @_;
+  my ($aligned_ctm, $seg_start_index, $seg_end_index, $max_seg_length) = @_;
 
   # Scan in the reversed order so we can maximize the length.
-    my $split_point = $seg_start_index;
-    for (my $x = $seg_end_index; $x > $seg_start_index; $x -= 1) {
+  my $split_point = $seg_start_index;
+  for (my $x = $seg_end_index; $x > $seg_start_index; $x -= 1) {
     my $current_seg_length = $aligned_ctm->[$x]->[1] +
                              $aligned_ctm->[$x]->[2] -
                              $aligned_ctm->[$seg_start_index]->[1];
     if ($current_seg_length <= $max_seg_length) {
-	$split_point = $x;
-	last;
+      $split_point = $x;
+      last;
     }
-    }
-    return $split_point;
+  }
+  return $split_point;
 }
 
 # Computes segment length without surrounding silence.
 sub GetSegmentLengthNoSil {
-    my ($aligned_ctm, $seg_start_index, $seg_end_index) = @_;
-    while ($seg_start_index < scalar(@{$aligned_ctm}) &&
-	   $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
-	$seg_start_index += 1;
-    }
+  my ($aligned_ctm, $seg_start_index, $seg_end_index) = @_;
+  while ($seg_start_index < scalar(@{$aligned_ctm}) &&
+         $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
+    $seg_start_index += 1;
+  }
   while ($seg_end_index >= 0 &&
          $aligned_ctm->[$seg_end_index]->[0] eq "<eps>") {
-      $seg_end_index -= 1;
+    $seg_end_index -= 1;
   }
-    if ($seg_start_index > $seg_end_index) {
-	return 0;
-    }
+  if ($seg_start_index > $seg_end_index) {
+    return 0;
+  }
   my $current_seg_length = $aligned_ctm->[$seg_end_index]->[1] +
                            $aligned_ctm->[$seg_end_index]->[2] -
                            $aligned_ctm->[$seg_start_index]->[1];
-    return $current_seg_length;
+  return $current_seg_length;
 }
 
 # Force splits long segments.
@@ -227,8 +228,7 @@ sub SplitLongSegment {
                            $aligned_ctm->[$seg_end_index]->[2] -
                            $aligned_ctm->[$seg_start_index]->[1];
   my $current_seg_index = $seg_start_index;
-  my $aligned_ctm_size = keys($aligned_ctm);
-  
+  my $aligned_ctm_size = keys($aligned_ctm);    
   while ($current_seg_length > 1.5 * $max_seg_length && $current_seg_index < $aligned_ctm_size-1) {
     my $split_point = GetSplitPoint($aligned_ctm, $current_seg_index,
                                     $seg_end_index, $max_seg_length);
@@ -243,11 +243,11 @@ sub SplitLongSegment {
   }
 
   if ($current_seg_index eq $aligned_ctm_size-1) {
-    my $ans = PrintSegment($aligned_ctm, $wav_id, $min_sil_length,
-                           $min_seg_length, $current_seg_index, $current_seg_index,
-                           $current_seg_count, $SO, $TO);
-    $current_seg_count += 1 if ($ans != -1);
-    return ($current_seg_count, $current_seg_index);
+      my $ans = PrintSegment($aligned_ctm, $wav_id, $min_sil_length,
+                             $min_seg_length, $current_seg_index, $current_seg_index,
+                             $current_seg_count, $SO, $TO);
+      $current_seg_count += 1 if ($ans != -1);
+      return ($current_seg_count, $current_seg_index);
   }
 
   if ($current_seg_length > $max_seg_length) {
@@ -287,64 +287,64 @@ sub ProcessWav {
   my $ctm_index = 0;
   my @aligned_ctm = ();
   foreach my $entry (@{$current_align}) {
-      my $ref_word = $entry->[0];
-      my $hyp_word = $entry->[1];
-      if ($hyp_word eq $special_symbol) {
+    my $ref_word = $entry->[0];
+    my $hyp_word = $entry->[1];
+    if ($hyp_word eq $special_symbol) {
       # Case 1: deletion, $hyp does not correspond to a word in the ctm file.
-	  my $start = 0.0; my $dur = 0.0;
-	  if (defined($aligned_ctm[-1])) {
-	      $start = $aligned_ctm[-1]->[1] + $aligned_ctm[-1]->[2];
-	  }
-	  push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
-      } else {
+      my $start = 0.0; my $dur = 0.0;
+      if (defined($aligned_ctm[-1])) {
+        $start = $aligned_ctm[-1]->[1] + $aligned_ctm[-1]->[2];
+      }
+      push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
+    } else {
       # Case 2: non-deletion, now $hyp corresponds to a word in ctm file.
-	  while ($current_ctm->[$ctm_index]->[4] eq "<eps>") {
+      while ($current_ctm->[$ctm_index]->[4] eq "<eps>") {
         # Case 2.1: ctm contains silence at the corresponding place.
         push(@aligned_ctm, ["<eps>", $current_ctm->[$ctm_index]->[2],
-			    $current_ctm->[$ctm_index]->[3], 0]);
+                             $current_ctm->[$ctm_index]->[3], 0]);
         $ctm_index += 1;
-	  }
-	  my $ctm_word = $current_ctm->[$ctm_index]->[4];
+      }
+      my $ctm_word = $current_ctm->[$ctm_index]->[4];
       $hyp_word eq $ctm_word ||
-	  die "Error: got word $hyp_word in alignment but $ctm_word in ctm\n";
-	  my $start = $current_ctm->[$ctm_index]->[2];
-	  my $dur = $current_ctm->[$ctm_index]->[3];
-	  if ($ref_word ne $ctm_word) {
-	      if ($ref_word eq $special_symbol) {
+        die "Error: got word $hyp_word in alignment but $ctm_word in ctm\n";
+      my $start = $current_ctm->[$ctm_index]->[2];
+      my $dur = $current_ctm->[$ctm_index]->[3];
+      if ($ref_word ne $ctm_word) {
+        if ($ref_word eq $special_symbol) {
           # Case 2.2: insertion, we propagate the duration and error to the
           #           previous one.
-		  if (defined($aligned_ctm[-1])) {
-		      $aligned_ctm[-1]->[2] += $dur;
-		      $aligned_ctm[-1]->[3] += 1;
-		  } else {
-		      push(@aligned_ctm, ["<eps>", $start, $dur, 1]);
-		  }
-	      } else {
+          if (defined($aligned_ctm[-1])) {
+            $aligned_ctm[-1]->[2] += $dur;
+            $aligned_ctm[-1]->[3] += 1;
+          } else {
+            push(@aligned_ctm, ["<eps>", $start, $dur, 1]);
+          } 
+        } else {
           # Case 2.3: substitution.
-		  push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
-	      }
-	  } else {
+          push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
+        }
+      } else {
         # Case 2.4: correct.
-	      push(@aligned_ctm, [$ref_word, $start, $dur, 0]);
-	  }
-	  $ctm_index += 1;
+        push(@aligned_ctm, [$ref_word, $start, $dur, 0]);
       }
+      $ctm_index += 1;
+    }
   }
 
   # Save the aligned CTM if needed
   if(defined($ACT)){
-      for (my $i = 0; $i <= $#aligned_ctm; $i++) {
-	  print $ACT "$wav_id $channel_id $aligned_ctm[$i][1] $aligned_ctm[$i][2] ";
-	  print $ACT "$aligned_ctm[$i][0] $aligned_ctm[$i][3]\n";
-      }
+    for (my $i = 0; $i <= $#aligned_ctm; $i++) {
+      print $ACT "$wav_id $channel_id $aligned_ctm[$i][1] $aligned_ctm[$i][2] ";
+      print $ACT "$aligned_ctm[$i][0] $aligned_ctm[$i][3]\n";
+    }
   }
 
   # Second, we create segments from @align_ctm, using simple greedy method.
   my $current_seg_index = 0;
   my $current_seg_count = 0;
   for (my $x = 0; $x < @aligned_ctm; $x += 1) {
-      my $lcorrect = "true"; my $rcorrect = "true";
-      $lcorrect = "false" if ($x > 0 && $aligned_ctm[$x - 1]->[3] > 0);
+    my $lcorrect = "true"; my $rcorrect = "true";
+    $lcorrect = "false" if ($x > 0 && $aligned_ctm[$x - 1]->[3] > 0);
     $rcorrect = "false" if ($x < @aligned_ctm - 1 &&
                             $aligned_ctm[$x + 1]->[3] > 0);
 
@@ -395,36 +395,36 @@ sub ProcessWav {
 # 011 A 3.80 0.03 <eps>
 # 011 A 3.83 0.45 ASSETS
 sub InsertSilence {
-    my ($ctm_in, $ctm_out) = @_;
-    for (my $x = 1; $x < @{$ctm_in}; $x += 1) {
-	push(@{$ctm_out}, $ctm_in->[$x - 1]);
+  my ($ctm_in, $ctm_out) = @_;
+  for (my $x = 1; $x < @{$ctm_in}; $x += 1) {
+    push(@{$ctm_out}, $ctm_in->[$x - 1]);
 
     my $new_start = sprintf("%.2f",
                             $ctm_in->[$x - 1]->[2] + $ctm_in->[$x - 1]->[3]);
-	if ($new_start < $ctm_in->[$x]->[2]) {
-	    my $new_dur = sprintf("%.2f", $ctm_in->[$x]->[2] - $new_start);
-	    push(@{$ctm_out}, [$ctm_in->[$x - 1]->[0], $ctm_in->[$x - 1]->[1],
-			       $new_start, $new_dur, "<eps>"]);
-	}
+    if ($new_start < $ctm_in->[$x]->[2]) {
+      my $new_dur = sprintf("%.2f", $ctm_in->[$x]->[2] - $new_start);
+      push(@{$ctm_out}, [$ctm_in->[$x - 1]->[0], $ctm_in->[$x - 1]->[1],
+                         $new_start, $new_dur, "<eps>"]);
     }
-    push(@{$ctm_out}, $ctm_in->[@{$ctm_in} - 1]);
+  }
+  push(@{$ctm_out}, $ctm_in->[@{$ctm_in} - 1]);
 }
 
 # Reads the alignment.
 my %aligned = ();
 while (<AI>) {
-    chomp;
-    my @col = split;
-    @col >= 2 || die "Error: bad line $_\n";
-    my $wav = shift @col;
-    my @pairs = split(" $separator ", join(" ", @col));
-    for (my $x = 0; $x < @pairs; $x += 1) {
-	my @col1 = split(" ", $pairs[$x]);
-	@col1 == 2 || die "Error: bad pair $pairs[$x]\n";
-	$pairs[$x] = \@col1;
-    }
-    ! defined($aligned{$wav}) || die "Error: $wav has already been processed\n";
-    $aligned{$wav} = \@pairs;
+  chomp;
+  my @col = split;
+  @col >= 2 || die "Error: bad line $_\n";
+  my $wav = shift @col;
+  my @pairs = split(" $separator ", join(" ", @col));
+  for (my $x = 0; $x < @pairs; $x += 1) {
+    my @col1 = split(" ", $pairs[$x]);
+    @col1 == 2 || die "Error: bad pair $pairs[$x]\n";
+    $pairs[$x] = \@col1;
+  }
+  ! defined($aligned{$wav}) || die "Error: $wav has already been processed\n";
+  $aligned{$wav} = \@pairs;
 }
 
 # Reads the ctm file and creates the segmentation.
@@ -432,34 +432,34 @@ my $previous_wav_id = "";
 my $previous_channel_id = "";
 my @current_wav = ();
 while (<CI>) {
-    chomp;
-    my @col = split;
-    @col >= 5 || die "Error: bad line $_\n";
-    if ($previous_wav_id eq $col[0] && $previous_channel_id eq $col[1]) {
-	push(@current_wav, \@col);
-    } else {
-	if (@current_wav > 0) {
-	    defined($aligned{$previous_wav_id}) ||
-		die "Error: no alignment info for $previous_wav_id\n";
-	    my @current_wav_silence = ();
-	    InsertSilence(\@current_wav, \@current_wav_silence);
-            ProcessWav($max_seg_length, $min_seg_length, $min_sil_length,
+  chomp;
+  my @col = split;
+  @col >= 5 || die "Error: bad line $_\n";
+  if ($previous_wav_id eq $col[0] && $previous_channel_id eq $col[1]) {
+    push(@current_wav, \@col);
+  } else {
+    if (@current_wav > 0) {
+      defined($aligned{$previous_wav_id}) ||
+        die "Error: no alignment info for $previous_wav_id\n";
+      my @current_wav_silence = ();
+      InsertSilence(\@current_wav, \@current_wav_silence);
+      ProcessWav($max_seg_length, $min_seg_length, $min_sil_length,
                  $special_symbol, \@current_wav_silence,
                  $aligned{$previous_wav_id}, $SO, $TO, $ACT);
-	}
-	@current_wav = ();
-	push(@current_wav, \@col);
-	$previous_wav_id = $col[0];
-	$previous_channel_id = $col[1];
     }
+    @current_wav = ();
+    push(@current_wav, \@col);
+    $previous_wav_id = $col[0];
+    $previous_channel_id = $col[1];
+  }
 }
 
 # The last wav file.
 if (@current_wav > 0) {
-    defined($aligned{$previous_wav_id}) ||
-	die "Error: no alignment info for $previous_wav_id\n";
-    my @current_wav_silence = ();
-    InsertSilence(\@current_wav, \@current_wav_silence);
+  defined($aligned{$previous_wav_id}) ||
+    die "Error: no alignment info for $previous_wav_id\n";
+  my @current_wav_silence = ();
+  InsertSilence(\@current_wav, \@current_wav_silence);
   ProcessWav($max_seg_length, $min_seg_length, $min_sil_length, $special_symbol,
              \@current_wav_silence, $aligned{$previous_wav_id}, $SO, $TO, $ACT);
 }

--- a/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
+++ b/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
@@ -27,7 +27,7 @@ If you are going to use --wer-cutoff to filter out segments with high WER, make
 sure you set it to a reasonable value. If the value you set is higher than the
 WER from your alignment file, then most of the segments will be filtered out.
 
-Usage: steps/cleanup/create_segments_from_ctm.pl [options] \
+    Usage: steps/cleanup/create_segments_from_ctm.pl [options] \
                               <ctm> <aligned.txt> <segments> <text>
  e.g.: steps/cleanup/create_segments_from_ctm.pl \
           train_si284_split.ctm train_si284_split.aligned.txt \
@@ -42,21 +42,21 @@ Allowed options:
                       (default = "<***>")
   --wer-cutoff      : Ignore segments with WER higher than the specified value.
                       -1 means no segment will be ignored. (default = -1)
-  --use-silence-midpoints : Set to 1 if you want to use silence midpoints 
+  --use-silence-midpoints : Set to 1 if you want to use silence midpoints
                       instead of min_sil_length for silence overhang.(default 0)
-  --force-correct-boundary-words : Set to zero if the segments will not be 
+  --force-correct-boundary-words : Set to zero if the segments will not be
                       required to have boundary words to be correct. Default 1
-  --aligned-ctm-filename : If set, the intermediate aligned ctm 
+  --aligned-ctm-filename : If set, the intermediate aligned ctm
                       is saved to this file
 EOU
 
-my $max_seg_length = 10.0;
+    my $max_seg_length = 10.0;
 my $min_seg_length = 2.0;
 my $min_sil_length = 0.5;
 my $separator = ";";
 my $special_symbol = "<***>";
 my $wer_cutoff = -1;
-my $use_silence_midpoints = 0; 
+my $use_silence_midpoints = 0;
 my $force_correct_boundary_words = 1;
 my $aligned_ctm_filename = "";
 GetOptions(
@@ -68,10 +68,10 @@ GetOptions(
   'force-correct-boundary-words=f' => \$force_correct_boundary_words,
   'aligned-ctm-filename=s' => \$aligned_ctm_filename,
   'separator=s'      => \$separator,
-  'special-symbol=s' => \$special_symbol);
+    'special-symbol=s' => \$special_symbol);
 
 if (@ARGV != 4) {
-  die $Usage;
+    die $Usage;
 }
 
 my ($ctm_in, $align_in, $segments_out, $text_out) = @ARGV;
@@ -90,45 +90,44 @@ sub PrintSegment {
       $seg_start_index, $seg_end_index, $seg_count, $SO, $TO) = @_;
 
   if ($seg_start_index > $seg_end_index) {
-    return -1;
+      return -1;
   }
-
   # Removes the surrounding silence.
   while ($seg_start_index < scalar(@{$aligned_ctm}) &&
          $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
-    $seg_start_index += 1;
+      $seg_start_index += 1;
   }
   while ($seg_end_index >= 0 &&
          $aligned_ctm->[$seg_end_index]->[0] eq "<eps>") {
-    $seg_end_index -= 1;
+      $seg_end_index -= 1;
   }
   if ($seg_start_index > $seg_end_index) {
-    return -1;
+      return -1;
   }
 
   # Filters out segments with high WER.
   if ($wer_cutoff != -1) {
-    my $num_errors = 0; my $num_words = 0;
-    for (my $i = $seg_start_index; $i <= $seg_end_index; $i += 1) {
-      if ($aligned_ctm->[$i]->[0] ne "<eps>") {
-        $num_words += 1;
+      my $num_errors = 0; my $num_words = 0;
+      for (my $i = $seg_start_index; $i <= $seg_end_index; $i += 1) {
+	  if ($aligned_ctm->[$i]->[0] ne "<eps>") {
+	      $num_words += 1;
+	  }
+	  $num_errors += $aligned_ctm->[$i]->[3];
       }
-      $num_errors += $aligned_ctm->[$i]->[3];
-    }
-    if ($num_errors / $num_words > $wer_cutoff || $num_words < 1) {
-      return -1;
-    }
+      if ($num_errors / $num_words > $wer_cutoff || $num_words < 1) {
+	  return -1;
+      }
   }
 
   # Works out the surrounding silence.
   my $index = $seg_start_index - 1;
-  while ($index >= 0 && $aligned_ctm->[$index]->[0] eq 
+  while ($index >= 0 && $aligned_ctm->[$index]->[0] eq
          "<eps>" && $aligned_ctm->[$index]->[3] == 0) {
-    $index -= 1;
+      $index -= 1;
   }
-  my $left_of_segment_has_deletion = "false"; 
-  $left_of_segment_has_deletion = "true" 
-      if ($index > 0 && $aligned_ctm->[$index-1]->[0] ne "<eps>" 
+  my $left_of_segment_has_deletion = "false";
+  $left_of_segment_has_deletion = "true"
+      if ($index > 0 && $aligned_ctm->[$index-1]->[0] ne "<eps>"
           && $aligned_ctm->[$index-1]->[3] == 0);
 
   my $pad_start_sil = ($aligned_ctm->[$seg_start_index]->[1] -
@@ -141,11 +140,11 @@ sub PrintSegment {
   my $right_of_segment_has_deletion = "false";
   $index = $seg_end_index + 1;
   while ($index < scalar(@{$aligned_ctm}) &&
-         $aligned_ctm->[$index]->[0] eq "<eps>" && 
+         $aligned_ctm->[$index]->[0] eq "<eps>" &&
          $aligned_ctm->[$index]->[3] == 0) {
-    $index += 1;
+      $index += 1;
   }
-  $right_of_segment_has_deletion = "true" 
+  $right_of_segment_has_deletion = "true"
       if ($index < scalar(@{$aligned_ctm})-1 && $aligned_ctm->[$index+1]->[0] ne
           "<eps>" && $aligned_ctm->[$index - 1]->[3] > 0);
   my $pad_end_sil = ($aligned_ctm->[$index - 1]->[1] +
@@ -155,12 +154,12 @@ sub PrintSegment {
   if (($right_of_segment_has_deletion eq "true") || !$use_silence_midpoints) {
       if ($pad_end_sil > $min_sil_length / 2.0) {
           $pad_end_sil = $min_sil_length / 2.0;
-      } 
+      }
   }
 
   my $seg_start = $aligned_ctm->[$seg_start_index]->[1] - $pad_start_sil;
   my $seg_end = $aligned_ctm->[$seg_end_index]->[1] +
-                $aligned_ctm->[$seg_end_index]->[2] + $pad_end_sil;
+      $aligned_ctm->[$seg_end_index]->[2] + $pad_end_sil;
   if ($seg_end - $seg_start < $min_seg_length) {
       return -1;
   }
@@ -172,9 +171,9 @@ sub PrintSegment {
 
   print $TO "$seg_id ";
   for (my $x = $seg_start_index; $x <= $seg_end_index; $x += 1) {
-    if ($aligned_ctm->[$x]->[0] ne "<eps>") {
-      print $TO "$aligned_ctm->[$x]->[0] ";
-    }
+      if ($aligned_ctm->[$x]->[0] ne "<eps>") {
+	  print $TO "$aligned_ctm->[$x]->[0] ";
+      }
   }
   print $TO "\n";
   return 0;
@@ -182,40 +181,40 @@ sub PrintSegment {
 
 # Computes split point.
 sub GetSplitPoint {
-  my ($aligned_ctm, $seg_start_index, $seg_end_index, $max_seg_length) = @_;
+    my ($aligned_ctm, $seg_start_index, $seg_end_index, $max_seg_length) = @_;
 
   # Scan in the reversed order so we can maximize the length.
-  my $split_point = $seg_start_index;
-  for (my $x = $seg_end_index; $x > $seg_start_index; $x -= 1) {
+    my $split_point = $seg_start_index;
+    for (my $x = $seg_end_index; $x > $seg_start_index; $x -= 1) {
     my $current_seg_length = $aligned_ctm->[$x]->[1] +
                              $aligned_ctm->[$x]->[2] -
                              $aligned_ctm->[$seg_start_index]->[1];
     if ($current_seg_length <= $max_seg_length) {
-      $split_point = $x;
-      last;
+	$split_point = $x;
+	last;
     }
-  }
-  return $split_point;
+    }
+    return $split_point;
 }
 
 # Computes segment length without surrounding silence.
 sub GetSegmentLengthNoSil {
-  my ($aligned_ctm, $seg_start_index, $seg_end_index) = @_;
-  while ($seg_start_index < scalar(@{$aligned_ctm}) &&
-         $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
-    $seg_start_index += 1;
-  }
+    my ($aligned_ctm, $seg_start_index, $seg_end_index) = @_;
+    while ($seg_start_index < scalar(@{$aligned_ctm}) &&
+	   $aligned_ctm->[$seg_start_index]->[0] eq "<eps>") {
+	$seg_start_index += 1;
+    }
   while ($seg_end_index >= 0 &&
          $aligned_ctm->[$seg_end_index]->[0] eq "<eps>") {
-    $seg_end_index -= 1;
+      $seg_end_index -= 1;
   }
-  if ($seg_start_index > $seg_end_index) {
-    return 0;
-  }
+    if ($seg_start_index > $seg_end_index) {
+	return 0;
+    }
   my $current_seg_length = $aligned_ctm->[$seg_end_index]->[1] +
                            $aligned_ctm->[$seg_end_index]->[2] -
                            $aligned_ctm->[$seg_start_index]->[1];
-  return $current_seg_length;
+    return $current_seg_length;
 }
 
 # Force splits long segments.
@@ -228,7 +227,9 @@ sub SplitLongSegment {
                            $aligned_ctm->[$seg_end_index]->[2] -
                            $aligned_ctm->[$seg_start_index]->[1];
   my $current_seg_index = $seg_start_index;
-  while ($current_seg_length > 1.5 * $max_seg_length) {
+  my $aligned_ctm_size = keys($aligned_ctm);
+  
+  while ($current_seg_length > 1.5 * $max_seg_length && $current_seg_index < $aligned_ctm_size-1) {
     my $split_point = GetSplitPoint($aligned_ctm, $current_seg_index,
                                     $seg_end_index, $max_seg_length);
     my $ans = PrintSegment($aligned_ctm, $wav_id, $min_sil_length,
@@ -239,6 +240,14 @@ sub SplitLongSegment {
     $current_seg_length = $aligned_ctm->[$seg_end_index]->[1] +
                           $aligned_ctm->[$seg_end_index]->[2] -
                           $aligned_ctm->[$current_seg_index]->[1];
+  }
+
+  if ($current_seg_index eq $aligned_ctm_size-1) {
+    my $ans = PrintSegment($aligned_ctm, $wav_id, $min_sil_length,
+                           $min_seg_length, $current_seg_index, $current_seg_index,
+                           $current_seg_count, $SO, $TO);
+    $current_seg_count += 1 if ($ans != -1);
+    return ($current_seg_count, $current_seg_index);
   }
 
   if ($current_seg_length > $max_seg_length) {
@@ -269,6 +278,7 @@ sub ProcessWav {
       $current_ctm, $current_align, $SO, $TO, $ACT) = @_;
 
   my $wav_id = $current_ctm->[0]->[0];
+  my $channel_id = $current_ctm->[0]->[1];
   defined($wav_id) || die "Error: empty wav section\n";
 
   # First, we have to align the ctm file to the Levenshtein alignment.
@@ -277,64 +287,64 @@ sub ProcessWav {
   my $ctm_index = 0;
   my @aligned_ctm = ();
   foreach my $entry (@{$current_align}) {
-    my $ref_word = $entry->[0];
-    my $hyp_word = $entry->[1];
-    if ($hyp_word eq $special_symbol) {
+      my $ref_word = $entry->[0];
+      my $hyp_word = $entry->[1];
+      if ($hyp_word eq $special_symbol) {
       # Case 1: deletion, $hyp does not correspond to a word in the ctm file.
-      my $start = 0.0; my $dur = 0.0;
-      if (defined($aligned_ctm[-1])) {
-        $start = $aligned_ctm[-1]->[1] + $aligned_ctm[-1]->[2];
-      }
-      push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
-    } else {
+	  my $start = 0.0; my $dur = 0.0;
+	  if (defined($aligned_ctm[-1])) {
+	      $start = $aligned_ctm[-1]->[1] + $aligned_ctm[-1]->[2];
+	  }
+	  push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
+      } else {
       # Case 2: non-deletion, now $hyp corresponds to a word in ctm file.
-      while ($current_ctm->[$ctm_index]->[4] eq "<eps>") {
+	  while ($current_ctm->[$ctm_index]->[4] eq "<eps>") {
         # Case 2.1: ctm contains silence at the corresponding place.
         push(@aligned_ctm, ["<eps>", $current_ctm->[$ctm_index]->[2],
-                             $current_ctm->[$ctm_index]->[3], 0]);
+			    $current_ctm->[$ctm_index]->[3], 0]);
         $ctm_index += 1;
-      }
-      my $ctm_word = $current_ctm->[$ctm_index]->[4];
+	  }
+	  my $ctm_word = $current_ctm->[$ctm_index]->[4];
       $hyp_word eq $ctm_word ||
-        die "Error: got word $hyp_word in alignment but $ctm_word in ctm\n";
-      my $start = $current_ctm->[$ctm_index]->[2];
-      my $dur = $current_ctm->[$ctm_index]->[3];
-      if ($ref_word ne $ctm_word) {
-        if ($ref_word eq $special_symbol) {
+	  die "Error: got word $hyp_word in alignment but $ctm_word in ctm\n";
+	  my $start = $current_ctm->[$ctm_index]->[2];
+	  my $dur = $current_ctm->[$ctm_index]->[3];
+	  if ($ref_word ne $ctm_word) {
+	      if ($ref_word eq $special_symbol) {
           # Case 2.2: insertion, we propagate the duration and error to the
           #           previous one.
-          if (defined($aligned_ctm[-1])) {
-            $aligned_ctm[-1]->[2] += $dur;
-            $aligned_ctm[-1]->[3] += 1;
-          } else {
-            push(@aligned_ctm, ["<eps>", $start, $dur, 1]);
-          }
-        } else {
+		  if (defined($aligned_ctm[-1])) {
+		      $aligned_ctm[-1]->[2] += $dur;
+		      $aligned_ctm[-1]->[3] += 1;
+		  } else {
+		      push(@aligned_ctm, ["<eps>", $start, $dur, 1]);
+		  }
+	      } else {
           # Case 2.3: substitution.
-          push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
-        }
-      } else {
+		  push(@aligned_ctm, [$ref_word, $start, $dur, 1]);
+	      }
+	  } else {
         # Case 2.4: correct.
-        push(@aligned_ctm, [$ref_word, $start, $dur, 0]);
+	      push(@aligned_ctm, [$ref_word, $start, $dur, 0]);
+	  }
+	  $ctm_index += 1;
       }
-      $ctm_index += 1;
-    }
   }
 
   # Save the aligned CTM if needed
-  if(tell($ACT) != -1){
-    for (my $i=0; $i<=$#aligned_ctm; $i++) {
-      print $ACT "$aligned_ctm[$i][0] $aligned_ctm[$i][1] ";
-      print $ACT "$aligned_ctm[$i][2] $aligned_ctm[$i][3]\n";
-    }
+  if(defined($ACT)){
+      for (my $i = 0; $i <= $#aligned_ctm; $i++) {
+	  print $ACT "$wav_id $channel_id $aligned_ctm[$i][1] $aligned_ctm[$i][2] ";
+	  print $ACT "$aligned_ctm[$i][0] $aligned_ctm[$i][3]\n";
+      }
   }
 
   # Second, we create segments from @align_ctm, using simple greedy method.
   my $current_seg_index = 0;
   my $current_seg_count = 0;
   for (my $x = 0; $x < @aligned_ctm; $x += 1) {
-    my $lcorrect = "true"; my $rcorrect = "true";
-    $lcorrect = "false" if ($x > 0 && $aligned_ctm[$x - 1]->[3] > 0);
+      my $lcorrect = "true"; my $rcorrect = "true";
+      $lcorrect = "false" if ($x > 0 && $aligned_ctm[$x - 1]->[3] > 0);
     $rcorrect = "false" if ($x < @aligned_ctm - 1 &&
                             $aligned_ctm[$x + 1]->[3] > 0);
 
@@ -345,8 +355,8 @@ sub ProcessWav {
     # length, and if there are no alignment error around it. We also make sure
     # that segment contains actual words, instead of pure silence.
     if ($aligned_ctm[$x]->[0] eq "<eps>" &&
-        $aligned_ctm[$x]->[2] >= $min_sil_length 
-       && (($force_correct_boundary_words && $lcorrect eq "true" && 
+        $aligned_ctm[$x]->[2] >= $min_sil_length
+       && (($force_correct_boundary_words && $lcorrect eq "true" &&
             $rcorrect eq "true") || !$force_correct_boundary_words)) {
       if ($current_seg_length <= $max_seg_length &&
           $current_seg_length >= $min_seg_length) {
@@ -378,43 +388,43 @@ sub ProcessWav {
 # 011 A 3.39 0.23 SELL
 # 011 A 3.62 0.18 OFF
 # 011 A 3.83 0.45 ASSETS
-# 
+#
 # Output ctm:
 # 011 A 3.39 0.23 SELL
 # 011 A 3.62 0.18 OFF
 # 011 A 3.80 0.03 <eps>
 # 011 A 3.83 0.45 ASSETS
 sub InsertSilence {
-  my ($ctm_in, $ctm_out) = @_;
-  for (my $x = 1; $x < @{$ctm_in}; $x += 1) {
-    push(@{$ctm_out}, $ctm_in->[$x - 1]);
+    my ($ctm_in, $ctm_out) = @_;
+    for (my $x = 1; $x < @{$ctm_in}; $x += 1) {
+	push(@{$ctm_out}, $ctm_in->[$x - 1]);
 
     my $new_start = sprintf("%.2f",
                             $ctm_in->[$x - 1]->[2] + $ctm_in->[$x - 1]->[3]);
-    if ($new_start <= $ctm_in->[$x]->[2]) {
-      my $new_dur = sprintf("%.2f", $ctm_in->[$x]->[2] - $new_start);
-      push(@{$ctm_out}, [$ctm_in->[$x - 1]->[0], $ctm_in->[$x - 1]->[1],
-                         $new_start, $new_dur, "<eps>"]);
+	if ($new_start < $ctm_in->[$x]->[2]) {
+	    my $new_dur = sprintf("%.2f", $ctm_in->[$x]->[2] - $new_start);
+	    push(@{$ctm_out}, [$ctm_in->[$x - 1]->[0], $ctm_in->[$x - 1]->[1],
+			       $new_start, $new_dur, "<eps>"]);
+	}
     }
-  }
-  push(@{$ctm_out}, $ctm_in->[@{$ctm_in} - 1]);
+    push(@{$ctm_out}, $ctm_in->[@{$ctm_in} - 1]);
 }
 
 # Reads the alignment.
 my %aligned = ();
 while (<AI>) {
-  chomp;
-  my @col = split;
-  @col >= 2 || die "Error: bad line $_\n";
-  my $wav = shift @col;
-  my @pairs = split(" $separator ", join(" ", @col));
-  for (my $x = 0; $x < @pairs; $x += 1) {
-    my @col1 = split(" ", $pairs[$x]);
-    @col1 == 2 || die "Error: bad pair $pairs[$x]\n";
-    $pairs[$x] = \@col1;
-  }
-  ! defined($aligned{$wav}) || die "Error: $wav has already been processed\n";
-  $aligned{$wav} = \@pairs;
+    chomp;
+    my @col = split;
+    @col >= 2 || die "Error: bad line $_\n";
+    my $wav = shift @col;
+    my @pairs = split(" $separator ", join(" ", @col));
+    for (my $x = 0; $x < @pairs; $x += 1) {
+	my @col1 = split(" ", $pairs[$x]);
+	@col1 == 2 || die "Error: bad pair $pairs[$x]\n";
+	$pairs[$x] = \@col1;
+    }
+    ! defined($aligned{$wav}) || die "Error: $wav has already been processed\n";
+    $aligned{$wav} = \@pairs;
 }
 
 # Reads the ctm file and creates the segmentation.
@@ -422,34 +432,34 @@ my $previous_wav_id = "";
 my $previous_channel_id = "";
 my @current_wav = ();
 while (<CI>) {
-  chomp;
-  my @col = split;
-  @col >= 5 || die "Error: bad line $_\n";
-  if ($previous_wav_id eq $col[0] && $previous_channel_id eq $col[1]) {
-    push(@current_wav, \@col);
-  } else {
-    if (@current_wav > 0) {
-      defined($aligned{$previous_wav_id}) ||
-        die "Error: no alignment info for $previous_wav_id\n";
-      my @current_wav_silence = ();
-      InsertSilence(\@current_wav, \@current_wav_silence);
-      ProcessWav($max_seg_length, $min_seg_length, $min_sil_length,
+    chomp;
+    my @col = split;
+    @col >= 5 || die "Error: bad line $_\n";
+    if ($previous_wav_id eq $col[0] && $previous_channel_id eq $col[1]) {
+	push(@current_wav, \@col);
+    } else {
+	if (@current_wav > 0) {
+	    defined($aligned{$previous_wav_id}) ||
+		die "Error: no alignment info for $previous_wav_id\n";
+	    my @current_wav_silence = ();
+	    InsertSilence(\@current_wav, \@current_wav_silence);
+            ProcessWav($max_seg_length, $min_seg_length, $min_sil_length,
                  $special_symbol, \@current_wav_silence,
                  $aligned{$previous_wav_id}, $SO, $TO, $ACT);
+	}
+	@current_wav = ();
+	push(@current_wav, \@col);
+	$previous_wav_id = $col[0];
+	$previous_channel_id = $col[1];
     }
-    @current_wav = ();
-    push(@current_wav, \@col);
-    $previous_wav_id = $col[0];
-    $previous_channel_id = $col[1];
-  }
 }
 
 # The last wav file.
 if (@current_wav > 0) {
-  defined($aligned{$previous_wav_id}) ||
-    die "Error: no alignment info for $previous_wav_id\n";
-  my @current_wav_silence = ();
-  InsertSilence(\@current_wav, \@current_wav_silence);
+    defined($aligned{$previous_wav_id}) ||
+	die "Error: no alignment info for $previous_wav_id\n";
+    my @current_wav_silence = ();
+    InsertSilence(\@current_wav, \@current_wav_silence);
   ProcessWav($max_seg_length, $min_seg_length, $min_sil_length, $special_symbol,
              \@current_wav_silence, $aligned{$previous_wav_id}, $SO, $TO, $ACT);
 }
@@ -458,4 +468,4 @@ close(CI);
 close(AI);
 close($SO);
 close($TO);
-close($ACT);
+close($ACT) if defined($ACT);


### PR DESCRIPTION
Creates segments and text file from the input ctm and aligned text. Outputs an optional aligned_ctm file in proper ctm format (if --aligned-ctm-filename flag is set). The final column of align_ctm file is an error count and not confidence scores. It is useful for debugging