### PR TITLE
Speed up SoftmaxComponent::Backprop()

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -155,6 +155,9 @@ void cudaF_diff_tanh(dim3 Gr, dim3 Bl, float *eout, const float *e, const float 
 void cudaF_regularize_l1(dim3 Gr, dim3 Bl, float *wei, float *grad, float l1, float lr, MatrixDim d, int stride_grad);
 void cudaF_find_row_max_id(dim3 Gr, dim3 Bl, const float *mat, float *vec_val, int32_cuda *vec_id, MatrixDim d);
 void cudaF_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda *vec_tgt, float *mat_net_out, float *vec_log_post, MatrixDim d);
+void cudaF_diff_softmax(dim3 Gr, dim3 Bl, float* x, const MatrixDim dim,
+                        const float* value, const int value_stride,
+                        const float* diff, const int diff_stride);
 void cudaF_copy_rows_from_vec(dim3 Gr, dim3 Bl, float *mat_out, MatrixDim d_out, const float *v_in);
 
 void cudaF_randomize(dim3 Gr, dim3 Bl, float *y, const float *x, const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);
@@ -302,6 +305,9 @@ void cudaD_diff_tanh(dim3 Gr, dim3 Bl, double *eout, const double *e, const doub
 void cudaD_regularize_l1(dim3 Gr, dim3 Bl, double *wei, double *grad, double l1, double lr, MatrixDim d, int stride_grad);
 void cudaD_find_row_max_id(dim3 Gr, dim3 Bl, const double *mat, double *vec_val, int32_cuda *vec_id, MatrixDim d);
 void cudaD_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda *vec_tgt, double *mat_net_out, double *vec_log_post, MatrixDim d);
+void cudaD_diff_softmax(dim3 Gr, dim3 Bl, double* x, const MatrixDim dim,
+                        const double* value, const int value_stride,
+                        const double* diff, const int diff_stride);
 void cudaD_copy_rows_from_vec(dim3 Gr, dim3 Bl, double *mat_out, MatrixDim d_out, const double *v_in);
 
 void cudaD_randomize(dim3 Gr, dim3 Bl, double *y, const double *x, const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -2306,6 +2306,54 @@ static void _diff_xent(const int32_cuda* vec_tgt, Real* mat_net_out, Real* vec_l
   }
 }
 
