### PR TITLE
Fix bug introduced in #863

### DIFF
--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -955,6 +955,7 @@ void SoftmaxComponent::Backprop(const ChunkInfo &in_info,
     d = diag(p) e - p (p^T e).
     d_i = p_i e_i - p_i (p^T e).
   */
+  in_deriv->Resize(out_deriv.NumRows(), out_deriv.NumCols());
   in_deriv->DiffSoftmaxPerRow(out_value, out_deriv);
 
   // The SoftmaxComponent does not have any real trainable parameters, but


### PR DESCRIPTION
Fix bug introduced in #863

Restore the original behavior of nnet2::SoftmaxComponent::Backprop(): resize the result matrix before back-propagation.

The bug is first discovered here.
https://groups.google.com/forum/#!topic/kaldi-help/i1MsopD1Khk




