### PR TITLE
nnet3: fix to ConstantFunctionComponent

### DIFF
--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -2141,10 +2141,35 @@ void ConstantFunctionComponent::Backprop(
 }
 
 void ConstantFunctionComponent::Read(std::istream &is, bool binary) {
-  ReadUpdatableCommon(is, binary);  // Read the opening tag and learning rate
-  ExpectOneOrTwoTokens(is, binary, "<ConstantFunctionComponent>",
-                       "<InputDim>");
-  ReadBasicType(is, binary, &input_dim_);
+  std::string token;
+  ReadToken(is, binary, &token);
+  if (token == "<ConstantFunctionComponent>") {
+    ReadToken(is, binary, &token);
+  }
+  if (token == "<LearningRateFactor>") {
+    ReadBasicType(is, binary, &learning_rate_factor_);
+    ReadToken(is, binary, &token);
+  } else {
+    learning_rate_factor_ = 1.0;
+  }
+  if (token == "<IsGradient>") {
+    ReadBasicType(is, binary, &is_gradient_);
+    ReadToken(is, binary, &token);
+  } else {
+    is_gradient_ = false;
+  }
+  if (token == "<LearningRate>") {
+    ReadBasicType(is, binary, &learning_rate_);
+    ReadToken(is, binary, &token);
+  } else {
+    learning_rate_ = 0.001;
+  }
+  if (token == "<InputDim>") {
+    ReadBasicType(is, binary, &input_dim_);
+  } else {
+    KALDI_ERR << "Expected token <InputDim>, got "
+              << token;
+  }
   ExpectToken(is, binary, "<Output>");
   output_.Read(is, binary);
   ExpectToken(is, binary, "<IsUpdatable>");
@@ -2156,7 +2181,6 @@ void ConstantFunctionComponent::Read(std::istream &is, bool binary) {
 
 void ConstantFunctionComponent::Write(std::ostream &os, bool binary) const {
   WriteUpdatableCommon(os, binary);  // Write the opening tag and learning rate
-  WriteToken(os, binary, "<ConstantFunctionComponent>");
   WriteToken(os, binary, "<InputDim>");
   WriteBasicType(os, binary, input_dim_);
   WriteToken(os, binary, "<Output>");

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -2081,7 +2081,8 @@ void PerElementOffsetComponent::UnVectorize(
 
 std::string ConstantFunctionComponent::Info() const {
   std::ostringstream stream;
-  stream << Type() << ", input-dim=" << InputDim()
+  stream << UpdatableComponent::Info()
+         << ", " << Type() << ", input-dim=" << InputDim()
          << ", output-dim=" << OutputDim()
          << ", is-updatable=" << std::boolalpha << is_updatable_
          << ", use-natural-gradient=" << std::boolalpha
@@ -2140,6 +2141,7 @@ void ConstantFunctionComponent::Backprop(
 }
 
 void ConstantFunctionComponent::Read(std::istream &is, bool binary) {
+  ReadUpdatableCommon(is, binary);  // Read the opening tag and learning rate
   ExpectOneOrTwoTokens(is, binary, "<ConstantFunctionComponent>",
                        "<InputDim>");
   ReadBasicType(is, binary, &input_dim_);
@@ -2153,6 +2155,7 @@ void ConstantFunctionComponent::Read(std::istream &is, bool binary) {
 }
 
 void ConstantFunctionComponent::Write(std::ostream &os, bool binary) const {
+  WriteUpdatableCommon(os, binary);  // Write the opening tag and learning rate
   WriteToken(os, binary, "<ConstantFunctionComponent>");
   WriteToken(os, binary, "<InputDim>");
   WriteBasicType(os, binary, input_dim_);


### PR DESCRIPTION
Fix to ConstantFunctionComponent so that it reads and writes its learning rate. This fixes a bug which prevented it from being updated via nnet3-copy during training.

NOTE: This fix will break any existing models that use ConstantFunctionComponent. However, I don't think this component is widely used outside of a few experimental branches.