### PR TITLE
Enable cross compile

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -28,6 +28,14 @@
 #        # built for the target install to /opt/cross/armv8hf and that the
 #        # armv8-rpi3-linux-gnueabihf toolchain is available in your path
 # ./configure --static --fst-root=/opt/cross/armv8hf --atlas-root=/opt/cross/armv8hf --host=armv8-rpi3-linux-gnueabihf
+#        # Cross compile for Android on arm
+#        # The only difference here is the addtion of the the --android-includes
+#        # flag because the toolchains produced by the Android NDK don't always
+#        # include the C++ stdlib headers in the normal cross compile include
+#        # path
+# ./configure --static --openblas-root=/opt/cross/arm-linux-androideabi \
+# --fst-root=/opt/cross/arm-linux-androideabi --host=arm-linux-androideabi \
+# --fst-version=1.4.1 --android-includes=/opt/cross/arm-linux-androideabi/sysroot/usr/include
 
 #This should be incremented after every significant change of the configure script
 #I.e. after each change that affects the kaldi.mk or the build system as whole
@@ -82,7 +90,7 @@ function usage {
   [--openblas-root=OPENBLASROOOT] [--clapack-root=CLAPACKROOT] [--mkl-root=MKLROOT] [--mkl-libdir=MKLLIBDIR]
   [--omp-libdir=OMPDIR] [--static-fst={yes|no}] [--static-math={yes|no}] [--threaded-math={yes|no}] [--mathlib=ATLAS|MKL|CLAPACK|OPENBLAS]
   [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp] [--fst-version=VERSION]
-  [--host=HOST]';
+  [--host=HOST] [--android-includes=ANDROID_INC_DIR]';
 }
 
 threaded_atlas=false #  By default, use the un-threaded version of ATLAS.
@@ -96,6 +104,7 @@ mkl_threading=sequential
 # switch.  TARGET_ARCH will be the first value in HOST if set, and `uname -m` otherwise
 HOST=""
 TARGET_ARCH=""
+android=false
 
 cmd_line="$0 $@"  # Save the command line to include in kaldi.mk
 
@@ -204,6 +213,15 @@ do
     # this script will infer the target architecture from the specified triple.
     HOST=`expr "X$1" : '[^=]*=\(.*\)'`;
     shift ;;
+  --android-includes=*)
+    threaded_math=false;
+    static_math=true;
+    static_fst=true;
+    dynamic_kaldi=false;
+    MATHLIB='OPENBLAS';
+    android=true;
+    ANDROIDINC=`read_dirname $1`;
+    shift;;
   *)  echo "Unknown argument: $1, exiting"; usage; exit 1 ;;
   esac
 done
@@ -985,6 +1003,42 @@ fi
 
 # Most of the OS-specific steps below will append to kaldi.mk
 echo "Doing OS specific configurations ..."
+
+if $android ; then
+  OPENFSTLIBS="$FSTROOT/lib/libfst.a"
+  echo "OPENFSTLIBS = $OPENFSTLIBS" >> kaldi.mk
+
+  if [ -z $ANDROIDINC ] ;  then
+    failure "--android-includes must be specified for android builds"
+  fi
+
+  if [ -z $HOST ] ; then
+    failure "HOST must be specified for android builds"
+  fi
+
+  OPENBLASROOT=`rel2abs "$OPENBLASROOT"`
+  if [ -z "$OPENBLASROOT" ]; then
+    failure "Must specify the location of OPENBLAS with --openblas-root option (and it must exist)"
+  fi
+  if [ ! -f $OPENBLASROOT/lib/libopenblas.a ]; then
+    failure "Expected to find the file $OPENBLASROOT/lib/libopenblas.a"
+  fi
+  echo "Your math library seems to be OpenBLAS.  Configuring appropriately."
+
+  OPENBLASLIBS="$OPENBLASROOT/lib/libopenblas.a $OPENBLASROOT/lib/libclapack.a $OPENBLASROOT/lib/liblapack.a $OPENBLASROOT/lib/libblas.a $OPENBLASROOT/lib/libf2c.a"
+  echo "OPENBLASROOT = $OPENBLASROOT" >> kaldi.mk
+  echo "OPENBLASLIBS = $OPENBLASLIBS" >> kaldi.mk
+  echo "ANDROIDINC = $ANDROIDINC" >> kaldi.mk
+
+  cat makefiles/android_openblas.mk >> kaldi.mk
+
+  add_cross_tools
+
+  echo "Successfully configured OpenBLAS from $OPENBLASROOT."
+  echo "Configuration succeeded for platform Android"
+  exit_success
+fi
+
 
 # Check for Darwin at first, because we later call uname -o (for Cygwin)
 # which crashes on Darwin. Also the linear algebra libraries on Macs are

