### PR TITLE
WIP: Shrink in-value of ClipGradientComponent toward some smaller value when clipping proportion exceeds some threshold

### DIFF
--- a/egs/swbd/s5c/RESULTS
+++ b/egs/swbd/s5c/RESULTS
@@ -152,6 +152,14 @@ exit 0
 %WER 19.4 | 2628 21594 | 82.7 12.0 5.3 2.1 19.4 54.9 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_fsh_fg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
 %WER 20.8 | 2628 21594 | 81.3 13.1 5.6 2.2 20.8 56.9 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_tg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
 
+# bidirectional LSTM with the same configuration as the above experiment, plus self-repair of all nonliearities and clipgradient activated
+%WER 10.4 | 1831 21395 | 90.5 6.2 3.3 0.9 10.4 44.2 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_fsh_fg/score_11_0.0/eval2000_hires.ctm.swbd.filt.sys
+%WER 11.3 | 1831 21395 | 89.8 6.8 3.3 1.1 11.3 46.7 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_tg/score_10_0.0/eval2000_hires.ctm.swbd.filt.sys
+%WER 15.0 | 4459 42989 | 86.5 9.1 4.5 1.5 15.0 50.4 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_fsh_fg/score_11_0.0/eval2000_hires.ctm.filt.sys
+%WER 16.0 | 4459 42989 | 85.6 9.9 4.5 1.6 16.0 52.7 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_tg/score_10_0.0/eval2000_hires.ctm.filt.sys
+%WER 19.6 | 2628 21594 | 82.5 12.1 5.5 2.1 19.6 54.8 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_fsh_fg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
+%WER 20.7 | 2628 21594 | 81.4 12.9 5.7 2.2 20.7 56.8 | exp/nnet3/lstm_bidirectional_sp/decode_eval2000_sw1_tg/score_10_0.0/eval2000_hires.ctm.callhm.filt.sys
+
 # results with nnet3 tdnn: local/nnet3/run_tdnn.sh (11.10.2015) (2 epoch training on speed-perturbed and volume perturbed data)
 %WER 12.1 | 1831 21395 | 89.1 7.1 3.8 1.3 12.1 48.1 | exp/nnet3/tdnn_sp/decode_eval2000_hires_sw1_fsh_fg/score_12_0.0/eval2000_hires.ctm.swbd.filt.sys
 %WER 13.6 | 1831 21395 | 87.9 8.2 3.9 1.5 13.6 51.0 | exp/nnet3/tdnn_sp/decode_eval2000_hires_sw1_tg/score_11_0.0/eval2000_hires.ctm.swbd.filt.sys

--- a/egs/swbd/s5c/local/nnet3/run_lstm.sh
+++ b/egs/swbd/s5c/local/nnet3/run_lstm.sh
@@ -99,7 +99,8 @@ if [ $stage -le 9 ]; then
     --recurrent-projection-dim $recurrent_projection_dim \
     --non-recurrent-projection-dim $non_recurrent_projection_dim \
     --label-delay $label_delay \
-    --self-repair-scale 0.00001 \
+    --self-repair-scale-nonlinearity 0.00001 \
+    --self-repair-scale-clipgradient 1.0 \
    $dir/configs || exit 1;
 
 fi

--- a/egs/wsj/s5/steps/nnet3/components.py
+++ b/egs/wsj/s5/steps/nnet3/components.py
@@ -104,6 +104,7 @@ def AddAffRelNormLayer(config_lines, name, input, output_dim, ng_affine_options 
     components = config_lines['components']
     component_nodes = config_lines['component-nodes']
 
+    # self_repair_scale is a constant scaling the self-repair vector computed in RectifiedLinearComponent
     self_repair_string = "self-repair-scale={0:.10f}".format(self_repair_scale) if self_repair_scale is not None else ''
     components.append("component name={0}_affine type=NaturalGradientAffineComponent input-dim={1} output-dim={2} {3}".format(name, input['dimension'], output_dim, ng_affine_options))
     components.append("component name={0}_relu type=RectifiedLinearComponent dim={1} {2}".format(name, output_dim, self_repair_string))
@@ -222,6 +223,7 @@ def AddSigmoidLayer(config_lines, name, input, self_repair_scale = None):
     components = config_lines['components']
     component_nodes = config_lines['component-nodes']
 
+    # self_repair_scale is a constant scaling the self-repair vector computed in SigmoidComponent
     self_repair_string = "self-repair-scale={0:.10f}".format(self_repair_scale) if self_repair_scale is not None else ''
     components.append("component name={0}_sigmoid type=SigmoidComponent dim={1}".format(name, input['dimension'], self_repair_string))
     component_nodes.append("component-node name={0}_sigmoid component={0}_sigmoid input={1}".format(name, input['descriptor']))
@@ -285,7 +287,8 @@ def AddLstmLayer(config_lines,
                  ng_per_element_scale_options = "",
                  ng_affine_options = "",
                  lstm_delay = -1,
-                 self_repair_scale = None):
+                 self_repair_scale_nonlinearity = None,
+                 self_repair_scale_clipgradient = None):
     assert(recurrent_projection_dim >= 0 and non_recurrent_projection_dim >= 0)
     components = config_lines['components']
     component_nodes = config_lines['component-nodes']
