### PR TITLE
vadfix: fixed bug in voice activity detection context, changed default context from 5 to 0

### DIFF
--- a/src/ivector/voice-activity-detection.cc
+++ b/src/ivector/voice-activity-detection.cc
@@ -51,7 +51,7 @@ void ComputeVadEnergy(const VadEnergyOptions &opts,
     for (int32 t2 = t - context; t2 <= t + context; t2++) {
       if (t2 >= 0 && t2 < T) {
         den_count++;
-        if (log_energy_data[t] > energy_threshold)
+        if (log_energy_data[t2] > energy_threshold)
           num_count++;
       }
     }

--- a/src/ivector/voice-activity-detection.h
+++ b/src/ivector/voice-activity-detection.h
@@ -47,7 +47,7 @@ struct VadEnergyOptions {
   
   VadEnergyOptions(): vad_energy_threshold(5.0),
                       vad_energy_mean_scale(0.5),
-                      vad_frames_context(5),
+                      vad_frames_context(0),
                       vad_proportion_threshold(0.6) { }
   void Register(OptionsItf *opts) {
     opts->Register("vad-energy-threshold", &vad_energy_threshold,


### PR DESCRIPTION
This pull request fixes issue #383.

Experimentation with different vad contexts on sre10 showed that a larger context did not seem to help. A vad context of 0 is equivalent to the bugged version. None of the results should change as a result of this fix.