### PR TITLE
Fix an apparent typo in nnet3::ComputeNnetComputationEpochs()

### DIFF
--- a/src/nnet3/nnet-graph-test.cc
+++ b/src/nnet3/nnet-graph-test.cc
@@ -135,14 +135,14 @@ void BuildTestTopSortOrder(std::vector<int32> *node_to_order) {
 
   // The topological sorting order of the above SCC graph is as follows (from
   // our particular algorithm):
-  // 0 --> 3
-  // 1 --> 2
-  // 2 --> 1
-  // 3 --> 0
-  (*node_to_order)[0] = 3;
-  (*node_to_order)[1] = 2;
-  (*node_to_order)[2] = 1;
-  (*node_to_order)[3] = 0;
+  // 0 --> 0
+  // 1 --> 1
+  // 2 --> 2
+  // 3 --> 3
+  (*node_to_order)[0] = 0;
+  (*node_to_order)[1] = 1;
+  (*node_to_order)[2] = 2;
+  (*node_to_order)[3] = 3;
 }
 
 void UnitTestComputeGraphTranspose() {

--- a/src/nnet3/nnet-graph.cc
+++ b/src/nnet3/nnet-graph.cc
@@ -230,18 +230,18 @@ void ComputeTopSortOrder(const std::vector<std::vector<int32> > &graph,
   std::vector<bool> cycle_detector(graph.size(), false);
   std::vector<bool> is_visited(graph.size(), false);
 
-  std::vector<int32> reversed_orders;
+  std::vector<int32> orders;
   for(int32 i = 0; i < graph.size(); ++i) {
     if (!is_visited[i]) {
       ComputeTopSortOrderRecursive(i, graph, &cycle_detector,
-                                   &is_visited, &reversed_orders);
+                                   &is_visited, &orders);
     }
   }
 
-  KALDI_ASSERT(node_to_order->size() == reversed_orders.size());
-  for (int32 i = 0; i < reversed_orders.size(); ++i) {
-    KALDI_ASSERT(reversed_orders[i] >= 0 && reversed_orders[i] < graph.size());
-    (*node_to_order)[reversed_orders[i]] = graph.size() - i - 1;
+  KALDI_ASSERT(node_to_order->size() == orders.size());
+  for (int32 i = 0; i < orders.size(); ++i) {
+    KALDI_ASSERT(orders[i] >= 0 && orders[i] < graph.size());
+    (*node_to_order)[orders[i]] = i;
   }
 }
 
@@ -283,7 +283,7 @@ void ComputeNnetComputationEpochs(const Nnet &nnet,
   ComputeGraphTranspose(scc_graph, &scc_graph_transpose);
 
   std::vector<int32> scc_node_to_epoch;
-  ComputeTopSortOrder(scc_graph, &scc_node_to_epoch);
+  ComputeTopSortOrder(scc_graph_transpose, &scc_node_to_epoch);
   if (GetVerboseLevel() >= 6) {
     std::ostringstream os;
     for (int32 i = 0; i < scc_node_to_epoch.size(); i++)

--- a/src/nnet3/nnet-graph.h
+++ b/src/nnet3/nnet-graph.h
@@ -45,8 +45,8 @@ std::string PrintGraphToString(const std::vector<std::vector<int32> > &graph);
 /// where graph->size() == nnet.NumNodes().  For each node-index
 /// n, the vector in (*graph)[n] will contain a list of all the nodes
 /// that have a direct dependency on node n (in order to compute them).
-/// For instance, if n is an input node, (*graph)[n] will be the empty
-/// list because it won't depend on anything.
+/// For instance, if n is the output node, (*graph)[n] will be the empty
+/// list because no other node will depend on it.
 void NnetToDirectedGraph(const Nnet &nnet,
                          std::vector<std::vector<int32> > *graph);
 


### PR DESCRIPTION
I was reading some nnet3 sources and while I'm not familiar with this code(yet!) it seems to me that the first argument to [ComputeTopSortOrder()](https://github.com/kaldi-asr/kaldi/blob/f5c1515b643b0badda7a3ca28ca8e9117032b5f4/src/nnet3/nnet-graph.cc#L286) should be scc_graph_transpose. I don't know yet how this fits into the whole computation steps compilation story - I'd guess it probably doesn't matter - but I think we should either apply this patch or remove the call to ComputeGraphTranspose(), along with the relevant comments.