--- a/src/configure
+++ b/src/configure
@@ -22,10 +22,16 @@
 # ./configure --atlas-root=../tools/ATLAS/build
 # ./configure --use-cuda=no   # disable CUDA detection (will build cpu-only
 #                             # version of kaldi even on CUDA-enabled machine
+#        # Cross compile for armv8hf, this assumes that you have openfst built
+#        # with the armv8-rpi3-linux-gnueabihf toolchain and installed to
+#        # /opt/cross/armv8hf.  It also assumes that you have an ATLAS library
+#        # built for the target install to /opt/cross/armv8hf and that the
+#        # armv8-rpi3-linux-gnueabihf toolchain is available in your path
+# ./configure --static --fst-root=/opt/cross/armv8hf --atlas-root=/opt/cross/armv8hf --host=armv8-rpi3-linux-gnueabihf
 
 #This should be incremented after every significant change of the configure script
 #I.e. after each change that affects the kaldi.mk or the build system as whole
-CONFIGURE_VERSION=4
+CONFIGURE_VERSION=5
 
 function rel2abs {
   if [ ! -z "$1" ]; then
@@ -69,12 +75,14 @@ unset MKLROOT
 unset CLAPACKROOT
 unset OPENBLASROOT
 unset MKLLIBDIR
+unset HOST
 
 function usage {
   echo 'Usage: ./configure [--static|--shared] [--threaded-atlas={yes|no}] [--atlas-root=ATLASROOT] [--fst-root=FSTROOT]
   [--openblas-root=OPENBLASROOOT] [--clapack-root=CLAPACKROOT] [--mkl-root=MKLROOT] [--mkl-libdir=MKLLIBDIR]
   [--omp-libdir=OMPDIR] [--static-fst={yes|no}] [--static-math={yes|no}] [--threaded-math={yes|no}] [--mathlib=ATLAS|MKL|CLAPACK|OPENBLAS]
-  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp] [--fst-version=VERSION]';
+  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp] [--fst-version=VERSION]
+  [--host=HOST]';
 }
 
 threaded_atlas=false #  By default, use the un-threaded version of ATLAS.
@@ -84,6 +92,10 @@ static_fst=false
 use_cuda=true
 dynamic_kaldi=false
 mkl_threading=sequential
+# HOST and TARGET_ARCH are used when cross compiling, the user will specify HOST via the --host
+# switch.  TARGET_ARCH will be the first value in HOST if set, and `uname -m` otherwise
+HOST=""
+TARGET_ARCH=""
 
 cmd_line="$0 $@"  # Save the command line to include in kaldi.mk
 
@@ -187,14 +199,34 @@ do
   --fst-version=*)
     OPENFST_VER=`expr "X$1" : '[^=]*=\(.*\)'`;
     shift;;
+  --host=*)
+    # This expects the same format of host "triple" as autotools based projects
+    # this script will infer the target architecture from the specified triple.
+    HOST=`expr "X$1" : '[^=]*=\(.*\)'`;
+    shift ;;
   *)  echo "Unknown argument: $1, exiting"; usage; exit 1 ;;
   esac
 done
+
 
 # the idea here is that if you change the configuration options from using
 # CUDA to not using it, or vice versa, we want to recompile all parts of the
 # code that may use a GPU.  Touching this file is a way to force this.
 touch cudamatrix/cu-common.h 2>/dev/null
