### PR TITLE
Implement CuVector::Sum, Max, Min with a _vector_reudce kernel template.

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -105,8 +105,8 @@ void cudaF_copy_from_vec_df(int Gr, int Bl, double* v_out, const float* v_in, in
 void cudaF_copy_from_vec_fd(int Gr, int Bl, float* v_out, const float* v_in, int dim);
 void cudaF_vec_mul_elements(int Gr, int Bl, float* v, const float* a, int dim);
 void cudaF_vec_soft_max(int Gr, int Bl, float* v, int dim);
-void cudaF_vec_min(const float* v, float* value, int dim);
-void cudaF_vec_max(const float* v, float* value, int dim);
+void cudaF_vec_min(int Gr, int Bl, const float* v, float* value, int dim, int inc);
+void cudaF_vec_max(int Gr, int Bl, const float* v, float* value, int dim, int inc);
 void cudaF_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const float* A, const float* B, MatrixDim dA, int B_stride, float* value);
 void cudaF_trace_mat_mat(dim3 Gr, dim3 Bl, const float* A, const float* B, MatrixDim dA, int B_stride, float* value);
 void cudaF_add_diag_mat_mat(int Gr, int Bl, float alpha, float* v, int v_dim, const float* M,
@@ -116,7 +116,6 @@ void cudaF_add_vec_vec(int Gr, int Bl, float alpha, float* v, const float* x, co
 void cudaF_copy_col_from_mat_df(int Gr, int Bl, double* v, int col, const float* mat, MatrixDim dmat, int dim);
 void cudaF_copy_col_from_mat_fd(int Gr, int Bl, float* v, int col, const float* mat, MatrixDim dmat, int dim);
 void cudaF_vec_sum(int Gr, int Bl, float* v, float* value, int dim, int inc);
-void cudaF_pvec_sum(int Gr, int Bl, float* vec, float* pvec_sum, int dim, int size);
 void cudaF_vec_copy_diag_from_packed(int Gr, int Bl, float *dst, const float *src, int dim);
 void cudaF_vec_apply_floor(int Gr, int Bl, float* v, float floor_val, float* num, int dim);
 void cudaF_vec_apply_ceiling(int Gr, int Bl, float* v, float ceiling_val, float* num, int dim);
@@ -163,7 +162,6 @@ void cudaF_take_mean(dim3 Gr, dim3 Bl, const float* x, float* y, MatrixDim d_in)
 void cudaF_matrix_add_elements(dim3 Gr, dim3 Bl, float *data, MatrixDim dim, float alpha, MatrixElement<float>* x, int num_elements);
 void cudaF_matrix_add_indexed_values(dim3 Gr, dim3 Bl, MatrixDim dim, float alpha, const Int32Pair* indices, const float* x, int s, float* data);
 void cudaF_comp_obj_deriv(dim3 Gr,dim3 Bl, MatrixElement<float>* x, int s, const float* z, MatrixDim d, float* z2, MatrixDim d2, float* t);
-void cudaF_transpose_matrix(dim3 Gr, dim3 Bl, float* mat, MatrixDim d);
 void cudaF_sy_add_tr2(dim3 Gr, dim3 Bl, float alpha, float beta, const float* T, MatrixDim tdim,
                       float *S, MatrixDim sdim);
 void cudaF_sum_column_ranges(dim3 Gr, dim3 Bl, float *data, MatrixDim dim,
@@ -246,8 +244,8 @@ void cudaD_copy_from_vec_df(int Gr, int Bl, double* v_out, const double* v_in, i
 void cudaD_copy_from_vec_fd(int Gr, int Bl, float* v_out, const double* v_in, int dim);
 void cudaD_vec_mul_elements(int Gr, int Bl, double* v, const double* a, int dim);
 void cudaD_vec_soft_max(int Gr, int Bl, double* v, int dim);
-void cudaD_vec_min(const double* v, double* value, int dim);
-void cudaD_vec_max(const double* v, double* value, int dim);
+void cudaD_vec_min(int Gr, int Bl, const double* v, double* value, int dim, int inc);
+void cudaD_vec_max(int Gr, int Bl, const double* v, double* value, int dim, int inc);
 void cudaD_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const double* A, const double* B, MatrixDim dA, int B_stride, double* value);
 void cudaD_trace_mat_mat(dim3 Gr, dim3 Bl, const double* A, const double* B, MatrixDim dA, int B_stride, double* value);
 void cudaD_add_diag_mat_mat(int Gr, int Bl, double alpha, double* v, int v_dim, const double* M,
@@ -257,7 +255,6 @@ void cudaD_add_vec_vec(int Gr, int Bl, double alpha, double* v, const double* x,
 void cudaD_copy_col_from_mat_df(int Gr, int Bl, double* v, int col, const double* mat, MatrixDim dmat, int dim);
 void cudaD_copy_col_from_mat_fd(int Gr, int Bl, float* v, int col, const double* mat, MatrixDim dmat, int dim);
 void cudaD_vec_sum(int Gr, int Bl, double* v, double* value, int dim, int inc);
-void cudaD_pvec_sum(int Gr, int Bl, double* vec, double* pvec_sum, int dim, int size);
 void cudaD_vec_copy_diag_from_packed(int Gr, int Bl, double *dst, const double *src, int dim);
 void cudaD_vec_apply_floor(int Gr, int Bl, double* v, double floor_val, float* num, int dim);
 void cudaD_vec_apply_ceiling(int Gr, int Bl, double* v, double ceiling_val, float* num, int dim);
@@ -333,7 +330,6 @@ void cudaD_matrix_add_elements(dim3 Gr, dim3 Bl, double *data, MatrixDim dim, do
 void cudaD_matrix_add_indexed_values(dim3 Gr, dim3 Bl, MatrixDim dim, double alpha, const Int32Pair* indices, const double* x, int s, double* data);
 void cudaD_comp_obj_deriv(dim3 Gr,dim3 Bl, MatrixElement<double>* x, int s, const double* z, MatrixDim d, double* z2, MatrixDim d2, double* t);
 
-void cudaD_transpose_matrix(dim3 Gr, dim3 Bl, double* mat, MatrixDim d);
 void cudaD_sy_add_tr2(dim3 Gr, dim3 Bl, double alpha, double beta, const double* T, MatrixDim tdim,
                       double *S, MatrixDim sdim);
 void cudaD_sum_column_ranges(dim3 Gr, dim3 Bl, double *data, MatrixDim dim,

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -56,87 +56,6 @@ static Real _sum_reduce(Real buffer[]) {
   return buffer[0];
 }
 
-
-template<typename Real>
-__device__
-static Real _min_reduce(Real buffer[]) {
-  // Total number of active threads
-  int32_cuda nTotalThreads = blockDim.x;
-  __syncthreads();
-  // perform tree-based reduction (min)
-  while(nTotalThreads > 1) {
-    int32_cuda halfPoint = ((1+nTotalThreads) >> 1); // divide by two
-    // only the first half of the threads will be active
-    if (threadIdx.x < halfPoint) {
-      if (threadIdx.x + halfPoint < nTotalThreads) {
-        Real temp = buffer[threadIdx.x + halfPoint];
-        if (temp < buffer[threadIdx.x])
-           buffer[threadIdx.x] = temp;
-      }
-    }
-    __syncthreads();
-    nTotalThreads = ((1+nTotalThreads) >> 1); // divide by two
-  }
-  // the result
-  return buffer[0];
-}
-
-
-template<typename Real>
-__device__
-static Real _max_reduce(Real buffer[]) {
-  // Total number of active threads
-  int32_cuda nTotalThreads = blockDim.x;
-  __syncthreads();
-  // perform tree-based reduction (max)
-  while(nTotalThreads > 1) {
-    int32_cuda halfPoint = ((1+nTotalThreads) >> 1);	// divide by two
-    // only the first half of the threads will be active.
-    if (threadIdx.x < halfPoint)  {
-      // Get the shared value stored by another thread
-      if(threadIdx.x+halfPoint < nTotalThreads) {
-        Real temp = buffer[threadIdx.x + halfPoint];
-        if (temp > buffer[threadIdx.x])
-          buffer[threadIdx.x] = temp;
-      }
-    }
-    __syncthreads();
-    nTotalThreads = ((1+nTotalThreads) >> 1);	// divide by two.
-  }
-  // the result
-  return buffer[0];
-}
-
-
-
-template<typename Real>
-__device__
-static int32_cuda _max_id_reduce(Real val[], int32_cuda idx[]) {
-  // Total number of active threads
-  int32_cuda nTotalThreads = blockDim.x;
-  __syncthreads();
-  // perform tree-based reduction (get index of maximum)
-  while(nTotalThreads > 1) {
-    int32_cuda halfPoint = ((1+nTotalThreads) >> 1);	// divide by two
-    // only the first half of the threads will be active.
-    if (threadIdx.x < halfPoint)  {
-      // Get the shared value stored by another thread
-      Real temp = -1e20;
-      if(threadIdx.x+halfPoint < nTotalThreads) {
-        temp = val[idx[threadIdx.x + halfPoint]];
-      }
-      if (temp > val[idx[threadIdx.x]]) idx[threadIdx.x]=idx[threadIdx.x + halfPoint];
-    }
-    __syncthreads();
-    nTotalThreads = ((1+nTotalThreads) >> 1);	// divide by two.
-  }
-  // the result
-  return idx[0];
-}
-
-
-
-
 /***********************************************************************
  * CUDA kernels
  * the functions are templated to have the float/double operations
@@ -308,20 +227,6 @@ static void _trace_mat_smat(const Real* mat_in, const MatrixElement<Real>* smat_
   if (smat_index >= smat_d_in) return;
   int mat_index = smat_in[smat_index].column * mat_d_in.stride + smat_in[smat_index].row;
   trace_vec_out[smat_index] = mat_in[mat_index] * smat_in[smat_index].weight;
-}
-
-template<typename Real>
-__global__
-static void _transpose_matrix(Real* mat, MatrixDim d) {
-  // Transposes a square matrix in-place.
-  int32_cuda i = blockIdx.x * blockDim.x + threadIdx.x; // row-index
-  int32_cuda j = blockIdx.y * blockDim.y + threadIdx.y; // col-index
-  if (j >= i || i >= d.rows) { return; } // Only half the threads act.
-  int32_cuda index_a = j + i * d.stride,
-      index_b = i + j * d.stride;
-  Real a = mat[index_a], b = mat[index_b];
-  mat[index_a] = b;
-  mat[index_b] = a;
 }
 
 template<typename Real>
@@ -806,61 +711,6 @@ static void _copy_from_vec_fd(float* v_out, const Real* v_in, int dim) {
 }
 
 
-template<typename Real>
-__global__
-static void _vec_min(const Real* v, Real* value, int dim) {
-  int32_cuda i = blockIdx.x * blockDim.x + threadIdx.x;
-
-  if(i >= CU1DBLOCK) return;
-
-  __shared__ Real row_data[CU1DBLOCK];
-
-  int block_size = (dim + CU1DBLOCK - 1) / CU1DBLOCK;
-
-  Real min = 1.0 / 0.0; // infinity.
-
-  for (int j = i * block_size; j < (i+1) * block_size && j < dim; j++) {
-     Real v_j = v[j];
-     if (v_j < min) min = v_j;
-  }
-
-  row_data[i] = min;
-
-  __syncthreads();
-
-  //get the sum
-  *value = _min_reduce(row_data);
-}
-
-
-template<typename Real>
-__global__
-static void _vec_max(const Real* v, Real* value, int dim) {
-  int32_cuda i = blockIdx.x * blockDim.x + threadIdx.x;
-  if(blockIdx.y > 0) return;
-
-  __shared__ Real row_data[CU1DBLOCK];
-
-  if(i >= CU1DBLOCK) return;
-
-  int block_size = (dim + CU1DBLOCK - 1) / CU1DBLOCK;
-
-  Real max = -1.0 / 0.0; // -infinity.
-
-  for (int j = i * block_size; j < (i+1) * block_size && j < dim; j++) {
-     Real v_j = v[j];
-     if (v_j > max) max = v_j;
-  }
-
-  row_data[i] = max;
-
-  __syncthreads();
-
-  //get the sum
-  *value = _max_reduce(row_data);
-}
-
-
 // _trace_mat_mat reduce the partial sum to value[blockIdx.y * gridDim.x + blockIdx.x]
 // It use shared mem to transpose matrix B to ensure coalesced memory access
 template<int TileDim, typename Real>
@@ -1186,54 +1036,87 @@ static void _equal_element_mask(const Real *mat1, const Real *mat2, Real *mask, 
     mask[index_mask] = (mat1[index_mat1] == mat2[index_mat2] ? 1.0 : 0.0);
 }
 
+enum EnumReduceType {
+  MAX, MIN, SUM
+};
+
+template<EnumReduceType ReduceType, typename Real>
+struct ReduceOperation {
+  __device__ __forceinline__ Real InitValue() {
+    return Real(0);
+  }
+  __device__ __forceinline__ Real operator()(const Real& a, const Real& b) {
+    return Real(0);
+  }
+};
 template<typename Real>
-__global__
-static void _vec_sum(Real *v, Real *sum, int dim, int inc) {
-  int i = threadIdx.x;
-  __shared__ Real row_data[CU1DBLOCK];
-
-  if (i >= CU1DBLOCK) return;
-
-  Real tmp_sum = 0;
-  int size = dim / CU1DBLOCK; //the least size in a loop (later part)
-  int threshold = dim - size * CU1DBLOCK; //any loop below this number would + 1
-
-  int loop_start;
-  int loop_end;
-  if(i < threshold) {
-    loop_start = i * (size + 1);
-    loop_end = (i+1) * (size + 1);
+struct ReduceOperation<MAX, Real> {
+  __device__ __forceinline__ Real InitValue() {
+    return Real(-1.0 / 0.0);
   }
-  else {
-    loop_start = threshold + i * size;
-    loop_end = threshold + (i+1) * size;
+  __device__ __forceinline__ Real operator()(const Real& a, const Real& b) {
+    return max(a, b);
   }
-  for(int j = loop_start; j< loop_end; j++) {
-    tmp_sum += v[j * inc];
-  }
-
-  row_data[threadIdx.x] = tmp_sum;
-  __syncthreads();
-  *sum = _sum_reduce(row_data);
-}
-
-
+};
 template<typename Real>
-__global__
-static void _pvec_sum(Real* v, Real* g, int dim, int size) {
-  int i = blockIdx.x * blockDim.x + threadIdx.x;
-  int start = size * i;
-  int end = start + size;
-  if (end > dim) end = dim;
-  __shared__ Real row_data[CU1DBLOCK];
-  Real sum = 0;
-  for (int j = start; j < end; j++)
-    sum += v[j];
-  row_data[threadIdx.x] = sum;
-  __syncthreads();
-  g[blockIdx.x] = _sum_reduce(row_data);
-}
+struct ReduceOperation<MIN, Real> {
+  __device__ __forceinline__ Real InitValue() {
+    return Real(1.0 / 0.0);
+  }
+  __device__ __forceinline__ Real operator()(const Real& a, const Real& b) {
+    return min(a, b);
+  }
+};
+template<typename Real>
+struct ReduceOperation<SUM, Real> {
+  __device__ __forceinline__ Real InitValue() {
+    return Real(0);
+  }
+  __device__ __forceinline__ Real operator()(const Real& a, const Real& b) {
+    return a + b;
+  }
+};
 
+// Vector reduce.
+template<EnumReduceType ReduceType, typename Real>
+__global__
+static void _vec_reduce(const Real* v, Real* result, const int dim,
+    const int inc) {
+
+  ReduceOperation<ReduceType, Real> reduce;
+  __shared__ Real sdata[CU1DBLOCK];
+  Real tdata = reduce.InitValue();
+  const int vec_len = dim * inc;
+  const int grid_stride = gridDim.x * blockDim.x * inc;
+  int i = (blockIdx.x * blockDim.x + threadIdx.x) * inc;
+
+
+  // Grid reduce. Loop over the whole vector v.
+  for (; i < vec_len; i += grid_stride)
+    tdata = reduce(tdata, v[i]);
+  sdata[threadIdx.x] = tdata;
+  __syncthreads();
+
+  // Tree reduce
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (threadIdx.x < shift)
+      sdata[threadIdx.x] = reduce(sdata[threadIdx.x],
+          sdata[threadIdx.x + shift]);
+    __syncthreads();
+  }
+
+  // Reduce last warp. Threads implicitly synchronized within a warp.
+  if (threadIdx.x < warpSize) {
+    for (int shift = warpSize; shift > 0; shift >>= 1)
+      sdata[threadIdx.x] = reduce(sdata[threadIdx.x],
+          sdata[threadIdx.x + shift]);
+  }
+
+  // Output to vector result.
+  if (threadIdx.x == 0)
+    result[blockIdx.x] = sdata[0];
+}
 
 
 template<typename Real>
@@ -2240,10 +2123,6 @@ void cudaFD_copy_from_tp(dim3 Gr, dim3 Bl, float* A, const double* B, MatrixDim 
   _copy_from_tp<<<Gr,Bl>>>(A,B,dmat);
 }
 
-void cudaF_transpose_matrix(dim3 Gr, dim3 Bl, float* mat, MatrixDim d) {
-  _transpose_matrix<<<Gr,Bl>>>(mat, d);
-}
-
 void cudaF_apply_exp(dim3 Gr, dim3 Bl, float* mat, MatrixDim d) {
   _apply_exp<<<Gr,Bl>>>(mat,d);
 }
@@ -2450,12 +2329,12 @@ void cudaF_vec_mul_elements(int Gr, int Bl, float* v, const float* a, int dim) {
   _vec_mul_elements<<<Gr,Bl>>>(v, a, dim);
 }
 
-void cudaF_vec_min(const float* v, float* value, int dim) {
-  _vec_min<<<1,CU1DBLOCK>>>(v, value, dim);
+void cudaF_vec_min(int Gr, int Bl, const float* v, float* value, int dim, int inc) {
+  _vec_reduce<MIN><<<Gr,Bl>>>(v, value, dim, inc);
 }
 
-void cudaF_vec_max(const float* v, float* value, int dim) {
-  _vec_max<<<1,CU1DBLOCK>>>(v, value, dim);
+void cudaF_vec_max(int Gr, int Bl, const float* v, float* value, int dim, int inc) {
+  _vec_reduce<MAX><<<Gr,Bl>>>(v, value, dim, inc);
 }
 
 void cudaF_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const float* A, const float* B, MatrixDim dA, int B_stride, float* value) {
@@ -2479,11 +2358,7 @@ void cudaF_add_vec_vec(int Gr, int Bl, float alpha, float* v, const float* x, co
 }
 
 void cudaF_vec_sum(int Gr, int Bl, float* v, float* value, int dim, int inc) {
-  _vec_sum<<<Gr,Bl>>>(v, value, dim, inc);
-}
-
-void cudaF_pvec_sum(int Gr, int Bl, float* v, float* pvec_sum, int dim, int size) {
-  _pvec_sum<<<Gr,Bl>>>(v, pvec_sum, dim, size);
+  _vec_reduce<SUM><<<Gr,Bl>>>(v, value, dim, inc);
 }
 
 void cudaF_matrix_add_elements(dim3 Gr, dim3 Bl, float *data, MatrixDim dim, float alpha, MatrixElement<float>* x, int num_elements) {
@@ -2706,10 +2581,6 @@ void cudaDF_copy_from_tp(dim3 Gr, dim3 Bl, double* A, const float* B, MatrixDim 
   _copy_from_tp<<<Gr,Bl>>>(A,B,dmat);
 }
 
-void cudaD_transpose_matrix(dim3 Gr, dim3 Bl, double* mat, MatrixDim d) {
-  _transpose_matrix<<<Gr,Bl>>>(mat, d);
-}
-
 void cudaD_apply_exp(dim3 Gr, dim3 Bl, double* mat, MatrixDim d) {
   _apply_exp<<<Gr,Bl>>>(mat,d);
 }
@@ -2914,12 +2785,12 @@ void cudaD_vec_mul_elements(int Gr, int Bl, double* v, const double* a, int dim)
   _vec_mul_elements<<<Gr,Bl>>>(v, a, dim);
 }
 
-void cudaD_vec_min(const double* v, double* value, int dim) {
-  _vec_min<<<1,CU1DBLOCK>>>(v, value, dim);
+void cudaD_vec_min(int Gr, int Bl, const double* v, double* value, int dim, int inc) {
+  _vec_reduce<MIN><<<Gr,Bl>>>(v, value, dim, inc);
 }
 
-void cudaD_vec_max(const double* v, double* value, int dim) {
-  _vec_max<<<1,CU1DBLOCK>>>(v, value, dim);
+void cudaD_vec_max(int Gr, int Bl, const double* v, double* value, int dim, int inc) {
+  _vec_reduce<MAX><<<Gr,Bl>>>(v, value, dim, inc);
 }
 
 void cudaD_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const double* A, const double* B, MatrixDim dA, int B_stride, double* value) {
@@ -2950,11 +2821,7 @@ void cudaD_copy_col_from_mat_fd(int Gr, int Bl, float* v, int col, const double*
 }
 
 void cudaD_vec_sum(int Gr, int Bl, double* v, double* value, int dim, int inc) {
-  _vec_sum<<<Gr,Bl>>>(v,value,dim,inc);
-}
-
-void cudaD_pvec_sum(int Gr, int Bl, double* v, double* pvec_sum, int dim, int size) {
-  _pvec_sum<<<Gr,Bl>>>(v,pvec_sum,dim,size);
+  _vec_reduce<SUM><<<Gr,Bl>>>(v,value,dim,inc);
 }
 
 void cudaD_matrix_add_elements(dim3 Gr, dim3 Bl, double *data, MatrixDim dim, double alpha, MatrixElement<double>* x, int num_elements) {

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -173,7 +173,6 @@ inline void cuda_add_mat_blocks(dim3 Gr, dim3 Bl, float alpha, const float *src,
 inline void cuda_add_mat_mat_div_mat(dim3 Gr, dim3 Bl, const float *A, const float *B, const float *C, float *dst, MatrixDim d, int stride_a, int stride_b, int stride_c) { cudaF_add_mat_mat_div_mat(Gr,Bl,A,B,C,dst,d,stride_a,stride_b,stride_c); }
 inline void cuda_add_vec_to_cols(dim3 Gr, dim3 Bl, float alpha, const float *col, float beta, float *dst, MatrixDim d) { cudaF_add_vec_to_cols(Gr,Bl,alpha,col,beta,dst,d); }
 inline void cuda_add_vec_to_rows(dim3 Gr, dim3 Bl, float alpha, const float *row, float beta, float *dst, MatrixDim d) { cudaF_add_vec_to_rows(Gr,Bl,alpha,row,beta,dst,d); }
-inline void cuda_transpose_matrix(dim3 Gr, dim3 Bl, float* mat, MatrixDim d) { cudaF_transpose_matrix(Gr, Bl, mat, d); }
 inline void cuda_sy_add_tr2(dim3 Gr, dim3 Bl, float alpha, float beta, const float* T, MatrixDim tdim, float *S, MatrixDim sdim) { cudaF_sy_add_tr2(Gr, Bl, alpha, beta, T, tdim, S, sdim); }
 inline void cuda_add_mat_diag_vec(dim3 Gr, dim3 Bl, float alpha, float *mat, MatrixDim mat_dim, const float *mat2, int mat2_row_stride, int mat2_col_stride, const float *vec,  float beta) { cudaF_add_mat_diag_vec(Gr, Bl, alpha, mat, mat_dim, mat2, mat2_row_stride, mat2_col_stride, vec, beta); }
 inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, float *data, const float *srcA_data, const float *srcB_data, MatrixDim dim, int srcA_stride, int srcB_stride, float alpha, float beta) { cudaF_add_mat_mat_elements(Gr, Bl, data, srcA_data, srcB_data, dim, srcA_stride, srcB_stride, alpha, beta); }
@@ -190,8 +189,8 @@ inline void cuda_copy_from_vec_df(int Gr, int Bl, double* v_out, const float* v_
 inline void cuda_copy_from_vec_fd(int Gr, int Bl, float* v_out, const float* v_in, int dim) { cudaF_copy_from_vec_fd(Gr,Bl,v_out,v_in,dim); }
 inline void cuda_vec_mul_elements(int Gr, int Bl, float* v, const float* a, int dim) { cudaF_vec_mul_elements(Gr,Bl,v,a,dim); }
 inline void cuda_vec_soft_max(int Gr, int Bl, float* v, int dim) { cudaF_vec_soft_max(Gr,Bl,v,dim); }
-inline void cuda_vec_min(const float* v, float* value, int dim) { cudaF_vec_min(v,value,dim); }
-inline void cuda_vec_max(const float* v, float* value, int dim) { cudaF_vec_max(v,value,dim); }
+inline void cuda_vec_min(int Gr, int Bl, const float* v, float* value, int dim, int inc) { cudaF_vec_min(Gr,Bl,v,value,dim,inc); }
+inline void cuda_vec_max(int Gr, int Bl, const float* v, float* value, int dim, int inc) { cudaF_vec_max(Gr,Bl,v,value,dim,inc); }
 inline void cuda_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const float* A, const float* B, MatrixDim dA, int B_stride, float* value) { cudaF_trace_mat_mat_trans(Gr,Bl,A,B,dA,B_stride,value); }
 inline void cuda_trace_mat_mat(dim3 Gr, dim3 Bl, const float* A, const float* B, MatrixDim dA, int B_stride, float* value) { cudaF_trace_mat_mat(Gr,Bl,A,B,dA,B_stride,value); }
 inline void cuda_add_diag_mat_mat(int Gr, int Bl, float alpha, float* v, int v_dim, const float* M,
@@ -204,7 +203,6 @@ inline void cuda_add_vec_vec(int Gr, int Bl, float alpha, float* v, const float*
 inline void cuda_copy_col_from_mat_df(int Gr, int Bl, double* v, int col, const float* mat, MatrixDim dmat, int dim) { cudaF_copy_col_from_mat_df(Gr,Bl,v,col,mat,dmat,dim); }
 inline void cuda_copy_col_from_mat_fd(int Gr, int Bl, float* v, int col, const float* mat, MatrixDim dmat, int dim) { cudaF_copy_col_from_mat_fd(Gr,Bl,v,col,mat,dmat,dim); }
 inline void cuda_vec_sum(int Gr, int Bl, float* v, float* value, int dim, int inc) { cudaF_vec_sum(Gr,Bl,v,value,dim,inc); }
-inline void cuda_pvec_sum(int Gr, int Bl, float* vec, float* pvec_sum, int dim, int size) { cudaF_pvec_sum(Gr, Bl, vec, pvec_sum, dim, size); }
 inline void cuda_vec_copy_diag_from_packed(int Gr, int Bl, float *dst, const float *src, int dim) { cudaF_vec_copy_diag_from_packed(Gr,Bl,dst,src,dim); }
 inline void cuda_vec_apply_floor(int Gr, int Bl, float* v, float floor_val, float* num, int dim) { cudaF_vec_apply_floor(Gr,Bl,v,floor_val,num,dim); }
 inline void cuda_vec_apply_ceiling(int Gr, int Bl, float* v, float floor_val, float* num, int dim) { cudaF_vec_apply_ceiling(Gr,Bl,v,floor_val,num,dim); }
@@ -360,7 +358,6 @@ inline void cuda_add_mat_blocks(dim3 Gr, dim3 Bl, double alpha, const double *sr
 inline void cuda_add_mat_mat_div_mat(dim3 Gr, dim3 Bl, const double *A, const double *B, const double *C, double *dst, MatrixDim d, int stride_a, int stride_b, int stride_c) { cudaD_add_mat_mat_div_mat(Gr,Bl,A,B,C,dst,d,stride_a,stride_b,stride_c); }
 inline void cuda_add_vec_to_cols(dim3 Gr, dim3 Bl, double alpha, const double *col, double beta, double *dst, MatrixDim d) { cudaD_add_vec_to_cols(Gr,Bl,alpha,col,beta,dst,d); }
 inline void cuda_add_vec_to_rows(dim3 Gr, dim3 Bl, double alpha, const double *row, double beta, double *dst, MatrixDim d) { cudaD_add_vec_to_rows(Gr,Bl,alpha,row,beta,dst,d); }
-inline void cuda_transpose_matrix(dim3 Gr, dim3 Bl, double *mat, MatrixDim d) { cudaD_transpose_matrix(Gr, Bl, mat, d); }
 inline void cuda_sy_add_tr2(dim3 Gr, dim3 Bl, double alpha, double beta, const double* T, MatrixDim tdim, double *S, MatrixDim sdim) { cudaD_sy_add_tr2(Gr, Bl, alpha, beta, T, tdim, S, sdim); }
 inline void cuda_add_mat_diag_vec(dim3 Gr, dim3 Bl, double alpha, double *mat, MatrixDim mat_dim, const double *mat2, int mat2_row_stride, int mat2_col_stride, const double *vec,  double beta) { cudaD_add_mat_diag_vec(Gr, Bl, alpha, mat, mat_dim, mat2, mat2_row_stride, mat2_col_stride, vec, beta); }
 inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, double *data, const double *srcA_data, const double *srcB_data, MatrixDim dim, int srcA_stride, int srcB_stride, double alpha, double beta) { cudaD_add_mat_mat_elements(Gr, Bl, data, srcA_data, srcB_data, dim, srcA_stride, srcB_stride, alpha, beta); }
@@ -375,8 +372,8 @@ inline void cuda_copy_from_vec_df(int Gr, int Bl, double* v_out, const double* v
 inline void cuda_copy_from_vec_fd(int Gr, int Bl, float* v_out, const double* v_in, int dim) { cudaD_copy_from_vec_fd(Gr,Bl,v_out,v_in,dim); }
 inline void cuda_vec_mul_elements(int Gr, int Bl, double* v, const double* a, int dim) { cudaD_vec_mul_elements(Gr,Bl,v,a,dim); }
 inline void cuda_vec_soft_max(int Gr, int Bl, double* v, int dim) { cudaD_vec_soft_max(Gr,Bl,v,dim); }
-inline void cuda_vec_min(const double* v, double* value, int dim) { cudaD_vec_min(v,value,dim); }
-inline void cuda_vec_max(const double* v, double* value, int dim) { cudaD_vec_max(v,value,dim); }
+inline void cuda_vec_min(int Gr, int Bl, const double* v, double* value, int dim, int inc) { cudaD_vec_min(Gr,Bl,v,value,dim,inc); }
+inline void cuda_vec_max(int Gr, int Bl, const double* v, double* value, int dim, int inc) { cudaD_vec_max(Gr,Bl,v,value,dim,inc); }
 inline void cuda_trace_mat_mat_trans(dim3 Gr, dim3 Bl, const double* A, const double* B, MatrixDim dA, int B_stride, double* value) { cudaD_trace_mat_mat_trans(Gr,Bl,A,B,dA,B_stride,value); }
 inline void cuda_trace_mat_mat(dim3 Gr, dim3 Bl, const double* A, const double* B, MatrixDim dA, int B_stride, double* value) { cudaD_trace_mat_mat(Gr,Bl,A,B,dA,B_stride,value); }
 inline void cuda_add_diag_mat_mat(int Gr, int Bl, double alpha, double* v, int v_dim, const double* M,
@@ -389,7 +386,6 @@ inline void cuda_add_vec_vec(int Gr, int Bl, double alpha, double* v, const doub
 inline void cuda_copy_col_from_mat_df(int Gr, int Bl, double* v, int col, const double* mat, MatrixDim dmat, int dim) { cudaD_copy_col_from_mat_df(Gr,Bl,v,col,mat,dmat,dim); }
 inline void cuda_copy_col_from_mat_fd(int Gr, int Bl, float* v, int col, const double* mat, MatrixDim dmat, int dim) { cudaD_copy_col_from_mat_fd(Gr,Bl,v,col,mat,dmat,dim); }
 inline void cuda_vec_sum(int Gr, int Bl, double* v, double* value, int dim, int inc) { cudaD_vec_sum(Gr,Bl,v,value,dim,inc); }
-inline void cuda_pvec_sum(int Gr, int Bl, double* vec, double* pvec_sum, int dim, int size) { cudaD_pvec_sum(Gr,Bl,vec,pvec_sum,dim,size); }
 inline void cuda_vec_copy_diag_from_packed(int Gr, int Bl, double *dst, const double *src, int dim) { cudaD_vec_copy_diag_from_packed(Gr,Bl,dst,src,dim); }
 inline void cuda_vec_apply_floor(int Gr, int Bl, double* v, double floor_val, float* num, int dim) { cudaD_vec_apply_floor(Gr,Bl,v,floor_val,num,dim); }
 inline void cuda_vec_apply_ceiling(int Gr, int Bl, double* v, double floor_val, float* num, int dim) { cudaD_vec_apply_ceiling(Gr,Bl,v,floor_val,num,dim); }

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -114,10 +114,10 @@ template<typename Real> void TestCuVectorSumChooseMinLength() {
       BaseFloat fdim = dim;
       gflops_cpu = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
     }
-    KALDI_LOG<< "CuVector::Sum" << NameOf<Real>() << ", dim: " << dim
-    << ", speed: GPU " << (gflops > gflops_cpu ? ">" : "<")
-    << " CPU, GPU speed: " << gflops << " Gflops. CPU speed: " << gflops_cpu
-    << " Gflops. Result diff: " << (result - result_cpu);
+    KALDI_LOG << "CuVector::Sum" << NameOf<Real>() << ", dim: " << dim
+              << ", speed: GPU " << (gflops > gflops_cpu ? ">" : "<")
+              << " CPU, GPU speed: " << gflops << " Gflops. CPU speed: "
+              << gflops_cpu << " Gflops. Result diff: " << (result - result_cpu);
   }
 }
 #endif

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -73,6 +73,54 @@ template<typename Real> void TestCuVectorSum(int32 dim) {
             << dim << ", speed was " << gflops << " gigaflops.";
 }
 
+#if HAVE_CUDA == 1
+// This test choose the min length of vectors to be reduced on GPU.
+// Smaller vector will be copied to RAM and reduced on CPU.
+template<typename Real> void TestCuVectorSumChooseMinLength() {
+  BaseFloat time_in_secs = 0.02;
+  for (int dim = 100; dim < 1000000; dim = dim * 1.5 + 1 ) {
+    CuVector<Real> M(dim);
+    BaseFloat gflops, gflops_cpu;
+    Real result = 0, result_cpu = 0;
+    M.SetRandn();
+    {
+      Timer tim;
+      int32 iter = 0;
+      for (; tim.Elapsed() < time_in_secs; iter++) {
+        // Force GPU reduction
+        int dimBlock = CU1DBLOCK;
+        int dimGrid = n_blocks(M.Dim(), dimBlock);
+        if (dimGrid > 256) {
+          dimGrid = 256;
+        }
+        CuVector<Real> ans(dimGrid, kUndefined);
+        cuda_vec_sum(dimGrid, dimBlock, M.Data(), ans.Data(), M.Dim(), 1);
+        CU_SAFE_CALL(cudaGetLastError());
+        Vector<Real> ans_cpu(ans);
+        result = ans_cpu.Sum();
+      }
+
+      BaseFloat fdim = dim;
+      gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+    }
+    {
+      Timer tim;
+      int32 iter = 0;
+      for (; tim.Elapsed() < time_in_secs; iter++) {
+        Vector<Real> M_cpu(M);
+        result_cpu = M_cpu.Sum();
+      }
+
+      BaseFloat fdim = dim;
+      gflops_cpu = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+    }
+    KALDI_LOG<< "CuVector::Sum" << NameOf<Real>() << ", dim: " << dim
+    << ", speed: GPU " << (gflops > gflops_cpu ? ">" : "<")
+    << " CPU, GPU speed: " << gflops << " Gflops. CPU speed: " << gflops_cpu
+    << " Gflops. Result diff: " << (result - result_cpu);
+  }
+}
+#endif
 
 template<typename Real> void TestCuVectorVecVecOne(int32 dim) {
   BaseFloat time_in_secs = 0.02;
@@ -199,6 +247,9 @@ template<typename Real> void CudaVectorSpeedTest() {
   int32 ns = sizes.size();
   for (int32 s = 0; s < ns; s++)
     TestCuVectorSoftmax<Real>(sizes[s]);
+#if HAVE_CUDA == 1
+  TestCuVectorSumChooseMinLength<Real>();
+#endif
   for (int32 s = 0; s < ns; s++)
     TestCuVectorSum<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -297,8 +297,8 @@ template<typename Real> void CuVectorUnitTestInvertElements() {
 }
 
 template<typename Real> void CuVectorUnitTestSum() {
-  for (int32 i =1; i < 10; i++) {
-    MatrixIndexT dim = 2048 * i + 100 % Rand();
+  for (int32 p = 1; p <= 1000000; p *= 2) {
+    MatrixIndexT dim = p + Rand() % 500;
     CuVector<Real> A(dim), ones(dim);
     A.SetRandn();
     ones.Set(1.0);
@@ -429,8 +429,8 @@ template<typename Real> void CuVectorUnitTestNorm() {
 
 
 template<typename Real> void CuVectorUnitTestMin() {
-  for (int32 p = 0; p < 5; p++) {
-    int32 dim = 100 + Rand() % 500;
+  for (int32 p = 1; p <= 1000000; p *= 2) {
+    int32 dim = p + Rand() % 500;
     CuVector<Real> cu_vector(dim);
     cu_vector.SetRandn();
     Vector<Real> vector(cu_vector);
@@ -441,8 +441,8 @@ template<typename Real> void CuVectorUnitTestMin() {
 
 
 template<typename Real> void CuVectorUnitTestMax() {
-  for (int32 p = 0; p < 5; p++) {
-    int32 dim = 100 + Rand() % 500;
+  for (int32 p = 1; p <= 1000000; p *= 2) {
+    int32 dim = p + Rand() % 500;
     CuVector<Real> cu_vector(dim);
     cu_vector.SetRandn();
     Vector<Real> vector(cu_vector);

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -263,30 +263,30 @@ Real CuVectorBase<Real>::Sum() const {
     return 0.0;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
+    Real result;
     Timer tim;
-    int max_threads = 2048;
-    // This is the smallest block of consecutive vector elements, which
-    // its sum will save at the partial vector.
-    int block_size = (dim_ + max_threads - 1) / max_threads;
-    if (block_size > 3) {
-      int dimBlock(CU1DBLOCK);
-      int dimGrid(n_blocks(max_threads, CU1DBLOCK));
-      CuVector<Real> g(dimGrid);
-      cuda_pvec_sum(dimGrid, dimBlock, data_, g.Data(), dim_, block_size);
-      CU_SAFE_CALL(cudaGetLastError());
-      Vector<Real> tmp(dimGrid);
-      g.CopyToVec(&tmp);
-      CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
-      return tmp.Sum();
+
+    // Small vectors are copied to RAM and reduced on CPU.
+    // The length is chosen by cu-vector-speed-test
+    if (dim_ < 8192) {
+      Vector<Real> ans_cpu(*this);
+      result = ans_cpu.Sum();
     } else {
-      CuVector<Real> tmp(1, kUndefined);
-      int dimBlock(CU1DBLOCK);
-      int dimGrid = 1; // only 1 block here. we have loops in each thread.
-      cuda_vec_sum(dimGrid, dimBlock, data_, tmp.Data(), dim_, 1);
+      // Use no more than 256 blocks (still too many?)
+      int dimBlock = CU1DBLOCK;
+      int dimGrid = n_blocks(dim_, dimBlock);
+      if (dimGrid > 256) {
+        dimGrid = 256;
+      }
+      CuVector<Real> ans(dimGrid, kUndefined);
+      cuda_vec_sum(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
       CU_SAFE_CALL(cudaGetLastError());
-      CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
-      return tmp(0);
+      Vector<Real> ans_cpu(ans);
+      result = ans_cpu.Sum();
     }
+
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    return result;
   } else
 #endif
   {
@@ -637,10 +637,26 @@ Real CuVectorBase<Real>::Min() const {
       return std::numeric_limits<Real>::infinity();
     }
     Timer tim;
-    CuVector<Real> ans(1);
-    cuda_vec_min(data_, ans.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
-    result = ans(0);
+
+    // Small vectors are copied to RAM and reduced on CPU.
+    // The length is chosen by cu-vector-speed-test
+    if (dim_ < 8192) {
+      Vector<Real> ans_cpu(*this);
+      result = ans_cpu.Min();
+    } else {
+      // Use no more than 256 blocks (still too many?)
+      int dimBlock = CU1DBLOCK;
+      int dimGrid = n_blocks(dim_, dimBlock);
+      if (dimGrid > 256) {
+        dimGrid = 256;
+      }
+      CuVector<Real> ans(dimGrid, kUndefined);
+      cuda_vec_min(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
+      CU_SAFE_CALL(cudaGetLastError());
+      Vector<Real> ans_cpu(ans);
+      result = ans_cpu.Min();
+    }
+
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -659,10 +675,26 @@ Real CuVectorBase<Real>::Max() const {
       return -std::numeric_limits<Real>::infinity();
     }
     Timer tim;
-    CuVector<Real> ans(1);
-    cuda_vec_max(data_, ans.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
-    result = ans(0);
+
+    // Small vectors are copied to RAM and reduced on CPU.
+    // The length is chosen by cu-vector-speed-test
+    if (dim_ < 8192) {
+      Vector<Real> ans_cpu(*this);
+      result = ans_cpu.Max();
+    } else {
+      // Use no more than 256 blocks (still too many?)
+      int dimBlock = CU1DBLOCK;
+      int dimGrid = n_blocks(dim_, dimBlock);
+      if (dimGrid > 256) {
+        dimGrid = 256;
+      }
+      CuVector<Real> ans(dimGrid, kUndefined);
+      cuda_vec_max(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
+      CU_SAFE_CALL(cudaGetLastError());
+      Vector<Real> ans_cpu(ans);
+      result = ans_cpu.Max();
+    }
+
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -268,7 +268,7 @@ Real CuVectorBase<Real>::Sum() const {
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
-    if (dim_ < 8192) {
+    if (dim_ < 4096) {
       Vector<Real> ans_cpu(*this);
       result = ans_cpu.Sum();
     } else {
@@ -640,7 +640,7 @@ Real CuVectorBase<Real>::Min() const {
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
-    if (dim_ < 8192) {
+    if (dim_ < 4096) {
       Vector<Real> ans_cpu(*this);
       result = ans_cpu.Min();
     } else {
@@ -678,7 +678,7 @@ Real CuVectorBase<Real>::Max() const {
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
-    if (dim_ < 8192) {
+    if (dim_ < 4096) {
       Vector<Real> ans_cpu(*this);
       result = ans_cpu.Max();
     } else {


### PR DESCRIPTION
Vector will be reduced by CPU if it is short.

Benchmark for Sum():

New: For CuVector::Sum<float>, for dim = 16, speed was 0.000886179 gigaflops.
Old: For CuVector::Sum<float>, for dim = 16, speed was 0.000461866 gigaflops.
New: For CuVector::Sum<float>, for dim = 32, speed was 0.00119834 gigaflops.
Old: For CuVector::Sum<float>, for dim = 32, speed was 0.000936284 gigaflops.
New: For CuVector::Sum<float>, for dim = 64, speed was 0.00182674 gigaflops.
Old: For CuVector::Sum<float>, for dim = 64, speed was 0.00180461 gigaflops.
New: For CuVector::Sum<float>, for dim = 128, speed was 0.00721178 gigaflops.
Old: For CuVector::Sum<float>, for dim = 128, speed was 0.00350883 gigaflops.
New: For CuVector::Sum<float>, for dim = 256, speed was 0.0166563 gigaflops.
Old: For CuVector::Sum<float>, for dim = 256, speed was 0.00700597 gigaflops.
New: For CuVector::Sum<float>, for dim = 1024, speed was 0.0626621 gigaflops.
Old: For CuVector::Sum<float>, for dim = 1024, speed was 0.0273135 gigaflops.
New: For CuVector::Sum<float>, for dim = 2048, speed was 0.108495 gigaflops.
Old: For CuVector::Sum<float>, for dim = 2048, speed was 0.0529984 gigaflops.
New: For CuVector::Sum<float>, for dim = 4096, speed was 0.162914 gigaflops.
Old: For CuVector::Sum<float>, for dim = 4096, speed was 0.0930953 gigaflops.
New: For CuVector::Sum<float>, for dim = 8192, speed was 0.248687 gigaflops.
Old: For CuVector::Sum<float>, for dim = 8192, speed was 0.149376 gigaflops.
New: For CuVector::Sum<float>, for dim = 16384, speed was 0.491677 gigaflops.
Old: For CuVector::Sum<float>, for dim = 16384, speed was 0.197131 gigaflops.
New: For CuVector::Sum<float>, for dim = 32768, speed was 0.931507 gigaflops.
Old: For CuVector::Sum<float>, for dim = 32768, speed was 0.492249 gigaflops.
New: For CuVector::Sum<float>, for dim = 65536, speed was 1.75797 gigaflops.
Old: For CuVector::Sum<float>, for dim = 65536, speed was 0.657485 gigaflops.
New: For CuVector::Sum<double>, for dim = 16, speed was 0.00116685 gigaflops.
Old: For CuVector::Sum<double>, for dim = 16, speed was 0.000406633 gigaflops.
New: For CuVector::Sum<double>, for dim = 32, speed was 0.00229885 gigaflops.
Old: For CuVector::Sum<double>, for dim = 32, speed was 0.000836551 gigaflops.
New: For CuVector::Sum<double>, for dim = 64, speed was 0.00430313 gigaflops.
Old: For CuVector::Sum<double>, for dim = 64, speed was 0.00167463 gigaflops.
New: For CuVector::Sum<double>, for dim = 128, speed was 0.00840191 gigaflops.
Old: For CuVector::Sum<double>, for dim = 128, speed was 0.00338708 gigaflops.
New: For CuVector::Sum<double>, for dim = 256, speed was 0.0156417 gigaflops.
Old: For CuVector::Sum<double>, for dim = 256, speed was 0.00668978 gigaflops.
New: For CuVector::Sum<double>, for dim = 1024, speed was 0.051799 gigaflops.
Old: For CuVector::Sum<double>, for dim = 1024, speed was 0.0253556 gigaflops.
New: For CuVector::Sum<double>, for dim = 2048, speed was 0.09064 gigaflops.
Old: For CuVector::Sum<double>, for dim = 2048, speed was 0.0510465 gigaflops.
New: For CuVector::Sum<double>, for dim = 4096, speed was 0.122844 gigaflops.
Old: For CuVector::Sum<double>, for dim = 4096, speed was 0.081494 gigaflops.
New: For CuVector::Sum<double>, for dim = 8192, speed was 0.241084 gigaflops.
Old: For CuVector::Sum<double>, for dim = 8192, speed was 0.156451 gigaflops.
New: For CuVector::Sum<double>, for dim = 16384, speed was 0.468114 gigaflops.
Old: For CuVector::Sum<double>, for dim = 16384, speed was 0.311666 gigaflops.
New: For CuVector::Sum<double>, for dim = 32768, speed was 0.859946 gigaflops.
Old: For CuVector::Sum<double>, for dim = 32768, speed was 0.545834 gigaflops.
New: For CuVector::Sum<double>, for dim = 65536, speed was 1.53817 gigaflops.
Old: For CuVector::Sum<double>, for dim = 65536, speed was 0.914985 gigaflops.
