### PR TITLE
nnet1: creating tool 'nnet-set-learnrate', some structural changes in I/O,

### DIFF
--- a/src/nnet/nnet-activation.h
+++ b/src/nnet/nnet-activation.h
@@ -74,12 +74,11 @@ class BlockSoftmax : public Component {
     // parse config
     std::string token,
       dims_str;
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<BlockDims>") is >> dims_str;
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (BlockDims)";
-      is >> std::ws; // eat-up whitespace
     }
     // parse dims,
     if (!kaldi::SplitStringToIntegers(dims_str, ",:", false, &block_dims))
@@ -213,7 +212,7 @@ class Dropout : public Component {
     is >> std::ws; // eat-up whitespace
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<DropoutRetention>") ReadBasicType(is, false, &dropout_retention_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"

--- a/src/nnet/nnet-affine-transform.h
+++ b/src/nnet/nnet-affine-transform.h
@@ -50,7 +50,7 @@ class AffineTransform : public UpdatableComponent {
     float max_norm = 0.0;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<ParamStddev>") ReadBasicType(is, false, &param_stddev);
       else if (token == "<BiasMean>")    ReadBasicType(is, false, &bias_mean);

--- a/src/nnet/nnet-affine-transform.h
+++ b/src/nnet/nnet-affine-transform.h
@@ -89,7 +89,6 @@ class AffineTransform : public UpdatableComponent {
   void ReadData(std::istream &is, bool binary) {
     // Read all the '<Tokens>' in arbitrary order,
     while ('<' == Peek(is, binary)) {
-      std::string token;
       int first_char = PeekToken(is, binary);
       switch (first_char) {
         case 'L': ExpectToken(is, binary, "<LearnRateCoef>"); 
@@ -101,7 +100,9 @@ class AffineTransform : public UpdatableComponent {
         case 'M': ExpectToken(is, binary, "<MaxNorm>");
           ReadBasicType(is, binary, &max_norm_);
           break;
-        default: ReadToken(is, false, &token);
+        default: 
+          std::string token;
+          ReadToken(is, false, &token);
           KALDI_ERR << "Unknown token: " << token;
       }
     }
@@ -141,17 +142,17 @@ class AffineTransform : public UpdatableComponent {
   
   std::string Info() const {
     return std::string("\n  linearity") + MomentStatistics(linearity_) + 
-           ", lr-coef " + ToString(learn_rate_coef_) +
-           ", max-norm " + ToString(max_norm_) +
-           "\n  bias" + MomentStatistics(bias_) + 
-           ", lr-coef " + ToString(bias_learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_) +
+      ", max-norm " + ToString(max_norm_) +
+      "\n  bias" + MomentStatistics(bias_) + 
+      ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  linearity_grad") + MomentStatistics(linearity_corr_) + 
-           ", lr-coef " + ToString(learn_rate_coef_) +
-           ", max-norm " + ToString(max_norm_) +
-           "\n  bias_grad" + MomentStatistics(bias_corr_) + 
-           ", lr-coef " + ToString(bias_learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_) +
+      ", max-norm " + ToString(max_norm_) +
+      "\n  bias_grad" + MomentStatistics(bias_corr_) + 
+      ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
 
   void PropagateFnc(const CuMatrixBase<BaseFloat> &in, CuMatrixBase<BaseFloat> *out) {

--- a/src/nnet/nnet-affine-transform.h
+++ b/src/nnet/nnet-affine-transform.h
@@ -35,7 +35,7 @@ class AffineTransform : public UpdatableComponent {
     : UpdatableComponent(dim_in, dim_out), 
       linearity_(dim_out, dim_in), bias_(dim_out),
       linearity_corr_(dim_out, dim_in), bias_corr_(dim_out),
-      learn_rate_coef_(1.0), bias_learn_rate_coef_(1.0), max_norm_(0.0) 
+      max_norm_(0.0) 
   { }
   ~AffineTransform()
   { }
@@ -130,8 +130,11 @@ class AffineTransform : public UpdatableComponent {
   }
   
   std::string Info() const {
-    return std::string("\n  linearity") + MomentStatistics(linearity_) +
-           "\n  bias" + MomentStatistics(bias_);
+    return std::string("\n  linearity") + MomentStatistics(linearity_) + 
+           ", lr-coef " + ToString(learn_rate_coef_) +
+           ", max-norm " + ToString(max_norm_) +
+           "\n  bias" + MomentStatistics(bias_) + 
+           ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  linearity_grad") + MomentStatistics(linearity_corr_) + 
@@ -139,9 +142,7 @@ class AffineTransform : public UpdatableComponent {
            ", max-norm " + ToString(max_norm_) +
            "\n  bias_grad" + MomentStatistics(bias_corr_) + 
            ", lr-coef " + ToString(bias_learn_rate_coef_);
-           
   }
-
 
   void PropagateFnc(const CuMatrixBase<BaseFloat> &in, CuMatrixBase<BaseFloat> *out) {
     // precopy bias
@@ -231,8 +232,6 @@ class AffineTransform : public UpdatableComponent {
   CuMatrix<BaseFloat> linearity_corr_;
   CuVector<BaseFloat> bias_corr_;
 
-  BaseFloat learn_rate_coef_;
-  BaseFloat bias_learn_rate_coef_;
   BaseFloat max_norm_;
 };
 

--- a/src/nnet/nnet-affine-transform.h
+++ b/src/nnet/nnet-affine-transform.h
@@ -124,6 +124,7 @@ class AffineTransform : public UpdatableComponent {
     WriteBasicType(os, binary, bias_learn_rate_coef_);
     WriteToken(os, binary, "<MaxNorm>");
     WriteBasicType(os, binary, max_norm_);
+    if(!binary) os << "\n";
     // weights
     linearity_.Write(os, binary);
     bias_.Write(os, binary);

--- a/src/nnet/nnet-average-pooling-2d-component.h
+++ b/src/nnet/nnet-average-pooling-2d-component.h
@@ -52,7 +52,7 @@ class AveragePooling2DComponent : public Component {
   void InitData(std::istream &is) {
     // parse config
     std::string token;
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token);
       /**/ if (token == "<FmapXLen>") ReadBasicType(is, false, &fmap_x_len_);
       else if (token == "<FmapYLen>") ReadBasicType(is, false, &fmap_y_len_);
@@ -62,7 +62,6 @@ class AveragePooling2DComponent : public Component {
       else if (token == "<PoolYStep>") ReadBasicType(is, false, &pool_y_step_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (FmapXLen|FmapYLen|PoolXLen|PoolYLen|PoolXStep|PoolYStep)";
-      is >> std::ws;  // eat-up whitespace
     }
     // check
     KALDI_ASSERT(fmap_x_len_ * fmap_y_len_ * pool_x_len_ * pool_y_len_ * pool_x_step_ * pool_y_step_  != 0);

--- a/src/nnet/nnet-blstm-projected-streams.h
+++ b/src/nnet/nnet-blstm-projected-streams.h
@@ -1,7 +1,7 @@
 // nnet/nnet-blstm-projected-streams.h
 
-// Copyright 2014  Jiayu DU (Jerry), Wei Li
 // Copyright 2015  Chongjia Ni
+// Copyright 2014  Jiayu DU (Jerry), Wei Li
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,27 +81,23 @@ class BLstmProjectedStreams : public UpdatableComponent {
   }
 
   void InitData(std::istream &is) {
-    // define options
+    // define options,
     float param_scale = 0.02;
-    // parse config
+    // parse the line from prototype,
     std::string token;
     while (!is.eof()) {
       ReadToken(is, false, &token);
-      if (token == "<CellDim>")
-        ReadBasicType(is, false, &ncell_);
-      else if (token == "<ClipGradient>")
-        ReadBasicType(is, false, &clip_gradient_);
-      // else if (token == "<DropoutRate>")
-      //  ReadBasicType(is, false, &dropout_rate_);
-      else if (token == "<ParamScale>")
-        ReadBasicType(is, false, &param_scale);
+      /**/ if (token == "<CellDim>") ReadBasicType(is, false, &ncell_);
+      else if (token == "<ClipGradient>") ReadBasicType(is, false, &clip_gradient_);
+      else if (token == "<LearnRateCoef>") ReadBasicType(is, false, &learn_rate_coef_);
+      else if (token == "<BiasLearnRateCoef>") ReadBasicType(is, false, &bias_learn_rate_coef_);
+      else if (token == "<ParamScale>") ReadBasicType(is, false, &param_scale);
+      // else if (token == "<DropoutRate>") ReadBasicType(is, false, &dropout_rate_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
-               << " (CellDim|NumStream|ParamScale)";
-               //<< " (CellDim|NumStream|DropoutRate|ParamScale)";
-      is >> std::ws;
+                     << " (CellDim|ClipGradient|LearnRateCoef|BiasLearnRateCoef|ParamScale)";
     }
 
-    // init weight and bias (Uniform)
+    // init the weights and biases (from uniform dist.),
     // forward direction
     f_w_gifo_x_.Resize(4*ncell_, input_dim_, kUndefined);
     f_w_gifo_r_.Resize(4*ncell_, nrecur_, kUndefined);
@@ -154,7 +150,7 @@ class BLstmProjectedStreams : public UpdatableComponent {
     b_w_gifo_r_corr_.Resize(4*ncell_, nrecur_, kSetZero);
     b_bias_corr_.Resize(4*ncell_, kSetZero);
 
-    // peep hole connect
+    // peep-hole connections
     // forward direction
     f_peephole_i_c_corr_.Resize(ncell_, kSetZero);
     f_peephole_f_c_corr_.Resize(ncell_, kSetZero);
@@ -169,17 +165,39 @@ class BLstmProjectedStreams : public UpdatableComponent {
     // backward direction
     b_w_r_m_corr_.Resize(nrecur_, ncell_, kSetZero);
 
+    KALDI_ASSERT(ncell_ > 0);
     KALDI_ASSERT(clip_gradient_ >= 0.0);
+    KALDI_ASSERT(learn_rate_coef_ >= 0.0);
+    KALDI_ASSERT(bias_learn_rate_coef_ >= 0.0);
   }
 
 
   void ReadData(std::istream &is, bool binary) {
-    ExpectToken(is, binary, "<CellDim>");
-    ReadBasicType(is, binary, &ncell_);
-    ExpectToken(is, binary, "<ClipGradient>");
-    ReadBasicType(is, binary, &clip_gradient_);
-    // ExpectToken(is, binary, "<DropoutRate>");
-    // ReadBasicType(is, binary, &dropout_rate_);
+    // Read all the '<Tokens>' in arbitrary order,
+    while ('<' == Peek(is, binary)) {
+      std::string token;
+      int first_char = PeekToken(is, binary);
+      switch (first_char) {
+        case 'C': ReadToken(is, false, &token);
+          /**/ if (token == "<CellDim>") ReadBasicType(is, binary, &ncell_);
+          else if (token == "<ClipGradient>") ReadBasicType(is, binary, &clip_gradient_);
+          else KALDI_ERR << "Unknown token: " << token;
+          break;
+        //case 'D': ExpectToken(is, binary, "<DropoutRate>");
+        //  ReadBasicType(is, binary, &dropout_rate_);
+        //  break;
+        case 'L': ExpectToken(is, binary, "<LearnRateCoef>"); 
+          ReadBasicType(is, binary, &learn_rate_coef_);
+          break;
+        case 'B': ExpectToken(is, binary, "<BiasLearnRateCoef>"); 
+          ReadBasicType(is, binary, &bias_learn_rate_coef_);
+          break;
+        default: ReadToken(is, false, &token);
+          KALDI_ERR << "Unknown token: " << token;
+      }
+    }
+    KALDI_ASSERT(ncell_ != 0);
+    // Read the data (data follow the tokens),
 
     // reading parameters corresponding to forward direction
     f_w_gifo_x_.Read(is, binary);
@@ -236,6 +254,11 @@ class BLstmProjectedStreams : public UpdatableComponent {
     // WriteToken(os, binary, "<DropoutRate>");
     // WriteBasicType(os, binary, dropout_rate_);
 
+    WriteToken(os, binary, "<LearnRateCoef>");
+    WriteBasicType(os, binary, learn_rate_coef_);
+    WriteToken(os, binary, "<BiasLearnRateCoef>");
+    WriteBasicType(os, binary, bias_learn_rate_coef_);
+
     // writing parameters corresponding to forward direction
     f_w_gifo_x_.Write(os, binary);
     f_w_gifo_r_.Write(os, binary);
@@ -262,12 +285,12 @@ class BLstmProjectedStreams : public UpdatableComponent {
 
   int32 NumParams() const {
     return 2*( f_w_gifo_x_.NumRows() * f_w_gifo_x_.NumCols() +
-         f_w_gifo_r_.NumRows() * f_w_gifo_r_.NumCols() +
-         f_bias_.Dim() +
-         f_peephole_i_c_.Dim() +
-         f_peephole_f_c_.Dim() +
-         f_peephole_o_c_.Dim() +
-         f_w_r_m_.NumRows() * f_w_r_m_.NumCols() );
+      f_w_gifo_r_.NumRows() * f_w_gifo_r_.NumCols() +
+      f_bias_.Dim() +
+      f_peephole_i_c_.Dim() +
+      f_peephole_f_c_.Dim() +
+      f_peephole_o_c_.Dim() +
+      f_w_r_m_.NumRows() * f_w_r_m_.NumCols() );
   }
 
 
@@ -318,8 +341,6 @@ class BLstmProjectedStreams : public UpdatableComponent {
 
     offset += len; len = b_w_r_m_.NumRows() * b_w_r_m_.NumCols();
     wei_copy->Range(offset, len).CopyRowsFromMat(b_w_r_m_);
-
-    return;
   }
 
 
@@ -1013,30 +1034,29 @@ class BLstmProjectedStreams : public UpdatableComponent {
     }
   }
 
-
   void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff) {
     const BaseFloat lr  = opts_.learn_rate;
     // forward direction update
-    f_w_gifo_x_.AddMat(-lr, f_w_gifo_x_corr_);
-    f_w_gifo_r_.AddMat(-lr, f_w_gifo_r_corr_);
-    f_bias_.AddVec(-lr, f_bias_corr_, 1.0);
+    f_w_gifo_x_.AddMat(-lr * learn_rate_coef_, f_w_gifo_x_corr_);
+    f_w_gifo_r_.AddMat(-lr * learn_rate_coef_, f_w_gifo_r_corr_);
+    f_bias_.AddVec(-lr * bias_learn_rate_coef_, f_bias_corr_, 1.0);
 
-    f_peephole_i_c_.AddVec(-lr, f_peephole_i_c_corr_, 1.0);
-    f_peephole_f_c_.AddVec(-lr, f_peephole_f_c_corr_, 1.0);
-    f_peephole_o_c_.AddVec(-lr, f_peephole_o_c_corr_, 1.0);
+    f_peephole_i_c_.AddVec(-lr * bias_learn_rate_coef_, f_peephole_i_c_corr_, 1.0);
+    f_peephole_f_c_.AddVec(-lr * bias_learn_rate_coef_, f_peephole_f_c_corr_, 1.0);
+    f_peephole_o_c_.AddVec(-lr * bias_learn_rate_coef_, f_peephole_o_c_corr_, 1.0);
 
-    f_w_r_m_.AddMat(-lr, f_w_r_m_corr_);
+    f_w_r_m_.AddMat(-lr * learn_rate_coef_, f_w_r_m_corr_);
 
     // backward direction update
-    b_w_gifo_x_.AddMat(-lr, b_w_gifo_x_corr_);
-    b_w_gifo_r_.AddMat(-lr, b_w_gifo_r_corr_);
-    b_bias_.AddVec(-lr, b_bias_corr_, 1.0);
+    b_w_gifo_x_.AddMat(-lr * learn_rate_coef_, b_w_gifo_x_corr_);
+    b_w_gifo_r_.AddMat(-lr * learn_rate_coef_, b_w_gifo_r_corr_);
+    b_bias_.AddVec(-lr * bias_learn_rate_coef_, b_bias_corr_, 1.0);
 
-    b_peephole_i_c_.AddVec(-lr, b_peephole_i_c_corr_, 1.0);
-    b_peephole_f_c_.AddVec(-lr, b_peephole_f_c_corr_, 1.0);
-    b_peephole_o_c_.AddVec(-lr, b_peephole_o_c_corr_, 1.0);
+    b_peephole_i_c_.AddVec(-lr * bias_learn_rate_coef_, b_peephole_i_c_corr_, 1.0);
+    b_peephole_f_c_.AddVec(-lr * bias_learn_rate_coef_, b_peephole_f_c_corr_, 1.0);
+    b_peephole_o_c_.AddVec(-lr * bias_learn_rate_coef_, b_peephole_o_c_corr_, 1.0);
 
-    b_w_r_m_.AddMat(-lr, b_w_r_m_corr_);
+    b_w_r_m_.AddMat(-lr * learn_rate_coef_, b_w_r_m_corr_);
 
     /* For L2 regularization see "vanishing & exploding difficulties" in nnet-lstm-projected-streams.h */
   }

--- a/src/nnet/nnet-blstm-projected-streams.h
+++ b/src/nnet/nnet-blstm-projected-streams.h
@@ -259,6 +259,7 @@ class BLstmProjectedStreams : public UpdatableComponent {
     WriteToken(os, binary, "<BiasLearnRateCoef>");
     WriteBasicType(os, binary, bias_learn_rate_coef_);
 
+    if(!binary) os << "\n";
     // writing parameters corresponding to forward direction
     f_w_gifo_x_.Write(os, binary);
     f_w_gifo_r_.Write(os, binary);

--- a/src/nnet/nnet-component.cc
+++ b/src/nnet/nnet-component.cc
@@ -221,20 +221,30 @@ Component* Component::Read(std::istream &is, bool binary) {
   if (first_char == EOF) return NULL;
 
   ReadToken(is, binary, &token);
-  // Skip optional initial token
+  // Skip the optional initial token,
   if(token == "<Nnet>") {
-    ReadToken(is, binary, &token); // Next token is a Component
+    ReadToken(is, binary, &token); 
   }
-  // Finish reading when optional terminal token appears
+  // Network ends after terminal token appears,
   if(token == "</Nnet>") {
     return NULL;
   }
 
+  // Read the dims,
   ReadBasicType(is, binary, &dim_out); 
   ReadBasicType(is, binary, &dim_in);
 
+  // Create the component,
   Component *ans = NewComponentOfType(MarkerToType(token), dim_in, dim_out);
+  
+  // Read the content,
   ans->ReadData(is, binary);
+
+  // 'Eat' the component separtor (can be already consumed by 'ReadData(.)'),
+  if ('<' == Peek(is, binary) && '!' == PeekToken(is, binary)) {
+    ExpectToken(is, binary, "<!EndOfComponent>");
+  }
+
   return ans;
 }
 
@@ -245,6 +255,8 @@ void Component::Write(std::ostream &os, bool binary) const {
   WriteBasicType(os, binary, InputDim());
   if(!binary) os << "\n";
   this->WriteData(os, binary);
+  WriteToken(os, binary, "<!EndOfComponent>"); // Introduce component separator.
+  if(!binary) os << "\n";
 }
 
 

--- a/src/nnet/nnet-component.h
+++ b/src/nnet/nnet-component.h
@@ -93,7 +93,7 @@ class Component {
   /// Convert component type to marker
   static const char* TypeToMarker(ComponentType t);
   /// Convert marker to component type (case insensitive)
-  static ComponentType MarkerToType(const std::string &s);  
+  static ComponentType MarkerToType(const std::string &s);
  
  /// General interface of a component  
  public:
@@ -183,7 +183,8 @@ class Component {
 class UpdatableComponent : public Component {
  public: 
   UpdatableComponent(int32 input_dim, int32 output_dim)
-    : Component(input_dim, output_dim) { }
+    : Component(input_dim, output_dim), 
+      learn_rate_coef_(1.0), bias_learn_rate_coef_(1.0) { }
   virtual ~UpdatableComponent() { }
 
   /// Check if contains trainable parameters 
@@ -208,11 +209,24 @@ class UpdatableComponent : public Component {
     return opts_; 
   }
 
+  /// Sets the learn-rate coefficient,
+  virtual void SetLearnRateCoef(BaseFloat val) { 
+    learn_rate_coef_ = val; 
+  }
+  /// Sets the learn-rate coefficient for bias,
+  virtual void SetBiasLearnRateCoef(BaseFloat val) { 
+    bias_learn_rate_coef_ = val; 
+  }
+
   virtual void InitData(std::istream &is) = 0;
 
  protected:
   /// Option-class with training hyper-parameters
-  NnetTrainOptions opts_; 
+  NnetTrainOptions opts_;
+  /// Scalar applied to learning rate (for weight matrices, to be used in ::Update function),
+  BaseFloat learn_rate_coef_;
+  /// Scalar applied to learning rate (for bias, to be used in ::Update function),
+  BaseFloat bias_learn_rate_coef_;
 };
 
 

--- a/src/nnet/nnet-component.h
+++ b/src/nnet/nnet-component.h
@@ -1,6 +1,6 @@
 // nnet/nnet-component.h
 
-// Copyright 2011-2013  Brno University of Technology (Author: Karel Vesely)
+// Copyright 2011-2016  Brno University of Technology (Author: Karel Vesely)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -42,9 +42,9 @@ namespace nnet1 {
  */ 
 class Component {
 
- /// Component type identification mechanism
+ /// Component type identification mechanism,
  public: 
-  /// Types of Components
+  /// Types of Components,
   typedef enum {
     kUnknown = 0x0,
      
@@ -83,61 +83,76 @@ class Component {
     kFramePoolingComponent, 
     kParallelComponent
   } ComponentType;
-  /// A pair of type and marker 
+
+  /// A pair of type and marker,
   struct key_value {
     const Component::ComponentType key;
     const char *value;
   };
-  /// Mapping of types and markers (the table is defined in nnet-component.cc) 
+
+  /// The table with pairs of Component types and markers (defined in nnet-component.cc),
   static const struct key_value kMarkerMap[];
-  /// Convert component type to marker
+
+  /// Converts component type to marker,
   static const char* TypeToMarker(ComponentType t);
-  /// Convert marker to component type (case insensitive)
+
+  /// Converts marker to component type (case insensitive),
   static ComponentType MarkerToType(const std::string &s);
  
- /// General interface of a component  
+ /// Generic interface of a component,
  public:
-  Component(int32 input_dim, int32 output_dim) 
-      : input_dim_(input_dim), output_dim_(output_dim) { }
-  virtual ~Component() { }
+  Component(int32 input_dim, int32 output_dim) : 
+    input_dim_(input_dim), 
+    output_dim_(output_dim) 
+  { }
 
-  /// Copy component (deep copy).
+  virtual ~Component() 
+  { }
+
+  /// Copy component (deep copy),
   virtual Component* Copy() const = 0;
 
-  /// Get Type Identification of the component
-  virtual ComponentType GetType() const = 0;  
-  /// Check if contains trainable parameters 
-  virtual bool IsUpdatable() const { 
-    return false; 
+  /// Get Type Identification of the component,
+  virtual ComponentType GetType() const = 0;
+
+  /// Check if contains trainable parameters, 
+  virtual bool IsUpdatable() const {
+    return false;
   }
 
-  /// Get size of input vectors
+  /// Get the dimension of the input,
   int32 InputDim() const { 
     return input_dim_; 
-  }  
-  /// Get size of output vectors 
+  }
+
+  /// Get the dimension of the output,
   int32 OutputDim() const { 
     return output_dim_; 
   }
  
-  /// Perform forward pass propagation Input->Output
+  /// Perform forward-pass propagation 'in' -> 'out',
   void Propagate(const CuMatrixBase<BaseFloat> &in, CuMatrix<BaseFloat> *out); 
-  /// Perform backward pass propagation, out_diff -> in_diff
-  /// '&in' and '&out' will sometimes be unused... 
+
+  /// Perform backward-pass propagation 'out_diff' -> 'in_diff'.
+  /// Note: 'in' and 'out' will be used only sometimes...
   void Backpropagate(const CuMatrixBase<BaseFloat> &in,
                      const CuMatrixBase<BaseFloat> &out,
                      const CuMatrixBase<BaseFloat> &out_diff,
                      CuMatrix<BaseFloat> *in_diff); 
 
-  /// Initialize component from a line in config file
+  /// Initialize component from a line in config file,
   static Component* Init(const std::string &conf_line);
-  /// Read component from stream
+
+  /// Read the component from a stream (static method),
   static Component* Read(std::istream &is, bool binary);
-  /// Write component to stream
+
+  /// Write the component to a stream,
   void Write(std::ostream &os, bool binary) const;
 
-  /// Optionally print some additional info
+  /// Print some additional info (after <ComponentName> and the dims),
   virtual std::string Info() const { return ""; }
+
+  /// Print some additional info about gradient (after <...> and dims),
   virtual std::string InfoGradient() const { return ""; }
 
 
@@ -146,12 +161,15 @@ class Component {
   /// Forward pass transformation (to be implemented by descending class...)
   virtual void PropagateFnc(const CuMatrixBase<BaseFloat> &in,
                             CuMatrixBase<BaseFloat> *out) = 0;
+
   /// Backward pass transformation (to be implemented by descending class...)
   virtual void BackpropagateFnc(const CuMatrixBase<BaseFloat> &in,
                                 const CuMatrixBase<BaseFloat> &out,
                                 const CuMatrixBase<BaseFloat> &out_diff,
                                 CuMatrixBase<BaseFloat> *in_diff) = 0;
 
+ /// Virtual interface for initialization and I/O,
+ protected:
   /// Initialize internal data of a component
   virtual void InitData(std::istream &is) { }
 
@@ -161,75 +179,89 @@ class Component {
   /// Writes the component content
   virtual void WriteData(std::ostream &os, bool binary) const { }
 
- /// Data members
+ /// Data members,
  protected:
-  int32 input_dim_;  ///< Size of input vectors
-  int32 output_dim_; ///< Size of output vectors
+  int32 input_dim_;  ///< Dimension of the input of the Component,
+  int32 output_dim_; ///< Dimension of the output of the Component,
 
+ /// Private members (descending classes cannot call this),
  private:
-  /// Create new intance of component
-  static Component* NewComponentOfType(ComponentType t, 
-                      int32 input_dim, int32 output_dim);
-  
- protected:
-  //KALDI_DISALLOW_COPY_AND_ASSIGN(Component);
+  /// Create a new intance of component,
+  static Component* NewComponentOfType(
+    ComponentType t, int32 input_dim, int32 output_dim
+  );
 };
 
 
 /**
  * Class UpdatableComponent is a Component which has trainable parameters,
- * contains SGD training hyper-parameters in NnetTrainOptions.
+ * it contains SGD training hyper-parameters in NnetTrainOptions.
+ * The constants 'learning_rate_coef_' and 'bias_learn_rate_coef_'
+ * are separate, and should be stored by ::WriteData(...),
  */
 class UpdatableComponent : public Component {
  public: 
-  UpdatableComponent(int32 input_dim, int32 output_dim)
-    : Component(input_dim, output_dim), 
-      learn_rate_coef_(1.0), bias_learn_rate_coef_(1.0) { }
-  virtual ~UpdatableComponent() { }
+  UpdatableComponent(int32 input_dim, int32 output_dim) : 
+    Component(input_dim, output_dim),
+    learn_rate_coef_(1.0),
+    bias_learn_rate_coef_(1.0)
+  { }
 
-  /// Check if contains trainable parameters 
+  virtual ~UpdatableComponent()
+  { }
+
+  /// Check if contains trainable parameters,
   bool IsUpdatable() const { 
     return true; 
   }
 
-  /// Number of trainable parameters
+  /// Number of trainable parameters,
   virtual int32 NumParams() const = 0;
+
+  /// Get the trainable parameters reshaped as a vector,
   virtual void GetParams(Vector<BaseFloat> *params) const = 0;
 
-  /// Compute gradient and update parameters
+  /// Compute gradient and update parameters,
   virtual void Update(const CuMatrixBase<BaseFloat> &input,
                       const CuMatrixBase<BaseFloat> &diff) = 0;
 
-  /// Sets the training options to the component
+  /// Set the training options to the component,
   virtual void SetTrainOptions(const NnetTrainOptions &opts) {
     opts_ = opts;
   }
-  /// Gets the training options from the component
+
+  /// Get the training options from the component,
   const NnetTrainOptions& GetTrainOptions() const { 
     return opts_; 
   }
 
-  /// Sets the learn-rate coefficient,
+  /// Set the learn-rate coefficient,
   virtual void SetLearnRateCoef(BaseFloat val) { 
     learn_rate_coef_ = val; 
   }
-  /// Sets the learn-rate coefficient for bias,
+
+  /// Set the learn-rate coefficient for bias,
   virtual void SetBiasLearnRateCoef(BaseFloat val) { 
     bias_learn_rate_coef_ = val; 
   }
 
+  /// Initialize the content of the component by the 'line' from the prototype,
   virtual void InitData(std::istream &is) = 0;
 
  protected:
-  /// Option-class with training hyper-parameters
+  /// Option-class with training hyper-parameters,
   NnetTrainOptions opts_;
-  /// Scalar applied to learning rate (for weight matrices, to be used in ::Update function),
+  /// Scalar applied to learning rate (for weight matrices, to be used in ::Update method),
   BaseFloat learn_rate_coef_;
-  /// Scalar applied to learning rate (for bias, to be used in ::Update function),
+  /// Scalar applied to learning rate (for bias, to be used in ::Update method),
   BaseFloat bias_learn_rate_coef_;
 };
 
 
+
+/*
+ * Inline methods for ::Component,
+ */
 inline void Component::Propagate(const CuMatrixBase<BaseFloat> &in,
                                  CuMatrix<BaseFloat> *out) {
   // Check the dims
@@ -243,7 +275,6 @@ inline void Component::Propagate(const CuMatrixBase<BaseFloat> &in,
   // Call the propagation implementation of the component
   PropagateFnc(in, out);
 }
-
 
 inline void Component::Backpropagate(const CuMatrixBase<BaseFloat> &in,
                                      const CuMatrixBase<BaseFloat> &out,

--- a/src/nnet/nnet-convolutional-2d-component.h
+++ b/src/nnet/nnet-convolutional-2d-component.h
@@ -74,7 +74,7 @@ class Convolutional2DComponent : public UpdatableComponent {
       fmap_x_len_(0), fmap_y_len_(0),
       filt_x_len_(0), filt_y_len_(0),
       filt_x_step_(0), filt_y_step_(0),
-      connect_fmap_(0), learn_rate_coef_(1.0), bias_learn_rate_coef_(1.0)
+      connect_fmap_(0)
   { }
   ~Convolutional2DComponent()
   { }
@@ -238,7 +238,9 @@ class Convolutional2DComponent : public UpdatableComponent {
 
   std::string Info() const {
     return std::string("\n  filters") + MomentStatistics(filters_) +
-           "\n  bias" + MomentStatistics(bias_);
+           ", lr-coef " + ToString(learn_rate_coef_) +
+           "\n  bias" + MomentStatistics(bias_) +
+           ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  filters_grad") + MomentStatistics(filters_grad_) +
@@ -444,9 +446,6 @@ class Convolutional2DComponent : public UpdatableComponent {
     filt_x_len_, filt_y_len_,  ///< 2D filter dimensions, x_ temporal, y_ spectral
     filt_x_step_, filt_y_step_,  ///< 2D shifts along temporal and spectral
     connect_fmap_;  ///< if connect_fmap_ = 1, then each fmap has num_filt
-
-  BaseFloat learn_rate_coef_;
-  BaseFloat bias_learn_rate_coef_;
 
   CuMatrix<BaseFloat> filters_;  ///< row = vectorized rectangular filter
   CuVector<BaseFloat> bias_;  ///< bias for each filter

--- a/src/nnet/nnet-convolutional-2d-component.h
+++ b/src/nnet/nnet-convolutional-2d-component.h
@@ -202,6 +202,8 @@ class Convolutional2DComponent : public UpdatableComponent {
     WriteBasicType(os, binary, learn_rate_coef_);
     WriteToken(os, binary, "<BiasLearnRateCoef>");
     WriteBasicType(os, binary, bias_learn_rate_coef_);
+    if(!binary) os << "\n";
+
     // convolution hyperparameters
     WriteToken(os, binary, "<FmapXLen>");
     WriteBasicType(os, binary, fmap_x_len_);
@@ -217,11 +219,14 @@ class Convolutional2DComponent : public UpdatableComponent {
     WriteBasicType(os, binary, filt_y_step_);
     WriteToken(os, binary, "<ConnectFmap>");
     WriteBasicType(os, binary, connect_fmap_);
+    if(!binary) os << "\n";
 
     // trainable parameters
     WriteToken(os, binary, "<Filters>");
+    if(!binary) os << "\n";
     filters_.Write(os, binary);
     WriteToken(os, binary, "<Bias>");
+    if(!binary) os << "\n";
     bias_.Write(os, binary);
   }
 

--- a/src/nnet/nnet-convolutional-component.h
+++ b/src/nnet/nnet-convolutional-component.h
@@ -157,6 +157,7 @@ class ConvolutionalComponent : public UpdatableComponent {
         case 'M': ExpectToken(is, binary, "<MaxNorm>");
           ReadBasicType(is, binary, &max_norm_);
           break;
+        case '!': ExpectToken(is, binary, "<!EndOfComponent>");
         default: end_loop = true;
       }
     }
@@ -230,17 +231,18 @@ class ConvolutionalComponent : public UpdatableComponent {
 
   std::string Info() const {
     return std::string("\n  filters") + MomentStatistics(filters_) +
-           ", lr-coef " + ToString(learn_rate_coef_) +
-           ", max-norm " + ToString(max_norm_) +
-           "\n  bias" + MomentStatistics(bias_) +
-           ", lr-coef " + ToString(bias_learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_) +
+      ", max-norm " + ToString(max_norm_) +
+      "\n  bias" + MomentStatistics(bias_) +
+      ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
+
   std::string InfoGradient() const {
     return std::string("\n  filters_grad") + MomentStatistics(filters_grad_) +
-           ", lr-coef " + ToString(learn_rate_coef_) +
-           ", max-norm " + ToString(max_norm_) +
-           "\n  bias_grad" + MomentStatistics(bias_grad_) +
-           ", lr-coef " + ToString(bias_learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_) +
+      ", max-norm " + ToString(max_norm_) +
+      "\n  bias_grad" + MomentStatistics(bias_grad_) +
+      ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
 
   void PropagateFnc(const CuMatrixBase<BaseFloat> &in,

--- a/src/nnet/nnet-convolutional-component.h
+++ b/src/nnet/nnet-convolutional-component.h
@@ -79,7 +79,7 @@ class ConvolutionalComponent : public UpdatableComponent {
     BaseFloat bias_mean = -2.0, bias_range = 2.0, param_stddev = 0.1;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<ParamStddev>") ReadBasicType(is, false, &param_stddev);
       else if (token == "<BiasMean>")    ReadBasicType(is, false, &bias_mean);
@@ -92,7 +92,6 @@ class ConvolutionalComponent : public UpdatableComponent {
       else if (token == "<MaxNorm>") ReadBasicType(is, false, &max_norm_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (ParamStddev|BiasMean|BiasRange|PatchDim|PatchStep|PatchStride)";
-      is >> std::ws; // eat-up whitespace
     }
 
     //

--- a/src/nnet/nnet-convolutional-component.h
+++ b/src/nnet/nnet-convolutional-component.h
@@ -66,7 +66,7 @@ class ConvolutionalComponent : public UpdatableComponent {
   ConvolutionalComponent(int32 dim_in, int32 dim_out) 
     : UpdatableComponent(dim_in, dim_out),
       patch_dim_(0), patch_step_(0), patch_stride_(0), 
-      learn_rate_coef_(1.0), bias_learn_rate_coef_(1.0), max_norm_(0.0)  
+      max_norm_(0.0)  
   { }
   ~ConvolutionalComponent()
   { }
@@ -220,7 +220,10 @@ class ConvolutionalComponent : public UpdatableComponent {
 
   std::string Info() const {
     return std::string("\n  filters") + MomentStatistics(filters_) +
-           "\n  bias" + MomentStatistics(bias_);
+           ", lr-coef " + ToString(learn_rate_coef_) +
+           ", max-norm " + ToString(max_norm_) +
+           "\n  bias" + MomentStatistics(bias_) +
+           ", lr-coef " + ToString(bias_learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  filters_grad") + MomentStatistics(filters_grad_) +
@@ -432,8 +435,6 @@ class ConvolutionalComponent : public UpdatableComponent {
   CuMatrix<BaseFloat> filters_grad_; ///< gradient of filters
   CuVector<BaseFloat> bias_grad_; ///< gradient of biases
 
-  BaseFloat learn_rate_coef_; ///< weight learn rate
-  BaseFloat bias_learn_rate_coef_; ///< bias learn rate
   BaseFloat max_norm_; ///< limit L2 norm of a neuron weights to positive value
 
   /** Buffer of reshaped inputs:

--- a/src/nnet/nnet-frame-pooling-component.h
+++ b/src/nnet/nnet-frame-pooling-component.h
@@ -40,10 +40,12 @@ namespace nnet1 {
  */
 class FramePoolingComponent : public UpdatableComponent {
  public:
-  FramePoolingComponent(int32 dim_in, int32 dim_out) 
-    : UpdatableComponent(dim_in, dim_out), 
-      feature_dim_(0), normalize_(false)
+  FramePoolingComponent(int32 dim_in, int32 dim_out) : 
+    UpdatableComponent(dim_in, dim_out), 
+    feature_dim_(0), 
+    normalize_(false)
   { }
+
   ~FramePoolingComponent()
   { }
 

--- a/src/nnet/nnet-frame-pooling-component.h
+++ b/src/nnet/nnet-frame-pooling-component.h
@@ -62,7 +62,7 @@ class FramePoolingComponent : public UpdatableComponent {
     float learn_rate_coef = 0.01;
     // parse config
     std::string token;
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token);
       /**/ if (token == "<FeatureDim>") ReadBasicType(is, false, &feature_dim_);
       else if (token == "<CentralOffset>") ReadIntegerVector(is, false, &central_offset);
@@ -72,7 +72,6 @@ class FramePoolingComponent : public UpdatableComponent {
       else if (token == "<Normalize>") ReadBasicType(is, false, &normalize_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (FeatureDim|CentralOffset <vec>|PoolSize <vec>|LearnRateCoef|Normalize)";
-      is >> std::ws; // eat-up whitespace
     }
     // check inputs:
     KALDI_ASSERT(feature_dim_ > 0);

--- a/src/nnet/nnet-frame-pooling-component.h
+++ b/src/nnet/nnet-frame-pooling-component.h
@@ -41,7 +41,8 @@ namespace nnet1 {
 class FramePoolingComponent : public UpdatableComponent {
  public:
   FramePoolingComponent(int32 dim_in, int32 dim_out) 
-    : UpdatableComponent(dim_in, dim_out), feature_dim_(0), learn_rate_coef_(0.01), normalize_(false)
+    : UpdatableComponent(dim_in, dim_out), 
+      feature_dim_(0), normalize_(false)
   { }
   ~FramePoolingComponent()
   { }
@@ -257,7 +258,6 @@ class FramePoolingComponent : public UpdatableComponent {
   std::vector<Vector<BaseFloat> > weight_; // vector of pooling weight vectors
   std::vector<Vector<BaseFloat> > weight_diff_; // detivatives of weight vectors
 
-  BaseFloat learn_rate_coef_; // learninig rate multiplier
   bool normalize_; // apply normalization after each update
 };
 

--- a/src/nnet/nnet-linear-transform.h
+++ b/src/nnet/nnet-linear-transform.h
@@ -109,6 +109,7 @@ class LinearTransform : public UpdatableComponent {
   void WriteData(std::ostream &os, bool binary) const {
     WriteToken(os, binary, "<LearnRateCoef>");
     WriteBasicType(os, binary, learn_rate_coef_);
+    if(!binary) os << "\n";
     linearity_.Write(os, binary);
   }
 

--- a/src/nnet/nnet-linear-transform.h
+++ b/src/nnet/nnet-linear-transform.h
@@ -85,9 +85,20 @@ class LinearTransform : public UpdatableComponent {
   }
 
   void ReadData(std::istream &is, bool binary) {
-    // learning-rate coefficien
-    ExpectToken(is, binary, "<LearnRateCoef>");
-    ReadBasicType(is, binary, &learn_rate_coef_);
+    // Read all the '<Tokens>' in arbitrary order,
+    while ('<' == Peek(is, binary)) {
+      std::string token;
+      int first_char = PeekToken(is, binary);
+      switch (first_char) {
+        case 'L': ExpectToken(is, binary, "<LearnRateCoef>"); 
+          ReadBasicType(is, binary, &learn_rate_coef_);
+          break;
+        default: ReadToken(is, false, &token);
+          KALDI_ERR << "Unknown token: " << token;
+      }
+    }
+    // Read the data (data follow the tokens),
+    
     // weights
     linearity_.Read(is, binary);
 

--- a/src/nnet/nnet-linear-transform.h
+++ b/src/nnet/nnet-linear-transform.h
@@ -48,14 +48,13 @@ class LinearTransform : public UpdatableComponent {
     std::string read_matrix_file;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<ParamStddev>") ReadBasicType(is, false, &param_stddev);
       else if (token == "<LearnRateCoef>") ReadBasicType(is, false, &learn_rate_coef);
       else if (token == "<ReadMatrix>") ReadToken(is, false, &read_matrix_file);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (ParamStddev|ReadMatrix|LearnRateCoef)";
-      is >> std::ws; // eat-up whitespace
     }
 
     //

--- a/src/nnet/nnet-linear-transform.h
+++ b/src/nnet/nnet-linear-transform.h
@@ -33,7 +33,7 @@ class LinearTransform : public UpdatableComponent {
  public:
   LinearTransform(int32 dim_in, int32 dim_out) 
     : UpdatableComponent(dim_in, dim_out), 
-      linearity_(dim_out, dim_in), linearity_corr_(dim_out, dim_in), learn_rate_coef_(1.0)
+      linearity_(dim_out, dim_in), linearity_corr_(dim_out, dim_in)
   { }
   ~LinearTransform()
   { }
@@ -110,7 +110,8 @@ class LinearTransform : public UpdatableComponent {
   }
   
   std::string Info() const {
-    return std::string("\n  linearity") + MomentStatistics(linearity_);
+    return std::string("\n  linearity") + MomentStatistics(linearity_) +
+           ", lr-coef " + ToString(learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  linearity_grad") + MomentStatistics(linearity_corr_) +
@@ -170,8 +171,6 @@ class LinearTransform : public UpdatableComponent {
  private:
   CuMatrix<BaseFloat> linearity_;
   CuMatrix<BaseFloat> linearity_corr_;
-  
-  BaseFloat learn_rate_coef_;
 };
 
 } // namespace nnet1

--- a/src/nnet/nnet-linear-transform.h
+++ b/src/nnet/nnet-linear-transform.h
@@ -31,10 +31,12 @@ namespace nnet1 {
 
 class LinearTransform : public UpdatableComponent {
  public:
-  LinearTransform(int32 dim_in, int32 dim_out) 
-    : UpdatableComponent(dim_in, dim_out), 
-      linearity_(dim_out, dim_in), linearity_corr_(dim_out, dim_in)
+  LinearTransform(int32 dim_in, int32 dim_out) : 
+    UpdatableComponent(dim_in, dim_out), 
+    linearity_(dim_out, dim_in), 
+    linearity_corr_(dim_out, dim_in)
   { }
+
   ~LinearTransform()
   { }
 
@@ -86,13 +88,14 @@ class LinearTransform : public UpdatableComponent {
   void ReadData(std::istream &is, bool binary) {
     // Read all the '<Tokens>' in arbitrary order,
     while ('<' == Peek(is, binary)) {
-      std::string token;
       int first_char = PeekToken(is, binary);
       switch (first_char) {
         case 'L': ExpectToken(is, binary, "<LearnRateCoef>"); 
           ReadBasicType(is, binary, &learn_rate_coef_);
           break;
-        default: ReadToken(is, false, &token);
+        default: 
+          std::string token;
+          ReadToken(is, false, &token);
           KALDI_ERR << "Unknown token: " << token;
       }
     }
@@ -122,11 +125,11 @@ class LinearTransform : public UpdatableComponent {
   
   std::string Info() const {
     return std::string("\n  linearity") + MomentStatistics(linearity_) +
-           ", lr-coef " + ToString(learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_);
   }
   std::string InfoGradient() const {
     return std::string("\n  linearity_grad") + MomentStatistics(linearity_corr_) +
-           ", lr-coef " + ToString(learn_rate_coef_);
+      ", lr-coef " + ToString(learn_rate_coef_);
   }
 
   void PropagateFnc(const CuMatrixBase<BaseFloat> &in, CuMatrixBase<BaseFloat> *out) {

--- a/src/nnet/nnet-lstm-projected-streams.h
+++ b/src/nnet/nnet-lstm-projected-streams.h
@@ -189,6 +189,7 @@ class LstmProjectedStreams : public UpdatableComponent {
     WriteToken(os, binary, "<BiasLearnRateCoef>");
     WriteBasicType(os, binary, bias_learn_rate_coef_);
 
+    if(!binary) os << "\n";
     w_gifo_x_.Write(os, binary);
     w_gifo_r_.Write(os, binary);
     bias_.Write(os, binary);

--- a/src/nnet/nnet-lstm-projected-streams.h
+++ b/src/nnet/nnet-lstm-projected-streams.h
@@ -79,7 +79,7 @@ class LstmProjectedStreams : public UpdatableComponent {
     float param_scale = 0.02;
     // parse the line from prototype,
     std::string token;
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token);
       /**/ if (token == "<CellDim>") ReadBasicType(is, false, &ncell_);
       else if (token == "<ClipGradient>") ReadBasicType(is, false, &clip_gradient_);

--- a/src/nnet/nnet-lstm-projected-streams.h
+++ b/src/nnet/nnet-lstm-projected-streams.h
@@ -110,7 +110,7 @@ class LstmProjectedStreams : public UpdatableComponent {
     InitVecParam(peephole_f_c_, param_scale);
     InitVecParam(peephole_o_c_, param_scale);
 
-    // init delta buffers,
+    // init buffers for gradient,
     w_gifo_x_corr_.Resize(4*ncell_, input_dim_, kSetZero);
     w_gifo_r_corr_.Resize(4*ncell_, nrecur_, kSetZero);
     bias_corr_.Resize(4*ncell_, kSetZero);

--- a/src/nnet/nnet-max-pooling-2d-component.h
+++ b/src/nnet/nnet-max-pooling-2d-component.h
@@ -52,7 +52,7 @@ class MaxPooling2DComponent : public Component {
   void InitData(std::istream &is) {
     // parse config
     std::string token;
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token);
       /**/ if (token == "<FmapXLen>") ReadBasicType(is, false, &fmap_x_len_);
       else if (token == "<FmapYLen>") ReadBasicType(is, false, &fmap_y_len_);
@@ -62,7 +62,6 @@ class MaxPooling2DComponent : public Component {
       else if (token == "<PoolYStep>") ReadBasicType(is, false, &pool_y_step_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (FmapXLen|FmapYLen|PoolXLen|PoolYLen|PoolXStep|PoolYStep)";
-      is >> std::ws;  // eat-up whitespace
     }
     // check
     KALDI_ASSERT(fmap_x_len_ * fmap_y_len_ * pool_x_len_ * pool_y_len_ * pool_x_step_ * pool_y_step_  != 0);

--- a/src/nnet/nnet-max-pooling-component.h
+++ b/src/nnet/nnet-max-pooling-component.h
@@ -49,14 +49,13 @@ class MaxPoolingComponent : public Component {
   void InitData(std::istream &is) {
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token);
       /**/ if (token == "<PoolSize>") ReadBasicType(is, false, &pool_size_);
       else if (token == "<PoolStep>") ReadBasicType(is, false, &pool_step_);
       else if (token == "<PoolStride>") ReadBasicType(is, false, &pool_stride_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (PoolSize|PoolStep|PoolStride)";
-      is >> std::ws; // eat-up whitespace
     }
     // check
     KALDI_ASSERT(pool_size_ != 0 && pool_step_ != 0 && pool_stride_ != 0);

--- a/src/nnet/nnet-parallel-component.h
+++ b/src/nnet/nnet-parallel-component.h
@@ -70,7 +70,7 @@ class ParallelComponent : public UpdatableComponent {
     std::vector<std::string> nested_nnet_filename;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<NestedNnet>" || token == "<NestedNnetFilename>") {
         while(!is.eof()) {
@@ -88,7 +88,6 @@ class ParallelComponent : public UpdatableComponent {
         }
       } else KALDI_ERR << "Unknown token " << token << ", typo in config?"
                        << " (NestedNnet|NestedNnetFilename|NestedNnetProto)";
-      is >> std::ws; // eat-up whitespace
     }
     // initialize
     KALDI_ASSERT((nested_nnet_proto.size() > 0) ^ (nested_nnet_filename.size() > 0)); //xor

--- a/src/nnet/nnet-parallel-component.h
+++ b/src/nnet/nnet-parallel-component.h
@@ -42,6 +42,28 @@ class ParallelComponent : public UpdatableComponent {
   Component* Copy() const { return new ParallelComponent(*this); }
   ComponentType GetType() const { return kParallelComponent; }
 
+  void SetLearnRateCoef(BaseFloat val) {
+    for (int32 i=0; i<nnet_.size(); i++) {
+      for (int32 j=0; j<nnet_[i].NumComponents(); j++) {
+        if (nnet_[i].GetComponent(j).IsUpdatable()) {
+          UpdatableComponent& comp = dynamic_cast<UpdatableComponent&>(nnet_[i].GetComponent(j));
+          comp.SetLearnRateCoef(val);
+        }
+      }
+    }
+  }
+
+  void SetBiasLearnRateCoef(BaseFloat val) {
+    for (int32 i=0; i<nnet_.size(); i++) {
+      for (int32 j=0; j<nnet_[i].NumComponents(); j++) {
+        if (nnet_[i].GetComponent(j).IsUpdatable()) {
+          UpdatableComponent& comp = dynamic_cast<UpdatableComponent&>(nnet_[i].GetComponent(j));
+          comp.SetBiasLearnRateCoef(val);
+        }
+      }
+    }
+  }
+
   void InitData(std::istream &is) {
     // define options
     std::vector<std::string> nested_nnet_proto;

--- a/src/nnet/nnet-parallel-component.h
+++ b/src/nnet/nnet-parallel-component.h
@@ -151,9 +151,11 @@ class ParallelComponent : public UpdatableComponent {
     //
     WriteToken(os, binary, "<NestedNnetCount>");
     WriteBasicType(os, binary, nnet_count);
+    if(!binary) os << "\n";
     for (int32 i=0; i<nnet_count; i++) {
       WriteToken(os, binary, "<NestedNnet>");
       WriteBasicType(os, binary, i+1);
+      if(!binary) os << "\n";
       nnet_[i].Write(os, binary);
     }
     WriteToken(os, binary, "</ParallelComponent>");

--- a/src/nnet/nnet-rbm.h
+++ b/src/nnet/nnet-rbm.h
@@ -107,7 +107,7 @@ class Rbm : public RbmBase {
     std::string vis_bias_cmvn_file; // initialize biases to logit(p_active)
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<VisibleType>") ReadToken(is, false, &vis_type);
       else if (token == "<HiddenType>") ReadToken(is, false, &hid_type);
@@ -118,7 +118,6 @@ class Rbm : public RbmBase {
       else if (token == "<ParamStddev>") ReadBasicType(is, false, &param_stddev);
       else if (token == "<VisibleBiasCmvnFilename>") ReadToken(is, false, &vis_bias_cmvn_file);
       else KALDI_ERR << "Unknown token " << token << " Typo in config?";
-      is >> std::ws; // eat-up whitespace
     }
 
     //

--- a/src/nnet/nnet-sentence-averaging-component.h
+++ b/src/nnet/nnet-sentence-averaging-component.h
@@ -65,7 +65,6 @@ class SimpleSentenceAveragingComponent : public Component {
   void ReadData(std::istream &is, bool binary) {
     bool end_loop = false;
     while (!end_loop && '<' == Peek(is, binary)) {
-      std::string token;
       int first_char = PeekToken(is, binary);
       switch (first_char) {
         case 'G': ExpectToken(is, binary, "<GradientBoost>");

--- a/src/nnet/nnet-sentence-averaging-component.h
+++ b/src/nnet/nnet-sentence-averaging-component.h
@@ -72,7 +72,16 @@ class SimpleSentenceAveragingComponent : public Component {
     }
     if(PeekToken(is, binary) == 'O') {
       ExpectToken(is, binary, "<OnlySumming>");
-      ReadBasicType(is, binary, &only_summing_);
+      // compatibility trick, 
+      // in some models 'only_summing_' was float '0.0',
+      // from now 'only_summing_' is 'bool':
+      try {
+        ReadBasicType(is, binary, &only_summing_);
+      } catch(const std::exception &e) {
+        KALDI_WARN << "ERROR was handled by exception!";
+        BaseFloat dummy_float;
+        ReadBasicType(is, binary, &dummy_float);
+      }
     }
   }
 
@@ -137,7 +146,7 @@ class SimpleSentenceAveragingComponent : public Component {
 
 
 
-/** Deprecated, keeping it as Katka Zmolikova used it in JSALT 2015 */
+/** Deprecated!!!, keeping it as Katka Zmolikova used it in JSALT 2015 */
 class SentenceAveragingComponent : public UpdatableComponent {
  public:
   SentenceAveragingComponent(int32 dim_in, int32 dim_out) 

--- a/src/nnet/nnet-various.h
+++ b/src/nnet/nnet-various.h
@@ -340,7 +340,7 @@ class LengthNormComponent: public Component {
 class AddShift : public UpdatableComponent {
  public:
   AddShift(int32 dim_in, int32 dim_out)
-    : UpdatableComponent(dim_in, dim_out), shift_data_(dim_in), learn_rate_coef_(1.0)
+    : UpdatableComponent(dim_in, dim_out), shift_data_(dim_in)
   { }
   ~AddShift()
   { }
@@ -390,7 +390,8 @@ class AddShift : public UpdatableComponent {
   }
    
   std::string Info() const {
-    return std::string("\n  shift_data") + MomentStatistics(shift_data_);
+    return std::string("\n  shift_data") + MomentStatistics(shift_data_) +
+           ", lr-coef " + ToString(learn_rate_coef_);
   }
 
   std::string InfoGradient() const {
@@ -406,7 +407,7 @@ class AddShift : public UpdatableComponent {
 
   void BackpropagateFnc(const CuMatrixBase<BaseFloat> &in, const CuMatrixBase<BaseFloat> &out,
                         const CuMatrixBase<BaseFloat> &out_diff, CuMatrixBase<BaseFloat> *in_diff) {
-    //derivative of additive constant is zero...
+    // derivative of additive constant is zero...
     in_diff->CopyFromMat(out_diff);
   }
 
@@ -435,7 +436,6 @@ class AddShift : public UpdatableComponent {
  protected:
   CuVector<BaseFloat> shift_data_;
   CuVector<BaseFloat> shift_data_grad_;
-  BaseFloat learn_rate_coef_;
 };
 
 
@@ -447,7 +447,7 @@ class AddShift : public UpdatableComponent {
 class Rescale : public UpdatableComponent {
  public:
   Rescale(int32 dim_in, int32 dim_out)
-    : UpdatableComponent(dim_in, dim_out), scale_data_(dim_in), learn_rate_coef_(1.0)
+    : UpdatableComponent(dim_in, dim_out), scale_data_(dim_in)
   { }
   ~Rescale()
   { }
@@ -497,7 +497,8 @@ class Rescale : public UpdatableComponent {
   }
  
   std::string Info() const {
-    return std::string("\n  scale_data") + MomentStatistics(scale_data_);
+    return std::string("\n  scale_data") + MomentStatistics(scale_data_) +
+           ", lr-coef " + ToString(learn_rate_coef_);
   }
   
   std::string InfoGradient() const {
@@ -545,7 +546,6 @@ class Rescale : public UpdatableComponent {
  protected:
   CuVector<BaseFloat> scale_data_;
   CuVector<BaseFloat> scale_data_grad_;
-  BaseFloat learn_rate_coef_;
 };
 
 

--- a/src/nnet/nnet-various.h
+++ b/src/nnet/nnet-various.h
@@ -55,7 +55,7 @@ class Splice: public Component {
     std::vector<std::vector<int32> > build_vector;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<ReadVector>") {
         ReadIntegerVector(is, false, &frame_offsets);
@@ -74,7 +74,6 @@ class Splice: public Component {
         KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                   << " (ReadVector|BuildVector)";
       }
-      is >> std::ws; // eat-up whitespace
     }
 
     // build the vector, using <BuildVector> ... </BuildVector> inputs
@@ -169,7 +168,7 @@ class CopyComponent: public Component {
     std::vector<std::vector<int32> > build_vector;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<ReadVector>") {
         ReadIntegerVector(is, false, &copy_from_indices);
@@ -188,7 +187,6 @@ class CopyComponent: public Component {
         KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                   << " (ReadVector|BuildVector)";
       }
-      is >> std::ws; // eat-up whitespace
     }
 
     // build the vector, using <BuildVector> ... </BuildVector> inputs
@@ -353,13 +351,12 @@ class AddShift : public UpdatableComponent {
     float init_param = 0.0;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<InitParam>") ReadBasicType(is, false, &init_param);
       else if (token == "<LearnRateCoef>") ReadBasicType(is, false, &learn_rate_coef_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (InitParam)";
-      is >> std::ws; // eat-up whitespace
     }
     // initialize
     shift_data_.Resize(InputDim(), kSetZero); // set to zero
@@ -460,13 +457,12 @@ class Rescale : public UpdatableComponent {
     float init_param = 0.0;
     // parse config
     std::string token; 
-    while (!is.eof()) {
+    while (is >> std::ws, !is.eof()) {
       ReadToken(is, false, &token); 
       /**/ if (token == "<InitParam>") ReadBasicType(is, false, &init_param);
       else if (token == "<LearnRateCoef>") ReadBasicType(is, false, &learn_rate_coef_);
       else KALDI_ERR << "Unknown token " << token << ", a typo in config?"
                      << " (InitParam)";
-      is >> std::ws; // eat-up whitespace
     }
     // initialize
     scale_data_.Resize(InputDim(), kSetZero);

--- a/src/nnet/nnet-various.h
+++ b/src/nnet/nnet-various.h
@@ -40,9 +40,10 @@ namespace nnet1 {
  */
 class Splice: public Component {
  public:
-  Splice(int32 dim_in, int32 dim_out)
-    : Component(dim_in, dim_out)
+  Splice(int32 dim_in, int32 dim_out) :
+    Component(dim_in, dim_out)
   { }
+
   ~Splice()
   { }
 
@@ -153,9 +154,10 @@ class Splice: public Component {
  */
 class CopyComponent: public Component {
  public:
-  CopyComponent(int32 dim_in, int32 dim_out)
-    : Component(dim_in, dim_out)
+  CopyComponent(int32 dim_in, int32 dim_out) : 
+    Component(dim_in, dim_out)
   { }
+
   ~CopyComponent()
   { }
 
@@ -293,9 +295,10 @@ class CopyComponent: public Component {
  */
 class LengthNormComponent: public Component {
  public:
-  LengthNormComponent(int32 dim_in, int32 dim_out)
-    : Component(dim_in, dim_out)
+  LengthNormComponent(int32 dim_in, int32 dim_out) : 
+    Component(dim_in, dim_out)
   { }
+
   ~LengthNormComponent()
   { }
 
@@ -337,9 +340,10 @@ class LengthNormComponent: public Component {
  */
 class AddShift : public UpdatableComponent {
  public:
-  AddShift(int32 dim_in, int32 dim_out)
-    : UpdatableComponent(dim_in, dim_out), shift_data_(dim_in)
+  AddShift(int32 dim_in, int32 dim_out) : 
+    UpdatableComponent(dim_in, dim_out), shift_data_(dim_in)
   { }
+
   ~AddShift()
   { }
 
@@ -443,9 +447,11 @@ class AddShift : public UpdatableComponent {
  */
 class Rescale : public UpdatableComponent {
  public:
-  Rescale(int32 dim_in, int32 dim_out)
-    : UpdatableComponent(dim_in, dim_out), scale_data_(dim_in)
+  Rescale(int32 dim_in, int32 dim_out) : 
+    UpdatableComponent(dim_in, dim_out), 
+    scale_data_(dim_in)
   { }
+
   ~Rescale()
   { }
 

--- a/src/nnetbin/Makefile
+++ b/src/nnetbin/Makefile
@@ -16,7 +16,7 @@ BINFILES = nnet-train-frmshuff \
         transf-to-nnet cmvn-to-nnet nnet-initialize \
         nnet-kl-hmm-acc nnet-kl-hmm-mat-to-component \
 	feat-to-post paste-post train-transitions \
-	cuda-gpu-available
+	cuda-gpu-available nnet-set-learnrate
 
 OBJFILES =
 

--- a/src/nnetbin/nnet-set-learnrate.cc
+++ b/src/nnetbin/nnet-set-learnrate.cc
@@ -1,0 +1,92 @@
+// nnetbin/nnet-set-learnrate.cc
+
+// Copyright 2016 Brno University of Technology (Author: Katerina Zmolikova, Karel Vesely)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/common-utils.h"
+#include "nnet/nnet-nnet.h"
+#include "nnet/nnet-component.h"
+#include "nnet/nnet-affine-transform.h"
+#include "nnet/nnet-activation.h"
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::nnet1;
+    typedef kaldi::int32 int32;
+
+    const char *usage = 
+      "Sets learning rate coefficient inside of 'nnet1' model\n"
+      "Usage: nnet-set-learnrate --components=<csl> --coef=<float> <nnet-in> <nnet-out>\n";
+
+    ParseOptions po(usage);
+    bool binary = true;
+    po.Register("binary", &binary, "Write output in binary mode");   
+
+    std::string components_str = "";
+    po.Register("components", &components_str, 
+        "Select components by csl, starts from 1. Layout as in the 'nnet-info' output, (example 1:2:3)");
+    
+    float coef = 1.0, weight_coef = 1.0, bias_coef = 1.0;
+    po.Register("coef", &coef, "Learn-rate coefficient for both weight matrices and biases.");
+    po.Register("weight-coef", &weight_coef, "Learn-rate coefficient for weight matrices.");
+    po.Register("bias-coef", &bias_coef, "Learn-rate coefficient for bias.");
+
+    po.Read(argc, argv);
+    
+    if (po.NumArgs() != 2) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    std::string nnet_in_filename = po.GetArg(1), 
+      nnet_out_filename = po.GetArg(2);
+
+    Nnet nnet;
+    nnet.Read(nnet_in_filename);
+
+    // A vector which contains indices of components,
+    // where we will set the 'learn-rate coefficients',
+    std::vector<int32> components;
+    if (components_str == "") {
+      // select all the components (1..Ncomp),
+      for (int32 i=1; i<=nnet.NumComponents(); i++) {
+        components.push_back(i);
+      }
+    } else {
+      // select only some components,
+      kaldi::SplitStringToIntegers(components_str, ":", false, &components);
+    }
+
+    // Setting the learning rate coefficients,
+    for (int32 i=0; i<components.size(); i++) {
+      if (nnet.GetComponent(components[i]-1).IsUpdatable()) {
+        UpdatableComponent& comp = dynamic_cast<UpdatableComponent&>(nnet.GetComponent(components[i]-1));
+        comp.SetLearnRateCoef(coef * weight_coef); // lr. coef for weight matrices,
+        comp.SetBiasLearnRateCoef(coef * bias_coef); // lr. coef for biases,
+      }
+    }
+
+    // Write the component,  
+    nnet.Write(nnet_out_filename, binary); 
+    
+    return 0;
+  } catch(const std::exception &e) {
+    return -1;
+  }
+}
+


### PR DESCRIPTION
- @Dan, @Yenda : this is a somewhat bigger change in 'nnet1', so I felt it appropriate to integrate it via a pull request. You can go through the code if you like, while it might not be necessary as it concerns the nnet1 code only.

- new tool 'nnet-set-learnrate', sets the scalar to individual components or whole Nnet.
- learn_rate_coef_, bias_learn_rate_coef_ is now part of interface UpdatableComponent, each component responsible to store it.
- many components are now reading <Tokens> in arbitrary order at ReadData(...), this will be good for backward-compatibility with old models when new <Tokens> are added.
- (planning to better follow the Google coding standard, this is not part of this pull-request)