+template<typename Real>
+__global__
+static void _diff_softmax(Real* x, const MatrixDim dim, const Real* value,
+                          const int value_stride, const Real* diff,
+                          const int diff_stride) {
+  __shared__ Real ssum[CU1DBLOCK];
+  const int tid = threadIdx.x;
+  const int i = blockIdx.x;
+  const int value_start = i * value_stride;
+  const int diff_start = i * diff_stride;
+  const int x_start = i * dim.stride;
+
+  // Loop along the matrix row. Reduce to CU1DBLOCK elements per row.
+  Real tsum = Real(0);
+  for (int j = tid; j < dim.cols; j += CU1DBLOCK) {
+    tsum += value[value_start + j] * diff[diff_start + j];
+  }
+  ssum[tid] = tsum;
+  __syncthreads();
+
+  // Tree reduce to 2x warpSize elements.
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      ssum[tid] += ssum[tid + shift];
+    }
+    __syncthreads();
+  }
+
+  // Warp reduce to 1 element. Threads implicitly synchronized within a warp.
+  if (tid < warpSize) {
+#   pragma unroll
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      ssum[tid] += ssum[tid + shift];
+    }
+  }
+
+  // Broadcast result to all threads
+  __syncthreads();
+  const Real pe = ssum[0];
+
+  // Apply element-wise x = value * (diff - pe)
+  for (int j = tid; j < dim.cols; j += CU1DBLOCK) {
+    x[x_start + j] = value[value_start + j] * (diff[diff_start + j] - pe);
+  }
+}
+
+
 
 
 /***********************************************************************
@@ -2779,6 +2827,12 @@ void cudaF_find_row_max_id(dim3 Gr, dim3 Bl, const float* mat, float* vec_val, i
 
 void cudaF_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda* vec_tgt, float* mat_net_out, float* vec_log_post, MatrixDim d) {
   _diff_xent<<<Gr,Bl>>>(vec_tgt,mat_net_out,vec_log_post,d);
+}
+
+void cudaF_diff_softmax(dim3 Gr, dim3 Bl, float* x, const MatrixDim dim,
+                        const float* value, const int value_stride,
+                        const float* diff, const int diff_stride) {
+  _diff_softmax<<<Gr, Bl>>>(x, dim, value, value_stride, diff, diff_stride);
 }
 
 void cudaF_copy_rows_from_vec(dim3 Gr, dim3 Bl, float *mat_out, MatrixDim d_out, const float *v_in) {
@@ -3266,6 +3320,12 @@ void cudaD_find_row_max_id(dim3 Gr, dim3 Bl, const double* mat, double* vec_val,
 
 void cudaD_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda* vec_tgt, double* mat_net_out, double* vec_log_post, MatrixDim d) {
   _diff_xent<<<Gr,Bl>>>(vec_tgt,mat_net_out,vec_log_post,d);
+}
+
+void cudaD_diff_softmax(dim3 Gr, dim3 Bl, double* x, const MatrixDim dim,
+                        const double* value, const int value_stride,
+                        const double* diff, const int diff_stride) {
+  _diff_softmax<<<Gr, Bl>>>(x, dim, value, value_stride, diff, diff_stride);
 }
 
 void cudaD_copy_rows_from_vec(dim3 Gr, dim3 Bl, double *mat_out, MatrixDim d_out, const double *v_in) {

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -257,6 +257,11 @@ inline void cuda_log_softmax_reduce(size_t Gr, size_t Bl, float *y, const float 
 inline void cuda_regularize_l1(dim3 Gr, dim3 Bl, float *wei, float *grad, float l1, float lr, MatrixDim d, int stride_grad) { cudaF_regularize_l1(Gr,Bl,wei,grad,l1,lr,d,stride_grad); }
 inline void cuda_find_row_max_id(dim3 Gr, dim3 Bl, const float *mat, float *vec_val, int32_cuda *vec_id, MatrixDim d) { cudaF_find_row_max_id(Gr,Bl,mat,vec_val,vec_id,d); }
 inline void cuda_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda *vec_tgt, float *mat_net_out, float *vec_log_post, MatrixDim d) { cudaF_diff_xent(Gr,Bl,vec_tgt,mat_net_out,vec_log_post,d); }
+inline void cuda_diff_softmax(dim3 Gr, dim3 Bl, float* x, const MatrixDim dim,
+                              const float* value, const int value_stride,
+                              const float* diff, const int diff_stride) {
+  cudaF_diff_softmax(Gr, Bl, x, dim, value, value_stride, diff, diff_stride);
+}
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, float *mat_out, MatrixDim d_out, const float *v_in) {
   cudaF_copy_rows_from_vec(Gr, Bl, mat_out, d_out, v_in);
 }
@@ -444,6 +449,11 @@ inline void cuda_regularize_l1(dim3 Gr, dim3 Bl, double *wei, double *grad, doub
 inline void cuda_find_row_max_id(dim3 Gr, dim3 Bl, const double *mat, double *vec_val, int32_cuda *vec_id, MatrixDim d) { cudaD_find_row_max_id(Gr,Bl,mat,vec_val,vec_id,d); }
 inline void cuda_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda *vec_tgt, double *mat_net_out, double *vec_log_post, MatrixDim d) {
   cudaD_diff_xent(Gr,Bl,vec_tgt,mat_net_out,vec_log_post,d);
+}
+inline void cuda_diff_softmax(dim3 Gr, dim3 Bl, double* x, const MatrixDim dim,
+                              const double* value, const int value_stride,
+                              const double* diff, const int diff_stride) {
+  cudaD_diff_softmax(Gr, Bl, x, dim, value, value_stride, diff, diff_stride);
 }
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, double *mat_out, MatrixDim d_out, const double *v_in) {
   cudaD_copy_rows_from_vec(Gr, Bl, mat_out, d_out, v_in);

--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -459,6 +459,24 @@ template<typename Real> void TestCuMatrixMulRowsGroupMat(int32 dim) {
 }
 
 
+template<typename Real> void TestCuMatrixDiffSoftmax(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim), N(dim, dim), L(dim, dim);
+  M.SetRandn();
+  N.SetRandn();
+  L.SetRandn();
+  Timer tim;
+  int32 iter = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    N.DiffSoftmaxPerRow(M, L);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuMatrix::DiffSoftmaxPerRow" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+}
+
 template<typename Real> void TestCuMatrixSoftmax(int32 dim) {
   BaseFloat time_in_secs = 0.025;
   CuMatrix<Real> M(dim, dim), N(dim, dim);
@@ -981,6 +999,8 @@ template<typename Real> void CudaMatrixSpeedTest() {
     TestCuMatrixMulRowsGroupMat<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixSoftmax<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixDiffSoftmax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixLogSoftmax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -309,6 +309,13 @@ class CuMatrixBase {
   void DiffTanh(const CuMatrixBase<Real> &value,
                 const CuMatrixBase<Real> &diff);
 
+  /// Differentiate backward through the softmax function.  Here, "value" is the
+  /// softmax output. Does, for each row i,
+  /// *this(i) =  diff(i) * diag(value(i)) - diff(i) * (value(i)^T * value(i))
+  /// xxxx(i) is row-vector; '*' and '-' are matrix operations.
+  void DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
+                         const CuMatrixBase<Real> &diff);
+
   /// Differentiate the block [softmax+cross-entropy] :
   /// dE/da = posterior_mat - target_mat,
   /// 'E' is error function, 'a' is activation on softmax input

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -955,31 +955,7 @@ void SoftmaxComponent::Backprop(const ChunkInfo &in_info,
     d = diag(p) e - p (p^T e).
     d_i = p_i e_i - p_i (p^T e).
   */
