### PR TITLE
base/kaldi_error : the error messages are no longer printed 2x

### DIFF
--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -170,20 +170,20 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
   
   // Build the log-message 'header',
   std::stringstream header;
-  if (envelope.severity > LogMessageEnvelope::Info) {
+  if (envelope.severity > LogMessageEnvelope::kInfo) {
     header << "VLOG[" << envelope.severity << "] (";
   } else {
     switch (envelope.severity) {
-      case LogMessageEnvelope::Info :
+      case LogMessageEnvelope::kInfo :
         header << "LOG (";
         break;
-      case LogMessageEnvelope::Warning :
+      case LogMessageEnvelope::kWarning :
         header << "WARNING (";
         break;
-      case LogMessageEnvelope::Error :
+      case LogMessageEnvelope::kError :
         header << "ERROR (";
         break;
-      case LogMessageEnvelope::AssertFailed :
+      case LogMessageEnvelope::kAssertFailed :
         header << "ASSERTION_FAILED (";
         break;
       default:
@@ -195,11 +195,11 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
          << envelope.file << ':' << envelope.line << ")";
 
   // In following lines we decide what to do,
-  if (envelope.severity >= LogMessageEnvelope::Warning) {
+  if (envelope.severity >= LogMessageEnvelope::kWarning) {
     // VLOG, LOG, WARNING: 
     // print to stderr,
     fprintf(stderr, "%s %s\n", header.str().c_str(), message);
-  } else if (envelope.severity == LogMessageEnvelope::Error) {
+  } else if (envelope.severity == LogMessageEnvelope::kError) {
     // ERROR:
     // print to stderr (with stack-trace), 
     fprintf(stderr, "%s %s\n\n%s\n", header.str().c_str(), message, 
@@ -215,7 +215,7 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
       // in a destructor of some local object).
       abort();
     }
-  } else if (envelope.severity == LogMessageEnvelope::AssertFailed) {
+  } else if (envelope.severity == LogMessageEnvelope::kAssertFailed) {
     // ASSERT_FAILED:
     // print to stderr (with stack-trace), call abort(),
     fprintf(stderr, "%s %s\n\n%s\n", header.str().c_str(), message, 
@@ -231,7 +231,7 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
 
 void KaldiAssertFailure_(const char *func, const char *file,
                          int32 line, const char *cond_str) {
-  MessageLogger ml(LogMessageEnvelope::AssertFailed, func, file, line);
+  MessageLogger ml(LogMessageEnvelope::kAssertFailed, func, file, line);
   ml.stream() << ": '" << cond_str << "' ";
 }
 

--- a/src/base/kaldi-error.h
+++ b/src/base/kaldi-error.h
@@ -1,5 +1,6 @@
 // base/kaldi-error.h
 
+// Copyright 2016 Brno University of Technology (author: Karel Vesely)
 // Copyright 2009-2011  Microsoft Corporation;  Ondrej Glembek;  Lukas Burget;
 //                      Saarland University
 
@@ -29,20 +30,22 @@
 
 #include "base/kaldi-types.h"
 #include "base/kaldi-utils.h"
-
 /* Important that this file does not depend on any other kaldi headers. */
 
+// By adding 'KALDI_NOEXCEPT(bool)' immediately after function declaration,
+// we can tell the compiler that the function must-not produce 
+// exceptions (true), or may produce exceptions (false):
 #if _MSC_VER >= 1900 || (!defined(_MSC_VER) && __cplusplus >= 201103L)
-#define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
+  #define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
 #elif defined(__GXX_EXPERIMENTAL_CXX0X__) && \
   (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
-#define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
+  #define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
 #else
-#define KALDI_NOEXCEPT(Predicate)
+  #define KALDI_NOEXCEPT(Predicate)
 #endif
 
 #ifdef _MSC_VER
-#define __func__ __FUNCTION__
+  #define __func__ __FUNCTION__
 #endif
 
 namespace kaldi {
@@ -50,7 +53,9 @@ namespace kaldi {
 /// \addtogroup error_group
 /// @{
 
-/// This is set by util/parse-options.{h, cc} if you set --verbose = ? option.
+/***** VERBOSITY LEVEL *****/
+  
+/// This is set by util/parse-options.{h, cc} if you set --verbose=? option.
 extern int32 g_kaldi_verbose_level;
 
 /// This is set by util/parse-options.{h, cc} (from argv[0]) and used (if set)
@@ -66,9 +71,13 @@ inline int32 GetVerboseLevel() { return g_kaldi_verbose_level; }
 /// automatically from ParseOptions.
 inline void SetVerboseLevel(int32 i) { g_kaldi_verbose_level = i; }
 
+
+/***** KALDI LOGGING *****/
+
 /// Log message severity and source location info.
 struct LogMessageEnvelope {
   enum Severity {
+    AssertFailed = -3,
     Error = -2,
     Warning = -1,
     Info = 0,
@@ -80,35 +89,58 @@ struct LogMessageEnvelope {
   int32 line;
 };
 
-/// Type of user-provided logging function.
-typedef void (*LogHandler)(const LogMessageEnvelope &envelope,
-                           const char *message);
-
-/// Set logging handler. If called with a non-NULL function pointer, the
-/// function pointed by it is called to send messages to a caller-provided
-/// log. If called with NULL pointer, restores default Kaldi error logging to
-/// stderr.  SetLogHandler is obviously not thread safe.
-LogHandler SetLogHandler(LogHandler);
-
-// Class MessageLogger is invoked from the KALDI_ERR, KALDI_WARN, KALDI_LOG and
+// Class MessageLogger is invoked from the KALDI_ASSERT, KALDI_ERR, KALDI_WARN and
 // KALDI_LOG macros. It formats the message, then either prints it to stderr or
 // passes to the log custom handler if provided, then, in case of the error,
-// throws an std::runtime_exception.
+// throws an std::runtime_exception, in case of failed KALDI_ASSERT calls abort().
 //
-// Note: we avoid using std::cerr, since it does not guarantee thread safety
-// in general, until C++11; even then, in "cerr << a << b", other thread's
-// output is allowed to intrude between a and b. fprintf(stderr,...) is
-// guaranteed thread-safe, and outputs its formatted string atomically.
+// Note: we avoid using std::cerr for thread safety issues.
+// fprintf(stderr,...) is guaranteed thread-safe, and outputs 
+// its formatted string atomically.
 class MessageLogger {
 public:
-  MessageLogger(LogMessageEnvelope::Severity severity, const char *func,
-                  const char *file, int32 line);
+  /// Constructor stores the info,
+  MessageLogger(LogMessageEnvelope::Severity severity, 
+                const char *func,
+                const char *file, 
+                int32 line);
+
+  /// Destructor, calls 'SendToLog' which prints the message,
+  /// (since C++11 a 'throwing' destructor must be declared 'noexcept(false)')
   ~MessageLogger() KALDI_NOEXCEPT(false);
+
+  /// The hook for the 'insertion operator', e.g.
+  /// 'KALDI_LOG << "Message,"',
   inline std::ostream &stream() { return ss_; }
+
+private:
+  /// The logging function,
+  static void SendToLog(const LogMessageEnvelope &env, const char *msg);
+
 private:
   LogMessageEnvelope envelope_;
   std::ostringstream ss_;
 };
+
+// The definition of the logging macros,
+#define KALDI_ERR \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Error, \
+                         __func__, __FILE__, __LINE__).stream()
+#define KALDI_WARN \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Warning, \
+                         __func__, __FILE__, __LINE__).stream()
+#define KALDI_LOG \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Info, \
+                         __func__, __FILE__, __LINE__).stream()
+#define KALDI_VLOG(v) if ((v) <= ::kaldi::g_kaldi_verbose_level)     \
+  ::kaldi::MessageLogger((::kaldi::LogMessageEnvelope::Severity)(v), \
+                         __func__, __FILE__, __LINE__).stream()
+
+
+/***** KALDI ASSERTS *****/
+
+void KaldiAssertFailure_(const char *func, const char *file,
+                         int32 line, const char *cond_str);
 
 // Note on KALDI_ASSERT and KALDI_PARANOID_ASSERT
 // The original (simple) version of the code was this
@@ -138,7 +170,7 @@ private:
 #else
 #define KALDI_ASSERT(cond) (void)0
 #endif
-// also see KALDI_COMPILE_TIME_ASSERT, defined in base/kaldi-utils.h,
+// Also see KALDI_COMPILE_TIME_ASSERT, defined in base/kaldi-utils.h,
 // and KALDI_ASSERT_IS_INTEGER_TYPE and KALDI_ASSERT_IS_FLOATING_TYPE,
 // also defined there.
 // some more expensive asserts only checked if this defined
@@ -150,25 +182,26 @@ private:
 #endif
 
 
-#define KALDI_ERR \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Error, \
-                         __func__, __FILE__, __LINE__).stream()
-#define KALDI_WARN \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Warning, \
-                         __func__, __FILE__, __LINE__).stream()
-#define KALDI_LOG \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Info, \
-                         __func__, __FILE__, __LINE__).stream()
-#define KALDI_VLOG(v) if ((v) <= ::kaldi::g_kaldi_verbose_level)     \
-  ::kaldi::MessageLogger((::kaldi::LogMessageEnvelope::Severity)(v), \
-                         __func__, __FILE__, __LINE__).stream()
+/***** THIRD-PARTY LOG-HANDLER *****/
 
+/// Type of third-party logging function,
+typedef void (*LogHandler)(const LogMessageEnvelope &envelope,
+                           const char *message);
+
+/// Set logging handler. If called with a non-NULL function pointer, the
+/// function pointed by it is called to send messages to a caller-provided
+/// log. If called with NULL pointer, restores default Kaldi error logging to
+/// stderr.  SetLogHandler is obviously not thread safe.
+LogHandler SetLogHandler(LogHandler);
+
+
+/***** DEPRECATED *****/
+/// TODO: Deprecated function, get rid of it if possible!
 inline bool IsKaldiError(const std::string &str) {
+  KALDI_WARN << "Deprecated!";
   return(!strncmp(str.c_str(), "ERROR ", 6));
 }
 
-void KaldiAssertFailure_(const char *func, const char *file,
-                         int32 line, const char *cond_str);
 
 /// @} end "addtogroup error_group"
 

--- a/src/base/kaldi-error.h
+++ b/src/base/kaldi-error.h
@@ -36,16 +36,16 @@
 // we can tell the compiler that the function must-not produce 
 // exceptions (true), or may produce exceptions (false):
 #if _MSC_VER >= 1900 || (!defined(_MSC_VER) && __cplusplus >= 201103L)
-  #define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
+#define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
 #elif defined(__GXX_EXPERIMENTAL_CXX0X__) && \
-  (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
-  #define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
+      (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#define KALDI_NOEXCEPT(Predicate) noexcept((Predicate))
 #else
-  #define KALDI_NOEXCEPT(Predicate)
+#define KALDI_NOEXCEPT(Predicate)
 #endif
 
 #ifdef _MSC_VER
-  #define __func__ __FUNCTION__
+#define __func__ __FUNCTION__
 #endif
 
 namespace kaldi {
@@ -105,7 +105,7 @@ public:
                 const char *file, 
                 int32 line);
 
-  /// Destructor, calls 'SendToLog' which prints the message,
+  /// Destructor, calls 'HandleMessage' which prints the message,
   /// (since C++11 a 'throwing' destructor must be declared 'noexcept(false)')
   ~MessageLogger() KALDI_NOEXCEPT(false);
 
@@ -115,7 +115,7 @@ public:
 
 private:
   /// The logging function,
-  static void SendToLog(const LogMessageEnvelope &env, const char *msg);
+  static void HandleMessage(const LogMessageEnvelope &env, const char *msg);
 
 private:
   LogMessageEnvelope envelope_;
@@ -193,15 +193,6 @@ typedef void (*LogHandler)(const LogMessageEnvelope &envelope,
 /// log. If called with NULL pointer, restores default Kaldi error logging to
 /// stderr.  SetLogHandler is obviously not thread safe.
 LogHandler SetLogHandler(LogHandler);
-
-
-/***** DEPRECATED *****/
-/// TODO: Deprecated function, get rid of it if possible!
-inline bool IsKaldiError(const std::string &str) {
-  KALDI_WARN << "Deprecated!";
-  return(!strncmp(str.c_str(), "ERROR ", 6));
-}
-
 
 /// @} end "addtogroup error_group"
 

--- a/src/base/kaldi-error.h
+++ b/src/base/kaldi-error.h
@@ -77,10 +77,10 @@ inline void SetVerboseLevel(int32 i) { g_kaldi_verbose_level = i; }
 /// Log message severity and source location info.
 struct LogMessageEnvelope {
   enum Severity {
-    AssertFailed = -3,
-    Error = -2,
-    Warning = -1,
-    Info = 0,
+    kAssertFailed = -3,
+    kError = -2,
+    kWarning = -1,
+    kInfo = 0,
   };
   // An 'enum Severity' value, or a positive number indicating verbosity level.
   int severity;
@@ -124,13 +124,13 @@ private:
 
 // The definition of the logging macros,
 #define KALDI_ERR \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Error, \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::kError, \
                          __func__, __FILE__, __LINE__).stream()
 #define KALDI_WARN \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Warning, \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::kWarning, \
                          __func__, __FILE__, __LINE__).stream()
 #define KALDI_LOG \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::Info, \
+  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::kInfo, \
                          __func__, __FILE__, __LINE__).stream()
 #define KALDI_VLOG(v) if ((v) <= ::kaldi::g_kaldi_verbose_level)     \
   ::kaldi::MessageLogger((::kaldi::LogMessageEnvelope::Severity)(v), \

--- a/src/feat/wave-reader.h
+++ b/src/feat/wave-reader.h
@@ -135,8 +135,8 @@ class WaveHolder {
       t.Write(os);  // throws exception on failure.
       return true;
     } catch (const std::exception &e) {
-      KALDI_WARN << "Exception caught in WaveHolder object (writing).";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught in WaveHolder object (writing). " 
+                 << e.what();
       return false;  // write failure.
     }
   }
@@ -162,8 +162,8 @@ class WaveHolder {
       t_.Read(is);  // throws exception on failure.
       return true;
     } catch (const std::exception &e) {
-      KALDI_WARN << "Exception caught in WaveHolder object (reading).";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught in WaveHolder object (reading). " 
+                 << e.what();
       return false;  // write failure.
     }
   }
@@ -213,8 +213,8 @@ class WaveInfoHolder {
       t_.Read(is, WaveData::kLeaveDataUndefined);  // throws exception on failure.
       return true;
     } catch (const std::exception &e) {
-      KALDI_WARN << "Exception caught in WaveHolder object (reading).";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught in WaveHolder object (reading). " 
+                 << e.what();
       return false;  // write failure.
     }
   }

--- a/src/hmm/posterior.cc
+++ b/src/hmm/posterior.cc
@@ -129,8 +129,7 @@ bool PosteriorHolder::Write(std::ostream &os, bool binary, const T &t) {
     WritePosterior(os, binary, t);
     return true;
   } catch(const std::exception &e) {
-    KALDI_WARN << "Exception caught writing table of posteriors";
-    if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+    KALDI_WARN << "Exception caught writing table of posteriors. " << e.what();
     return false;  // Write failure.
   }
 }
@@ -147,8 +146,7 @@ bool PosteriorHolder::Read(std::istream &is) {
     ReadPosterior(is, is_binary, &t_);
     return true;
   } catch (std::exception &e) {
-    KALDI_WARN << "Exception caught reading table of posteriors";
-    if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+    KALDI_WARN << "Exception caught reading table of posteriors. " << e.what();
     t_.clear();
     return false;
   }
@@ -174,8 +172,7 @@ bool GaussPostHolder::Write(std::ostream &os, bool binary, const T &t) {
     if(!binary) os << '\n';
     return os.good();
   } catch (const std::exception &e) {
-    KALDI_WARN << "Exception caught writing table of posteriors";
-    if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+    KALDI_WARN << "Exception caught writing table of posteriors. " << e.what();
     return false;  // Write failure.
   }
 }
@@ -210,8 +207,7 @@ bool GaussPostHolder::Read(std::istream &is) {
     }
     return true;
   } catch (std::exception &e) {
-    KALDI_WARN << "Exception caught reading table of posteriors";
-    if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+    KALDI_WARN << "Exception caught reading table of posteriors. " << e.what();
     t_.clear();
     return false;
   }

--- a/src/util/kaldi-holder-inl.h
+++ b/src/util/kaldi-holder-inl.h
@@ -52,8 +52,7 @@ template<class KaldiType> class KaldiObjectHolder {
       t.Write(os, binary);
       return os.good();
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught writing Table object: " << e.what();
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught writing Table object. " << e.what();
       return false;  // Write failure.
     }
   }
