### PR TITLE
CuMatrixBase::Max, Min and Sum by _reduce_mat_cols kernel template

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -99,6 +99,9 @@ void cudaF_add_mat_mat_elements(dim3 Gr, dim3 Bl, float *data, const float *srcA
 /*
  * CuVector
  */
+void cudaF_max_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d);
+void cudaF_min_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d);
+void cudaF_sum_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d);
 void cudaF_replace_value(int Gr, int Bl, float *v, int dim, float orig, float changed);
 void cudaF_set_bias_params(int Gr, int Bl, float* v, const float* a, float param_1, float param_2, float param_3, int* flag, int dim);
 void cudaF_copy_from_vec_df(int Gr, int Bl, double* v_out, const float* v_in, int dim);
@@ -238,6 +241,9 @@ void cudaD_add_mat_mat_elements(dim3 Gr, dim3 Bl, double *data, const double *sr
 /*
  * CuVector
  */
+void cudaD_max_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d);
+void cudaD_min_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d);
+void cudaD_sum_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d);
 void cudaD_replace_value(int Gr, int Bl, double *v, int dim, double orig, double changed);
 void cudaD_set_bias_params(int Gr, int Bl, double* v, const double* a, double param_1, double param_2, double param_3, int* flag, int dim);
 void cudaD_copy_from_vec_df(int Gr, int Bl, double* v_out, const double* v_in, int dim);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -182,6 +182,9 @@ inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, float *data, const float
 /*
  * CuVector
  */
+inline void cuda_max_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d) { cudaF_max_mat_cols(Gr, Bl, result, mat, d); }
+inline void cuda_min_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d) { cudaF_min_mat_cols(Gr, Bl, result, mat, d); }
+inline void cuda_sum_mat_cols(int Gr, int Bl, float* result, const float* mat, const MatrixDim d) { cudaF_sum_mat_cols(Gr, Bl, result, mat, d); }
 inline void cuda_replace_value(int Gr, int Bl, float *v, int dim, float orig, float changed) {cudaF_replace_value(Gr, Bl, v, dim, orig, changed); }
 inline void cuda_div_rows_vec(dim3 Gr, dim3 Bl, float *mat, const float *vec_div, MatrixDim d) { cudaF_div_rows_vec(Gr,Bl,mat,vec_div,d); }
 inline void cuda_set_bias_params(int Gr, int Bl, float* v, const float* a, float param_1, float param_2, float param_3, int* flag, int dim) { cudaF_set_bias_params(Gr,Bl,v,a,param_1,param_2,param_3,flag,dim); }
@@ -365,6 +368,10 @@ inline void cuda_add_mat_mat_elements(dim3 Gr, dim3 Bl, double *data, const doub
 /*
  * CuVector
  */
+
+inline void cuda_max_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d) { cudaD_max_mat_cols(Gr, Bl, result, mat, d); }
+inline void cuda_min_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d) { cudaD_min_mat_cols(Gr, Bl, result, mat, d); }
+inline void cuda_sum_mat_cols(int Gr, int Bl, double* result, const double* mat, const MatrixDim d) { cudaD_sum_mat_cols(Gr, Bl, result, mat, d); }
 inline void cuda_replace_value(int Gr, int Bl, double *v, int dim, double orig, double changed) {cudaD_replace_value(Gr, Bl, v, dim, orig, changed); }
 inline void cuda_div_rows_vec(dim3 Gr, dim3 Bl, double *mat, const double *vec_div, MatrixDim d) { cudaD_div_rows_vec(Gr,Bl,mat,vec_div,d); }
 inline void cuda_set_bias_params(int Gr, int Bl, double* v, const double* a, double param_1, double param_2, double param_3, int* flag, int dim) { cudaD_set_bias_params(Gr,Bl,v,a,param_1,param_2,param_3,flag,dim); }

--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -41,6 +41,57 @@ std::string NameOf() {
   return (sizeof(Real) == 8 ? "<double>" : "<float>");
 }
 