-  in_deriv->Resize(out_deriv.NumRows(), out_deriv.NumCols());
-  KALDI_ASSERT(SameDim(out_value, out_deriv) && SameDim(out_value, *in_deriv));
-  const CuMatrixBase<BaseFloat> &P(out_value), &E(out_deriv);
-  CuMatrixBase<BaseFloat> &D (*in_deriv);
-
-
-#if 1
-  D.CopyFromMat(P);
-  D.MulElements(E);
-  // At this point, D = P .* E (in matlab notation)
-  CuVector<BaseFloat> pe_vec(D.NumRows()); // For each row i, the dot product (p_t . e_t).
-  pe_vec.AddDiagMatMat(1.0, P, kNoTrans, E, kTrans, 0.0);
-
-  D.AddDiagVecMat(-1.0, pe_vec, P, kNoTrans, 1.0); // does D -= diag(pe_vec) * P.
-#else
-  // The old code, where we did stuff row-by-row, is as follows;
-  //   we had to rework it to use whole-matrix operations in order
-  //   to use CUDA more effectively.
-  for (int32 r = 0; r < P.NumRows(); r++) {
-    CuSubVector<BaseFloat> p(P, r), e(E, r), d(D, r);
-    d.AddVecVec(1.0, p, e, 0.0); // d_i = p_i e_i.
-    BaseFloat pT_e = VecVec(p, e); // p^T e.
-    d.AddVec(-pT_e, p); // d_i -= (p^T e) p_i
-  }
-#endif
+  in_deriv->DiffSoftmaxPerRow(out_value, out_deriv);
 
   // The SoftmaxComponent does not have any real trainable parameters, but
   // during the backprop we store some statistics on the average counts;

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -2829,16 +2829,7 @@ void SoftmaxComponent::Backprop(const std::string &debug_info,
     d = diag(p) e - p (p^T e).
     d_i = p_i e_i - p_i (p^T e).
   */
-  const CuMatrixBase<BaseFloat> &P(out_value), &E(out_deriv);
-  CuMatrixBase<BaseFloat> &D (*in_deriv);
-
-  D.CopyFromMat(P);
-  D.MulElements(E);
-  // At this point, D = P .* E (in matlab notation)
-  CuVector<BaseFloat> pe_vec(D.NumRows()); // For each row i, the dot product (p_t . e_t).
-  pe_vec.AddDiagMatMat(1.0, P, kNoTrans, E, kTrans, 0.0);
-
-  D.AddDiagVecMat(-1.0, pe_vec, P, kNoTrans, 1.0); // does D -= diag(pe_vec) * P.
+  in_deriv->DiffSoftmaxPerRow(out_value, out_deriv);
 }
 
 void SoftmaxComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {


### PR DESCRIPTION
Speed up `SoftmaxComponent::Backprop()` by merging multiple CUDA kernels into one.

```
                                     dim  old     new    speedup
CuMatrix::DiffSoftmaxPerRow<float>,   16  0.0036  0.0166 4.66x
CuMatrix::DiffSoftmaxPerRow<float>,   32  0.0146  0.0679 4.66x
CuMatrix::DiffSoftmaxPerRow<float>,   64  0.0583  0.2474 4.24x
CuMatrix::DiffSoftmaxPerRow<float>,  128  0.2251  0.8984 3.99x
CuMatrix::DiffSoftmaxPerRow<float>,  256  0.8341  2.8901 3.46x
CuMatrix::DiffSoftmaxPerRow<float>,  512  1.9272  6.7216 3.49x
CuMatrix::DiffSoftmaxPerRow<float>, 1024  2.7828 10.4916 3.77x
CuMatrix::DiffSoftmaxPerRow<double>,   16  0.0026  0.0149 5.70x
CuMatrix::DiffSoftmaxPerRow<double>,   32  0.0121  0.0587 4.85x
CuMatrix::DiffSoftmaxPerRow<double>,   64  0.0528  0.2289 4.34x
CuMatrix::DiffSoftmaxPerRow<double>,  128  0.1757  0.7635 4.34x
CuMatrix::DiffSoftmaxPerRow<double>,  256  0.5835  2.4046 4.12x
CuMatrix::DiffSoftmaxPerRow<double>,  512  1.4246  4.5517 3.19x
CuMatrix::DiffSoftmaxPerRow<double>, 1024  1.9497  4.3642 2.24x
```