### PR TITLE
WIP: combine_data.sh: combine data with and without segments

### DIFF
--- a/egs/wsj/s5/utils/combine_data.sh
+++ b/egs/wsj/s5/utils/combine_data.sh
@@ -71,24 +71,20 @@ fi
 extra_files=$(echo "$extra_files"|sed -e "s/utt2uniq//g")
 
 # segments are treated similarly to utt2uniq. If it exists in some, but not all
-# src directories, then we create segments files where necessary.
-# These are stored in the src directories.
+# src directories, then we generate segments where necessary.
 has_segments=false
 segments_absent_somewhere=false
 for in_dir in $*; do
   if [ -f $in_dir/segments ]; then
     has_segments=true
-  else
-    segments_absent_somewhere=true
+    break
   fi
 done
 
 if $has_segments; then
-  if $segments_absent_somewhere; then
-    echo "$0 [info]: will generate missing segments"
-  fi
   for in_dir in $*; do
     if [ ! -f $in_dir/segments ]; then
+      echo "$0 [info]: will generate missing segments for $in_dir" 1>&2
       utils/data/get_segments_for_data.sh $in_dir
     else
       cat $in_dir/segments

--- a/egs/wsj/s5/utils/combine_data.sh
+++ b/egs/wsj/s5/utils/combine_data.sh
@@ -9,7 +9,7 @@
 # about what these directories contain.
 
 # Begin configuration section.
-extra_files= # specify addtional files in 'src-data-dir' to merge, ex. "file1 file2 ..."
+extra_files= # specify additional files in 'src-data-dir' to merge, ex. "file1 file2 ..."
 skip_fix=false # skip the fix_data_dir.sh in the end
 # End configuration section.
 
@@ -20,7 +20,8 @@ if [ -f path.sh ]; then . ./path.sh; fi
 
 if [ $# -lt 2 ]; then
   echo "Usage: combine_data.sh [--extra-files 'file1 file2'] <dest-data-dir> <src-data-dir1> <src-data-dir2> ..."
-  echo "Note, files that don't appear in first source dir will not be added even if they appear in later ones."
+  echo "Note, files that don't appear in all source dirs will not be combined,"
+  echo "with the exception of utt2uniq and segments, which are created where necessary."
   exit 1
 fi
 
@@ -63,11 +64,42 @@ if $has_utt2uniq; then
     fi
   done | sort -k1 > $dest/utt2uniq
   echo "$0: combined utt2uniq"
+else
+  echo "$0 [info]: not combining utt2uniq as it does not exist"
 fi
 # some of the old scripts might provide utt2uniq as an extrafile, so just remove it
 extra_files=$(echo "$extra_files"|sed -e "s/utt2uniq//g")
 
-for file in utt2spk utt2lang utt2dur feats.scp text cmvn.scp segments reco2file_and_channel wav.scp spk2gender $extra_files; do
+# segments are treated similarly to utt2uniq. If it exists in some, but not all
+# src directories, then we create segments files where necessary.
+# These are stored in the src directories.
+has_segments=false
+segments_absent_somewhere=false
+for in_dir in $*; do
+  if [ -f $in_dir/segments ]; then
+    has_segments=true
+  else
+    segments_absent_somewhere=true
+  fi
+done
+
+if $has_segments; then
+  if $segments_absent_somewhere; then
+    echo "$0 [info]: will generate missing segments"
+  fi
+  for in_dir in $*; do
+    if [ ! -f $in_dir/segments ]; then
+      utils/data/get_segments_for_data.sh $in_dir
+    else
+      cat $in_dir/segments
+    fi
+  done | sort -k1 > $dest/segments
+  echo "$0: combined segments"
+else
+  echo "$0 [info]: not combining segments as it does not exist"
+fi
+
+for file in utt2spk utt2lang utt2dur feats.scp text cmvn.scp reco2file_and_channel wav.scp spk2gender $extra_files; do
   exists_somewhere=false
   absent_somewhere=false
   for d in $*; do

--- a/egs/wsj/s5/utils/combine_data.sh
+++ b/egs/wsj/s5/utils/combine_data.sh
@@ -73,7 +73,6 @@ extra_files=$(echo "$extra_files"|sed -e "s/utt2uniq//g")
 # segments are treated similarly to utt2uniq. If it exists in some, but not all
 # src directories, then we generate segments where necessary.
 has_segments=false
-segments_absent_somewhere=false
 for in_dir in $*; do
   if [ -f $in_dir/segments ]; then
     has_segments=true

--- a/egs/wsj/s5/utils/data/get_segments_for_data.sh
+++ b/egs/wsj/s5/utils/data/get_segments_for_data.sh
@@ -20,7 +20,7 @@ fi
 data=$1
 
 if [ ! -f $data/utt2dur ]; then
-  utils/data/get_utt2dur.sh $data 2>/dev/null || exit 1;
+  utils/data/get_utt2dur.sh $data 1>&2 || exit 1;
 fi
 
 # <utt-id> <utt-id> 0 <utt-dur>

--- a/egs/wsj/s5/utils/data/get_segments_for_data.sh
+++ b/egs/wsj/s5/utils/data/get_segments_for_data.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script operates on a data directory, such as in data/train/,
+# and writes new segments to stdout. The file 'segments' maps from
+# utterance to time offsets into a recording, with the format:
+#   <utterance-id> <recording-id> <segment-begin> <segment-end>
+# This script assumes utterance and recording ids are the same (i.e., that
+# wav.scp is indexed by utterance), and uses durations from 'utt2dur', 
+# created if necessary by get_utt2dur.sh.
+
+. ./path.sh
+
+if [ $# != 1 ]; then
+  echo "Usage: $0 [options] <datadir>"
+  echo "e.g.:"
+  echo " $0 data/train > data/train/segments"
+  exit 1
+fi
+
+data=$1
+
+if [ ! -f $data/utt2dur ]; then
+  utils/data/get_utt2dur.sh $data 2>/dev/null || exit 1;
+fi
+
+# <utt-id> <utt-id> 0 <utt-dur>
+awk '{ print $1, $1, 0, $2 }' $data/utt2dur
+
+exit 0


### PR DESCRIPTION
See #797 . Requires first source directory to include a segments file (as before). Subsequent directories which do not include one will have one generated with the format: "uttid uttid 0 -1".

Could move the check for segments out of the inner for loop, but that would duplicate some code (cat, sort etc.). This is still pretty much instant on some large corpora. Not sure if there are more elegant ways of doing this.

Note that for a data directory which has uttid ≠ recid, the new segments will be pruned by fix_data_dir.sh as it compares wav.scp to the 2nd column in segments.