### PR TITLE
Fixed pitch_functions to behave correctly with snip_edges=false

### DIFF
--- a/src/feat/feature-window.cc
+++ b/src/feat/feature-window.cc
@@ -105,16 +105,20 @@ FeatureWindowFunction::FeatureWindowFunction(const FrameExtractionOptions &opts)
   int32 frame_length = opts.WindowSize();
   KALDI_ASSERT(frame_length > 0);
   window.Resize(frame_length);
+  double a = M_2PI / (frame_length-1);
   for (int32 i = 0; i < frame_length; i++) {
-    BaseFloat i_fl = static_cast<BaseFloat>(i);
+    double i_fl = static_cast<double>(i);
     if (opts.window_type == "hanning") {
-      window(i) = 0.5  - 0.5*cos(M_2PI * i_fl / (frame_length-1));
+      window(i) = 0.5  - 0.5*cos(a * i_fl);
     } else if (opts.window_type == "hamming") {
-      window(i) = 0.54 - 0.46*cos(M_2PI * i_fl / (frame_length-1));
+      window(i) = 0.54 - 0.46*cos(a * i_fl);
     } else if (opts.window_type == "povey") {  // like hamming but goes to zero at edges.
-      window(i) = pow(0.5 - 0.5*cos(M_2PI * i_fl / (frame_length-1)), 0.85);
+      window(i) = pow(0.5 - 0.5*cos(a * i_fl), 0.85);
     } else if (opts.window_type == "rectangular") {
       window(i) = 1.0;
+    } else if (opts.window_type == "blackman") {
+      window(i) = opts.blackman_coeff - 0.5*cos(a * i_fl) +
+        (0.5 - opts.blackman_coeff) * cos(2 * a * i_fl);
     } else {
       KALDI_ERR << "Invalid window type " << opts.window_type;
     }

--- a/src/feat/feature-window.h
+++ b/src/feat/feature-window.h
@@ -41,8 +41,9 @@ struct FrameExtractionOptions {
   bool remove_dc_offset;  // Subtract mean of wave before FFT.
   std::string window_type;  // e.g. Hamming window
   bool round_to_power_of_two;
+  BaseFloat blackman_coeff;
   bool snip_edges;
-  // Maybe "hamming", "rectangular", "povey", "hanning"
+  // May be "hamming", "rectangular", "povey", "hanning", "blackman"
   // "povey" is a window I made to be similar to Hamming but to go to zero at the
   // edges, it's pow((0.5 - 0.5*cos(n/N*2*pi)), 0.85)
   // I just don't think the Hamming window makes sense as a windowing function.
@@ -55,6 +56,7 @@ struct FrameExtractionOptions {
       remove_dc_offset(true),
       window_type("povey"),
       round_to_power_of_two(true),
+      blackman_coeff(0.42),
       snip_edges(true){ }
 
   void Register(OptionsItf *opts) {
@@ -69,7 +71,10 @@ struct FrameExtractionOptions {
                    "Subtract mean from waveform on each frame");
     opts->Register("dither", &dither, "Dithering constant (0.0 means no dither)");
     opts->Register("window-type", &window_type, "Type of window "
-                   "(\"hamming\"|\"hanning\"|\"povey\"|\"rectangular\")");
+                   "(\"hamming\"|\"hanning\"|\"povey\"|\"rectangular\""
+                   "|\"blackmann\")");
+    opts->Register("blackman-coeff", &blackman_coeff,
+                   "Constant coefficient for generalized Blackman window.");
     opts->Register("round-to-power-of-two", &round_to_power_of_two,
                    "If true, round window size to power of two.");
     opts->Register("snip-edges", &snip_edges,

--- a/src/feat/pitch-functions-test.cc
+++ b/src/feat/pitch-functions-test.cc
@@ -65,6 +65,89 @@ static void UnitTestSimple() {
   KALDI_LOG << "Test passed :)";
 }
 
+// Make sure the snip edges options works as expected, i.e.
+// disabling the option should introduce a delay equivalent to
+// half the window length
+static void UnitTestSnipEdges() {
+  KALDI_LOG << "=== UnitTestSnipEdges() ===\n";
+  PitchExtractionOptions op_SnipEdges, op_NoSnipEdges;
+  Matrix<BaseFloat> m1, m2;
+  ProcessPitchOptions opp;
+  int nbad = 0;
+
+  // Load test wave file
+  WaveData wave;
+  {
+    std::ifstream is("test_data/test.wav");
+    wave.Read(is);
+  }
+  KALDI_ASSERT(wave.Data().NumRows() == 1);
+  SubVector<BaseFloat> waveform(wave.Data(), 0);
+
+  // Process files with snip edge enabled or disabled, on various 
+  // frame shifts and frame lengths
+  for (int fs = 1; fs <= 10; fs++) {
+    for (int wl = 20; wl <= 100; wl += 10) { 
+      // Rather dirty way to round, but works fine
+      int32 ms_fs = (int32)(wave.SampFreq() * 0.001 * fs + 0.5);
+      int32 ms_wl = (int32)(wave.SampFreq() * 0.001 * wl + 0.5);
+      op_SnipEdges.snip_edges = true;
+      op_SnipEdges.frame_shift_ms = fs;
+      op_SnipEdges.frame_length_ms = wl;
+      op_NoSnipEdges.snip_edges = false;
+      op_NoSnipEdges.frame_shift_ms = fs;
+      op_NoSnipEdges.frame_length_ms = wl;
+      ComputeAndProcessKaldiPitch(op_SnipEdges, opp, waveform, &m1);
+      ComputeAndProcessKaldiPitch(op_NoSnipEdges, opp, waveform, &m2);
+  
+      // Check the output differ in a predictable manner:
+      // 1. The length of the output should only depend on the window size & window shift
+      KALDI_LOG << "Output: " << m1.NumRows() << " ; " << m2.NumRows();
+      //   - with snip edges disabled, depends on file size and frame shift only */ 
+      AssertEqual(m2.NumRows(), ((int)(wave.Data().NumCols() + ms_fs / 2)) / ms_fs);
+      //   - with snip edges disabled, depend on file size, frame shift, frame length */
+      AssertEqual(m1.NumRows(), ((int)(wave.Data().NumCols() - ms_wl + ms_fs)) / ms_fs);
+      // 2. The signal should be delayed in a predictable manner
+      Vector<BaseFloat> f0_1(m1.NumRows());
+      f0_1.CopyColFromMat(m1, 1);
+      Vector<BaseFloat> f0_2(m2.NumRows());
+      f0_2.CopyColFromMat(m2, 1);
+
+      BaseFloat bcorr = -1;
+      int32 blag = -1;
+      int32 max_lag =  wl / fs * 2;
+      int num_frames_f0 = m1.NumRows() - max_lag;
+      
+      /* Looks for the best correlation between the output signals,
+         identify the lag, compares it with theoretical value */
+      SubVector<BaseFloat> sub_vec1(f0_1, 0, num_frames_f0);
+      for (int32 lag = 0; lag < max_lag + 1; lag++) {
+        SubVector<BaseFloat> sub_vec2(f0_2, lag, num_frames_f0);
+        BaseFloat corr = VecVec(sub_vec1, sub_vec2);
+        if (corr > bcorr) {
+          bcorr = corr;
+          blag = lag;
+        }
+      }
+      KALDI_LOG << "Best lag: " << blag * fs << "ms with value: " << bcorr << 
+        "; expected lag: " << wl / 2 + 10 - fs / 2 << " ± " << fs;
+      // BP: the lag should in theory be equal to wl / 2 - fs / 2, but it seems 
+      // to be: wl / 2 + 10 - fs / 2! It appears the 10 ms comes from the nccf_lag which
+      // is 82 samples with the default settings => nccf_lag / resample_freq / 2 => 10.25ms
+      // We should really be using the full_frame_length of the algorithm for accurate results,
+      // but there is no method to obtain it (and it is potentially variable), so that makes
+      // the pitch value *with snip edge* particularly unreliable.
+      if (!ApproxEqual(blag * fs, (BaseFloat)(wl / 2 + 10 - fs / 2), (BaseFloat)fs / wl)) {
+        KALDI_WARN << "Bad lag for window size " << wl << " and frame shift " << fs;
+        nbad++;
+      }
+      /*AssertEqual(blag * fs, (BaseFloat)(wl / 2 + 10 - fs / 2), (BaseFloat)fs / wl);*/
+    }
+  }
+  /* If more than 10% of tests fail, crash */
+  if (nbad > 9) KALDI_ERR << "Too many bad lags: " << nbad;
+
+}
 
 // Make sure that doing a calculation on the whole waveform gives
 // the same results as doing on the waveform broken into pieces.
@@ -513,6 +596,7 @@ void UnitTestProcess() {
 static void UnitTestFeatNoKeele() {
   UnitTestSimple();
   UnitTestPieces();
+  UnitTestSnipEdges();
   UnitTestDelay();
   UnitTestSearch();
 }

--- a/src/feat/pitch-functions.cc
+++ b/src/feat/pitch-functions.cc
@@ -773,13 +773,22 @@ int32 OnlinePitchFeatureImpl::NumFramesAvailable(
   // of frames only if the input is not finished.
   if (!input_finished_)
     frame_length += nccf_last_lag_;
-  if (num_downsampled_samples < frame_length) return 0;
-  else
-    if (input_finished_ && !snip_edges) {
-      return (int32)(num_downsampled_samples * 1.0f / frame_shift + 0.5f);
+  if (num_downsampled_samples < frame_length) {
+    return 0;
+  } else {
+    if (!snip_edges) {
+      if (input_finished_) {
+        return static_cast<int32>(num_downsampled_samples * 1.0f /
+                                  frame_shift + 0.5f);
+      } else {
+        return static_cast<int32>((num_downsampled_samples - frame_length / 2) *
+                                   1.0f / frame_shift + 0.5f);
+      }
+    } else {
+      return static_cast<int32>((num_downsampled_samples - frame_length) /
+                                 frame_shift + 1);
     }
-    else
-      return ((num_downsampled_samples - frame_length) / frame_shift) + 1;
+  }
 }
 
 void OnlinePitchFeatureImpl::UpdateRemainder(
@@ -835,19 +844,35 @@ void OnlinePitchFeatureImpl::ExtractFrame(
   int32 offset = static_cast<int32>(sample_index -
                                     downsampled_samples_processed_);
 
+  // Treat edge cases first
+  if (sample_index < 0) {
+    // Part of the frame is before the beginning of the signal. This
+    // should only happen if opts_.snip_edges == false, when we are
+    // processing the first few frames of signal. In this case
+    // we pad with zeros.
+    KALDI_ASSERT(opts_.snip_edges == false);
+    int32 sub_frame_length = sample_index + full_frame_length;
+    int32 sub_frame_index = full_frame_length - sub_frame_length;
+    KALDI_ASSERT(sub_frame_length > 0 && sub_frame_index > 0);
+    window->SetZero();
+    SubVector<BaseFloat> sub_window(*window, sub_frame_index, sub_frame_length);
+    ExtractFrame(downsampled_wave_part, 0, &sub_window);
+    return;
+  }
+
   if (offset + full_frame_length > downsampled_wave_part.Dim()) {
     // Requested frame is past end of the signal.  This should only happen if
     // input_finished_ == true, when we're flushing out the last couple of
     // frames of signal.  In this case we pad with zeros.
     KALDI_ASSERT(input_finished_);
-    int32 new_full_frame_length = downsampled_wave_part.Dim() - offset;
-    KALDI_ASSERT(new_full_frame_length > 0);
+    int32 sub_frame_length = downsampled_wave_part.Dim() - offset;
+    KALDI_ASSERT(sub_frame_length > 0);
     window->SetZero();
-    SubVector<BaseFloat> sub_window(*window, 0, new_full_frame_length);
+    SubVector<BaseFloat> sub_window(*window, 0, sub_frame_length);
     ExtractFrame(downsampled_wave_part, sample_index, &sub_window);
     return;
   }
-  
+
   // "offset" is the offset of the start of the frame, into this
   // signal.
   if (offset >= 0) {
@@ -1076,7 +1101,17 @@ void OnlinePitchFeatureImpl::AcceptWaveform(
 
   for (int32 frame = start_frame; frame < end_frame; frame++) {
     // start_sample is index into the whole wave, not just this part.
-    int64 start_sample = static_cast<int64>(frame) * frame_shift;
+    int64 start_sample;
+    if (opts_.snip_edges) {
+      // Usual case: offset starts at 0
+      start_sample = static_cast<int64>(frame) * frame_shift;
+    } else { 
+      // When we are not snipping the edges, the first offsets may be
+      // negative. In this case we will pad with zeros, it should not impact
+      // the pitch tracker.
+      start_sample = 
+        static_cast<int64>((frame + 0.5) * frame_shift) - full_frame_length / 2;
+    }
     ExtractFrame(downsampled_wave, start_sample, &window);
     if (opts_.nccf_ballast_online) {
       // use only up to end of current frame to compute root-mean-square value.

--- a/src/feat/pitch-functions.h
+++ b/src/feat/pitch-functions.h
@@ -138,7 +138,8 @@ struct PitchExtractionOptions {
                    "file, if specified there)");
     opts->Register("frame-length", &frame_length_ms, "Frame length in "
                    "milliseconds");
-    opts->Register("frame-shift", &frame_shift_ms, "Frame shift in milliseconds");
+    opts->Register("frame-shift", &frame_shift_ms, "Frame shift in "
+                   "milliseconds");
     opts->Register("preemphasis-coefficient", &preemph_coeff,
                    "Coefficient for use in signal preemphasis (deprecated)");
     opts->Register("min-f0", &min_f0,
@@ -190,20 +191,21 @@ struct PitchExtractionOptions {
                    "if --frames-per-chunk > 0 and "
                    "--simulate-first-pass-online=true");
     opts->Register("snip-edges", &snip_edges, "If this is set to false, the "
-                   "incomplete frames near the ending edge won't be snipped, so "
-                   "that the number of frames is the file size divided by the "
-                   "frame-shift. This makes different types of features give the "
-                   "same number of frames.");
-
+                   "incomplete frames near the ending edge won't be snipped, "
+                   "so that the number of frames is the file size divided by "
+                   "the frame-shift. This makes different types of features "
+                   "give the same number of frames.");
   }
   /// Returns the window-size in samples, after resampling.  This is the
   /// "basic window size", not the full window size after extending by max-lag.
+  // Because of floating point representation, it is more reliable to divide
+  // by 1000 instead of multiplying by 0.001, but it is a bit slower.
   int32 NccfWindowSize() const {
-    return static_cast<int32>(resample_freq * 0.001 * frame_length_ms);
+    return static_cast<int32>(resample_freq * frame_length_ms / 1000.0);
   }
   /// Returns the window-shift in samples, after resampling.
   int32 NccfWindowShift() const {
-    return static_cast<int32>(resample_freq * 0.001 * frame_shift_ms);
+    return static_cast<int32>(resample_freq * frame_shift_ms / 1000.0);
   }
 };
 
@@ -224,12 +226,12 @@ struct ProcessPitchOptions {
 
   int32 delta_window;
   int32 delay;
-  
-  bool add_pov_feature;  
-  bool add_normalized_log_pitch;  
+
+  bool add_pov_feature;
+  bool add_normalized_log_pitch;
   bool add_delta_pitch;
   bool add_raw_log_pitch;
-  
+
   ProcessPitchOptions() :
       pitch_scale(2.0),
       pov_scale(2.0),
@@ -272,7 +274,8 @@ struct ProcessPitchOptions {
                    "Number of frames on each side of central frame, to use for "
                    "delta window.");
     opts->Register("delay", &delay,
-                   "Number of frames by which the pitch information is delayed.");
+                   "Number of frames by which the pitch information is "
+                   "delayed.");
     opts->Register("add-pov-feature", &add_pov_feature,
                    "If true, the warped NCCF is added to output features");
     opts->Register("add-normalized-log-pitch", &add_normalized_log_pitch,
@@ -301,7 +304,7 @@ class OnlinePitchFeature: public OnlineBaseFeature {
   virtual int32 Dim() const { return 2; /* (NCCF, pitch) */ }
 
   virtual int32 NumFramesReady() const;
-  
+
   virtual BaseFloat FrameShiftInSeconds() const;
 
   virtual bool IsLastFrame(int32 frame) const;
@@ -333,10 +336,10 @@ class OnlineProcessPitch: public OnlineFeatureInterface {
   virtual bool IsLastFrame(int32 frame) const {
     if (frame <= -1)
       return src_->IsLastFrame(-1);
-    else if (frame < opts_.delay) 
+    else if (frame < opts_.delay)
       return src_->IsLastFrame(-1) == true ? false : src_->IsLastFrame(0);
     else
-      return src_->IsLastFrame(frame - opts_.delay); 
+      return src_->IsLastFrame(frame - opts_.delay);
   }
   virtual BaseFloat FrameShiftInSeconds() const {
     return src_->FrameShiftInSeconds();
@@ -353,9 +356,9 @@ class OnlineProcessPitch: public OnlineFeatureInterface {
                      OnlineFeatureInterface *src);
 
  private:
-  enum { kRawFeatureDim = 2}; // anonymous enum to define a constant. 
-                              // kRawFeatureDim defines the dimension 
-                              // of the input: (nccf, pitch)
+  enum { kRawFeatureDim = 2};  // anonymous enum to define a constant.
+                               // kRawFeatureDim defines the dimension
+                               // of the input: (nccf, pitch)
 
   ProcessPitchOptions opts_;
   OnlineFeatureInterface *src_;
@@ -378,15 +381,15 @@ class OnlineProcessPitch: public OnlineFeatureInterface {
   std::vector<NormalizationStats> normalization_stats_;
 
   /// Computes and returns the POV feature for this frame.
-  /// Called from GetFrame().  
-  inline BaseFloat GetPovFeature(int32 frame) const;  
+  /// Called from GetFrame().
+  inline BaseFloat GetPovFeature(int32 frame) const;
 
   /// Computes and returns the delta-log-pitch feature for this frame.
   /// Called from GetFrame().
   inline BaseFloat GetDeltaPitchFeature(int32 frame);
 
   /// Computes and returns the raw log-pitch feature for this frame.
-  /// Called from GetFrame().  
+  /// Called from GetFrame().
   inline BaseFloat GetRawLogPitchFeature(int32 frame) const;
 
   /// Computes and returns the mean-subtracted log-pitch feature for this frame.


### PR DESCRIPTION
The snip_edges option had not been implemented correctly in the pitch tracker, and while it was generating the right number of ouput frames, the delay was not at all as expected.

I have therefore fixed snip_edges=false behaviour to have an expected feature delay of frame_shift/2 instead of being identical to the delay of snip_edges=true (which itself has a delay > frame_length / 2).

Added a unit test that ensure snip_edges=false behaves as expected, by calculating the actual delay between outputs only differing by snip_edge through cross-correlation.

Note that the feature delay of snip_edges=true (the default) is rather difficult to predict (and almost certainly not what people assume), which almost certainly makes the use of pitch features problematic at the moment.
I would suggest switching to snip_edges=false for new recipes.