### PR TITLE
Remove old memory alignment flags

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -46,25 +46,14 @@
 #endif
 #endif
 
-#ifdef HAVE_POSIX_MEMALIGN
-#  define KALDI_MEMALIGN(align, size, pp_orig) \
-     (!posix_memalign(pp_orig, align, size) ? *(pp_orig) : NULL)
-#  define KALDI_MEMALIGN_FREE(x) free(x)
-#elif defined(HAVE_MEMALIGN)
-  /* Some systems have memalign() but no declaration for it */
-  void * memalign(size_t align, size_t size);
-#  define KALDI_MEMALIGN(align, size, pp_orig) \
-     (*(pp_orig) = memalign(align, size))
-#  define KALDI_MEMALIGN_FREE(x) free(x)
-#elif defined(_MSC_VER)
+#ifdef _MSC_VER
 #  define KALDI_MEMALIGN(align, size, pp_orig) \
   (*(pp_orig) = _aligned_malloc(size, align))
 #  define KALDI_MEMALIGN_FREE(x) _aligned_free(x)
 #else
-#error Manual memory alignment is no longer supported.  Note: if you see this error \
-it will usually be due to Makefile problems-- you are probably not using the flags \
-that the Kaldi configure script would normally add to the Makefile, or they are \
-somehow not getting passed to your compilation command line.
+#  define KALDI_MEMALIGN(align, size, pp_orig) \
+     (!posix_memalign(pp_orig, align, size) ? *(pp_orig) : NULL)
+#  define KALDI_MEMALIGN_FREE(x) free(x)
 #endif
 
 #ifdef __ICC

--- a/src/makefiles/cygwin.mk
+++ b/src/makefiles/cygwin.mk
@@ -6,7 +6,7 @@ endif
 
 DOUBLE_PRECISION = 0
 CXXFLAGS = -msse -msse2 -Wall -I.. -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
-    -DHAVE_POSIX_MEMALIGN -DHAVE_CLAPACK -I ../../tools/CLAPACK/ \
+    -DHAVE_CLAPACK -I ../../tools/CLAPACK/ \
     -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
     -I ../../tools/CLAPACK/ \
     -I $(FSTROOT)/include \

--- a/src/makefiles/darwin_10_10.mk
+++ b/src/makefiles/darwin_10_10.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
       -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H \
       -DHAVE_CLAPACK \

--- a/src/makefiles/darwin_10_11.mk
+++ b/src/makefiles/darwin_10_11.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
       -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H \
       -DHAVE_CLAPACK \

--- a/src/makefiles/darwin_10_6.mk
+++ b/src/makefiles/darwin_10_6.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
 	  -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -rdynamic \
       -DHAVE_CLAPACK \

--- a/src/makefiles/darwin_10_7.mk
+++ b/src/makefiles/darwin_10_7.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
 	  -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -rdynamic \
       -DHAVE_CLAPACK \

--- a/src/makefiles/darwin_10_8.mk
+++ b/src/makefiles/darwin_10_8.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
 	   -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -rdynamic \
       -DHAVE_CLAPACK \

--- a/src/makefiles/darwin_10_9.mk
+++ b/src/makefiles/darwin_10_9.mk
@@ -7,7 +7,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS += -msse -msse2 -Wall -I.. \
       -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Winit-self \
       -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H \
       -DHAVE_CLAPACK \

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -16,7 +16,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS = -msse -msse2 -Wall -I.. \
 	   -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
       -DHAVE_ATLAS -I$(ATLASINC) \

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -2,7 +2,7 @@
 
 DOUBLE_PRECISION = 0
 CXXFLAGS = -msse -Wall -I.. -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -msse2 -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -msse2 \
       -Wno-sign-compare -Wno-unused-local-typedefs \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
       -DHAVE_CLAPACK -I ../../tools/CLAPACK \

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -16,7 +16,7 @@ endif
 DOUBLE_PRECISION = 0
 CXXFLAGS = -msse -msse2 -Wall -I.. \
            -pthread \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
       -DHAVE_OPENBLAS -I $(OPENBLASROOT)/include \

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -21,7 +21,7 @@ MKLLIB ?= $(MKLROOT)/lib/em64t
 
 DOUBLE_PRECISION = 0
 CXXFLAGS = -m64 -msse -msse2 -pthread -Wall -I.. \
-      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -DHAVE_POSIX_MEMALIGN \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
       -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
       -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
       -DHAVE_MKL -I$(MKLROOT)/include \


### PR DESCRIPTION
As far as I can tell, this resolves #740. Tested on Ubuntu. Should be tested on Windows.