### PR TITLE
yesno recipe data prep: paths to absolute + misc. 

### DIFF
--- a/egs/yesno/s5/local/prepare_data.sh
+++ b/egs/yesno/s5/local/prepare_data.sh
@@ -12,9 +12,10 @@ train_base_name=train_yesno
 test_base_name=test_yesno
 waves_dir=$1
 
+ls -1 $waves_dir > data/local/waves_all.list
+
 cd data/local
 
-ls -1 ../../$waves_dir > waves_all.list
 ../../local/create_yesno_waves_test_train.pl waves_all.list waves.test waves.train
 
 ../../local/create_yesno_wav_scp.pl ${waves_dir} waves.test > ${test_base_name}_wav.scp


### PR DESCRIPTION
Proposed fix for issue #457 . Tried to make the recipe more similar to other typical Kaldi recipes (e.g. WSJ):

- Changed relative paths to absolute
- Added usage message if missing argument
- Exit clauses
- "Data preparation succeeded" message
- Removed superfluous scripts variable

Tested to create identical data directories as the original recipe (diff -ra ...), and a full run yields 0.00% WER.

Let me know if this is in line with what you thought for the issue. Happy to revise.