### PR TITLE
Added --speex-* options to configure.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -71,6 +71,7 @@ unset MKLLIBDIR
 function usage {
   echo 'Usage: ./configure [--static|--shared] [--threaded-atlas={yes|no}] [--atlas-root=ATLASROOT] [--fst-root=FSTROOT]
   [--openblas-root=OPENBLASROOOT] [--clapack-root=CLAPACKROOT] [--mkl-root=MKLROOT] [--mkl-libdir=MKLLIBDIR]
+  [--speex-root=SPEEXROOT] [--speex-libdir=SPEEXLIBDIR] [--speex-includedir=SPEEXINCLUDEDIR]
   [--omp-libdir=OMPDIR] [--static-fst={yes|no}] [--static-math={yes|no}] [--threaded-math={yes|no}] [--mathlib=ATLAS|MKL|CLAPACK|OPENBLAS]
   [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp]';
 }
@@ -163,6 +164,15 @@ do
     shift ;;
   --mkl-libdir=*)
     MKLLIBDIR=`read_dirname $1`;
+    shift ;;
+  --speex-root=*)
+    SPEEXROOT=`read_dirname $1`;
+    shift ;;
+  --speex-libdir=*)
+    SPEEXLIBDIR=`read_dirname $1`;
+    shift ;;
+  --speex-includedir=*)
+    SPEEXINCLUDEDIR=`read_dirname $1`;
     shift ;;
   --omp-libdir=*)
     OMPLIBDIR=`read_dirname $1`;
@@ -462,7 +472,9 @@ function configure_cuda {
 
 function linux_configure_speex {
   #check whether the user has called tools/extras/install_speex.sh or not
-  SPEEXROOT=`pwd`/../tools/speex
+  [ ! -z "$SPEEXROOT" ] || SPEEXROOT=`pwd`/../tools/speex
+  [ ! -z "$SPEEXLIBDIR" ] || SPEEXLIBDIR="$SPEEXROOT"/lib
+  [ ! -z "$SPEEXINCLUDEDIR" ] || SPEEXINCLUDEDIR="$SPEEXROOT"/include
   static_speex=$1
   if [ "foo"$static_speex == "foo" ]; then
     static_speex=false
@@ -473,20 +485,20 @@ function linux_configure_speex {
   else
     spx_type=so
   fi
-  if [ ! -f "$SPEEXROOT/lib/libspeex.${spx_type}" ];then
+  if [ ! -f "$SPEEXLIBDIR/libspeex.${spx_type}" ];then
     echo "Static=[$static_speex] Speex library not found: You can still build Kaldi without Speex."
     return
   fi
 
-  if [ -f $SPEEXROOT/include/speex/speex.h ]; then
+  if [ -f $SPEEXINCLUDEDIR/speex/speex.h ]; then
     echo >> kaldi.mk
-    echo CXXFLAGS += -DHAVE_SPEEX -I${SPEEXROOT}/include >> kaldi.mk
+    echo CXXFLAGS += -DHAVE_SPEEX -I${SPEEXINCLUDEDIR} >> kaldi.mk
 
     if $static_speex; then
-      echo LDLIBS += $SPEEXROOT/lib/libspeex.a
+      echo LDLIBS += $SPEEXLIBDIR/libspeex.a
     else
-      echo LDLIBS += -L${SPEEXROOT}/lib -lspeex >> kaldi.mk
-      echo LDFLAGS += -Wl,-rpath=${SPEEXROOT}/lib >> kaldi.mk
+      echo LDLIBS += -L${SPEEXLIBDIR} -lspeex >> kaldi.mk
+      echo LDFLAGS += -Wl,-rpath=${SPEEXLIBDIR} >> kaldi.mk
     fi
 
     echo "Successfully configured with Speex at $SPEEXROOT, (static=[$static_speex])"


### PR DESCRIPTION
This pull request adds three options (--speex-root, --speex-libdir, --speex-includedir) that can be used to locate speex library. In my setup speex lib are in /usr/lib/x86_64-linux-gnu, while include files are in /usr/include:
```./configure --speex-libdir=/usr/lib/x86_64-linux-gnu --speex-root=/usr``` lets me use the system library instead of a custom one.