### PR TITLE
LogLikelihoodRatio function should be const. Does not modify the PLDA

### DIFF
--- a/src/ivector/plda.cc
+++ b/src/ivector/plda.cc
@@ -112,7 +112,7 @@ float Plda::TransformIvector(const PldaConfig &config,
 double Plda::LogLikelihoodRatio(
     const VectorBase<double> &transformed_train_ivector,
     int32 n, // number of training utterances.
-    const VectorBase<double> &transformed_test_ivector) {
+    const VectorBase<double> &transformed_test_ivector) const {
   int32 dim = Dim();
   double loglike_given_class, loglike_without_class;
   { // work out loglike_given_class.

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -98,7 +98,7 @@ class Plda {
   /// the transformed iVectors.
   double LogLikelihoodRatio(const VectorBase<double> &transformed_train_ivector,
                             int32 num_train_utts,
-                            const VectorBase<double> &transformed_test_ivector);
+                            const VectorBase<double> &transformed_test_ivector) const;
 
 
   /// This function smooths the within-class covariance by adding to it,


### PR DESCRIPTION
The LogLikelihoodRatio member function of the PLDA code only uses the PLDA model to compute the log likelihood ratio between the ivectors and does not modify the PLDA model or its parameters. As a result we believe it should have a const declaration.