### PR TITLE
force to generate utt2dur for every srcdir while calling combine_data.sh

### DIFF
--- a/egs/librispeech/s5/local/data_prep.sh
+++ b/egs/librispeech/s5/local/data_prep.sh
@@ -31,6 +31,7 @@ wav_scp=$dst/wav.scp; [[ -f "$wav_scp" ]] && rm $wav_scp
 trans=$dst/text; [[ -f "$trans" ]] && rm $trans
 utt2spk=$dst/utt2spk; [[ -f "$utt2spk" ]] && rm $utt2spk
 spk2gender=$dst/spk2gender; [[ -f $spk2gender ]] && rm $spk2gender
+utt2dur=$dst/utt2dur; [[ -f "$utt2dur" ]] && rm $utt2dur
 
 for reader_dir in $(find $src -mindepth 1 -maxdepth 1 -type d | sort); do
   reader=$(basename $reader_dir)
@@ -77,6 +78,8 @@ ntrans=$(wc -l <$trans)
 nutt2spk=$(wc -l <$utt2spk)
 ! [ "$ntrans" -eq "$nutt2spk" ] && \
   echo "Inconsistent #transcripts($ntrans) and #utt2spk($nutt2spk)" && exit 1;
+
+utils/data/get_utt2dur.sh $utt2dur 1>&2 || exit 1
 
 utils/validate_data_dir.sh --no-feats $dst || exit 1;
 

--- a/egs/wsj/s5/utils/combine_data.sh
+++ b/egs/wsj/s5/utils/combine_data.sh
@@ -67,7 +67,9 @@ extra_files=$(echo "$extra_files"|sed -e "s/utt2uniq//g")
 
 for file in utt2spk utt2lang utt2dur feats.scp text cmvn.scp segments reco2file_and_channel wav.scp spk2gender $extra_files; do
   if [ -f $first_src/$file ]; then
+    set -o pipefail
     ( for f in $*; do cat $f/$file; done ) | sort -k1 > $dest/$file || exit 1;
+    set +o pipefail
     echo "$0: combined $file"
   else
     echo "$0 [info]: not combining $file as it does not exist"

--- a/egs/wsj/s5/utils/subset_data_dir.sh
+++ b/egs/wsj/s5/utils/subset_data_dir.sh
@@ -106,6 +106,7 @@ function do_filtering {
   [ -f $srcdir/feats.scp ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/feats.scp >$destdir/feats.scp
   [ -f $srcdir/vad.scp ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/vad.scp >$destdir/vad.scp
   [ -f $srcdir/utt2lang ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/utt2lang >$destdir/utt2lang
+  [ -f $srcdir/utt2dur ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/utt2dur >$destdir/utt2dur
   [ -f $srcdir/wav.scp ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/wav.scp >$destdir/wav.scp
   [ -f $srcdir/spk2warp ] && utils/filter_scp.pl $destdir/spk2utt <$srcdir/spk2warp >$destdir/spk2warp
   [ -f $srcdir/utt2warp ] && utils/filter_scp.pl $destdir/utt2spk <$srcdir/utt2warp >$destdir/utt2warp


### PR DESCRIPTION
It was trying to fix a problem when the first srcdir of combine_data.sh contains utt2dur but not every other srcdir else. 

For example, when librispeech's run.sh was trying to combine train_clean_100(containing utt2dur) and train_clean_360(not containing utt2dur), the current script will result in a "combined" utt2dur file with entries only from train_clean_100.