### PR TITLE
bn-music-speech-fix: Changing LDC numbers in egs/bn_music_speech

### DIFF
--- a/egs/bn_music_speech/v1/README
+++ b/egs/bn_music_speech/v1/README
@@ -2,5 +2,5 @@
    http://www.openslr.org/17/
 
  The test requires Broadcast News data. The LDC Catalog numbers are:
-   Speech      LDC98S71
-   Transcripts LDC98T28
+   Speech      LDC97S66
+   Transcripts LDC97T22

--- a/egs/bn_music_speech/v1/local/make_bn.sh
+++ b/egs/bn_music_speech/v1/local/make_bn.sh
@@ -4,8 +4,8 @@
 #
 # This script, called by ../run.sh, creates the HUB4 Broadcast News
 # data directory. The required datasets can be found at:
-#   https://catalog.ldc.upenn.edu/LDC98S71
-#   https://catalog.ldc.upenn.edu/LDC98T28
+#   https://catalog.ldc.upenn.edu/LDC97S66
+#   https://catalog.ldc.upenn.edu/LDC97T22
 
 set -e
 sph_dir=$1


### PR DESCRIPTION
Changing LDC numbers in the README and scripts in egs/bn_music_speech, so that they refer to the correct corpra.