@@ -80,8 +79,7 @@ template<class KaldiType> class KaldiObjectHolder {
       t_->Read(is, is_binary);
       return true;
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught reading Table object ";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught reading Table object. " << e.what();
       delete t_;
       t_ = NULL;
       return false;
@@ -137,8 +135,7 @@ template<class BasicType> class BasicHolder {
       // easier to manipulate.
       return os.good();
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught writing Table object: " << e.what();
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught writing Table object. " << e.what();
       return false;  // Write failure.
     }
   }
@@ -186,8 +183,7 @@ template<class BasicType> class BasicHolder {
       }
       return true;
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught reading Table object";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught reading Table object. " << e.what();
       return false;
     }
   }
@@ -252,8 +248,8 @@ template<class BasicType> class BasicVectorHolder {
       }
       return os.good();
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught writing Table object (BasicVector). ";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught writing Table object (BasicVector). "
+                 << e.what();
       return false;  // Write failure.
     }
   }
@@ -290,8 +286,7 @@ template<class BasicType> class BasicVectorHolder {
         return true;
       } catch(const std::exception &e) {
         KALDI_WARN << "BasicVectorHolder::Read, could not interpret line: "
-                   << line;
-        if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+                   << "'" << line << "'" << "\n" << e.what();
         return false;
       }
     } else {  // binary mode.
@@ -390,8 +385,7 @@ template<class BasicType> class BasicVectorVectorHolder {
       }
       return os.good();
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught writing Table object. ";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught writing Table object. " << e.what();
       return false;  // Write failure.
     }
   }
