### PR TITLE
rm/s5: Don't use the no-longer-existing '--max-arcs' option when call…

### DIFF
--- a/egs/rm/s5/local/test_decoders.sh
+++ b/egs/rm/s5/local/test_decoders.sh
@@ -4,12 +4,12 @@
 dir=exp/tri1/decode/tmp
 mkdir -p $dir
 acwt=0.083333
-beam=15.0 
+beam=15.0
 n=100 # number of utts to decode
 
 . ./path.sh
 
-gmm-latgen-faster --max-arcs=-1 --beam=$beam --lattice-beam=6.0 --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=exp/tri1/graph/words.txt exp/tri1/final.mdl exp/tri1/graph/HCLG.fst "ark,s,cs:apply-cmvn --norm-vars=false --utt2spk=ark:data/test/utt2spk scp:data/test/cmvn.scp 'scp:head -n $n data/test/feats.scp|' ark:- | add-deltas ark:- ark:- |" "ark:|lattice-1best --acoustic-scale=$acwt ark:- ark:- | gzip -c > $dir/lat.1.gz" 2>$dir/decode_latgen_faster.log &
+gmm-latgen-faster --beam=$beam --lattice-beam=6.0 --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=exp/tri1/graph/words.txt exp/tri1/final.mdl exp/tri1/graph/HCLG.fst "ark,s,cs:apply-cmvn --norm-vars=false --utt2spk=ark:data/test/utt2spk scp:data/test/cmvn.scp 'scp:head -n $n data/test/feats.scp|' ark:- | add-deltas ark:- ark:- |" "ark:|lattice-1best --acoustic-scale=$acwt ark:- ark:- | gzip -c > $dir/lat.1.gz" 2>$dir/decode_latgen_faster.log &
 
 gmm-decode-faster --beam=$beam --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=exp/tri1/graph/words.txt exp/tri1/final.mdl exp/tri1/graph/HCLG.fst "ark,s,cs:apply-cmvn --norm-vars=false --utt2spk=ark:data/test/utt2spk scp:data/test/cmvn.scp 'scp:head -n $n data/test/feats.scp|' ark:- | add-deltas ark:- ark:- |" ark:/dev/null ark:/dev/null "ark:|gzip -c > $dir/lat.2.gz" 2>$dir/decode_faster.log &
 
@@ -26,4 +26,3 @@ wait
 
 echo "$0: decoder comparison test succeeded"
 exit 0;
-


### PR DESCRIPTION
…ing gmm-latgen-faster

The binary complains that there is no such option and exits abnormally, which in turn causes
local/test_decoders.sh to fail with a scary error message.