### PR TITLE
Fix #819 on CuMatrix::DivRowsVec

### DIFF
--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -92,6 +92,25 @@ template<typename Real> void TestCuMatrixMin(int32 dim) {
   << dim << ", speed was " << gflops << " gigaflops, result = " << result;
 }
 
+template<typename Real> void TestCuMatrixDivRowsVec(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim);
+  CuVector<Real> V(dim);
+  M.SetRandn();
+  V.SetRandn();
+
+  Timer tim;
+  int32 iter = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    M.DivRowsVec(V);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG<< "For CuMatrix::DivRowsVec" << NameOf<Real>() << ", for dim = "
+  << dim << ", speed was " << gflops << " gigaflops.";
+}
+
 template<typename Real> void TestCuMatrixTransposeNS(int32 dim) {
   BaseFloat time_in_secs = 0.025;
   CuMatrix<Real> M(dim, dim / 2);
@@ -907,6 +926,8 @@ template<typename Real> void CudaMatrixSpeedTest() {
   sizes.push_back(512);
   sizes.push_back(1024);
   int32 ns = sizes.size();
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixDivRowsVec<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixResize<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1072,13 +1072,14 @@ template<typename Real> static void UnitTestCuMatrixAddMatMatElements() {
 
 template<typename Real>
 static void UnitTestCuMatrixDivRowsVec() {
-  Matrix<Real> Hm(100,99);
-  Vector<Real> Hv(100);
+  MatrixIndexT dimM = 1000, dimN = 5;
+  Matrix<Real> Hm(dimM, dimN);
+  Vector<Real> Hv(dimM);
   Hm.SetRandn();
   InitRand(&Hv);
 
-  CuMatrix<Real> Dm(100,99);
-  CuVector<Real> Dv(100);
+  CuMatrix<Real> Dm(dimM, dimN);
+  CuVector<Real> Dv(dimM);
   Dm.CopyFromMat(Hm);
   Dv.CopyFromVec(Hv);
 
@@ -1086,10 +1087,10 @@ static void UnitTestCuMatrixDivRowsVec() {
   Hv.InvertElements();
   Hm.MulRowsVec(Hv);
 
-  Matrix<Real> Hm2(100,99);
+  Matrix<Real> Hm2(dimM, dimN);
   Dm.CopyToMat(&Hm2);
 
-  AssertEqual(Hm,Hm2);
+  AssertEqual(Hm, Hm2);
 }
 
 


### PR DESCRIPTION
Fix #819 and speed up for large float matrix.


```
New: For CuMatrix::DivRowsVec<float>, for dim = 16, speed was 0.0180391 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 16, speed was 0.017677 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 32, speed was 0.0686798 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 32, speed was 0.0682798 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 64, speed was 0.290613 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 64, speed was 0.273113 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 128, speed was 1.12576 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 128, speed was 1.08792 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 256, speed was 3.79354 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 256, speed was 3.48151 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 512, speed was 9.247 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 512, speed was 8.70703 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 1024, speed was 16.535 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 1024, speed was 12.8467 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 2048, speed was 21.0912 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 2048, speed was 14.6946 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 4096, speed was 21.8187 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 4096, speed was 15.1197 gigaflops.
New: For CuMatrix::DivRowsVec<float>, for dim = 8192, speed was 20.9238 gigaflops.
Old: For CuMatrix::DivRowsVec<float>, for dim = 8192, speed was 15.2273 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 16, speed was 0.0171395 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 16, speed was 0.0173988 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 32, speed was 0.0708914 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 32, speed was 0.0745867 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 64, speed was 0.302615 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 64, speed was 0.279866 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 128, speed was 1.12123 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 128, speed was 1.15183 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 256, speed was 3.73959 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 256, speed was 3.61588 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 512, speed was 6.75394 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 512, speed was 6.86088 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 1024, speed was 10.2967 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 1024, speed was 9.63553 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 2048, speed was 11.3301 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 2048, speed was 10.9322 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 4096, speed was 11.063 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 4096, speed was 10.7829 gigaflops.
New: For CuMatrix::DivRowsVec<double>, for dim = 8192, speed was 10.6967 gigaflops.
Old: For CuMatrix::DivRowsVec<double>, for dim = 8192, speed was 10.6246 gigaflops.
```