@@ -436,8 +430,7 @@ template<class BasicType> class BasicVectorVectorHolder {
           }
         }
       } catch(const std::exception &e) {
-        KALDI_WARN << "BasicVectorVectorHolder::Read, read error";
-        if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+        KALDI_WARN << "BasicVectorVectorHolder::Read, read error. " << e.what();
         return false;
       }
     } else {  // binary mode.
@@ -532,8 +525,7 @@ template<class BasicType> class BasicPairVectorHolder {
       }
       return os.good();
     } catch(const std::exception &e) {
-      KALDI_WARN << "Exception caught writing Table object. ";
-      if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+      KALDI_WARN << "Exception caught writing Table object. " << e.what();
       return false;  // Write failure.
     }
   }
@@ -589,8 +581,7 @@ template<class BasicType> class BasicPairVectorHolder {
           }
         }
       } catch(const std::exception &e) {
-        KALDI_WARN << "BasicPairVectorHolder::Read, read error";
-        if (!IsKaldiError(e.what())) { std::cerr << e.what(); }
+        KALDI_WARN << "BasicPairVectorHolder::Read, read error. " << e.what();
         return false;
       }
     } else {  // binary mode.


### PR DESCRIPTION
- e.what() contains stackttrace or is empty string

- we should also consider changing binaries to have:
  'std::cerr << e.what();' -> 'fprintf(stderr, e.what().c_str());'
- fprintf is thread-safe, it is better not to mix 'std::cerr' and
  'stderr', and 'stderr' is already used for logging...