### PR TITLE
Fix bug: static link to MKL 11.3.2 failed.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -328,7 +328,7 @@ function linux_configure_mkl_extra {
 
   declare -A extra_libs
   extra_libs=(
-    [sequential]="-lpthread -lm"
+    [sequential]="-ldl -lpthread -lm"
     [gomp]="-lgomp -ldl -lpthread -lm"
     [iomp]="-ldl -lpthread -lm"
     [tbb]=" -ldl -lpthread -lm "


### PR DESCRIPTION
$ ./configure --mkl-root=/opt/intel/mkl --static-math=yes
...
Configuring MKL library directory: Found: /opt/intel/mkl/lib/intel64
MKL configured with threading: sequential, libs:  -Wl,--start-group /opt/intel/mkl/lib/intel64/libmkl_intel_lp64.a /opt/intel/mkl/lib/intel64/libmkl_core.a /opt/intel/mkl/lib/intel64/libmkl_sequential.a -Wl,--end-group
MKL include directory configured as: /opt/intel/mkl/include
Configuring MKL threading as sequential
MKL threading libraries configured as   -lpthread -lm
Using Intel MKL as the linear algebra library.
/opt/intel/mkl/lib/intel64/libmkl_core.a(mkl_memory_patched.o): In function `mkl_serv_set_memory_limit':
mkl_memory.c:(.text+0x49c): undefined reference to `dlsym'
mkl_memory.c:(.text+0x4b2): undefined reference to `dlsym'
mkl_memory.c:(.text+0x4c8): undefined reference to `dlsym'
/opt/intel/mkl/lib/intel64/libmkl_core.a(mkl_memory_patched.o): In function `mkl_serv_allocate':
mkl_memory.c:(.text+0x1251): undefined reference to `dlsym'
mkl_memory.c:(.text+0x1267): undefined reference to `dlsym'
...