@@ -306,7 +309,11 @@ def AddLstmLayer(config_lines,
     else:
         add_non_recurrent_projection = True
 
-    self_repair_string = "self-repair-scale={0:.10f}".format(self_repair_scale) if self_repair_scale is not None else ''
+    # self_repair_scale_nonlinearity is a constant scaling the self-repair vector computed in derived classes of NonlinearComponent,
+    # i.e.,  SigmoidComponent, TanhComponent and RectifiedLinearComponent
+    self_repair_nonlinearity_string = "self-repair-scale={0:.10f}".format(self_repair_scale_nonlinearity) if self_repair_scale_nonlinearity is not None else ''
+    # self_repair_scale_clipgradient is a constant scaling the self-repair vector computed in ClipGradientComponent
+    self_repair_clipgradient_string = "self-repair-scale={0:.2f}".format(self_repair_scale_clipgradient) if self_repair_scale_clipgradient is not None else ''
     # Natural gradient per element scale parameters
     ng_per_element_scale_options += " param-mean=0.0 param-stddev=1.0 "
     # Parameter Definitions W*(* replaced by - to have valid names)
@@ -330,17 +337,17 @@ def AddLstmLayer(config_lines,
 
 
     components.append("# Defining the non-linearities")
-    components.append("component name={0}_i type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_string))
-    components.append("component name={0}_f type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_string))
-    components.append("component name={0}_o type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_string))
-    components.append("component name={0}_g type=TanhComponent dim={1} {2}".format(name, cell_dim, self_repair_string))
-    components.append("component name={0}_h type=TanhComponent dim={1} {2}".format(name, cell_dim, self_repair_string))
+    components.append("component name={0}_i type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_nonlinearity_string))
+    components.append("component name={0}_f type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_nonlinearity_string))
+    components.append("component name={0}_o type=SigmoidComponent dim={1} {2}".format(name, cell_dim, self_repair_nonlinearity_string))
+    components.append("component name={0}_g type=TanhComponent dim={1} {2}".format(name, cell_dim, self_repair_nonlinearity_string))
+    components.append("component name={0}_h type=TanhComponent dim={1} {2}".format(name, cell_dim, self_repair_nonlinearity_string))
 
     components.append("# Defining the cell computations")
     components.append("component name={0}_c1 type=ElementwiseProductComponent input-dim={1} output-dim={2}".format(name, 2 * cell_dim, cell_dim))
     components.append("component name={0}_c2 type=ElementwiseProductComponent input-dim={1} output-dim={2}".format(name, 2 * cell_dim, cell_dim))
     components.append("component name={0}_m type=ElementwiseProductComponent input-dim={1} output-dim={2}".format(name, 2 * cell_dim, cell_dim))
-    components.append("component name={0}_c type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} ".format(name, cell_dim, clipping_threshold, norm_based_clipping))
+    components.append("component name={0}_c type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} {4}".format(name, cell_dim, clipping_threshold, norm_based_clipping, self_repair_clipgradient_string))
 
     # c1_t and c2_t defined below
     component_nodes.append("component-node name={0}_c_t component={0}_c input=Sum({0}_c1_t, {0}_c2_t)".format(name))
@@ -379,7 +386,7 @@ def AddLstmLayer(config_lines,
     if (add_recurrent_projection and add_non_recurrent_projection):
         components.append("# projection matrices : Wrm and Wpm")
         components.append("component name={0}_W-m type=NaturalGradientAffineComponent input-dim={1} output-dim={2} {3}".format(name, cell_dim, recurrent_projection_dim + non_recurrent_projection_dim, ng_affine_options))
-        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} ".format(name, recurrent_projection_dim, clipping_threshold, norm_based_clipping))
+        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} {4}".format(name, recurrent_projection_dim, clipping_threshold, norm_based_clipping, self_repair_clipgradient_string))
         component_nodes.append("# r_t and p_t")
         component_nodes.append("component-node name={0}_rp_t component={0}_W-m input={0}_m_t".format(name))
         component_nodes.append("dim-range-node name={0}_r_t_preclip input-node={0}_rp_t dim-offset=0 dim={1}".format(name, recurrent_projection_dim))
@@ -390,7 +397,7 @@ def AddLstmLayer(config_lines,
     elif add_recurrent_projection:
         components.append("# projection matrices : Wrm")
         components.append("component name={0}_Wrm type=NaturalGradientAffineComponent input-dim={1} output-dim={2} {3}".format(name, cell_dim, recurrent_projection_dim, ng_affine_options))
-        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} ".format(name, recurrent_projection_dim, clipping_threshold, norm_based_clipping))
+        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} {4}".format(name, recurrent_projection_dim, clipping_threshold, norm_based_clipping, self_repair_clipgradient_string))
         component_nodes.append("# r_t")
         component_nodes.append("component-node name={0}_r_t_preclip component={0}_Wrm input={0}_m_t".format(name))
         component_nodes.append("component-node name={0}_r_t component={0}_r input={0}_r_t_preclip".format(name))
@@ -398,7 +405,7 @@ def AddLstmLayer(config_lines,
         output_dim = recurrent_projection_dim
 
     else:
-        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} ".format(name, cell_dim, clipping_threshold, norm_based_clipping))
+        components.append("component name={0}_r type=ClipGradientComponent dim={1} clipping-threshold={2} norm-based-clipping={3} {4}".format(name, cell_dim, clipping_threshold, norm_based_clipping, self_repair_clipgradient_string))
         component_nodes.append("component-node name={0}_r_t component={0}_r input={0}_m_t".format(name))
         output_descriptor = '{0}_r_t'.format(name)
         output_dim = cell_dim

--- a/egs/wsj/s5/steps/nnet3/components.py
+++ b/egs/wsj/s5/steps/nnet3/components.py
@@ -424,18 +424,23 @@ def AddBLstmLayer(config_lines,
                   ng_per_element_scale_options = "",
                   ng_affine_options = "",
                   lstm_delay = [-1,1],
-                  self_repair_scale = None):
+                  self_repair_scale_nonlinearity = None,
+                  self_repair_scale_clipgradient = None):
     assert(len(lstm_delay) == 2 and lstm_delay[0] < 0 and lstm_delay[1] > 0)
     output_forward = AddLstmLayer(config_lines, "{0}_forward".format(name), input, cell_dim,
                                   recurrent_projection_dim, non_recurrent_projection_dim,
                                   clipping_threshold, norm_based_clipping,
                                   ng_per_element_scale_options, ng_affine_options,
-                                  lstm_delay = lstm_delay[0], self_repair_scale = self_repair_scale)
+                                  lstm_delay = lstm_delay[0],
+                                  self_repair_scale_nonlinearity = self_repair_scale_nonlinearity,
+                                  self_repair_scale_clipgradient = self_repair_scale_clipgradient)
     output_backward = AddLstmLayer(config_lines, "{0}_backward".format(name), input, cell_dim,
                                    recurrent_projection_dim, non_recurrent_projection_dim,
                                    clipping_threshold, norm_based_clipping,
                                    ng_per_element_scale_options, ng_affine_options,
-                                   lstm_delay = lstm_delay[1], self_repair_scale = self_repair_scale)
+                                   lstm_delay = lstm_delay[1],
+                                   self_repair_scale_nonlinearity = self_repair_scale_nonlinearity,
+                                   self_repair_scale_clipgradient = self_repair_scale_clipgradient)
     output_descriptor = 'Append({0}, {1})'.format(output_forward['descriptor'], output_backward['descriptor'])
     output_dim = output_forward['dimension'] + output_backward['dimension']
 

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -353,7 +353,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
     cuda_vec_apply_ceiling(dimGrid, dimBlock, data_, ceiling_val, count_vec.Data(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
     num_ceiled = count_vec.Sum();
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloor", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyCeiling", tim.Elapsed());
   } else
 #endif
   {
@@ -376,7 +376,7 @@ void CuVectorBase<Real>::ApplyPow(Real power) {
     // num_cols is Dim(), num_rows is 1, stride is 1 (it's a don't-care).
     cuda_apply_pow(dimGrid, dimBlock, data_, power, fake_matrix_dim);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloor", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyPow", tim.Elapsed());
   } else
 #endif
   {

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -354,6 +354,11 @@ bool TestSimpleComponentDataDerivative(const Component &c,
               << "with dim=1.";
     return true;
   }
+  else if (c.Type() == "ClipGradientComponent") {
+    KALDI_LOG << "Accepting deriv differences since "
+              << "it is ClipGradientComponent.";
+    return true;
+  }
   return ans;
 }
 

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -558,10 +558,20 @@ void ClipGradientComponent::Read(std::istream &is, bool binary) {
   ReadBasicType(is, binary, &clipping_threshold_);
   ExpectToken(is, binary, "<NormBasedClipping>");
   ReadBasicType(is, binary, &norm_based_clipping_);
+  ExpectToken(is, binary, "<SelfRepairClippedProportionThreshold>");
+  ReadBasicType(is, binary, &self_repair_clipped_proportion_threshold_);
+  ExpectToken(is, binary, "<SelfRepairTarget>");
+  ReadBasicType(is, binary, &self_repair_target_);
+  ExpectToken(is, binary, "<SelfRepairScale>");
+  ReadBasicType(is, binary, &self_repair_scale_);
   ExpectToken(is, binary, "<NumElementsClipped>");
   ReadBasicType(is, binary, &num_clipped_);
   ExpectToken(is, binary, "<NumElementsProcessed>");
   ReadBasicType(is, binary, &count_);
+  ExpectToken(is, binary, "<NumSelfRepaired>");
+  ReadBasicType(is, binary, &num_self_repaired_);
+  ExpectToken(is, binary, "<NumBackpropped>");
+  ReadBasicType(is, binary, &num_backpropped_);
   ExpectToken(is, binary, "</ClipGradientComponent>");
 }
 
@@ -573,10 +583,20 @@ void ClipGradientComponent::Write(std::ostream &os, bool binary) const {
   WriteBasicType(os, binary, clipping_threshold_);
   WriteToken(os, binary, "<NormBasedClipping>");
   WriteBasicType(os, binary, norm_based_clipping_);
+  WriteToken(os, binary, "<SelfRepairClippedProportionThreshold>");
+  WriteBasicType(os, binary, self_repair_clipped_proportion_threshold_);
+  WriteToken(os, binary, "<SelfRepairTarget>");
+  WriteBasicType(os, binary, self_repair_target_);
+  WriteToken(os, binary, "<SelfRepairScale>");
+  WriteBasicType(os, binary, self_repair_scale_);
   WriteToken(os, binary, "<NumElementsClipped>");
   WriteBasicType(os, binary, num_clipped_);
   WriteToken(os, binary, "<NumElementsProcessed>");
   WriteBasicType(os, binary, count_);
+  WriteToken(os, binary, "<NumSelfRepaired>");
+  WriteBasicType(os, binary, num_self_repaired_);
+  WriteToken(os, binary, "<NumBackpropped>");
+  WriteBasicType(os, binary, num_backpropped_);
   WriteToken(os, binary, "</ClipGradientComponent>");
 }
 
@@ -588,20 +608,38 @@ std::string ClipGradientComponent::Info() const {
          << ", clipping-threshold=" << clipping_threshold_
          << ", clipped-proportion="
          << (count_ > 0 ? static_cast<BaseFloat>(num_clipped_)/count_ : 0);
+  if (self_repair_scale_ != 0.0)
+    stream << ", self-repair-clipped-proportion-threshold="
+           << self_repair_clipped_proportion_threshold_
+           << ", self-repair-target=" << self_repair_target_
+           << ", self-repair-scale=" << self_repair_scale_;
   return stream.str();
 }
 
 void ClipGradientComponent::Init(int32 dim,
                                  BaseFloat clipping_threshold,
                                  bool norm_based_clipping,
+                                 BaseFloat self_repair_clipped_proportion_threshold,
+                                 BaseFloat self_repair_target,
+                                 BaseFloat self_repair_scale,
                                  int32 num_clipped,
-                                 int32 count)  {
-  KALDI_ASSERT(clipping_threshold >= 0 && dim > 0);
+                                 int32 count,
+                                 int32 num_self_repaired,
+                                 int32 num_backpropped)  {
+  KALDI_ASSERT(clipping_threshold >= 0 && dim > 0 &&
+      self_repair_clipped_proportion_threshold >= 0.0 && 
+      self_repair_target >= 0.0 && self_repair_scale >= 0.0);
   dim_ = dim;
   norm_based_clipping_ = norm_based_clipping;
   clipping_threshold_ = clipping_threshold;
+  self_repair_clipped_proportion_threshold_ =
+      self_repair_clipped_proportion_threshold;
+  self_repair_target_ = self_repair_target;
+  self_repair_scale_ = self_repair_scale;
   num_clipped_ = num_clipped;
   count_ = count;
+  num_self_repaired_ = num_self_repaired;
+  num_backpropped_ = num_backpropped;
 }
 
 void ClipGradientComponent::InitFromConfig(ConfigLine *cfl) {
@@ -609,13 +647,26 @@ void ClipGradientComponent::InitFromConfig(ConfigLine *cfl) {
   bool ok = cfl->GetValue("dim", &dim);
   bool norm_based_clipping = false;
   BaseFloat clipping_threshold = 15.0;
+  BaseFloat self_repair_clipped_proportion_threshold = 0.01;
+  BaseFloat self_repair_target = 0.0;
+  BaseFloat self_repair_scale = 1.0;
   cfl->GetValue("clipping-threshold", &clipping_threshold);
   cfl->GetValue("norm-based-clipping", &norm_based_clipping);
+  cfl->GetValue("self-repair-clipped-proportion-threshold",
+                &self_repair_clipped_proportion_threshold);
+  cfl->GetValue("self-repair-target",
+                &self_repair_target);
+  cfl->GetValue("self-repair-scale", &self_repair_scale);
   if (!ok || cfl->HasUnusedValues() ||
-      clipping_threshold < 0 || dim <= 0)
+      clipping_threshold < 0 || dim <= 0 ||
+      self_repair_clipped_proportion_threshold < 0.0 || 
+      self_repair_target < 0.0 || self_repair_scale < 0.0)
     KALDI_ERR << "Invalid initializer for layer of type "
               << Type() << ": \"" << cfl->WholeLine() << "\"";
-  Init(dim, clipping_threshold, norm_based_clipping, 0, 0);
+  Init(dim, clipping_threshold, norm_based_clipping,
+       self_repair_clipped_proportion_threshold,
+       self_repair_target,
+       self_repair_scale, 0, 0, 0, 0);
 }
 
 void ClipGradientComponent::Propagate(
@@ -628,7 +679,7 @@ void ClipGradientComponent::Propagate(
 
 void ClipGradientComponent::Backprop(const std::string &debug_info,
                              const ComponentPrecomputedIndexes *indexes,
-                             const CuMatrixBase<BaseFloat> &,
+                             const CuMatrixBase<BaseFloat> &in_value,
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &out_deriv,
                              Component *to_update_in, // may be NULL; may be identical
@@ -640,7 +691,6 @@ void ClipGradientComponent::Backprop(const std::string &debug_info,
 
   ClipGradientComponent *to_update =
       dynamic_cast<ClipGradientComponent*>(to_update_in);
-  KALDI_ASSERT(to_update != NULL);
 
   if (clipping_threshold_ > 0) {
     if (norm_based_clipping_) {
@@ -659,21 +709,109 @@ void ClipGradientComponent::Backprop(const std::string &debug_info,
         // now clipping_scales contains max(1,
         //       clipping_threshold/vector_norm)
         in_deriv->MulRowsVec(clipping_scales);
-        to_update->num_clipped_ += (clipping_scales.Dim() - num_not_scaled);
+        if (to_update != NULL)
+          to_update->num_clipped_ += (clipping_scales.Dim() - num_not_scaled);
        }
-      to_update->count_ += clipping_scales.Dim();
+      if (to_update != NULL)
+        to_update->count_ += clipping_scales.Dim();
     } else {
       // each element of the derivative matrix, is clipped to be below the
       // clipping_threshold_
       in_deriv->ApplyCeiling(clipping_threshold_);
       in_deriv->ApplyFloor(-1 * clipping_threshold_);
     }
+
+    if (to_update != NULL) {
+      to_update->num_backpropped_ += 1;
+      RepairGradients(debug_info, in_value, in_deriv, to_update);
+    }
   }
+}
+
+void ClipGradientComponent::RepairGradients(
+    const std::string &debug_info,
+    const CuMatrixBase<BaseFloat> &in_value,
+    CuMatrixBase<BaseFloat> *in_deriv, ClipGradientComponent *to_update) const {
+  KALDI_ASSERT(to_update != NULL);
+
+  // we use this 'repair_probability' (hardcoded for now) to limit
+  // this code to running on about half of the minibatches.
+  BaseFloat repair_probability = 0.5;
+  if (self_repair_clipped_proportion_threshold_ >= 1.0 ||
+      self_repair_scale_ == 0.0 || count_ == 0 ||
+      RandUniform() > repair_probability)
+    return;
+
+  KALDI_ASSERT(self_repair_target_ >= 0.0 && self_repair_scale_ > 0.0);
+
+  BaseFloat clipped_proportion =
+    (count_ > 0 ? static_cast<BaseFloat>(num_clipped_) / count_ : 0);
+  // in-deriv would be modified only when clipped_proportion exceeds the
+  // threshold
+  if (clipped_proportion <= self_repair_clipped_proportion_threshold_)
+    return;
+
+  to_update->num_self_repaired_ += 1;
+  if (to_update->debug_info_ == "") // get the component-node name
+    to_update->debug_info_ = debug_info;
+  if (to_update->num_self_repaired_ == 1)
+    KALDI_LOG << "ClipGradientComponent(node_name=" << debug_info
+              << ")'s self-repair was activated as the first time at the "
+              << to_update->num_backpropped_
+              << "-th call of Backprop() in this training job.";
+
+  // sign_mat = sign(in_value), i.e.,
+  // An element in sign_mat is 1 if its corresponding element in in_value > 0,
+  // or -1 otherwise
+  CuMatrix<BaseFloat> sign_mat(in_value);
+  sign_mat.ApplyHeaviside();
+  sign_mat.Scale(2.0);
+  sign_mat.Add(-1.0);
+
+  // repair_mat =
+  // floor(abs(in_value) - self_repair_target_, 0) .* sign(in_value)
+  CuMatrix<BaseFloat> repair_mat(in_value);
+  repair_mat.ApplyPowAbs(1.0);
+  repair_mat.Add(-self_repair_target_);
+  repair_mat.ApplyFloor(0.0);
+  repair_mat.MulElements(sign_mat);
+
+  // magnitude =
+  // self_repair_scale_ * clipped_proportion * average norm of in-deriv
+  CuVector<BaseFloat> in_deriv_norm_vec(in_deriv->NumRows());
+  in_deriv_norm_vec.AddDiagMat2(1.0, *in_deriv, kNoTrans, 0.0);
+  in_deriv_norm_vec.ApplyPow(0.5);
+  double in_deriv_norm_sum = in_deriv_norm_vec.Sum();
+  BaseFloat magnitude = self_repair_scale_ * clipped_proportion *
+                        (in_deriv_norm_sum / in_deriv_norm_vec.Dim());
+ 
+  CuVector<BaseFloat> repair_mat_norm_vec(repair_mat.NumRows());
+  repair_mat_norm_vec.AddDiagMat2(1.0, repair_mat, kNoTrans, 0.0);
+  repair_mat_norm_vec.ApplyPow(0.5);
+  double repair_mat_norm_sum = repair_mat_norm_vec.Sum();
+  double scale = 0.0;
+  if (repair_mat_norm_sum != 0.0)
+    scale = magnitude / (repair_mat_norm_sum / repair_mat_norm_vec.Dim());
+  // repair_mat is scaled so that on average the rows have the norm
+  // (magnitude / repair_probability). This will give higher magnitude of
+  // self-repair to input vectors that have larger absolute value, which tend to
+  // be those that are diverging.
+  in_deriv->AddMat(-scale / repair_probability, repair_mat);
+  CuVector<BaseFloat> in_deriv_repaired_norm_vec(in_deriv->NumRows());
+  in_deriv_repaired_norm_vec.AddDiagMat2(1.0, *in_deriv, kNoTrans, 0.0);
+  in_deriv_repaired_norm_vec.ApplyPow(0.5);
+  // scale in_deriv to have the same norm as that before adding the self-repair
+  // term, in order to avoid increase of the norm caused by self-repair,
+  // which may incur more clip of gradient and thus more self-repair
+  double in_deriv_repaired_norm_sum = in_deriv_repaired_norm_vec.Sum();
+  in_deriv->Scale(in_deriv_norm_sum / in_deriv_repaired_norm_sum);
 }
 
 void ClipGradientComponent::ZeroStats()  {
   count_ = 0.0;
   num_clipped_ = 0.0;
+  num_self_repaired_ = 0;
+  num_backpropped_ = 0;
 }
 
 void ClipGradientComponent::Scale(BaseFloat scale) {

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -728,6 +728,14 @@ void ClipGradientComponent::Backprop(const std::string &debug_info,
   }
 }
 
+// This function will add a self-repair term to in-deriv, attempting to shrink
+// the maginitude of the input towards self_repair_target_.
+// This term is proportional to [-(input vector - self_repair_target_)].
+// The avarage magnitude of this term is equal to
+// [self_repair_scale_ * clipped_proportion * average norm of input derivative].
+// We use norm of input derivative when computing the magnitude so that it is
+// comparable to the magnitude of input derivative, especially when the gradient
+// explosion is actually happening.
 void ClipGradientComponent::RepairGradients(
     const std::string &debug_info,
     const CuMatrixBase<BaseFloat> &in_value,

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -1209,8 +1209,14 @@ static void GenerateRandomComponentConfig(std::string *component_type,
       *component_type = "ClipGradientComponent";
       os << "dim=" << RandInt(1, 50);
       os << " clipping-threshold=" << RandInt(1, 50)
-         << " norm-based-clipping=" << (RandInt(0, 1) == 0 ? "false" : "true")
-         << " self-repair-scale=" << (RandInt(0, 1) == 0 ? 0 : RandInt(1, 50));
+         << " norm-based-clipping=" << (RandInt(0, 1) == 0 ? "false" : "true");
+      if (RandInt(0, 1) == 1)
+        os << " self-repair-scale="
+           << (RandInt(0, 1) == 0 ? 0 : RandInt(1, 50));
+      if (RandInt(0, 1) == 1)
+        os << " self-repair-clipped-proportion-threshold=" << RandUniform();
+      if (RandInt(0, 1) == 1)
+        os << " self-repair-target=" << RandUniform();
       break;
     } 
     default:

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -926,7 +926,7 @@ void ComputeExampleComputationRequestSimple(
 static void GenerateRandomComponentConfig(std::string *component_type,
                                           std::string *config) {
 
-  int32 n = RandInt(0, 27);
+  int32 n = RandInt(0, 28);
   BaseFloat learning_rate = 0.001 * RandInt(1, 3);
 
   std::ostringstream os;
@@ -1205,6 +1205,14 @@ static void GenerateRandomComponentConfig(std::string *component_type,
          << " use-natural-gradient=" << std::boolalpha << use_natural_gradient;
       break;
     }
+    case 28: {
+      *component_type = "ClipGradientComponent";
+      os << "dim=" << RandInt(1, 50);
+      os << " clipping-threshold=" << RandInt(1, 50)
+         << " norm-based-clipping=" << (RandInt(0, 1) == 0 ? "false" : "true")
+         << " self-repair-scale=" << (RandInt(0, 1) == 0 ? 0 : RandInt(1, 50));
+      break;
+    } 
     default:
       KALDI_ERR << "Error generating random component";
   }


### PR DESCRIPTION
It looks taking effective on BLSTM: the likelihood with self-repair get matched with one without self-repair. Will play around with some alternatives, e.g., on what basis to average magnitude of the gradients. etc.

Yiming