### PR TITLE
haihua's nnet1 multilingual training recipe

### DIFF
--- a/egs/rm/s5/local/nnet/run-multilingual.sh
+++ b/egs/rm/s5/local/nnet/run-multilingual.sh
@@ -1,0 +1,393 @@
+#!/bin/bash
+
+# Copyright 2015  University of Illinois (Author: Amit Das)
+# Copyright 2012-2015  Brno University of Technology (Author: Karel Vesely)
+
+# Apache 2.0
+
+# This example script trains Multi-lingual DNN with <BlockSoftmax> output, using FBANK features.
+# The network is trained on multiple languages simultaneously, creating a separate softmax layer
+# per language while sharing hidden layers across all languages.
+# The script supports arbitrary number of languages.
+
+. path.sh
+. cmd.sh
+
+echo
+echo "## LOG: $0 $@"
+echo
+# begin options
+cmd=run.pl
+nj=40
+steps=
+validating_rate=0.1
+pretrain_rate=0.2
+learn_rate=0.008
+train_tool=nnet-train-frmshuff-mling
+train_tool_opts="--minibatch-size=2048 --randomizer-size=32768 --randomizer-seed=777"
+train_opts="--nn-depth 6 --hid-dim 2048 --splice 10"
+pretrain_cmd="steps/nnet/pretrain_dbn.sh --feat-type traps  --copy_feats_tmproot /local/hhx502"
+dnn_nnet_init=
+train_cmd="steps/nnet/train.sh --copy_feats_tmproot /local/hhx502"
+cmvn_opts="--norm-means=true --norm-vars=true"
+delta_opts="--delta-order=2"
+
+bn1_dim=80
+train_part1_cmd="steps/nnet/train.sh --hid-dim 1500 --hid-layers 2 --feat-type traps --splice 5"
+bnfe_nnet_init=
+bn2_dim=30
+train_part2_cmd="steps/nnet/train.sh --hid-layers 2 --hid-dim 1500"
+
+# end options
+
+. parse_options.sh  || exit 1
+
+function Usage {
+ cat<<END
+
+ Usage $(basename $0) [options] <lang_code_csl> <lang_weight_csl> <ali_dir_csl> <data_dir_csl> <tgtdir>
+ [options]:
+ --cmd                                  # value, "$cmd"
+ --steps                                # value, "$steps"
+ --validating-rate                      # value, "$validating_rate"
+ --pretrain-rate                        # value, $pretrain_rate
+ --learn-rate                           # value, $learn_rate
+ --train-tool-opts                      # value, "$train_tool_opts"
+ --train-opts                           # value, "$train_opts"
+ --pretrain-cmd                         # value, "$pretrain_cmd"
+ --dnn-nnet-init                        # value, "$dnn_nnet_init"
+ --train-cmd                            # value, "$train_cmd"
+ --cmvn-opts                            # value, "$cmvn_opts"
+ --delta-opts                           # value, "$delta_opts"
+
+ --bn1-dim                              # value, $bn1_dim
+ --train-part1-cmd                      # value, "$train_part1_cmd"
+ --bnfe-nnet-init                       # value, "$bnfe_nnet_init"
+ --bn2-dim                              # value, $bn2_dim
+ --train-part2-cmd                      # value, "$train_part2_cmd"
+ [steps]: 
+ 1: prepare features
+ 2: prepare targets
+ 3: pretraining
+ 4: dnn training
+ 5: train part1 bnf extractor
+ 6: prepare feature_transform for part2 bnf extractor
+ 7: train part2 bnf extractor
+ 
+ 8: make target label (splitting method)
+ 9: make mling_opts_csl for dnn (go back to step3 for pretraining)
+ 10: train mling dnn (splitting method)
+ 
+ 11: make mling_opts_csl for bnfe1
+ 12: train bnfe1 (go back to step6)
+ 13: make mling_opts_csl for bnfe2
+ 14: train bnfe2
+
+ [example]:
+ 
+ $0 --steps 4  cant,assa,beng,pashto \
+     1.0,1.0,1.0,1.0 \
+     /home2/hhx502/kws2016/babel101b-v0.4c-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel102b-v0.5a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel103b-v0.4b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel104b-v0.4bY-build/exp/tri4a/ali_merge-train \
+    /home2/hhx502/kws2016/babel101b-v0.4c-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel102b-v0.5a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel103b-v0.4b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel104b-v0.4bY-build/data/merge_train/fbank-pitch   \
+ /home2/hhx502/kws2016/mling4-test
+
+$0 --steps 1,8,3,9,10 cant,pash,turk,taga,viet 1.0,1.0,1.0,1.0,1.0 \
+../w2015/monoling/cant101/llp2/exp/tri4a/ali_train,../w2015/monoling/pash104/llp2/exp/tri4a/ali_train,../w2015/monoling/turk105/llp2/exp/tri4a/ali_train,../w2015/monoling/taga106/llp2/exp/tri4a/ali_train,../w2015/monoling/viet107/llp2/exp/tri4a/ali_train \
+../w2015/monoling/cant101/llp2/data/train/fbank-pitch,../w2015/monoling/pash104/llp2/data/train/fbank-pitch,../w2015/monoling/turk105/llp2/data/train/fbank-pitch,../w2015/monoling/taga106/llp2/data/train/fbank-pitch,../w2015/monoling/viet107/llp2/data/train/fbank-pitch \
+kws2016/llp2-mling/exp/mling5-test
+
+$0 --steps 1,2,3,4  cant,assa,beng,pash,turk,taga,viet,hait,swah,lao,tami,kurm,zulu,tokp,cebu,kaza,telu,lith,guar,igbu,amha,mong,java,dhol \
+1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0 \
+/home2/hhx502/kws2016/babel101b-v0.4c-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel102b-v0.5a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel103b-v0.4b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel104b-v0.4bY-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel105b-v0.5-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel106b-v0.2g-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel107b-v0.7-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel201b-v0.2b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel202b-v1.0d-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel203b-v3.1a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel204b-v1.1b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel205b-v1.0a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel206b-v0.1e-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel207b-v1.0e-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel301b-v2.0b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel302b-v1.0a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel303b-v1.0a-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel304b-v1.0b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel305b-v1.0c-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel306b-v2.0c-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel307b-v1.0b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel401b-v2.0b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel402b-v1.0b-build/exp/tri4a/ali_merge-train,/home2/hhx502/kws2016/babel403b-v1.0b-build/exp/tri4a/ali_merge-train \
+/home2/hhx502/kws2016/babel101b-v0.4c-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel102b-v0.5a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel103b-v0.4b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel104b-v0.4bY-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel105b-v0.5-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel106b-v0.2g-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel107b-v0.7-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel201b-v0.2b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel202b-v1.0d-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel203b-v3.1a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel204b-v1.1b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel205b-v1.0a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel206b-v0.1e-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel207b-v1.0e-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel301b-v2.0b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel302b-v1.0a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel303b-v1.0a-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel304b-v1.0b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel305b-v1.0c-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel306b-v2.0c-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel307b-v1.0b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel401b-v2.0b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel402b-v1.0b-build/data/merge_train/fbank-pitch,/home2/hhx502/kws2016/babel403b-v1.0b-build/data/merge_train/fbank-pitch \
+/home2/hhx502/kws2016/mling24
+
+END
+}
+
+if [ $# -ne 5 ]; then
+  echo "## lOG: $0 $@"
+  Usage && exit 1
+fi
+lang_code_csl=$1
+lang_weight_csl=$2
+ali_dir_csl=$3
+data_dir_csl=$4
+tgtdir=$5
+
+if [ ! -z "$steps" ]; then
+  for x in $(echo $steps|sed 's/[,:]/ /g'); do
+    index=$(printf "%02d" $x);
+    declare step$index=1
+  done
+fi
+
+## set -euxo pipefail
+pretrain_cmd="$pretrain_cmd $train_opts"
+[ ! -z $dnn_nnet_init ] && pretrain_cmd="$pretrain_cmd --only-feature-transform true"
+train_cmd="$train_cmd --learn-rate $learn_rate"
+train_part1_cmd="$train_part1_cmd --learn-rate $learn_rate --bn-dim $bn1_dim"
+train_part2_cmd="$train_part2_cmd --learn-rate $learn_rate --bn-dim $bn2_dim"
+# Convert 'csl' to bash array (accept separators ',' ':'),
+lang_code=($(echo $lang_code_csl | tr ',:' ' ')) 
+ali_dir=($(echo $ali_dir_csl | tr ',:' ' '))
+data_dir=($(echo $data_dir_csl | tr ',:' ' '))
+
+# Make sure we have same number of items in lists,
+! [ ${#lang_code[@]} -eq ${#ali_dir[@]} -a ${#lang_code[@]} -eq ${#data_dir[@]} ] && \
+  echo "## ERROR, Non-matching number of 'csl' items: lang_code ${#lang_code[@]}, ali_dir ${ali_dir[@]}, data_dir ${#data_dir[@]}" && \
+  exit 1
+num_langs=${#lang_code[@]}
+# Check if all the input directories exist,
+for i in $(seq 0 $[num_langs-1]); do
+  echo "lang = ${lang_code[$i]}, alidir = ${ali_dir[$i]}, datadir = ${data_dir[$i]}"
+  [ ! -d ${ali_dir[$i]} ] && echo  "Missing ${ali_dir[$i]}" && exit 1
+  [ ! -d ${data_dir[$i]} ] && echo "Missing ${data_dir[$i]}" && exit 1
+done
+data=$tgtdir/data-resource
+train_data=$data/combined-tr$validating_rate
+cv_data=$data/combined-cv$validating_rate
+pretrain_data=$data/combined-pretrain$pretrain_rate
+if [ ! -z $step01 ]; then
+  echo "## LOG: prepare data started @ `date`"
+  train_x=""
+  cv_x=""
+  for i in $(seq 0 $[num_langs-1]);do
+    code=${lang_code[$i]}
+    sdata1=${data_dir[$i]}
+    sdata=$data/$code
+    utils/copy_data_dir.sh --utt-prefix ${code}_ --spk-prefix ${code}_ $sdata1 $sdata
+    cur_tr=$data/${code}_train
+    cur_cv=$data/${code}_cv
+    echo "sdata=$sdata, cur_tr=$cur_tr, cur_cv=$cur_cv"
+    local/nnet/subset_data.sh --subset_time_ratio $validating_rate \
+    --random true \
+    --data2 $cur_tr \
+    $sdata  $cur_cv || exit 1
+    cat $cur_tr/utt2spk | awk -v c=$code '{$2=c; print;}' > $cur_tr/utt2lang
+    cat $cur_cv/utt2spk | awk -v c=$code '{$2=c; print;}' > $cur_cv/utt2lang
+    train_x="$train_x $cur_tr"
+    cv_x="$cv_x $cur_cv"
+  done
+  # Merge the datasets
+  utils/combine_data.sh $train_data $train_x
+  utils/combine_data.sh $cv_data $cv_x
+  # Validate
+  utils/validate_data_dir.sh $train_data
+  utils/validate_data_dir.sh $cv_data
+  local/nnet/subset_data.sh --subset_time_ratio $pretrain_rate \
+  --random true \
+  $train_data  $pretrain_data || exit 1
+  echo "## LOG: data preparation done @ `date`"
+fi
+
+# Extract the tied-state numbers from transition models,
+for i in $(seq 0 $[num_langs-1]); do
+  ali_dim[i]=$(hmm-info ${ali_dir[i]}/final.mdl | grep pdfs | awk '{ print $NF }')
+done
+ali_dim_csl=$(echo ${ali_dim[@]} | tr ' ' ',')
+echo "## LOG: ali_dim_csl=$ali_dim_csl"
+
+# Total number of DNN outputs (sum of all per-language blocks),
+output_dim=$(echo ${ali_dim[@]} | tr ' ' '\n' | awk '{ sum += $i; } END{ print sum; }')
+echo "## LOG: Total number of DNN outputs: $output_dim = $(echo ${ali_dim[@]} | sed 's: : + :g')"
+
+# Objective function string (per-language weights are imported from '$lang_weight_csl'),
+objective_function="multitask$(echo ${ali_dim[@]} | tr ' ' '\n' | \
+  awk -v w=$lang_weight_csl 'BEGIN{ split(w,w_arr,/[,:]/); } { printf(",xent,%d,%s", $1, w_arr[NR]); }')"
+echo "## LOG: Multitask objective function: $objective_function"
+
+tgtalidir=$data/ali-post
+if [ ! -z $step02 ]; then
+  echo "## LOG: prepare to merge the targets started @ `date`"
+  [ -d $tgtalidir ] || mkdir -p $tgtalidir
+  # re-saving the ali in posterior format, indexed by 'scp',
+  for i in $(seq 0 $[num_langs-1]); do
+    code=${lang_code[$i]}
+    ali=${ali_dir[$i]}
+    # utt suffix added by 'awk',
+    ali-to-pdf $ali/final.mdl "ark:gunzip -c ${ali}/ali.*.gz |" ark,t:- | awk -v c=$code '{ $1=c"_"$1; print $0; }' | \
+    ali-to-post ark:- ark,scp:$tgtalidir/$code.ark,$tgtalidir/$code.scp
+  done
+  # pasting the ali's, adding language-specific offsets to the posteriors,
+  featlen="ark:feat-to-len 'scp:cat $train_data/feats.scp $cv_data/feats.scp |' ark,t:- |" # get number of frames for every utterance,
+  post_scp_list=$(echo ${lang_code[@]} | tr ' ' '\n' | awk -v d=$tgtalidir '{ printf(" scp:%s/%s.scp", d, $1); }')
+  paste-post --allow-partial=true "$featlen" "${ali_dim_csl}" ${post_scp_list} \
+    ark,scp:$tgtalidir/combined.ark,$tgtalidir/combined.scp
+  echo "## LOG: targets merging ended @ `date`"
+fi
+if [ ! -z $step08 ]; then
+  echo "## LOG: step08, combine post @ `date`"
+  [ -d $tgtalidir ] || mkdir -p $tgtalidir
+  # re-saving the ali in posterior format, indexed by 'scp',
+  for i in $(seq 0 $[num_langs-1]); do
+    code=${lang_code[$i]}
+    ali=${ali_dir[$i]}
+    # utt suffix added by 'awk',
+    ali-to-pdf $ali/final.mdl "ark:gunzip -c ${ali}/ali.*.gz |" ark,t:- | awk -v c=$code '{ $1=c"_"$1; print $0; }' | \
+    ali-to-post ark:- ark,scp:$tgtalidir/$code.ark,$tgtalidir/$code.scp
+  done
+  # pasting the ali's, adding language-specific offsets to the posteriors,
+  featlen="ark:feat-to-len 'scp:cat $train_data/feats.scp $cv_data/feats.scp |' ark,t:- |" # get number of frames for every utterance,
+  post_scp_list=$(echo ${lang_code[@]} | tr ' ' '\n' | awk -v d=$tgtalidir '{ printf(" scp:%s/%s.scp", d, $1); }')
+  paste-post --allow-partial=true --no-merge=true "$featlen" "${ali_dim_csl}" ${post_scp_list} \
+  ark,scp:$tgtalidir/combined-label.ark,$tgtalidir/combined-label.scp
+  echo "## LOG: step08, done @ `date`"
+fi
+nn_depth=$(echo "$train_opts" | perl -pe 'if(m/--nn-depth\s+(\d+)/){$_=$1;}else{exit 1;}')
+hid_dim=$(echo "$train_opts" | perl -pe 'if(m/--hid-dim\s+(\d+)/){$_=$1;}else{exit 1;}')
+nnet_dir=$tgtdir/dnn-m${num_langs}-layers$nn_depth
+dbn=$tgtdir/pretrain_dbn/${nn_depth}.dbn
+feature_transform=$tgtdir/pretrain_dbn/final.feature_transform
+nnet_init=$nnet_dir/nnet.init
+if [ ! -z $step03 ]; then
+  echo "## LOG: pretraining started @ `date`"
+  $pretrain_cmd --delta-opts $delta_opts --cmvn-opts "$cmvn_opts" \
+  $pretrain_data $tgtdir/pretrain_dbn
+  echo "## LOG: done @ `date`"
+fi
+function make_mling_opts_csl {
+  local x_dir=$1
+  local x_hid_dim=$2
+  for i in $(seq 0 $[num_langs-1]); do
+    code=${lang_code[i]}
+    local tgt_num=${ali_dim[i]}
+    local curdir=$x_dir/$code
+    [ -d $curdir ] || mkdir -p $curdir
+    utils/nnet/make_nnet_proto.py $x_hid_dim $tgt_num 0 $x_hid_dim > $curdir/nnet.proto
+    nnet-initialize $curdir/nnet.proto $curdir/nnet.init
+    mnet_dir[i]="$curdir/nnet.init"
+  done
+  mnet_dir_csl=$(echo "${mnet_dir[*]}" | tr ' ' ',')
+  [ -f $x_dir/utt2lang ] || \
+  cat $train_data/utt2lang $cv_data/utt2lang > $x_dir/utt2lang
+  mling_opts_csl="ark:$x_dir/utt2lang;$lang_code_csl;$mnet_dir_csl"
+  echo "$lang_code_csl" >$x_dir/lang_code_csl
+  echo "$ali_dir_csl" >$x_dir/ali_dir_csl
+  echo "$data_dir_csl" >$x_dir/data_dir_csl
+  echo "$ali_dim_csl" >$x_dir/ali_dim_csl
+}
+if [ ! -z $step09 ]; then
+  echo "## LOG: step09, make language dependent softmax nnet @ `date`"
+  make_mling_opts_csl $nnet_dir $hid_dim
+  x_nnet_init=$nnet_dir/${lang_code[0]}/nnet.init
+  [ -f $x_nnet_init ] || { echo "## ERROR: step09, file $x_nnet_init expected"; exit 1; }
+  if [ -z $dnn_nnet_init ]; then
+    nnet-concat $dbn  $x_nnet_init $nnet_init
+  else
+    nnet_init=$dnn_nnet_init
+  fi
+  echo "## LOG: step09, mling_opts_csl=$mling_opts_csl"
+  echo "## LOG: step09, done @ `date`"
+fi
+if [ ! -z $step10 ]; then
+  echo "## LOG: step10, train mling dnn @ `date`"
+  for x in $nnet_init $feature_transform; do
+    [ -e $x ] || { echo "ERROR: step10, $x expected"; exit 1; }
+  done
+  if [ ! -f $nnet_dir/nnet.init ]; then
+    srcnnet=$(cd $(dirname $nnet_init); pwd)/$(basename $nnet_init)
+    (cd $nnet_dir; ln -s $srcnnet nnet.init)
+  fi
+  $train_cmd  --nnet-init $nnet_init  \
+        --copy-feats true \
+        --feature-transform $feature_transform \
+        --train-tool $train_tool \
+        --train-tool-opts  "$train_tool_opts" \
+        --schedule-cmd "steps/nnet/train_scheduler_mling.sh" \
+        --mling-opts "$mling_opts_csl" \
+        --labels "scp:$tgtalidir/combined-label.scp" \
+        ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $nnet_dir
+
+  echo "## LOG: step10, ended @ `date`"
+fi
+if [ ! -z $step04 ]; then
+  echo "## LOG: train multilingual dnn started @ `date`"
+   $train_cmd  --hid-dim $hid_dim  \
+        --feature-transform $feature_transform \
+        --train-tool-opts  "$train_tool_opts" \
+        --hid-layers 0 --dbn $dbn \
+        --labels "scp:$tgtalidir/combined.scp" --num-tgt $output_dim \
+        --proto-opts "--block-softmax-dims=${ali_dim_csl}" \
+        --train-tool "nnet-train-frmshuff --objective-function=$objective_function" \
+        ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $nnet_dir
+  echo "## LOG: ended @ `date`"
+fi
+dir_part1=$tgtdir/bnf-extractor-part1
+if [ ! -z $step05 ]; then
+  echo "## LOG: train 1st bnf extractor started @ `date`"
+  $train_part1_cmd --cmvn-opts "$cmvn_opts" --delta-opts $delta_opts \
+  --train-tool-opts "$train_tool_opts" \
+  --labels "scp:$tgtalidir/combined.scp" --num-tgt $output_dim \
+  --proto-opts "--block-softmax-dims=${ali_dim_csl}" \
+  --train-tool "nnet-train-frmshuff --objective-function=$objective_function" \
+  ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $dir_part1
+  echo "## LOG: train 1st ended @ `date`"
+fi
+
+if [ ! -z $step11 ]; then
+  echo "## LOG: step11, make language dependent softmax nnet (bnf) @ `date`"
+  bnfe_hid_dim=$(echo "$train_part1_cmd" | perl -pe 'chomp; if(/--hid-dim\s+(\d+)\s+/) {$_=$1;}')
+  make_mling_opts_csl $dir_part1 $bnfe_hid_dim
+  echo "## LOG: step11, mling_opts_csl=$mling_opts_csl done @ `date`"
+fi
+if [ ! -z $step12 ]; then
+  echo "## LOG: step12, train 1st bnf extractor @ `date`"
+  if [ ! -f $dir_part1/nnet.init ] && [ ! -z $bnfe_nnet_init ]; then
+    srcnnet=$(cd $(dirname $bnfe_nnet_init); pwd)/$(basename $bnfe_nnet_init)
+    (cd $dir_part1; ln -s $srcnnet nnet.init)
+    bnfe_nnet_init=$dir_part1/nnet.init
+  fi
+  $train_part1_cmd --cmvn-opts "$cmvn_opts" --delta-opts $delta_opts \
+  --schedule-cmd "steps/nnet/train_scheduler_mling.sh" \
+  --mling-opts "$mling_opts_csl" \
+  --train-tool-opts "$train_tool_opts" \
+  ${bnfe_nnet_init:+ --nnet-init $bnfe_nnet_init} \
+  --labels "scp:$tgtalidir/combined-label.scp" --no-hmm-info true --num-tgt ${ali_dim[0]} \
+  --train-tool $train_tool\
+  ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $dir_part1
+
+  echo "## LOG: step12, done @ `date`"
+fi
+feature_transform=$dir_part1/final.feature_transform.part1
+if [ ! -z $step06 ]; then
+  echo "## LOG: prepare feature transform for 2nd part @ `date`"
+  # Compose feature_transform for 2nd part,
+  nnet-initialize <(echo "<Splice> <InputDim> $bn1_dim <OutputDim> $((13*bn1_dim)) <BuildVector> -10 -5:5 10 </BuildVector>") \
+  $dir_part1/splice_for_bottleneck.nnet 
+  nnet-concat $dir_part1/final.feature_transform "nnet-copy --remove-last-layers=4 $dir_part1/final.nnet - |" \
+  $dir_part1/splice_for_bottleneck.nnet $feature_transform
+  echo "## LOG: done @ `date`"
+fi
+dir_part2=$tgtdir/bnf-extractor-part2
+if [ ! -z $step07 ]; then
+  echo "## LOG: train 2nd bnf extractor @ `date`"
+  $train_part2_cmd  \
+  --feature-transform $feature_transform \
+  --train-tool-opts  "$train_tool_opts" \
+  --labels "scp:$tgtalidir/combined.scp" --num-tgt $output_dim \
+  --proto-opts "--block-softmax-dims=${ali_dim_csl}" \
+  --train-tool "nnet-train-frmshuff --objective-function=$objective_function" \
+  ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $dir_part2
+  echo "## LOG: done @ `date`"
+fi
+if [ ! -z $step13 ]; then
+  echo "## LOG: step13, make multi-softmax nnet (bnf) @ `date`"
+  bnfe_hid_dim=$(echo "$train_part2_cmd" | perl -pe 'chomp; if(/--hid-dim\s+(\d+)\s+/) {$_=$1;}')
+  echo "## LOG: step13, bnfe_hid_dim=$bnfe_hid_dim"
+  make_mling_opts_csl $dir_part2 $bnfe_hid_dim
+  echo "## LOG: step13, mling_opts_csl=$mling_opts_csl done @ `date`"
+fi
+
+if [ ! -z $step14 ]; then
+  echo "## LOG: step14, train 2nd bnf extractor @ `date`"
+  $train_part2_cmd  \
+  --feature-transform $feature_transform \
+  --schedule-cmd "steps/nnet/train_scheduler_mling.sh" \
+  --mling-opts "$mling_opts_csl" \
+  --train-tool-opts  "$train_tool_opts" \
+  --labels "scp:$tgtalidir/combined-label.scp" --no-hmm-info true  --num-tgt ${ali_dim[0]} \
+  --train-tool "$train_tool" \
+  ${train_data} ${cv_data} lang-dummy ali-dummy ali-dummy $dir_part2
+  echo "## LOG: step14, done @ `date`"
+fi

--- a/egs/rm/s5/local/nnet/subset_data.sh
+++ b/egs/rm/s5/local/nnet/subset_data.sh
@@ -1,0 +1,98 @@
+#!/bin/bash 
+
+# begin options
+exclude_uttlist=
+subset_time_ratio=0.1
+random=false
+data2=
+# end options
+function print_options {
+  echo 
+  echo "Select subset data from the source data, data2 is optional, and"
+  echo "it is complementary with the data, taking sdata as the super set."
+  echo
+  echo "Usage: $0 [options] <sdata> <data>"
+cat<<END
+
+ [options]:
+ --exclude-uttlist			# value, "$exclude_uttlist"
+ --subset_time_ratio			# value, $subset_time_ratio
+ --random				# value, $random
+ --data2				# value, "$data2"
+END
+}
+
+. utils/parse_options.sh || \
+{ echo "$0: ERROR, utils/parse_options.sh expected"; exit 1; }
+
+if [ $# -lt 2 ]; then
+  print_options
+  exit 1
+fi
+
+sdata=$1
+data=$2
+
+for x in $sdata/{segments,utt2spk}; do
+  [ -f $x ] || { echo "$0: ERROR, file $x expected"; exit 1; }
+done
+[ -d $data ] || mkdir -p $data
+if [ ! -z $exclude_uttlist ]; then
+  cat $sdata/segments | \
+  perl -e '($uttlist) = @ARGV;
+    open(U, "$uttlist") or die;
+    while(<U>) {
+      chomp; @A = split(" "); $uttName = $A[0];
+      $vocab{$uttName} ++;
+    }  close U;
+    while(<STDIN>) {
+      chomp;
+      @A = split(" "); $uttName = $A[0];
+      if(not exists $vocab{$uttName}) {
+        print $_."\n";
+      }
+    }
+  '  $exclude_uttlist  > $data/.uttlist
+  numLine=$(wc -l < $data/.uttlist)
+  if [ $numLine -eq 0 ]; then
+    echo "ERROR, zero utterance extracted" && exit 1
+  fi
+  echo "$numLine utterances are extracted"
+  utils/subset_data_dir.sh --utt-list $data/.uttlist  $sdata $data
+  echo "Done !" && exit 0
+fi
+[ ! -z $data2 ] &&  mkdir -p $data2
+
+x=$subset_time_ratio
+if [ $(bc -l <<< "$x < 1 && $x > 0") -ne 1 ]; then
+  echo "$0: ERROR, subset_time_ratio($subset_time_ratio) should be (0, 1)" && exit 1
+fi
+
+tot_hour=$(cat $sdata/segments| awk '{x+=$4-$3;}END{print x/3600;}')
+sel_hour=$(perl -e "print $tot_hour*$subset_time_ratio")
+echo "$0: tot_hour=$tot_hour, sel_hour=$sel_hour"
+super_utt2spk=$sdata/utt2spk
+if $random; then
+  super_utt2spk_new=$data/.feats_shuffled.scp
+  cat $super_utt2spk | \
+  perl -MList::Util -e 'print List::Util::shuffle <>' > $super_utt2spk_new
+  line_num_new=$(wc -l < $super_utt2spk_new)
+  [ -z $line_num_new ] && \
+  { echo "$0: ERROR, file $super_utt2spk_new is failed to generate"; exit 1; }
+  line_num=$(wc -l < $super_utt2spk)
+  [ $line_num_new -eq $line_num ] || \
+  { echo "$0: ERROR, original lines: $line_num ($super_utt2spk), new lines: $line_num_new($super_utt2spk_new), are mismatched"; exit 1; }
+  super_utt2spk=$super_utt2spk_new
+fi
+uttlist2=/dev/null
+[ ! -z $data2 ] && uttlist2=$data2/uttlist
+cat $super_utt2spk | \
+source/egs/swahili/subset_lines.pl $sel_hour $sdata/segments $data/uttlist \
+>$uttlist2
+utils/subset_data_dir.sh --utt-list $data/uttlist  $sdata $data
+[ ! -z $data2 ] && \
+utils/subset_data_dir.sh --utt-list $data2/uttlist $sdata  $data2
+
+echo "$0: Done !"
+
+

--- a/egs/wsj/s5/steps/nnet/train_scheduler_mling.sh
+++ b/egs/wsj/s5/steps/nnet/train_scheduler_mling.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+# Copyright 2012-2015  Brno University of Technology (author: Karel Vesely)
+# Apache 2.0
+
+# Schedules epochs and controls learning rate during the neural network training
+
+# Begin configuration.
+
+# training options,
+learn_rate=0.008
+momentum=0
+l1_penalty=0
+l2_penalty=0
+
+# data processing,
+train_tool="nnet-train-frmshuff"
+train_tool_opts="--minibatch-size=256 --randomizer-size=32768 --randomizer-seed=777"
+feature_transform=
+mling_opts=
+# learn rate scheduling,
+max_iters=20
+min_iters=0 # keep training, disable weight rejection, start learn-rate halving as usual,
+keep_lr_iters=0 # fix learning rate for N initial epochs, disable weight rejection,
+start_halving_impr=0.01
+end_halving_impr=0.001
+halving_factor=0.5
+
+# misc,
+verbose=1
+frame_weights=
+utt_weights=
+ 
+# End configuration.
+
+echo "$0 $@"  # Print the command line for logging
+[ -f path.sh ] && . ./path.sh; 
+
+. parse_options.sh || exit 1;
+
+set -euo pipefail
+
+if [ $# != 6 ]; then
+   echo "Usage: $0 <mlp-init> <feats-tr> <feats-cv> <labels-tr> <labels-cv> <exp-dir>"
+   echo " e.g.: $0 0.nnet scp:train.scp scp:cv.scp ark:labels_tr.ark ark:labels_cv.ark exp/dnn1"
+   echo "main options (for others, see top of script file)"
+   echo "  --config <config-file>  # config containing options"
+   exit 1;
+fi
+
+mlp_init=$1
+feats_tr=$2
+feats_cv=$3
+labels_tr=$4
+labels_cv=$5
+dir=$6
+
+[ ! -d $dir ] && mkdir $dir
+[ ! -d $dir/log ] && mkdir $dir/log
+[ ! -d $dir/nnet ] && mkdir $dir/nnet
+
+# Skip training
+[ -e $dir/final.nnet ] && echo "'$dir/final.nnet' exists, skipping training" && exit 0
+
+##############################
+# start training
+
+# choose mlp to start with,
+mlp_best=$mlp_init
+mlp_base=${mlp_init##*/}; mlp_base=${mlp_base%.*}
+
+# optionally resume training from the best epoch, using saved learning-rate,
+[ -e $dir/.mlp_best ] && mlp_best=$(cat $dir/.mlp_best)
+[ -e $dir/.learn_rate ] && learn_rate=$(cat $dir/.learn_rate)
+if [ ! -z "$mling_opts" ]; then
+  base_mling_opts=$(echo "$mling_opts" | perl -pe 'chomp; @A=split(/[;]/); $_= "$A[0];$A[1]";')
+  read_path_csl=""
+  path_csl=""
+  for path in $(echo "$mling_opts" | perl -pe 'chomp; @A=split(/[;]/); $A[2] =~ s/,/ /g; $_=$A[2]; '); do
+    curdir=$(dirname $path)
+    path_csl="$path_csl,$curdir"
+    if [ -e $curdir/.mlp_best ]; then
+      read_path_csl="$read_path_csl,$(cat $curdir/.mlp_best)"
+    else
+      read_path_csl="$read_path_csl,$path"
+    fi
+  done
+  read_path_csl=$(echo $read_path_csl|perl -pe 's/^,//;')
+  path_csl=$(echo $path_csl|perl -pe 's/^,//;')
+  mling_opts="$base_mling_opts;$read_path_csl"
+fi 
+# cross-validation on original network,
+log=$dir/log/iter00.initial.log; hostname>$log
+$train_tool --cross-validate=true --randomize=false --verbose=$verbose $train_tool_opts \
+  ${feature_transform:+ --feature-transform=$feature_transform} \
+  ${frame_weights:+ "--frame-weights=$frame_weights"} \
+  ${utt_weights:+ "--utt-weights=$utt_weights"} \
+  ${mling_opts:+ "--mling-opts=$mling_opts"} \
+  "$feats_cv" "$labels_cv" $mlp_best \
+  2>> $log
+
+loss=$(cat $dir/log/iter00.initial.log | grep "AvgLoss:" | tail -n 1 | awk '{ print $4; }')
+loss_type=$(cat $dir/log/iter00.initial.log | grep "AvgLoss:" | tail -n 1 | awk '{ print $5; }')
+echo "CROSSVAL PRERUN AVG.LOSS $(printf "%.4f" $loss) $loss_type"
+
+# resume lr-halving,
+halving=0
+[ -e $dir/.halving ] && halving=$(cat $dir/.halving)
+
+# training,
+for iter in $(seq -w $max_iters); do
+  echo -n "ITERATION $iter: "
+  mlp_next=$dir/nnet/${mlp_base}_iter${iter}
+  
+  # skip iteration (epoch) if already done,
+  [ -e $dir/.done_iter$iter ] && echo -n "skipping... " && ls $mlp_next* && continue 
+  if [ ! -z "$mling_opts" ]; then
+    write_path_csl=""
+    mlp_next_base=$(basename $mlp_next)
+    i=0
+    for path in $(echo "$path_csl"| perl -pe 'chomp; s/,/ /g;'); do
+      write_path[$i]=$(echo $mlp_next_base| awk -v path=$path '{printf("%s/%s", path, $1);}')
+      i=$[i+1]
+    done
+    write_path_csl=$(echo ${write_path[*]}| tr ' ' ',')
+    mling_opts="$base_mling_opts;$read_path_csl;$write_path_csl"
+  fi
+  # training,
+  log=$dir/log/iter${iter}.tr.log; hostname>$log
+  $train_tool --cross-validate=false --randomize=true --verbose=$verbose $train_tool_opts \
+    --learn-rate=$learn_rate --momentum=$momentum \
+    --l1-penalty=$l1_penalty --l2-penalty=$l2_penalty \
+    ${feature_transform:+ --feature-transform=$feature_transform} \
+    ${frame_weights:+ "--frame-weights=$frame_weights"} \
+    ${utt_weights:+ "--utt-weights=$utt_weights"} \
+    ${mling_opts:+ "--mling-opts=$mling_opts"} \
+    "$feats_tr" "$labels_tr" $mlp_best $mlp_next \
+    2>> $log || exit 1; 
+
+  tr_loss=$(cat $dir/log/iter${iter}.tr.log | grep "AvgLoss:" | tail -n 1 | awk '{ print $4; }')
+  echo -n "TRAIN AVG.LOSS $(printf "%.4f" $tr_loss), (lrate$(printf "%.6g" $learn_rate)), "
+  if [ ! -z "$mling_opts" ]; then
+    mling_opts="$base_mling_opts;$write_path_csl"
+  fi
+  # cross-validation,
+  log=$dir/log/iter${iter}.cv.log; hostname>$log
+  $train_tool --cross-validate=true --randomize=false --verbose=$verbose $train_tool_opts \
+    ${feature_transform:+ --feature-transform=$feature_transform} \
+    ${frame_weights:+ "--frame-weights=$frame_weights"} \
+    ${utt_weights:+ "--utt-weights=$utt_weights"} \
+    ${mling_opts:+ "--mling-opts=$mling_opts"} \
+    "$feats_cv" "$labels_cv" $mlp_next \
+    2>>$log || exit 1;
+  
+  loss_new=$(cat $dir/log/iter${iter}.cv.log | grep "AvgLoss:" | tail -n 1 | awk '{ print $4; }')
+  echo -n "CROSSVAL AVG.LOSS $(printf "%.4f" $loss_new), "
+
+  # accept or reject?
+  loss_prev=$loss
+  if [ 1 == $(bc <<< "$loss_new < $loss") -o $iter -le $keep_lr_iters -o $iter -le $min_iters ]; then
+    # accepting: the loss was better, or we had fixed learn-rate, or we had fixed epoch-number,
+    loss=$loss_new
+    mlp_best=$dir/nnet/${mlp_base}_iter${iter}_learnrate${learn_rate}_tr$(printf "%.4f" $tr_loss)_cv$(printf "%.4f" $loss_new)
+    [ $iter -le $min_iters ] && mlp_best=${mlp_best}_min-iters-$min_iters
+    [ $iter -le $keep_lr_iters ] && mlp_best=${mlp_best}_keep-lr-iters-$keep_lr_iters
+    mv $mlp_next $mlp_best
+    echo "nnet accepted ($(basename $mlp_best))"
+    echo $mlp_best > $dir/.mlp_best 
+    if [ ! -z "$mling_opts" ]; then
+      mlp_next_base=$(basename $mlp_next)
+      mlp_best_base=$(basename $mlp_best)
+      read_path_csl=""
+      for path in $(echo "$path_csl" | perl -pe 's/,/ /g;'); do
+        [ -f $path/$mlp_next_base ] || { echo "ERROR, mling, file $path/$mlp_next_base expected"; exit 1; }
+        mv $path/$mlp_next_base $path/$mlp_best_base
+        read_path_csl="$read_path_csl,$path/$mlp_best_base"
+        echo $path/$mlp_best_base > $path/.mlp_best
+      done
+      read_path_csl=$(echo $read_path_csl | perl -pe 's/^,//;')
+    fi
+  else
+    # rejecting,
+    mlp_reject=$dir/nnet/${mlp_base}_iter${iter}_learnrate${learn_rate}_tr$(printf "%.4f" $tr_loss)_cv$(printf "%.4f" $loss_new)_rejected
+    mv $mlp_next $mlp_reject
+    echo "nnet rejected ($(basename $mlp_reject))"
+    if [ ! -z "$mling_opts" ]; then
+      mlp_next_base=$(basename $mlp_next)
+      mlp_reject_base=$(basename $mlp_reject)
+      for path in $(echo "$path_csl" | perl -pe 's/,/ /g;'); do
+        mv $path/$mlp_next_base $path/$mlp_reject_base
+      done
+    fi
+  fi
+
+  # create .done file, the iteration (epoch) is completed,
+  touch $dir/.done_iter$iter
+  
+  # continue with original learn-rate,
+  [ $iter -le $keep_lr_iters ] && continue 
+
+  # stopping criterion,
+  rel_impr=$(bc <<< "scale=10; ($loss_prev-$loss)/$loss_prev")
+  if [ 1 == $halving -a 1 == $(bc <<< "$rel_impr < $end_halving_impr") ]; then
+    if [ $iter -le $min_iters ]; then
+      echo we were supposed to finish, but we continue as min_iters : $min_iters
+      continue
+    fi
+    echo finished, too small rel. improvement $rel_impr
+    break
+  fi
+
+  # start learning-rate fade-out when improvement is low,
+  if [ 1 == $(bc <<< "$rel_impr < $start_halving_impr") ]; then
+    halving=1
+    echo $halving >$dir/.halving
+  fi
+  
+  # reduce the learning-rate,
+  if [ 1 == $halving ]; then
+    learn_rate=$(awk "BEGIN{print($learn_rate*$halving_factor)}")
+    echo $learn_rate >$dir/.learn_rate
+  fi
+done
+
+# select the best network,
+if [ $mlp_best != $mlp_init ]; then 
+  mlp_final=${mlp_best}_final_
+  ( cd $dir/nnet; ln -s $(basename $mlp_best) $(basename $mlp_final); )
+  ( cd $dir; ln -s nnet/$(basename $mlp_final) final.nnet; )
+  echo "Succeeded training the Neural Network : $dir/final.nnet"
+else
+  "Error training neural network..."
+  exit 1
+fi
+

--- a/src/nnet/nnet-input-offset.h
+++ b/src/nnet/nnet-input-offset.h
@@ -1,0 +1,223 @@
+// nnet/nnet-input-offset.h
+
+#ifndef KALDI_NNET_NNET_INPUT_OFFSET_H_
+#define KALDI_NNET_NNET_INPUT_OFFSET_H_
+
+#include "nnet/nnet-nnet.h"
+
+namespace kaldi {
+namespace nnet1 {
+
+class ParallelOneNnet {  // single nnet
+ friend class Nnet;
+ public:
+  ParallelOneNnet(const bool freeze_update, const bool has_utt2spk, Nnet *nnet,
+                  NnetDataRandomizerOptions *rnd_opts ) : freeze_update_(freeze_update),
+                                                          has_utt2spk_(has_utt2spk),
+                                                          mNnet_(nnet) {
+    feed_forward_ = false;
+    if(rnd_opts != NULL)
+      feature_randomizer_.Init(*rnd_opts); 
+    else
+      feed_forward_ = true;
+  }
+  void InitFeatReader(const std::string &feature_rspecifier) {
+    if(parallel_valid_string(feature_rspecifier)) {
+      if(has_utt2spk_) 
+        vec_reader_.Open(feature_rspecifier);
+      else
+        feature_reader_.Open(feature_rspecifier);
+    }
+  }
+  void InitUtt2SpkReader(const std::string &utt2spk_filename) {
+    if(parallel_valid_string(utt2spk_filename)) {
+      utt2spk_reader_.Open(utt2spk_filename); 
+    }
+  }
+  void InitFeatTransform(const std::string &feature_transform) {
+    if(parallel_valid_string(feature_transform)) {
+      nnet_transf_.Read(feature_transform);
+    }
+  }
+  void InitNnet(const std::string &model_filename) {
+    nnet_.Read(model_filename);
+    nnet_.SetTrainOptions(mNnet_->GetTrainOptions());
+    nnet_.opts_.freeze_update = freeze_update_;  // overwrite the following two variables
+    nnet_.opts_.parallel_level = -1;
+  }
+  bool HasUtt(const std::string &utt) {
+    if(has_utt2spk_) {
+      return utt2spk_reader_.HasKey(utt);
+    }
+    return feature_reader_.HasKey(utt);
+  }
+  bool AddData(const std::string &utt, const int32 &nRows, const int32 time_shift = 0) {
+    Matrix<BaseFloat> mat;
+    if(has_utt2spk_) {
+      std::string spk = utt2spk_reader_.Value(utt);
+      Vector<BaseFloat> vec;
+      vec = vec_reader_.Value(spk);
+      mat.Resize(nRows, vec.Dim());
+      mat.CopyRowsFromVec(vec);
+    } else {
+      mat = feature_reader_.Value(utt);
+      if (mat.NumRows() < nRows)
+        return false;
+      else if(mat.NumRows() > nRows) {
+        mat.Resize(nRows, mat.NumCols(), kCopyData);
+      }
+    }
+    if(time_shift > 0) {
+      int32 last_row = mat.NumRows() - 1; // last row,
+      mat.Resize(mat.NumRows() + time_shift, mat.NumCols(), kCopyData);
+      for (int32 r = last_row+1; r<mat.NumRows(); r++) {
+        mat.CopyRowFromVec(mat.Row(last_row), r); // copy last row,
+      }
+    }
+    nnet_transf_.Feedforward(CuMatrix<BaseFloat>(mat), &feats_transf_);
+    if(!feed_forward_)
+      feature_randomizer_.AddData(feats_transf_);
+    return true;
+  }
+  void FeatRandomize(const std::vector<int32> &mask) {
+    feature_randomizer_.Randomize(mask);
+  }
+  void Propagate() {
+    const CuMatrixBase<BaseFloat>& nnet_in = feed_forward_ ? feats_transf_ : feature_randomizer_.Value();
+    nnet_.Propagate(nnet_in, &nnet_out_);
+    if(!feed_forward_)
+      feature_randomizer_.Next();
+  }
+  void Feedforward() {
+    nnet_.Feedforward(feats_transf_, &nnet_out_);
+  }
+  void Write(const std::string &target_model_name, const bool binary) {
+    nnet_.Write(target_model_name, binary);
+  }
+  static bool parallel_valid_string(const std::string &str) {
+    if(str.empty())
+      return false;
+    size_t startpos = str.find_last_not_of(" \t");
+    if(startpos == std::string::npos)
+      return false;
+    return true;
+  }
+ private:
+  bool freeze_update_;
+  RandomAccessBaseFloatMatrixReader  feature_reader_;
+  RandomAccessBaseFloatVectorReader  vec_reader_;
+  bool has_utt2spk_;
+  RandomAccessTokenReader utt2spk_reader_;
+  MatrixRandomizer feature_randomizer_;
+  CuMatrix<BaseFloat> feats_transf_, nnet_out_;
+  Nnet nnet_transf_;
+  Nnet nnet_;
+  Nnet *mNnet_;      // main nnet to which the current subnet attaches
+  bool feed_forward_;
+};
+
+class ParallelNnet {
+  friend class Nnet;
+ public:
+  ParallelNnet(NnetDataRandomizerOptions *rnd_opts, Nnet *nnet) : rnd_opts_(rnd_opts),
+                                                                  mNnet_(nnet)
+                                                                  { }
+  ParallelNnet(Nnet *nnet) : rnd_opts_(NULL),
+                             mNnet_(nnet)
+                             { }
+  ~ParallelNnet() {
+    Destroy();
+  }
+  void SetParallelOpts(ParallelNnetOptions &opts) {
+    opts_ = opts;
+    CheckUpdate();
+  }
+  void Init() {
+    for(int32 i = 0; i < vec_feature_.size(); ++i) {
+      bool has_utt2spk = false;
+      if(ParallelOneNnet::parallel_valid_string(vec_utt2spk_[i])) has_utt2spk =true;
+      ParallelOneNnet *pOneNnet = new ParallelOneNnet(opts_.parallel_freeze_update, has_utt2spk, mNnet_, rnd_opts_);
+      pOneNnet->InitNnet(vec_nnetfile_[i]);
+      pOneNnet->InitFeatReader(vec_feature_[i]);
+      pOneNnet->InitFeatTransform(vec_feature_transform_[i]);
+      pOneNnet->InitUtt2SpkReader(vec_utt2spk_[i]);
+      nnet_vec_.push_back(pOneNnet);
+    }
+    mNnet_->SetParallelNnet(&nnet_vec_, opts_.parallel_nnet_level);
+  }
+  bool HasUtt(const std::string &utt) {
+    for(int32 i = 0; i < nnet_vec_.size(); ++ i) {
+      if(! nnet_vec_[i]->HasUtt(utt))
+        return false;
+    }
+    return true;
+  }
+  bool AddData(const std::string &utt, const int32 &nRows, const int32 time_shift = 0) {
+    for(int32 i = 0; i < nnet_vec_.size(); ++i) {
+      if(! nnet_vec_[i]->AddData(utt, nRows, time_shift))
+        return false;
+    }
+    return true;
+  }
+  void FeatRandomize(const std::vector<int32> &mask) {
+    for(int32 i = 0; i < nnet_vec_.size(); ++i) {
+      nnet_vec_[i]->FeatRandomize(mask);
+    }
+  }
+  void Write(const bool binary) {
+    for(int32 i = 0; i < nnet_vec_.size(); ++i)
+      nnet_vec_[i]->Write(vec_updatefile_[i], binary);
+  }
+ private:
+  ParallelNnetOptions opts_;
+  std::vector<std::string> vec_feature_;
+  std::vector<std::string> vec_utt2spk_;
+  std::vector<std::string> vec_feature_transform_;
+  std::vector<std::string> vec_nnetfile_;
+  std::vector<std::string> vec_updatefile_;
+  NnetDataRandomizerOptions *rnd_opts_;
+  Nnet *mNnet_;
+  std::vector<ParallelOneNnet*> nnet_vec_; 
+  void CheckUpdate() {
+    const char *delim = ";";
+    if(!opts_.parallel_feature.empty()) {
+      SplitStringToVector(opts_.parallel_feature, delim, false, &vec_feature_);
+      for(int32 i = 0; i < vec_feature_.size(); ++i) {
+        vec_utt2spk_.push_back("");
+        vec_feature_transform_.push_back("");
+      }
+    }
+    if (!opts_.parallel_utt2spk.empty()) {
+      std::vector<std::string> vec_str;
+      SplitStringToVector(opts_.parallel_utt2spk, delim, false, &vec_str);
+      KALDI_ASSERT(vec_feature_.size() == vec_str.size());
+      for(int32 i = 0; i < vec_str.size(); ++i)
+        vec_utt2spk_[i] = vec_str[i];
+    }
+    if(!opts_.parallel_feature_transform.empty()) {
+      std::vector<std::string> vec_str;
+      SplitStringToVector(opts_.parallel_feature_transform, delim, false, &vec_str);
+      KALDI_ASSERT(vec_feature_.size() == vec_str.size());
+      for(int32 i = 0; i < vec_str.size(); ++i)
+        vec_feature_transform_[i] = vec_str[i];
+    }
+    if (!opts_.parallel_net.empty()) {
+      SplitStringToVector(opts_.parallel_net, delim, false, &vec_nnetfile_);
+      KALDI_ASSERT(vec_feature_.size() == vec_nnetfile_.size());
+    }
+    if (!opts_.parallel_update.empty()) {
+      SplitStringToVector(opts_.parallel_update, delim, false, &vec_updatefile_);
+      KALDI_ASSERT(vec_feature_.size() == vec_updatefile_.size());
+    }
+  }
+  void Destroy() {
+    for(int32 i = 0; i < nnet_vec_.size(); ++i)
+      delete nnet_vec_[i];
+    nnet_vec_.clear();
+  }
+};
+
+} // namespace nnet1
+} // namespace kaldi
+
+#endif

--- a/src/nnet/nnet-lhuc-sat.h
+++ b/src/nnet/nnet-lhuc-sat.h
@@ -1,0 +1,287 @@
+// nnet/nnet-lhuc-sat.h
+
+#ifndef KALDI_NNET_NNET_LHUC_SAT_H_
+#define KALDI_NNET_NNET_LHUC_SAT_H_
+
+#include "nnet/nnet-lhuc.h"
+#include "nnet/nnet-nnet.h"
+namespace kaldi {
+namespace nnet1 {
+class Nnet;
+class LhucNnet {
+ public:
+  LhucNnet(float lhuc_const, float lhuc_lrate_coef, 
+           Nnet *nnet, Component::ComponentType actType) : lhuc_const_(lhuc_const),
+                                                           lhuc_learn_rate_coef_(lhuc_lrate_coef),
+                                                           nnet_(nnet),
+                                                           act_type_(actType),
+                                                           lhuc_dim_(0) { }
+  LhucNnet() : lhuc_const_(2.0),
+               lhuc_learn_rate_coef_(1.0),
+               nnet_(NULL),
+               act_type_(Component::kSigmoid),
+               lhuc_dim_(0){ }
+  ~LhucNnet() { Destroy(); }
+  void SetNnet(Nnet *nnet) { nnet_ = nnet; }
+  void SetActType(Component::ComponentType actType) { act_type_ = actType; }
+  void SetLhucConst(float lhuc_const) { lhuc_const_ = lhuc_const; }
+  void SetLhucLrateCoef(float lhuc_lrate_coef) { lhuc_learn_rate_coef_ = lhuc_lrate_coef; }
+  void Init() {
+    KALDI_ASSERT(nnet_ != NULL && lhuc_const_ > 0 && lhuc_learn_rate_coef_ > 0);
+    int32 num_comp = nnet_->NumComponents();
+    int32 num_lhuc_comp = 0;
+    for(int32 i = 0; i < num_comp; ++i) {
+      const Component &comp = nnet_->GetComponent(i);
+      if(comp.GetType() == act_type_) {
+        if(lhuc_dim_ == 0) { 
+          lhuc_dim_ = comp.OutputDim(); 
+        }
+        num_lhuc_comp ++;
+        LhucComp *lhuc_comp =  new LhucComp(lhuc_dim_, lhuc_const_, lhuc_learn_rate_coef_);
+        lhuc_comp->SetScaleVec(NULL);
+        comp_vec_.push_back(lhuc_comp);
+        Insert(&comp, lhuc_comp);
+      }
+    }
+    KALDI_ASSERT(num_lhuc_comp > 0);
+  }
+  void Init(Matrix<BaseFloat> &mat) {
+    KALDI_ASSERT(nnet_ != NULL && lhuc_const_ > 0 && lhuc_learn_rate_coef_ > 0);
+    int32 num_comp = nnet_->NumComponents();
+    int32 lhuc_num_comp_required = 0;
+    for(int32 i = 0; i < num_comp; ++i) {
+      const Component &comp = nnet_->GetComponent(i);
+      if(comp.GetType() == act_type_) lhuc_num_comp_required ++;
+    }
+    if (mat.NumRows() != lhuc_num_comp_required) {
+      KALDI_ERR << "Required LHUC component number is " << lhuc_num_comp_required << ", but"
+                << " actual component number is " << mat.NumRows();
+    }
+    int32 lhuc_num_comp = 0;
+    for(int32 i = 0; i < num_comp; ++i) {
+      const Component &comp = nnet_->GetComponent(i);
+      if(comp.GetType() == act_type_) {
+        if(lhuc_dim_ == 0) {
+          lhuc_dim_ = mat.NumCols();
+          KALDI_ASSERT(lhuc_dim_ == comp.OutputDim());
+        }
+        Vector<BaseFloat> lhuc_vec(lhuc_dim_);
+        SubVector<BaseFloat>tmp(lhuc_vec, 0, lhuc_dim_);
+        tmp.CopyFromVec(mat.Row(lhuc_num_comp));
+        LhucComp *lhuc_comp =  new LhucComp(lhuc_dim_, lhuc_const_, lhuc_learn_rate_coef_);
+        lhuc_comp->SetScaleVec(&lhuc_vec);
+        comp_vec_.push_back(lhuc_comp);
+        Insert(&comp, lhuc_comp);
+        lhuc_num_comp ++;
+      }
+    }
+    KALDI_ASSERT(lhuc_num_comp == mat.NumRows()); 
+  }
+  void Update(Matrix<BaseFloat> *mat) {
+     mat->Resize(comp_vec_.size(), lhuc_dim_);
+    for(int32 i = 0; i < comp_vec_.size(); ++i) {
+      SubVector<BaseFloat> v(mat->Row(i));
+      comp_vec_[i]->GetLhucVec(&v);        
+    }
+  }
+  void LhucPropagate(const Component *input_comp, const CuMatrixBase<BaseFloat> &in, CuMatrix<BaseFloat> *out, bool *copy_done) {
+    if(input_comp->GetType() != act_type_) {
+      *copy_done = false;
+      return;
+    }
+    *copy_done = true;
+    it_ = comp_map_.find(input_comp), it_end_ = comp_map_.end();
+    KALDI_ASSERT(it_ != it_end_);
+    LhucComp *lhuc_comp = it_->second;
+    out->Resize(in.NumRows(), in.NumCols());
+    lhuc_comp->PropagateFnc(in, out);
+  }
+  void LhucBackpropagate(const Component *input_comp, const CuMatrixBase<BaseFloat> &in, const CuMatrixBase<BaseFloat> &out,
+                         const CuMatrixBase<BaseFloat> &out_diff, CuMatrix<BaseFloat> *in_diff) {
+    if(input_comp->GetType() != act_type_) {
+      return;
+    }
+    LhucComp *lhuc_comp = Find(input_comp);
+    lhuc_comp->BackpropagateFnc(in, out, out_diff, in_diff);
+    lhuc_comp->Update(in, out_diff);
+  }
+ private:
+  void Insert(const Component *main_comp, LhucComp *lhuc_comp) {
+    it_ = comp_map_.find(main_comp); 
+    it_end_ = comp_map_.end();
+    KALDI_ASSERT(it_ == it_end_);
+   comp_map_.insert(std::pair<const Component*, LhucComp*>(main_comp, lhuc_comp));
+  }
+  LhucComp* Find(const Component *main_comp) {
+    it_ = comp_map_.find(main_comp);
+    it_end_ = comp_map_.end();
+    KALDI_ASSERT(it_ != it_end_);
+    return it_->second;
+  }
+  void Destroy() {
+    it_ = comp_map_.begin(), it_end_ = comp_map_.end(); 
+    for(; it_ != it_end_; ++ it_) {
+      Component *lhuc_comp = it_->second;
+      delete lhuc_comp;
+    }
+    comp_map_.clear();
+  }
+ private:
+  float lhuc_const_;
+  float lhuc_learn_rate_coef_;
+  Nnet *nnet_;
+  Component::ComponentType act_type_;
+  int32 lhuc_dim_;
+  std::vector<LhucComp*> comp_vec_;
+  std::map<const Component*, LhucComp*> comp_map_;
+  std::map<const Component*, LhucComp*>::iterator it_, it_end_;
+};
+
+class LhucSat{
+ public:
+  LhucSat(float lhuc_const, float lhuc_lrcoef,
+          std::string &act_type, Nnet *nnet) : lhuc_const_(lhuc_const),
+                                        lhuc_learn_rate_coef_(lhuc_lrcoef),
+                                        act_type_(Component::MarkerToType(act_type)), model_wfilename_(""),
+                                        nnet_(nnet),
+                                        active_lhuc_nnet_(NULL) { }
+  LhucSat() : lhuc_const_(2.0),
+              lhuc_learn_rate_coef_(1.0),
+              act_type_(Component::kSigmoid), model_wfilename_(""),
+              nnet_(NULL),
+              active_lhuc_nnet_(NULL) { }
+  
+  ~LhucSat() { Destroy(); }
+  void SetLhucConst(float lhuc_const) { lhuc_const_ = lhuc_const; }
+  void SetLrCoef(float lr_coef) { lhuc_learn_rate_coef_ = lr_coef; }
+  void SetActType(std::string &act_type) { act_type_ = Component::MarkerToType(act_type); }
+  
+  void SetNnet(Nnet *nnet) {nnet_ = nnet; }
+  LhucNnet* InsertLhuc(std::string &key, bool insert = false) {
+    Matrix<BaseFloat> mat;
+    return InitLhucTable(key, mat, insert);
+  }
+  /// we define lhuc_opts_csl as 
+  /// lhuc_opts_csl=ark:utt2spk;input_model_filename,output_model_filename
+  /// for instance, lhuc_opts_cls=ark:utt2spk;in_lhuc_sat.mdl,out_lhuc_sat.mdl
+  void Init(const std::string &lhuc_opts_csl, Nnet *nnet) {
+    std::vector<std::string> vec_component_str;
+    SplitStringToVector(lhuc_opts_csl, ";", true, &vec_component_str);   
+    KALDI_ASSERT(vec_component_str.size() == 2);
+    std::vector<std::string> vec_str;
+    SplitStringToVector(vec_component_str[1], ",", true, &vec_str);
+    OpenUtt2Spk(vec_str[0]);
+    KALDI_ASSERT(vec_str.size() >= 1);
+    model_wfilename_ = "";
+    if(vec_str.size() == 2)
+      model_wfilename_ = vec_str[1];
+    Read(vec_str[0]);
+    nnet_ = nnet;
+  }
+  bool Utt2SpkLhuc(const std::string &utt) {
+    if(!utt2spk_reader_.HasKey(utt))
+      return false;
+    std::string spk = utt2spk_reader_.Value(utt);
+    if(InsertLhuc(spk, false) == NULL)
+      return false;
+    return true;
+  }
+  LhucNnet* GetActiveLhuc() { return active_lhuc_nnet_; }
+  void Read(std::string &file) {
+    bool binary;
+    Input in(file, &binary);
+    std::istream &is = in.Stream();
+    KALDI_ASSERT(is.good());
+    ExpectToken(is, binary, "<LhucConst>");
+    ReadBasicType(is, binary, &lhuc_const_);
+    ExpectToken(is, binary, "<LearnRateCoef>");
+    ReadBasicType(is, binary, &lhuc_learn_rate_coef_);
+    ExpectToken(is, binary, "<NetActType>");
+    std::string act_type;
+    ReadToken(is, binary, &act_type);
+    act_type_ = Component::MarkerToType(act_type);
+    ReadTable(is, binary);
+    in.Close();
+    if(map_spk2nnet_.size() == 0) {
+      KALDI_ERR << "Lhuc adaptive file '" << file << "' is empty.";
+    }   
+  }
+  void Write(std::string &file, bool binary) {
+    Output output(file, binary);
+    std::ostream &os = output.Stream();
+    WriteToken(os, binary, "<LhucConst>");
+    WriteBasicType(os, binary, lhuc_const_);
+    WriteToken(os, binary, "<LearnRateCoef>");
+    WriteBasicType(os, binary, lhuc_learn_rate_coef_);
+    WriteToken(os, binary, "<NetActType>");
+    std::string act_type = Component::TypeToMarker(act_type_);
+    WriteToken(os, binary, act_type);
+    it_ = map_spk2nnet_.begin(); 
+    it_end_ = map_spk2nnet_.end();
+    for(; it_ != it_end_; ++ it_) {
+      WriteToken(os, binary, it_->first);
+      LhucNnet *lhuc_nnet = it_->second;
+      Matrix<BaseFloat> mat;
+      lhuc_nnet->Update(&mat);
+      mat.Write(os, binary);
+    }   
+    output.Close();
+  }
+  void Write(bool binary) {
+    if(model_wfilename_ != "")
+    Write(model_wfilename_, binary);
+  }
+  void OpenUtt2Spk(const std::string &utt2spk_rspecifier) {
+    utt2spk_reader_.Open(utt2spk_rspecifier);
+  }
+ private:
+  void ReadTable(std::istream &is, bool binary) {
+    while(!is.eof()) {
+      is.clear();
+      std::string key;
+      is >> key;
+      if(key.empty()) break;
+      Matrix<BaseFloat> mat;
+      mat.Read(is, binary);
+      InitLhucTable(key, mat, true);
+    }
+  } 
+  LhucNnet* InitLhucTable(std::string &key, Matrix<BaseFloat> &mat, bool insert = true) {
+     it_ = map_spk2nnet_.find(key);
+     it_end_ = map_spk2nnet_.end();
+      if(it_ != it_end_) {
+        active_lhuc_nnet_ = it_->second;
+        return active_lhuc_nnet_;
+      }
+      if(!insert)
+        return NULL; 
+      LhucNnet *lhuc_nnet = new LhucNnet(lhuc_const_, lhuc_learn_rate_coef_, nnet_, act_type_);
+      if(mat.NumRows() != 0)
+        lhuc_nnet->Init(mat);
+      else
+        lhuc_nnet->Init();
+      map_spk2nnet_.insert(std::pair<std::string, LhucNnet*>(key, lhuc_nnet));
+      active_lhuc_nnet_ = lhuc_nnet;
+      return active_lhuc_nnet_;
+    }
+    void Destroy() {
+    it_ = map_spk2nnet_.begin(); it_end_ = map_spk2nnet_.end();
+    for(; it_ != it_end_; ++ it_) {
+      LhucNnet *lhuc_nnet = it_->second;
+      delete lhuc_nnet;
+    }
+  }
+ private:
+  float lhuc_const_;
+  float lhuc_learn_rate_coef_;
+  Component::ComponentType act_type_;
+  RandomAccessTokenReader utt2spk_reader_;
+  std::string model_wfilename_;
+  Nnet *nnet_;
+  LhucNnet *active_lhuc_nnet_;
+  std::map<std::string, LhucNnet*> map_spk2nnet_;
+  std::map<std::string, LhucNnet*>::iterator it_, it_end_;
+};
+}  // namespace nnet1
+}  // namespace kaldi
+#endif

--- a/src/nnet/nnet-lhuc.h
+++ b/src/nnet/nnet-lhuc.h
@@ -1,0 +1,96 @@
+// nnet/nnet-lhuc.h
+
+#ifndef KALDI_NNET_NNET_LHUC_H_
+#define KALDI_NNET_NNET_LHUC_H_
+
+#include "nnet/nnet-component.h"
+#include "nnet/nnet-utils.h"
+#include "cudamatrix/cu-math.h"
+#include "cudamatrix/cu-matrix.h"
+
+namespace kaldi {
+namespace nnet1 {
+class LhucComp : public UpdatableComponent {
+ public:
+  LhucComp(int32 dim_in, float lhuc_const, float learn_rate_coef)
+     : UpdatableComponent(dim_in, dim_in),
+       lhuc_const_(lhuc_const),
+       lhuc_vec_(dim_in), lhuc_scale_vec_(dim_in),
+       lhuc_vec_grad_(dim_in),
+       learn_rate_coef_(learn_rate_coef) { }
+  ~LhucComp() { }
+  Component* Copy() const { return new LhucComp(*this); }
+  ComponentType GetType() const { return kRescale; }
+  
+  void InitData(std::istream &is) { }
+  void ReadData(std::istream &is, bool binary) { }
+  void WriteData(std::ostream &os, bool binary) const { } 
+  int32 NumParams() const { return lhuc_vec_.Dim(); }
+  void GetParams(Vector<BaseFloat>* lhuc_vec_copy) const {
+    lhuc_vec_copy->Resize(InputDim());
+    lhuc_vec_.CopyToVec(lhuc_vec_copy);
+  }
+  void SetScaleVec(const Vector<BaseFloat> *lhuc_vec) {
+    if(lhuc_vec != NULL) {
+      KALDI_ASSERT(lhuc_vec->Dim() == lhuc_vec_.Dim());
+      lhuc_vec_.CopyFromVec(*lhuc_vec);
+    }
+    Vector<BaseFloat> cpu_lhuc_vec(lhuc_vec_.Dim());
+    lhuc_vec_.CopyToVec(&cpu_lhuc_vec);
+    Vector<BaseFloat> cpu_scale_vec(lhuc_vec_.Dim());
+    cpu_scale_vec.Sigmoid(cpu_lhuc_vec);
+    cpu_scale_vec.Scale(lhuc_const_);
+    lhuc_scale_vec_.CopyFromVec(cpu_scale_vec);
+  }
+
+  std::string Info() const {
+    return std::string("\n lhuc_vec") + MomentStatistics(lhuc_vec_);
+  }
+  std::string InfoGradient() const {
+    return std::string("\n lhuc_vec_grad") + MomentStatistics(lhuc_vec_grad_) +
+            ", lr-coef " + ToString(learn_rate_coef_);
+  }
+  void PropagateFnc(const CuMatrixBase<BaseFloat> &in, CuMatrixBase<BaseFloat> *out) {
+    out->CopyFromMat(in);
+    out->MulColsVec(lhuc_scale_vec_); 
+  }
+  void BackpropagateFnc(const CuMatrixBase<BaseFloat> &in, const CuMatrixBase<BaseFloat> &out,
+                        const CuMatrixBase<BaseFloat> &out_diff, CuMatrixBase<BaseFloat> *in_diff) {
+    in_diff->CopyFromMat(out_diff);
+    in_diff->MulColsVec(lhuc_scale_vec_);
+  }
+  void Update(const CuMatrixBase<BaseFloat> &input, const CuMatrixBase<BaseFloat> &diff) {
+
+    CuVector<BaseFloat> grad_vec(lhuc_scale_vec_);
+    grad_vec.Scale(1.0/lhuc_const_); 
+    CuVector<BaseFloat> sigmoid_vec(grad_vec);
+    grad_vec.Scale(-1.0);
+    grad_vec.Add(1.0);
+    grad_vec.MulElements(sigmoid_vec);
+    grad_vec.Scale(lhuc_const_);
+
+    
+    CuMatrix<BaseFloat> scaled_input(input);
+    scaled_input.MulColsVec(grad_vec);
+
+    CuMatrix<BaseFloat> gradient_aux(diff);
+    gradient_aux.MulElements(scaled_input);
+    lhuc_vec_grad_.AddRowSumMat(1.0, gradient_aux, 0.0);
+    const BaseFloat lr = opts_.learn_rate;
+    lhuc_vec_.AddVec(-lr*learn_rate_coef_, lhuc_vec_grad_);
+    SetScaleVec(NULL);
+  }
+  void GetLhucVec(VectorBase<BaseFloat> *vec) {
+    lhuc_vec_.CopyToVec(vec);
+  }
+ private:
+  float lhuc_const_;
+  CuVector<BaseFloat> lhuc_vec_;
+  CuVector<BaseFloat> lhuc_scale_vec_; 
+  CuVector<BaseFloat> lhuc_vec_grad_;
+  BaseFloat learn_rate_coef_;    
+};
+
+} // namespace nnet1
+} // namespace kaldi
+#endif

--- a/src/nnet/nnet-mnet.h
+++ b/src/nnet/nnet-mnet.h
@@ -1,0 +1,274 @@
+// nnet/nnet-mnet.h
+
+#ifndef KALDI_NNET_MNET_H_
+#define KALDI_NNET_MNET_H_
+
+#include "nnet/nnet-component.h"
+#include "nnet/nnet-loss.h"
+#include "nnet/nnet-utils.h"
+#include "cudamatrix/cu-math.h"
+#include "cudamatrix/cu-matrix.h"
+#include "nnet/nnet-nnet.h"
+
+namespace kaldi {
+namespace nnet1 {
+class MultiNnet {
+ public:
+  MultiNnet():objective_function_("xent"),
+              nnet_(NULL),
+              total_lang_absence_(0),
+              total_minibatch_(0) { }
+  ~MultiNnet() {
+    Destroy();
+  }
+  void Destroy() {
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      Nnet *pnnet = vec_nnet_[i];
+      delete pnnet;
+    }
+  }
+  void Init(const std::string &mling_opts_str,
+            const NnetTrainOptions trn_opts,
+            Nnet* nnet,  
+            const NnetDataRandomizerOptions &rnd_opts,
+            const std::string &objective_function) {
+    std::vector<std::string> vec_component_str;
+    SplitStringToVector(mling_opts_str, ";", true, &vec_component_str);   
+    if(vec_component_str.size() < 3) {
+      KALDI_ERR << "unexpected mling_opts_str " << "'" 
+      << mling_opts_str << "'";
+    }
+    nnet_ = nnet;
+    utt2lang_reader_.Open(vec_component_str[0]);
+    std::vector<std::string> vec_lang_name;
+    SplitStringToVector(vec_component_str[1], ",", true, &vec_lang_name);
+    std::vector<std::string> vec_model_rfilename;
+    SplitStringToVector(vec_component_str[2], ",", true, &vec_model_rfilename);
+    KALDI_ASSERT(vec_lang_name.size() == vec_model_rfilename.size());
+    FillMap(vec_lang_name);
+    InitNnet(vec_model_rfilename, trn_opts);
+    if(vec_component_str.size() > 3) {
+      SplitStringToVector(vec_component_str[3], ",", true, &vec_model_wfilename_);
+      KALDI_ASSERT(vec_model_wfilename_.size() == vec_model_rfilename.size());
+    }
+    lang_randomizer_.Init(rnd_opts);
+    objective_function_ = objective_function;
+    vec_nnet_.resize(vec_model_rfilename.size());
+  }
+  bool SetLangIdVec(const std::string &utt, int32 vec_dim) {
+    if(!utt2lang_reader_.HasKey(utt)) {
+      return false;
+    }
+    std::string lang_code = utt2lang_reader_.Value(utt); 
+    std::map<const std::string, int32>::iterator it, it_end = map_lang2index_.end();
+    int32 lang_id;
+    it = map_lang2index_.find(lang_code);
+    if(it == it_end)
+      return false;
+    lang_id = it->second;
+    lang_id_vec_.Resize(vec_dim);
+    lang_id_vec_.Set(static_cast<BaseFloat>(lang_id));
+    return true;
+  }
+  void Resize(int32 vec_dim) {
+    lang_id_vec_.Resize(vec_dim, kCopyData);
+  }
+  void AddData() {
+    lang_randomizer_.AddData(lang_id_vec_);
+  }
+  void Randomize(const std::vector<int32> &mask) {
+    lang_randomizer_.Randomize(mask); 
+  }
+  void GetData() {
+    const Vector<BaseFloat> &lang_id_vec = lang_randomizer_.Value();
+    lang_id_vec_.Resize(lang_id_vec.Dim());
+    lang_id_vec_.CopyFromVec(lang_id_vec);
+    lang_randomizer_.Next();  
+  }
+  void SetNnetTarget(const Posterior *nnet_tgt) {
+    nnet_tgt_ = nnet_tgt;
+  }
+  void SetObjective(Xent *xent, Mse *mse) {
+    xent_ = xent, mse_ = mse_;
+  }
+  // forward propagating
+  void Propagate(const CuMatrixBase<BaseFloat> &in, CuMatrix<BaseFloat> *out) {
+    KALDI_ASSERT(lang_id_vec_.Dim() == in.NumRows());
+    nnet_->propagate_buf_[0].Resize(in.NumRows(), in.NumCols());
+    nnet_->propagate_buf_[0].CopyFromMat(in);
+    int32 i = 0;
+    for(; i < nnet_->components_.size() - 2; i++) {
+      nnet_->components_[i]->Propagate(nnet_->propagate_buf_[i], &nnet_->propagate_buf_[i+1]);
+    }
+    // go through the last two layers
+    int32 total_rows = 0, nrows = nnet_->propagate_buf_[i].NumRows(), ncols = nnet_->propagate_buf_[i].NumCols();
+    vec_out_.resize(0); 
+    vec_index_.resize(0);
+    vec_tgt_.resize(0);
+    for (int32 j=0; j< vec_nnet_.size(); j++) {
+      int32 row_index = 0;
+      Posterior post;
+      CuMatrix<BaseFloat> tmp_mat(nrows, ncols);
+      for(int32 k=0; k<lang_id_vec_.Dim(); k++) {
+        int32 index_j = static_cast<int32>(lang_id_vec_(k));
+        if(index_j == j) {   // the input belongs to the current language
+          CuSubMatrix<BaseFloat> sub_mat(tmp_mat, row_index, 1, 0, ncols); 
+          sub_mat.CopyFromMat(nnet_->propagate_buf_[i].Range(k, 1, 0, ncols));
+          vec_index_.push_back(k);
+          post.push_back((*nnet_tgt_)[k]);
+          row_index ++; 
+        }
+      }
+      vec_tgt_.push_back(post);
+      if(row_index == 0) { // no input belongs to the current language
+        CuMatrix<BaseFloat> out;
+        vec_out_.push_back(out);   // an uninitialized matrix as output
+        total_lang_absence_ ++;
+        continue;
+      }
+      CuMatrix<BaseFloat> mling_in(row_index, ncols);
+      mling_in.CopyFromMat(tmp_mat.Range(0, row_index, 0, ncols));
+      Nnet *nnet = vec_nnet_[j];
+      CuMatrix<BaseFloat> mling_out;
+      nnet->Propagate(mling_in, &mling_out);
+      KALDI_ASSERT(mling_in.NumRows() == mling_out.NumRows());
+      vec_out_.push_back(mling_out);
+      total_rows += row_index;
+    }
+    KALDI_ASSERT(total_rows == nrows);
+    KALDI_ASSERT(vec_index_.size() == nrows && vec_tgt_.size() == vec_nnet_.size()); 
+    total_minibatch_ ++;
+    if(total_minibatch_ % 5000 == 0) {
+      KALDI_VLOG(1) << "After " << total_minibatch_ << " minibatches, "
+                    << "we have " << total_lang_absence_/total_minibatch_
+                    << " language absence per minibatches.";
+    }
+  }
+  void Eval(const Vector<BaseFloat> &frm_weights) {
+    vec_diff_.resize(0);
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      CuMatrix<BaseFloat> obj_diff;
+      if(vec_out_[i].NumRows() > 0) {
+        Vector<BaseFloat> cur_frm_weights(SubVector<BaseFloat>(frm_weights, 0, vec_out_[i].NumRows()));
+        if(objective_function_ == "xent") {
+          xent_->Eval(cur_frm_weights, vec_out_[i], vec_tgt_[i], &obj_diff); 
+        } else if(objective_function_ == "mse") {
+          mse_->Eval(cur_frm_weights, vec_out_[i], vec_tgt_[i], &obj_diff);
+        } else {
+          KALDI_ERR << "Unknown objective function code : " << objective_function_;
+        }
+      }
+      vec_diff_.push_back(obj_diff);
+    }
+  }
+  void Backpropagate(CuMatrix<BaseFloat> *in_diff) {
+    KALDI_ASSERT(nnet_->NumComponents() != 0 && vec_diff_.size() == vec_nnet_.size());
+    int32 num_rows = 0;
+    for(int32 i = 0; i < vec_diff_.size(); i++) {
+      num_rows += vec_diff_[i].NumRows();
+    }
+    KALDI_ASSERT(num_rows == vec_index_.size());
+    const int32 &num_cols = vec_nnet_[0]->InputDim();
+    CuMatrix<BaseFloat> out_diff(num_rows, num_cols, kSetZero);
+    int32 total_row = 0;
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      if(vec_out_[i].NumRows() > 0) {
+        CuMatrix<BaseFloat> cur_diff;
+        vec_nnet_[i]->Backpropagate(vec_diff_[i], &cur_diff);
+        for(int32 j = 0; j < cur_diff.NumRows(); ++j, ++total_row) {
+          int32 cur_row = vec_index_[total_row];
+          CuSubMatrix<BaseFloat> x(out_diff, cur_row, 1, 0, num_cols);
+          x.CopyFromMat(cur_diff.Range(j, 1, 0, num_cols));
+        }
+      }
+    }
+    KALDI_ASSERT(total_row == num_rows);
+    nnet_->backpropagate_buf_[nnet_->NumComponents()-2] = out_diff;
+    // backpropagate using buffers
+    for (int32 i = nnet_->NumComponents()-3; i >= 0; i--) {
+      nnet_->components_[i]->Backpropagate(nnet_->propagate_buf_[i], nnet_->propagate_buf_[i+1],
+                            nnet_->backpropagate_buf_[i+1], &nnet_->backpropagate_buf_[i]);
+      if (nnet_->components_[i]->IsUpdatable()) {
+        UpdatableComponent *uc = dynamic_cast<UpdatableComponent*>(nnet_->components_[i]);
+        uc->Update(nnet_->propagate_buf_[i], nnet_->backpropagate_buf_[i+1]);
+      }
+    }
+    // eventually export the derivative
+    if (NULL != in_diff) (*in_diff) = nnet_->backpropagate_buf_[0];
+  }
+  void InfoGradient(std::ostringstream &ostr, int32 mIndex) {
+    ostr << "Component " << mIndex+1 << " {" << std::endl;
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      ostr << "  Multilingual " << i+1 << " {" << std::endl;
+      ostr << "  " << vec_nnet_[i]->InfoGradient();
+      ostr << "  }" << std::endl; 
+    }
+    ostr << "}" << std::endl;
+  }
+  void InfoPropagate(std::ostringstream &ostr, int32 mIndex) {
+    ostr << "[" << mIndex + 1 << "] output of {" << std::endl;
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      ostr << "  Multilingual [" << i+1 << "[ {" << std::endl;
+      ostr << "  " << vec_nnet_[i]->InfoPropagate();
+      ostr << "  }" << std::endl;
+    }
+    ostr << "}" <<std::endl;
+  }
+  void InfoBackPropagate(std::ostringstream &ostr, int32 mIndex) {
+    ostr << "[" << mIndex + 1 << "] diff-output of {" << std::endl;
+    for(int32 i = 0; i < vec_nnet_.size(); ++i) {
+      ostr << "  Multilingual [" << i+1 << "[ {" << std::endl;
+      ostr << "  " << vec_nnet_[i]->InfoBackPropagate();
+      ostr << "  }" << std::endl;
+    }
+    ostr << "}" << std::endl;
+  }
+  void Write(bool binary) {
+    for(int32 i = 0; i < vec_nnet_.size(); i++) {
+      vec_nnet_[i]->Write(vec_model_wfilename_[i], binary);
+    }
+  }
+ private:
+  void FillMap(std::vector<std::string> &vec_lang_name) {
+    for(int32 i = 0; i < vec_lang_name.size(); i++) {
+      std::map<std::string, int32>::iterator it, it_end = map_lang2index_.end();
+      it = map_lang2index_.find(vec_lang_name[i]);
+      if(it != it_end) {
+        KALDI_ERR << "lang code " << vec_lang_name[i] << "duplicated";
+      }
+      map_lang2index_.insert(std::pair<std::string, int32>(vec_lang_name[i], i));
+    }
+  }
+  void InitNnet(std::vector<std::string> &vec_model_rfilename, 
+                const NnetTrainOptions &trn_opts) {
+    for(int32 i = 0; i < vec_model_rfilename.size(); i ++) {
+      Nnet *pNnet = new Nnet();
+      pNnet->Read(vec_model_rfilename[i]);
+      pNnet->SetTrainOptions(trn_opts);
+      vec_nnet_.push_back(pNnet);
+    }
+  }
+ private:
+  RandomAccessTokenReader utt2lang_reader_;
+  std::vector<std::string> vec_model_wfilename_;
+  std::map<const std::string,int32> map_lang2index_;
+  std::string objective_function_;
+  Vector<BaseFloat> lang_id_vec_;
+  
+  VectorRandomizer lang_randomizer_;
+  Nnet *nnet_;
+  std::vector<Nnet*> vec_nnet_;
+  std::vector<CuMatrix<BaseFloat> > vec_out_;
+  std::vector<int32> vec_index_;
+  const Posterior *nnet_tgt_;
+  std::vector<Posterior> vec_tgt_;
+  std::vector<CuMatrix<BaseFloat> > vec_diff_;
+  Xent *xent_;
+  Mse  *mse_;
+  int64 total_lang_absence_, total_minibatch_; // for log
+};
+
+}  // namespace nnet1
+}  // namespace kaldi
+
+#endif

--- a/src/nnet/nnet-trnopts.h
+++ b/src/nnet/nnet-trnopts.h
@@ -21,6 +21,7 @@
 #define KALDI_NNET_NNET_TRNOPTS_H_
 
 #include "base/kaldi-common.h"
+#include "util/text-utils.h"
 #include "itf/options-itf.h"
 
 namespace kaldi {
@@ -33,11 +34,15 @@ struct NnetTrainOptions {
   BaseFloat momentum;
   BaseFloat l2_penalty;
   BaseFloat l1_penalty;
+  bool  freeze_update;
+  int32 parallel_level;
   // default values
   NnetTrainOptions() : learn_rate(0.008),
                        momentum(0.0),
                        l2_penalty(0.0),
-                       l1_penalty(0.0) 
+                       l1_penalty(0.0),
+                       freeze_update(false),
+                       parallel_level(-1)
                        { }
   // register options
   void Register(OptionsItf *opts) {
@@ -45,6 +50,8 @@ struct NnetTrainOptions {
     opts->Register("momentum", &momentum, "Momentum");
     opts->Register("l2-penalty", &l2_penalty, "L2 penalty (weight decay)");
     opts->Register("l1-penalty", &l1_penalty, "L1 penalty (promote sparsity)");
+    opts->Register("freeze-update", &freeze_update, "disable updating the main nnet");
+    opts->Register("parallel-level", &parallel_level, "indicate at which hidden layer subnets are attached, indexed from 1");
   }
   // print for debug purposes
   friend std::ostream& operator<<(std::ostream& os, const NnetTrainOptions& opts) {
@@ -52,7 +59,9 @@ struct NnetTrainOptions {
        << "learn_rate" << opts.learn_rate << ", "
        << "momentum" << opts.momentum << ", "
        << "l2_penalty" << opts.l2_penalty << ", "
-       << "l1_penalty" << opts.l1_penalty;
+       << "l1_penalty" << opts.l1_penalty << ", "
+       << "freeze_update" << opts.freeze_update << ", "
+       << "parallel_level" << opts.parallel_level;
     return os;
   }
 };
@@ -98,6 +107,45 @@ struct RbmTrainOptions {
        << "momentum_steps" << opts.momentum_steps << ", "
        << "momentum_step_period" << opts.momentum_step_period << ", "
        << "l2_penalty" << opts.l2_penalty;
+    return os;
+  }
+};
+struct ParallelNnetOptions {
+  // int32 parallel_level_sub;
+  bool parallel_freeze_update;
+  std::string parallel_feature;
+  std::string parallel_utt2spk;
+  std::string parallel_feature_transform;
+  std::string parallel_net;
+  std::string parallel_update;
+  int32 parallel_nnet_level;
+  ParallelNnetOptions() : parallel_freeze_update(false),
+                          parallel_feature(""),
+                          parallel_utt2spk(""),
+                          parallel_feature_transform(""),
+                          parallel_net(""),
+                          parallel_update(""),
+                          parallel_nnet_level(-1)
+                          { }
+  void Register(OptionsItf *opts) {
+    // opts->Register("parallel-level", &parallel_level, "indicate which layer to insert the sub nnet, starting from 1");
+    opts->Register("parallel-freeze-update", &parallel_freeze_update, "determine if parameter is updatable");
+    opts->Register("parallel-feature", &parallel_feature, "feature reader specifiers, splitted with \';\' mark");
+    opts->Register("parallel-utt2spk", &parallel_utt2spk, "utt2spk specifiers, splitted with \';\' mark");
+    opts->Register("parallel-feature-transform", &parallel_feature_transform, "feature transform files, splitted with \';\' mark");
+    opts->Register("parallel-net", &parallel_net, "input sub net specifiers, splitted with \';\' mark");
+    opts->Register("parallel-update", &parallel_update, "updated sub net specifiers, splitted with \';\' mark");
+    opts->Register("parallel-nnet-level", &parallel_nnet_level, "indicate at which hidden layer subnets are attached, indexed from 1");
+  } 
+  friend std::ostream & operator<<(std::ostream& os, const ParallelNnetOptions opts) {
+    os << "ParallelOptions: "
+       << "parallel_freeze_update " << opts.parallel_freeze_update << ", "
+       << "parallel_feature " << opts.parallel_feature << ", "
+       << "parallel_utt2spk " << opts.parallel_utt2spk << ", "
+       << "parallel_feature_transform " << opts.parallel_feature_transform << ", "
+       << "parallel_net " << opts.parallel_net << ", "
+       << "parallel_update " << opts.parallel_update << std::endl << ", "
+       << "parallel_nnet_level " << opts.parallel_nnet_level << std::endl;
     return os;
   }
 };

--- a/src/nnetbin/nnet-train-frmshuff-mling.cc
+++ b/src/nnetbin/nnet-train-frmshuff-mling.cc
@@ -1,0 +1,376 @@
+// nnetbin/nnet-train-frmshuff.cc
+
+// Copyright 2013  Brno University of Technology (Author: Karel Vesely)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nnet/nnet-trnopts.h"
+#include "nnet/nnet-nnet.h"
+#include "nnet/nnet-mnet.h"
+#include "nnet/nnet-loss.h"
+#include "nnet/nnet-randomizer.h"
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "base/timer.h"
+#include "cudamatrix/cu-device.h"
+
+int main(int argc, char *argv[]) {
+  using namespace kaldi;
+  using namespace kaldi::nnet1;
+  typedef kaldi::int32 int32;  
+  
+  try {
+    const char *usage =
+        "Perform one iteration of Neural Network training by mini-batch Stochastic Gradient Descent.\n"
+        "This version use pdf-posterior as targets, prepared typically by ali-to-post.\n"
+        "Usage:  nnet-train-frmshuff [options] <feature-rspecifier> <targets-rspecifier> <model-in> [<model-out>]\n"
+        "e.g.: \n"
+        " nnet-train-frmshuff scp:feature.scp ark:posterior.ark nnet.init nnet.iter1\n";
+
+    ParseOptions po(usage);
+
+    NnetTrainOptions trn_opts;
+    trn_opts.Register(&po);
+    NnetDataRandomizerOptions rnd_opts;
+    rnd_opts.Register(&po);
+
+    bool binary = true, 
+         crossvalidate = false,
+         randomize = true;
+    po.Register("binary", &binary, "Write output in binary mode");
+    po.Register("cross-validate", &crossvalidate, "Perform cross-validation (don't backpropagate)");
+    po.Register("randomize", &randomize, "Perform the frame-level shuffling within the Cache::");
+
+    std::string feature_transform;
+    po.Register("feature-transform", &feature_transform, "Feature transform in Nnet format");
+    std::string objective_function = "xent";
+    po.Register("objective-function", &objective_function, "Objective function : xent|mse");
+
+    int32 length_tolerance = 5;
+    po.Register("length-tolerance", &length_tolerance, "Allowed length difference of features/targets (frames)");
+    
+    std::string frame_weights;
+    po.Register("frame-weights", &frame_weights, "Per-frame weights to scale gradients (frame selection/weighting).");
+
+    std::string utt_weights;
+    po.Register("utt-weights", &utt_weights, "Per-utterance weights (scalar applied to frame-weights).");
+
+    std::string use_gpu="yes";
+    po.Register("use-gpu", &use_gpu, "yes|no|optional, only has effect if compiled with CUDA");
+    std::string mling_opts = "";
+    po.Register("mling-opts", &mling_opts, "csl opts for multilingual training, the format                should be \"ark:utt2lang;lang1,lang2,...langN;in-nnetfiles;out-nnetfiles\""); 
+    double dropout_retention = 0.0;
+    po.Register("dropout-retention", &dropout_retention, "number between 0..1, saying how many neurons to preserve (0.0 will keep original value");
+     
+    
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 4-(crossvalidate?1:0)) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    std::string feature_rspecifier = po.GetArg(1),
+      targets_rspecifier = po.GetArg(2),
+      model_filename = po.GetArg(3);
+        
+    std::string target_model_filename;
+    if (!crossvalidate) {
+      target_model_filename = po.GetArg(4);
+    }
+
+    using namespace kaldi;
+    using namespace kaldi::nnet1;
+    typedef kaldi::int32 int32;
+
+    //Select the GPU
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().SelectGpuId(use_gpu);
+#endif
+
+    Nnet nnet_transf;
+    if(feature_transform != "") {
+      nnet_transf.Read(feature_transform);
+    }
+
+    Nnet nnet;
+    nnet.Read(model_filename);
+    nnet.SetTrainOptions(trn_opts);
+
+    if (dropout_retention > 0.0) {
+      nnet_transf.SetDropoutRetention(dropout_retention);
+      nnet.SetDropoutRetention(dropout_retention);
+    }
+    if (crossvalidate) {
+      nnet_transf.SetDropoutRetention(1.0);
+      nnet.SetDropoutRetention(1.0);
+    }
+
+    kaldi::int64 total_frames = 0;
+
+    SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
+    RandomAccessPosteriorReader targets_reader(targets_rspecifier);
+    RandomAccessBaseFloatVectorReader weights_reader;
+    if (frame_weights != "") {
+      weights_reader.Open(frame_weights);
+    }
+    RandomAccessBaseFloatReader utt_weights_reader;
+    if (utt_weights != "") {
+      utt_weights_reader.Open(utt_weights);
+    }
+    MultiNnet mNnet;
+    if(mling_opts != "") {
+      mNnet.Init(mling_opts, trn_opts, &nnet, rnd_opts, objective_function);
+      nnet.SetMultiNnet(&mNnet);
+    }
+    RandomizerMask randomizer_mask(rnd_opts);
+    MatrixRandomizer feature_randomizer(rnd_opts);
+    PosteriorRandomizer targets_randomizer(rnd_opts);
+    VectorRandomizer weights_randomizer(rnd_opts);
+
+    Xent xent;
+    Mse mse;
+    if(mling_opts != "") {
+      mNnet.SetObjective(&xent, &mse);
+    }
+    MultiTaskLoss multitask;
+    if (0 == objective_function.compare(0,9,"multitask")) {
+      // objective_function contains something like : 
+      // 'multitask,xent,2456,1.0,mse,440,0.001'
+      //
+      // the meaning is following:
+      // 'multitask,<type1>,<dim1>,<weight1>,...,<typeN>,<dimN>,<weightN>'
+      multitask.InitFromString(objective_function);
+    }
+    
+    CuMatrix<BaseFloat> feats_transf, nnet_out, obj_diff;
+
+    Timer time;
+    KALDI_LOG << (crossvalidate?"CROSS-VALIDATION":"TRAINING") << " STARTED";
+
+    int32 num_done = 0, num_no_tgt_mat = 0, num_other_error = 0;
+    while (!feature_reader.Done()) {
+#if HAVE_CUDA==1
+      // check the GPU is not overheated
+      CuDevice::Instantiate().CheckGpuHealth();
+#endif
+      // fill the randomizer
+      for ( ; !feature_reader.Done(); feature_reader.Next()) {
+        if (feature_randomizer.IsFull()) break; // suspend, keep utt for next loop
+        std::string utt = feature_reader.Key();
+        KALDI_VLOG(3) << "Reading " << utt;
+        // check that we have targets
+        if (!targets_reader.HasKey(utt)) {
+          KALDI_WARN << utt << ", missing targets";
+          num_no_tgt_mat++;
+          continue;
+        }
+        // check we have per-frame weights
+        if (frame_weights != "" && !weights_reader.HasKey(utt)) {
+          KALDI_WARN << utt << ", missing per-frame weights";
+          num_other_error++;
+          continue;
+        }
+        // check we have per-utterance weights
+        if (utt_weights != "" && !utt_weights_reader.HasKey(utt)) {
+          KALDI_WARN << utt << ", missing per-utterance weight";
+          num_other_error++;
+          continue;
+        }
+        // get feature / target pair
+        Matrix<BaseFloat> mat = feature_reader.Value();
+        if(mling_opts != "" && !mNnet.SetLangIdVec(utt, mat.NumRows())) {
+          KALDI_WARN << utt << ", missing language id";
+          num_other_error ++;
+          continue;
+        }
+        Posterior targets = targets_reader.Value(utt);
+        // get per-frame weights
+        Vector<BaseFloat> weights;
+        if (frame_weights != "") {
+          weights = weights_reader.Value(utt);
+        } else { // all per-frame weights are 1.0
+          weights.Resize(mat.NumRows());
+          weights.Set(1.0);
+        }
+        // multiply with per-utterance weight,
+        if (utt_weights != "") {
+          BaseFloat w = utt_weights_reader.Value(utt);
+          KALDI_ASSERT(w >= 0.0);
+          if (w == 0.0) continue; // remove sentence from training,
+          weights.Scale(w);
+        }
+
+        // correct small length mismatch ... or drop sentence
+        {
+          // add lengths to vector
+          std::vector<int32> lenght;
+          lenght.push_back(mat.NumRows());
+          lenght.push_back(targets.size());
+          lenght.push_back(weights.Dim());
+          // find min, max
+          int32 min = *std::min_element(lenght.begin(),lenght.end());
+          int32 max = *std::max_element(lenght.begin(),lenght.end());
+          // fix or drop ?
+          if (max - min < length_tolerance) {
+            if(mat.NumRows() != min) { 
+              mat.Resize(min, mat.NumCols(), kCopyData);
+              if(mling_opts != "")
+                mNnet.Resize(min);
+            }
+            if(targets.size() != min) targets.resize(min);
+            if(weights.Dim() != min) weights.Resize(min, kCopyData);
+          } else {
+            KALDI_WARN << utt << ", length mismatch of targets " << targets.size()
+                       << " and features " << mat.NumRows();
+            num_other_error++;
+            continue;
+          }
+        }
+        // apply optional feature transform
+        nnet_transf.Feedforward(CuMatrix<BaseFloat>(mat), &feats_transf);
+
+        // pass data to randomizers
+        KALDI_ASSERT(feats_transf.NumRows() == targets.size());
+        feature_randomizer.AddData(feats_transf);
+        targets_randomizer.AddData(targets);
+        weights_randomizer.AddData(weights);
+        if(mling_opts != "") mNnet.AddData();
+        num_done++;
+      
+        // report the speed
+        if (num_done % 5000 == 0) {
+          double time_now = time.Elapsed();
+          KALDI_VLOG(1) << "After " << num_done << " utterances: time elapsed = "
+                        << time_now/60 << " min; processed " << total_frames/time_now
+                        << " frames per second.";
+        }
+      }
+
+      // randomize
+      if (!crossvalidate && randomize) {
+        const std::vector<int32>& mask = randomizer_mask.Generate(feature_randomizer.NumFrames());
+        feature_randomizer.Randomize(mask);
+        targets_randomizer.Randomize(mask);
+        weights_randomizer.Randomize(mask);
+        if(mling_opts != "") mNnet.Randomize(mask);
+      }
+
+      // train with data from randomizers (using mini-batches)
+      for ( ; !feature_randomizer.Done(); feature_randomizer.Next(),
+                                          targets_randomizer.Next(),
+                                          weights_randomizer.Next()) {
+        // get block of feature/target pairs
+        const CuMatrixBase<BaseFloat>& nnet_in = feature_randomizer.Value();
+        const Posterior& nnet_tgt = targets_randomizer.Value();
+        const Vector<BaseFloat>& frm_weights = weights_randomizer.Value();
+        if(mling_opts != "") {
+          mNnet.SetNnetTarget(&nnet_tgt);
+          mNnet.GetData();
+        }
+        // forward pass
+        nnet.Propagate(nnet_in, &nnet_out);
+        if(mling_opts != "") {
+          mNnet.Eval(frm_weights);
+        } else {
+          // evaluate objective function we've chosen
+          if (objective_function == "xent") {
+            // gradients re-scaled by weights in Eval,
+            xent.Eval(frm_weights, nnet_out, nnet_tgt, &obj_diff); 
+          } else if (objective_function == "mse") {
+            // gradients re-scaled by weights in Eval,
+            mse.Eval(frm_weights, nnet_out, nnet_tgt, &obj_diff);
+          } else if (0 == objective_function.compare(0,9,"multitask")) {
+            // gradients re-scaled by weights in Eval,
+            multitask.Eval(frm_weights, nnet_out, nnet_tgt, &obj_diff);
+          } else {
+            KALDI_ERR << "Unknown objective function code : " << objective_function;
+          }
+        }
+        // backward pass
+        if (!crossvalidate) {
+          // backpropagate
+          nnet.Backpropagate(obj_diff, NULL);
+        }
+
+        // 1st minibatch : show what happens in network 
+        if (kaldi::g_kaldi_verbose_level >= 1 && total_frames == 0) { // vlog-1
+          KALDI_VLOG(1) << "### After " << total_frames << " frames,";
+          KALDI_VLOG(1) << nnet.InfoPropagate();
+          if (!crossvalidate) {
+            KALDI_VLOG(1) << nnet.InfoBackPropagate();
+            KALDI_VLOG(1) << nnet.InfoGradient();
+          }
+        }
+        
+        // monitor the NN training
+        if (kaldi::g_kaldi_verbose_level >= 2) { // vlog-2
+          if ((total_frames/25000) != ((total_frames+nnet_in.NumRows())/25000)) { // print every 25k frames
+            KALDI_VLOG(2) << "### After " << total_frames << " frames,";
+            KALDI_VLOG(2) << nnet.InfoPropagate();
+            if (!crossvalidate) {
+              KALDI_VLOG(2) << nnet.InfoGradient();
+            }
+          }
+        }
+        
+        total_frames += nnet_in.NumRows();
+      }
+    }
+    
+    // after last minibatch : show what happens in network 
+    if (kaldi::g_kaldi_verbose_level >= 1) { // vlog-1
+      KALDI_VLOG(1) << "### After " << total_frames << " frames,";
+      KALDI_VLOG(1) << nnet.InfoPropagate();
+      if (!crossvalidate) {
+        KALDI_VLOG(1) << nnet.InfoBackPropagate();
+        KALDI_VLOG(1) << nnet.InfoGradient();
+      }
+    }
+
+    if (!crossvalidate) {
+      nnet.Write(target_model_filename, binary);
+      mNnet.Write(binary);
+    }
+
+    KALDI_LOG << "Done " << num_done << " files, " << num_no_tgt_mat
+              << " with no tgt_mats, " << num_other_error
+              << " with other errors. "
+              << "[" << (crossvalidate?"CROSS-VALIDATION":"TRAINING")
+              << ", " << (randomize?"RANDOMIZED":"NOT-RANDOMIZED") 
+              << ", " << time.Elapsed()/60 << " min, fps" << total_frames/time.Elapsed()
+              << "]";  
+
+    if (objective_function == "xent") {
+      KALDI_LOG << xent.Report();
+    } else if (objective_function == "mse") {
+      KALDI_LOG << mse.Report();
+    } else if (0 == objective_function.compare(0,9,"multitask")) {
+      KALDI_LOG << multitask.Report();
+    } else {
+      KALDI_ERR << "Unknown objective function code : " << objective_function;
+    }
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().PrintProfile();
+#endif
+
+    return 0;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}

--- a/src/nnetbin/paste-post.cc
+++ b/src/nnetbin/paste-post.cc
@@ -56,7 +56,8 @@ int main(int argc, char *argv[]) {
     bool allow_partial = false;
     po.Register("allow-partial", &allow_partial, 
                 "Produce output also when the utterance is not in all input streams.");
-
+    bool no_merge = false;
+    po.Register("no-merge", &no_merge, "Make output in a copy mode");
     po.Read(argc, argv);
 
     if (po.NumArgs() < 5) {
@@ -134,7 +135,11 @@ int main(int argc, char *argv[]) {
               int32 id = post_s[f][i].first;
               BaseFloat val = post_s[f][i].second;
               KALDI_ASSERT(id < stream_dims[s]);
-              post[f].push_back(std::make_pair(stream_offset[s] + id, val));
+              if(!no_merge) {
+                post[f].push_back(std::make_pair(stream_offset[s] + id, val));
+              } else {
+                post[f].push_back(std::make_pair(id, val));
+              }
             }
           }
           empty = false;


### PR DESCRIPTION
1 multilingual training code  nnet-train-frmshuff-mling is added (see nnet-mnet.h for details)
2 multilingual training script run-multilingual.sh is added
2.1 If you want to try kaldi nnet1 multilingual training recipe, please use --steps 1,2,3,4 for dnn, and use --steps 5,6,7 for bottle-neck;  and --steps 1,3,7,8 for my multilingual training recipe.  Please type the command and see the help information
 