### PR TITLE
Update arpa2fst invocations in common (wsj/{utils,steps}) files

### DIFF
--- a/egs/wsj/s5/steps/make_phone_graph.sh
+++ b/egs/wsj/s5/steps/make_phone_graph.sh
@@ -4,7 +4,7 @@
 
 # Copyright 2013  Johns Hopkins University (Author: Daniel Povey).  Apache 2.0.
 
-# This script makes a phone-based LM, without smoothing to unigram, that 
+# This script makes a phone-based LM, without smoothing to unigram, that
 # is to be used for segmentation, and uses that together with a model to
 # make a decoding graph.
 # Uses SRILM.
@@ -46,7 +46,7 @@ done
 loc=`which ngram-count`;
 if [ -z $loc ]; then
   if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-    sdir=`pwd`/../../../tools/srilm/bin/i686-m64 
+    sdir=`pwd`/../../../tools/srilm/bin/i686-m64
   else
     sdir=`pwd`/../../../tools/srilm/bin/i686
   fi
@@ -92,17 +92,14 @@ fi
 
 if [ $stage -le 3 ]; then
   echo "$0: creating G_phones.fst from ARPA"
-  gunzip -c $dir/phone_graph/arpa_noug.gz | arpa2fst - - | fstprint | \
-    utils/eps2disambig.pl | utils/s2eps.pl | \
-    awk '{if (NF < 5 || $5 < 100.0) { print; }}' | \
-    fstcompile --isymbols=$lang/phones.txt --osymbols=$lang/phones.txt \
-       --keep_isymbols=false --keep_osymbols=false | \
-    fstconnect | \
-    fstrmepsilon > $dir/phone_graph/G_phones.fst
-   fstisstochastic $dir/phone_graph/G_phones.fst  || echo "[info]: G_phones not stochastic."
+  gunzip -c $dir/phone_graph/arpa_noug.gz | \
+    arpa2fst --disambig-symbol=#0 --read-symbol-table=$lang/phones.txt - - | \
+    fstprint | awk '{if (NF < 5 || $5 < 100.0) { print; }}' | fstcompile | \
+    fstconnect > $dir/phone_graph/G_phones.fst
+  fstisstochastic $dir/phone_graph/G_phones.fst || echo "[info]: G_phones not stochastic."
 fi
 
-  
+
 if [ $stage -le 4 ]; then
   echo "$0: creating CLG."
 
@@ -118,7 +115,7 @@ if [ $stage -le 5 ]; then
   echo "$0: creating Ha.fst"
   make-h-transducer --disambig-syms-out=$dir/phone_graph/disambig_tid.int \
     --transition-scale=$tscale $dir/phone_graph/ilabels_${N}_${P} $dir/tree $dir/final.mdl \
-       > $dir/phone_graph/Ha.fst 
+       > $dir/phone_graph/Ha.fst
 fi
 
 if [ $stage -le 6 ]; then
@@ -135,7 +132,7 @@ if [ $stage -le 7 ]; then
     $dir/final.mdl < $dir/phone_graph/HCLGa.fst > $dir/phone_graph/HCLG.fst || exit 1;
 
   if [ $tscale == 1.0 -a $loopscale == 1.0 ]; then
-    # No point doing this test if transition-scale not 1, as it is bound to fail. 
+    # No point doing this test if transition-scale not 1, as it is bound to fail.
     fstisstochastic $dir/phone_graph/HCLG.fst || echo "[info]: final HCLG is not stochastic."
   fi
 

--- a/egs/wsj/s5/utils/format_lm_sri.sh
+++ b/egs/wsj/s5/utils/format_lm_sri.sh
@@ -85,30 +85,15 @@ mkdir -p $out_dir
 cp -r $lang_dir/* $out_dir || exit 1;
 
 lm_base=$(basename $lm '.gz')
-gunzip -c $lm | utils/find_arpa_oovs.pl $out_dir/words.txt \
-  > $out_dir/oovs_${lm_base}.txt || exit 1;
-
-# Removing all "illegal" combinations of <s> and </s>, which are supposed to
-# occur only at being/end of utt.  These can cause determinization failures
-# of CLG [ends up being epsilon cycles].
-gunzip -c $lm \
-  | egrep -v '<s> <s>|</s> <s>|</s> </s>' \
-  | gzip -c > $tmpdir/lm.gz || exit 1;
-
 awk '{print $1}' $out_dir/words.txt > $tmpdir/voc || exit 1;
 
 # Change the LM vocabulary to be the intersection of the current LM vocabulary
 # and the set of words in the pronunciation lexicon. This also renormalizes the
 # LM by recomputing the backoff weights, and remove those ngrams whose
 # probabilities are lower than the backed-off estimates.
-change-lm-vocab -vocab $tmpdir/voc -lm $tmpdir/lm.gz -write-lm $tmpdir/out_lm \
-  $srilm_opts || exit 1;
-
-arpa2fst $tmpdir/out_lm | fstprint \
-  | utils/eps2disambig.pl | utils/s2eps.pl \
-  | fstcompile --isymbols=$out_dir/words.txt --osymbols=$out_dir/words.txt \
-    --keep_isymbols=false --keep_osymbols=false \
-  | fstrmepsilon | fstarcsort --sort_type=ilabel > $out_dir/G.fst || exit 1;
+change-lm-vocab -vocab $tmpdir/voc -lm $lm -write-lm - $srilm_opts | \
+  arpa2fst --disambig-symbol=#0 \
+           --read-symbol-table=$out_dir/words.txt - $out_dir/G.fst || exit 1
 
 fstisstochastic $out_dir/G.fst
 


### PR DESCRIPTION
Only 3 files, but changes are not quite as trivial as in egs scripts.

`steps/make_phone_graph.sh` and `utils/format_lm_sri.sh` are both invoked from `swbd/s5{b,c}`, could be tested by this recipe.

`egs/wsj/s5/utils/reverse_lm.sh` is called only from aurora4/s5 and sprakbanken/s5.