+
+
+function add_cross_tools {
+  # If the $HOST variable is set, we need to tell make to use the specified tools
+  if [ ! -z "$HOST" ]; then
+    echo '# A host triple was specified, we need to prepend all the tools with it' >> kaldi.mk
+    echo "HOST = $HOST" >> kaldi.mk
+    echo 'CC := $(HOST)-$(CC)' >> kaldi.mk
+    echo 'CXX := $(HOST)-$(CXX)' >> kaldi.mk
+    echo 'AR := $(HOST)-$(AR)' >> kaldi.mk
+    echo 'AS := $(HOST)-$(AS)' >> kaldi.mk
+    echo 'RANLIB := $(HOST)-$(RANLIB)' >> kaldi.mk
+  fi
+}
 
 function failure {
   echo "***configure failed: $* ***" >&2
@@ -207,8 +239,13 @@ function check_exists {
 }
 
 function check_for_bad_gcc {
-  if which gcc >&/dev/null; then  # gcc is on the path
-    gcc_version=$(gcc -dumpspecs 2>&1 | grep -A1 -F '*version:' | grep -v version)
+  if [ -z "$HOST" ] ; then
+    compiler="gcc"
+  else
+    compiler="$HOST-gcc"
+  fi
+  if which $compiler >&/dev/null; then  # gcc is on the path
+    gcc_version=$($compiler -dumpspecs 2>&1 | grep -A1 -F '*version:' | grep -v version)
     if [ "$gcc_version" == "4.8.2" ] || [ "$gcc_version" == "4.8.1" ]; then
       echo "*** WARNING: your version of gcc seems to be 4.8.1 or 4.8.2. ***"
       echo "*** These versions of gcc has a bug in nth_element ***"
@@ -221,16 +258,19 @@ function check_for_bad_gcc {
 }
 
 function check_for_slow_expf {
-  cd probe
-  rm -f exp-test
-  make -f Makefile.slow_expf 1>/dev/null
-  ./exp-test
-  if [ $? -eq 1 ]; then
-      echo "*** WARNING: expf() seems to be slower than exp() on your machine. This is a known bug in old versions of glibc. Please consider updating glibc. ***"
-      echo "*** Kaldi will be configured to use exp() instead of expf() in base/kaldi-math.h Exp() routine for single-precision floats. ***"
-      echo "CXXFLAGS += -DKALDI_NO_EXPF" >> ../kaldi.mk
+  # We cannot run this test if we are cross compiling.
+  if [[ "$TARGET_ARCH" == "`uname -m`" ]] ; then
+    cd probe
+    rm -f exp-test
+    make -f Makefile.slow_expf 1>/dev/null
+    ./exp-test
+    if [ $? -eq 1 ]; then
+        echo "*** WARNING: expf() seems to be slower than exp() on your machine. This is a known bug in old versions of glibc. Please consider updating glibc. ***"
+        echo "*** Kaldi will be configured to use exp() instead of expf() in base/kaldi-math.h Exp() routine for single-precision floats. ***"
+        echo "CXXFLAGS += -DKALDI_NO_EXPF" >> ../kaldi.mk
+    fi
+    cd ..
   fi
-  cd ..
 }
 
 
@@ -254,13 +294,38 @@ function check_library {
 }
 
 
-
 #Check if at least one of these variables is set
 #If yes, we want to switch to using the MKL
 is_set $MKLLIBDIR && echo "Force-configuring KALDI to use MKL" && export MATHLIB="MKL"
 is_set $MKLROOT && echo "Force-configuring KALDI to use MKL"&& export MATHLIB="MKL"
 is_set $CLAPACKROOT && echo "Force-configuring KALDI to use CLAPACK"&& export MATHLIB="CLAPACK"
 is_set $OPENBLASROOT && echo "Force-configuring KALDI to use OPENBLAS"&& export MATHLIB="OPENBLAS"
+
+
+# If HOST is specified, parse the TARGET_ARCH, otherwise use uname -m
+if [[ "$HOST" == "" ]] ; then
+  TARGET_ARCH="`uname -m`"
+else
+  # The HOST value will be something like "armv8-rpi3-linux-gnueabihf" and we need the first value
+  # as delimited by '-' to be used as the TARGET_ARCH for this build.  The read command is the
+  # bash equivalent of split() found in other scripting languages.  read uses the value in
+  # environment variable IFS as the field delimiter.  The following command will take the
+  # host string "armv8-rpi3-linux-gnueabihf" as streamed in from the HOST variable
+  # and return ["armv8", "rpi3", "linux", "gnueabihf"] in PARTS
+  #
+  # Note that by changing the value of IFS (which is an environment variable) on the same
+  # line as the read invocation, it is only changed for that invocation and not for the shell
+  # executing this script.  So we do not need to cache and reset the value.
+  IFS='-' read -ra PARTS <<< "$HOST"
+  # We only want the first entry from the list as the architecture
+  TARGET_ARCH="$PARTS"
+  if [[ "$TARGET_ARCH" != arm* && "$TARGET_ARCH" != ppc64le && "$TARGET_ARCH" != x86* ]] ; then
+    # We currently only support building for x86[_64], arm*, and ppc64le, if the
+    # TARGET_ARCH was read from the HOST variable, it must be one of these
+    failure "$TARGET_ARCH is an unsupported architecture, kaldi currently supports x86[_64], arm*, and ppc64le"
+  fi
+fi
+
 
 #MKL functions
 function linux_configure_mkllibdir {
@@ -436,6 +501,11 @@ function configure_cuda {
     if [ ! -f $CUDATKDIR/bin/nvcc ]; then
       failure "Cannnot find nvcc in CUDATKDIR=$CUDATKDIR"
     fi
+
+    if [[ "$TARGET_ARCH" != "`uname -m`" ]] ; then
+      failure "Cannot cross compile with CUDA support"
+    fi
+
     echo "Using CUDA toolkit $CUDATKDIR (nvcc compiler and runtime libraries)"
     echo >> kaldi.mk
     echo "#Next section enables CUDA for compilation" >> kaldi.mk
@@ -458,7 +528,7 @@ function configure_cuda {
     esac
     echo "CUDA_ARCH = $CUDA_ARCH" >> kaldi.mk
 
-    # 64bit/32bit?
+    # 64bit/32bit? We do not support cross compilation with CUDA so, use direct calls to uname -m here
     if [ "`uname -m`" == "x86_64" ]; then
       if [ "`uname`" == "Darwin" ]; then
         sed 's/lib64/lib/g' < makefiles/cuda_64bit.mk >> kaldi.mk
@@ -517,8 +587,13 @@ function linux_configure_speex {
 }
 
 function fix_cxx_flag {
-  CXXCOMPILER=`grep "CXX = " kaldi.mk | awk '{print $3}'`
-  if [ $CXXCOMPILER=="g++" ]; then
+  USINGGXX=`grep -c "CXX = g++" kaldi.mk`
+  if [ $USINGGXX -ge 1 ]; then
+    if [ -z "$HOST" ] ; then
+      CXXCOMPILER="g++"
+    else
+      CXXCOMPILER="$HOST-g++"
+    fi
     $CXXCOMPILER -dumpversion | \
     awk '{if(NR==1 && $1<"4.4") print "sed \"s/-Wno-unused-local-typedefs//g\" \
     kaldi.mk > tmpf; mv tmpf kaldi.mk; "}' | sh -
@@ -529,9 +604,9 @@ function linux_atlas_failure { # function we use when we couldn't find
    # ATLAS libs.
    echo ATLASINC = $ATLASROOT/include >> kaldi.mk
    echo ATLASLIBS = [somewhere]/liblapack.a [somewhere]/libcblas.a [somewhere]/libatlas.a [somewhere]/libf77blas.a $ATLASLIBDIR >> kaldi.mk
-   if [[ "`uname -m`" == arm* ]]; then
+   if [[ "$TARGET_ARCH" == arm* ]]; then
      cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-   elif [[ "`uname -m`" == ppc64le ]]; then
+   elif [[ "$TARGET_ARCH" == ppc64le ]]; then
      cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
    else
      cat makefiles/linux_atlas.mk >> kaldi.mk
@@ -561,7 +636,12 @@ function linux_check_static {
   if [ -f $dir/libatlas.a ]; then # candidate...
     # Note: on the next line, the variable assignment
     # LANG=en_US should apply just to the program called on that line.
-    if LANG=en_US gcc -o test_linking test_linking.cc -u ATL_flushcache $dir/libatlas.a 2>&1 | grep -i "incompatible" >/dev/null; then
+    if [ -z "$HOST" ] ; then
+      compiler="gcc"
+    else
+      compiler="$HOST-gcc"
+    fi
+    if LANG=en_US $compiler -o test_linking test_linking.cc -u ATL_flushcache $dir/libatlas.a 2>&1 | grep -i "incompatible" >/dev/null; then
       echo "Directory $dir may contain ATLAS libraries but seems to be wrong architecture";
       rm test_linking test_linking.cc 2>/dev/null
       return 1;
@@ -586,14 +666,15 @@ function linux_configure_debian_ubuntu {
   fi
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-   elif [[ "`uname -m`" == ppc64le ]]; then
+   elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   echo "Successfully configured for Debian/Ubuntu Linux [dynamic libraries] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
   linux_configure_speex
@@ -611,14 +692,15 @@ function linux_configure_debian_ubuntu3 {
   fi
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   echo "Successfully configured for Debian/Ubuntu Linux [dynamic libraries] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
   linux_configure_speex
@@ -639,14 +721,15 @@ function linux_configure_debian7 {
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS -Wl,-rpath=$libdir >> kaldi.mk
   echo
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   echo "Successfully configured for Debian 7 [dynamic libraries] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
   linux_configure_speex
@@ -664,14 +747,15 @@ function linux_configure_redhat {
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS -Wl,-rpath=$libdir >> kaldi.mk
   echo
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   echo "Successfully configured for red hat [dynamic libraries] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
   exit_success;
@@ -691,14 +775,15 @@ function linux_configure_redhat_fat {
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS -Wl,-rpath=$libdir >> kaldi.mk
   echo
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   echo "Successfully configured for red hat [dynamic libraries, fat] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
   exit_success;
@@ -750,14 +835,15 @@ function linux_configure_static {
 
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   $use_cuda && configure_cuda
   linux_configure_speex
   echo "Successfully configured for Linux [static libraries] with ATLASLIBS =$ATLASLIBS"
@@ -835,14 +921,15 @@ function linux_configure_dynamic {
 
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
-  if [[ "`uname -m`" == arm* ]]; then
+  if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
-  elif [[ "`uname -m`" == ppc64le ]]; then
+  elif [[ "$TARGET_ARCH" == ppc64le ]]; then
     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
   fix_cxx_flag
+  add_cross_tools
   $use_cuda && configure_cuda
   linux_configure_speex
   echo "Successfully configured for Linux [dynamic libraries] with ATLASLIBS =$ATLASLIBS"
@@ -1028,7 +1115,7 @@ if [ "`uname`" == "Linux" ]; then
     fi
 
   elif [ "$MATHLIB" == "MKL" ]; then
-    if [ "`uname -m`" != "x86_64" ]; then
+    if [ "$TARGET_ARCH" != "x86_64" ]; then
       failure "MKL on Linux only supported for Intel(R) 64 architecture (x86_64).
       See makefiles/linux_64_mkl.mk to manually configure for other platforms."
     fi
@@ -1094,12 +1181,13 @@ if [ "`uname`" == "Linux" ]; then
     if [ ! -f makefiles/linux_clapack.mk ]; then
       failure "makefiles/linux_clapack.mk not found."
     fi
-    if [[ "`uname -m`" == arm* ]]; then
+    if [[ "$TARGET_ARCH" == arm* ]]; then
       cat makefiles/linux_clapack_arm.mk >> kaldi.mk
     else
       cat makefiles/linux_clapack.mk >> kaldi.mk
     fi
     fix_cxx_flag
+    add_cross_tools
     echo "Warning (CLAPACK): this part of the configure process is not properly tested and will not work."
     $use_cuda && configure_cuda
     linux_configure_speex
@@ -1123,14 +1211,15 @@ if [ "`uname`" == "Linux" ]; then
     fi
     echo "OPENBLASLIBS = $OPENBLASLIBS" >> kaldi.mk
     echo "OPENBLASROOT = $OPENBLASROOT" >> kaldi.mk
-    if [[ "`uname -m`" == arm* ]]; then
+    if [[ "$TARGET_ARCH" == arm* ]]; then
       cat makefiles/linux_openblas_arm.mk >> kaldi.mk
-    elif [[ "`uname -m`" == ppc64le ]]; then
+    elif [[ "$TARGET_ARCH" == ppc64le ]]; then
       cat makefiles/linux_openblas_ppc64le.mk >> kaldi.mk
     else
       cat makefiles/linux_openblas.mk >> kaldi.mk
     fi
     fix_cxx_flag
+    add_cross_tools
     $use_cuda && configure_cuda
     linux_configure_speex
     echo "Successfully configured OpenBLAS from $OPENBLASROOT."

--- a/src/configure
+++ b/src/configure
@@ -74,7 +74,7 @@ function usage {
   echo 'Usage: ./configure [--static|--shared] [--threaded-atlas={yes|no}] [--atlas-root=ATLASROOT] [--fst-root=FSTROOT]
   [--openblas-root=OPENBLASROOOT] [--clapack-root=CLAPACKROOT] [--mkl-root=MKLROOT] [--mkl-libdir=MKLLIBDIR]
   [--omp-libdir=OMPDIR] [--static-fst={yes|no}] [--static-math={yes|no}] [--threaded-math={yes|no}] [--mathlib=ATLAS|MKL|CLAPACK|OPENBLAS]
-  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp]';
+  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR][--mkl-threading=sequential|iomp|tbb|gomp] [--fst-version=VERSION]';
 }
 
 threaded_atlas=false #  By default, use the un-threaded version of ATLAS.
@@ -184,6 +184,9 @@ do
   --cudatk-dir=*)
     CUDATKDIR=`read_dirname $1`;
     shift ;; #CUDA is used in src/cudamatrix and src/nnet{,bin} only
+  --fst-version=*)
+    OPENFST_VER=`expr "X$1" : '[^=]*=\(.*\)'`;
+    shift;;
   *)  echo "Unknown argument: $1, exiting"; usage; exit 1 ;;
   esac
 done

--- a/src/makefiles/android_openblas.mk
+++ b/src/makefiles/android_openblas.mk
@@ -1,0 +1,64 @@
+ifndef FSTROOT
+$(error FSTROOT not defined.)
+endif
+
+ifndef OPENFSTLIBS
+$(error OPENFSTLIBS not defined.)
+endif
+
+ifndef OPENBLASLIBS
+$(error OPENBLASLIBS not defined.)
+endif
+
+ifndef OPENBLASROOT
+$(error OPENBLASROOT not defined.)
+endif
+
+ifndef ANDROIDINC
+$(error ANDROIDINC not defined.)
+endif
+
+ CXXFLAGS += -mhard-float -D_NDK_MATH_NO_SOFTFP=1  -Wall -I.. \
+      -pthread -mfpu=neon -ftree-vectorize -mfloat-abi=hard \
+      -DHAVE_OPENBLAS -DANDROID_BUILD -I $(OPENBLASROOT)/include \
+      -I$(ANDROIDINC) \
+      -DKALDI_DOUBLEPRECISION=0 -DHAVE_POSIX_MEMALIGN \
+      -Wno-sign-compare -Winit-self \
+       -DHAVE_CXXABI_H \
+      -DHAVE_CLAPACK \
+      -I$(FSTROOT)/include \
+      $(EXTRA_CXXFLAGS) \
+      # -O0 -DKALDI_PARANOID
+
+ifeq ($(KALDI_FLAVOR), dynamic)
+CXXFLAGS += -fPIC
+endif
+
+LDFLAGS = -Wl,--no-warn-mismatch -pie
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(OPENBLASLIBS) -ldl -lm_hard
+
+CC = clang++
+CXX = clang++
+AR = ar
+AS = as
+RANLIB = ranlib
+
+# Add no-mismatched-tags flag to suppress the annoying clang warnings
+# that are perfectly valid per spec.
+COMPILER = $(shell $(CXX) -v 2>&1 )
+ifeq ($(findstring clang,$(COMPILER)),clang)
+  CXXFLAGS += -Wno-mismatched-tags
+  # Link with libstdc++ if we are building against OpenFst < 1.4
+  ifneq ("$(OPENFST_GE_10400)","1")
+    CXXFLAGS += -stdlib=libstdc++
+    LDFLAGS += -stdlib=libstdc++
+  endif
+endif
+
+# We need to tell recent versions of g++ to allow vector conversions without
+# an explicit cast provided the vectors are of the same size.
+ifeq ($(findstring GCC,$(COMPILER)),GCC)
+	CXXFLAGS += -flax-vector-conversions -Wno-unused-local-typedefs
+endif
+
+

--- a/src/thread/kaldi-barrier.h
+++ b/src/thread/kaldi-barrier.h
@@ -55,3 +55,12 @@ class Barrier {
 
 #endif // KALDI_THREAD_KALDI_BARRIER_H_
 
+/*
+ * Android does not support cancelling pthreads so the following symbols are not defined.
+ * Define them here, they can be a noop because we cannot cancel a pthread on Android.
+ */
+#ifdef ANDROID_BUILD
+#define PTHREAD_CANCEL_STATE 0
+#define pthread_setcancelstate(a, b) do { } while(0)
+#endif
+


### PR DESCRIPTION
The current build system does not allow a user to cross compile.  To get there we need to make some changes to the way the platform specific files under src/makefiles/*.mk are used.  At the end of this series, the user can effectively cross compile for any x86_[32|64]  or arm with the appropriate tool chain setup.