+template<typename Real> void TestCuMatrixSum(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim);
+  M.SetRandn();
+
+  Timer tim;
+  int32 iter = 0;
+  Real result = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    result = M.Sum();
+  }
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG<< "For CuMatrix::TestCuMatrixSum" << NameOf<Real>() << ", for dim = "
+  << dim << ", speed was " << gflops << " gigaflops, result = " << result;
+}
+
+template<typename Real> void TestCuMatrixMax(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim);
+  M.SetRandn();
+
+  Timer tim;
+  int32 iter = 0;
+  Real result = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    result = M.Max();
+  }
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG<< "For CuMatrix::TestCuMatrixMax" << NameOf<Real>() << ", for dim = "
+  << dim << ", speed was " << gflops << " gigaflops, result = " << result;
+}
+
+template<typename Real> void TestCuMatrixMin(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim);
+  M.SetRandn();
+
+  Timer tim;
+  int32 iter = 0;
+  Real result = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    result = M.Min();
+  }
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG<< "For CuMatrix::TestCuMatrixMin" << NameOf<Real>() << ", for dim = "
+  << dim << ", speed was " << gflops << " gigaflops, result = " << result;
+}
+
 template<typename Real> void TestCuMatrixTransposeNS(int32 dim) {
   BaseFloat time_in_secs = 0.025;
   CuMatrix<Real> M(dim, dim / 2);
@@ -932,6 +983,12 @@ template<typename Real> void CudaMatrixSpeedTest() {
     TestCuMatrixTransposeS<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixTransposeNS<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixSum<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixMax<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixMin<Real>(sizes[s]);
 }
 
 

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1183,7 +1183,7 @@ static void UnitTestCuMatrixAddMatBlocks() {
 }
 
 template<typename Real>
-static void UnitTestCuMatrixSum() {
+static void UnitTestCuMatrixReduceSum() {
   int32 M = 100 + Rand() % 300, N = 100 + Rand() % 300;
   CuMatrix<Real> A(M, N);
   A.SetRandn();
@@ -1191,6 +1191,23 @@ static void UnitTestCuMatrixSum() {
   KALDI_ASSERT(ApproxEqual(mA.Sum(), A.Sum()));
 }
 
+template<typename Real>
+static void UnitTestCuMatrixReduceMax() {
+  int32 M = 100 + Rand() % 300, N = 100 + Rand() % 300;
+  CuMatrix<Real> A(M, N);
+  A.SetRandn();
+  Matrix<Real> mA(A);
+  KALDI_ASSERT(ApproxEqual(mA.Max(), A.Max()));
+}
+
+template<typename Real>
+static void UnitTestCuMatrixReduceMin() {
+  int32 M = 100 + Rand() % 300, N = 100 + Rand() % 300;
+  CuMatrix<Real> A(M, N);
+  A.SetRandn();
+  Matrix<Real> mA(A);
+  KALDI_ASSERT(ApproxEqual(mA.Min(), A.Min()));
+}
 
 template<typename Real>
 static void UnitTestCuMatrixAddVecToCols() {
@@ -2473,7 +2490,9 @@ template<typename Real> void CudaMatrixUnitTest() {
   UnitTestCuMatrixDivRowsVec<Real>();
   UnitTestCuMatrixAddMat<Real>();
   UnitTestCuMatrixAddMatBlocks<Real>();
-  UnitTestCuMatrixSum<Real>();
+  UnitTestCuMatrixReduceSum<Real>();
+  UnitTestCuMatrixReduceMax<Real>();
+  UnitTestCuMatrixReduceMin<Real>();
   UnitTestCuMatrixAddVecToCols<Real>();
   UnitTestCuMatrixAddVecToRows<Real>();
   UnitTestCuMatrixAddMatMat<Real>();

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -2420,41 +2420,64 @@ void CuMatrixBase<Real>::CopyUpperToLower() {
 
 template<typename Real>
 Real CuMatrixBase<Real>::Sum() const {
-  CuVector<Real> row_sum(NumCols());
-  row_sum.AddRowSumMat(1.0, *this, 0.0);
-  return row_sum.Sum();
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
+    Timer tim;
+
+    CuVector<Real> col_sum(num_rows_, kUndefined);
+    cuda_sum_mat_cols(num_rows_, CU1DBLOCK, col_sum.Data(), data_, Dim());
+    Real ans = col_sum.Sum();
+
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    return ans;
+  } else
+#endif
+  {
+    return Mat().Sum();
+  }
 }
 
 
 template<typename Real>
 Real CuMatrixBase<Real>::Max() const {
-  Timer tim;
-  // TODO rewrite in CUDA,
-  Matrix<Real> tmp(NumRows(), NumCols(), kUndefined);
-  CopyToMat(&tmp);
-  Real ans = tmp.Max();
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
+    KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
+    Timer tim;
+
+    CuVector<Real> col_max(num_rows_, kUndefined);
+    cuda_max_mat_cols(num_rows_, CU1DBLOCK, col_max.Data(), data_, Dim());
+    Real ans = col_max.Max();
+
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
-  }
+    return ans;
+  } else
 #endif
-  return ans;
+  {
+    return Mat().Max();
+  }
 }
 
 
 template<typename Real>
 Real CuMatrixBase<Real>::Min() const {
-  Timer tim;
-  // TODO rewrite in CUDA,
-  Matrix<Real> tmp(NumRows(), NumCols(), kUndefined);
-  CopyToMat(&tmp);
-  Real ans = tmp.Min();
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
+    KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
+    Timer tim;
+
+    CuVector<Real> col_min(num_rows_, kUndefined);
+    cuda_min_mat_cols(num_rows_, CU1DBLOCK, col_min.Data(), data_, Dim());
+    Real ans = col_min.Min();
+
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
-  }
+    return ans;
+  } else
 #endif
-  return ans;
+  {
+    return Mat().Min();
+  }
 }
 
 

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -522,8 +522,8 @@ class CuMatrixBase {
   }
 
   Real Sum() const;
-  Real Max() const; ///< proxy to MatrixBase::Max(), cuda not used
-  Real Min() const; ///< proxy to MatrixBase::Min(), cuda not used
+  Real Max() const;
+  Real Min() const;
 
   /// Return the trace. If check_square = true, will crash if matrix is not square.
   Real Trace(bool check_square = true) const;


### PR DESCRIPTION
Matrix is reduced to a column vector first, then to one element. Sum is ~2x faster.


New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 16, speed was 0.00954969 gigaflops, result = 26.2034
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 16, speed was 0.00340611 gigaflops, result = 26.2034
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 32, speed was 0.0400381 gigaflops, result = 17.9455
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 32, speed was 0.0141018 gigaflops, result = 17.9455
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 64, speed was 0.152595 gigaflops, result = 31.6159
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 64, speed was 0.0575425 gigaflops, result = 31.6159
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 128, speed was 0.546459 gigaflops, result = 81.3117
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 128, speed was 0.229418 gigaflops, result = 81.3117
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 256, speed was 1.94432 gigaflops, result = 572.224
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 256, speed was 0.778943 gigaflops, result = 572.224
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 512, speed was 6.23377 gigaflops, result = 39.6669
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 512, speed was 3.11055 gigaflops, result = 39.6668
New: For CuMatrix::TestCuMatrixSum\<float>, for dim = 1024, speed was 16.0119 gigaflops, result = 518.841
Old: For CuMatrix::TestCuMatrixSum\<float>, for dim = 1024, speed was 7.50506 gigaflops, result = 518.842
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 16, speed was 0.00916145 gigaflops, result = -2.71724
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 16, speed was 0.00216499 gigaflops, result = -2.71724
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 32, speed was 0.0366853 gigaflops, result = 43.261
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 32, speed was 0.00863257 gigaflops, result = 43.261
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 64, speed was 0.144912 gigaflops, result = 30.3323
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 64, speed was 0.0513208 gigaflops, result = 30.3323
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 128, speed was 0.501765 gigaflops, result = -152.665
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 128, speed was 0.20313 gigaflops, result = -152.665
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 256, speed was 1.83353 gigaflops, result = -355.256
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 256, speed was 0.759338 gigaflops, result = -355.256
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 512, speed was 5.609 gigaflops, result = 744.185
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 512, speed was 2.60159 gigaflops, result = 744.185
New: For CuMatrix::TestCuMatrixSum\<double>, for dim = 1024, speed was 12.6693 gigaflops, result = -857.049
Old: For CuMatrix::TestCuMatrixSum\<double>, for dim = 1024, speed was 7.2258 gigaflops, result = -857.049
