### PR TITLE
Fixes #883

### DIFF
--- a/egs/wsj/s5/steps/nnet3/train_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_dnn.py
@@ -367,7 +367,7 @@ def TrainOneIteration(dir, iter, egs_dir,
       # model-averaging isn't always helpful when the model is changing too fast
       # (i.e. it can worsen the objective function), and the smaller minibatch
       # size will help to keep the update stable.
-      cur_minibatch_size = minibatch_size / 2
+      cur_minibatch_size = minibatch_size // 2
       cur_max_param_change = float(max_param_change) / math.sqrt(2)
 
     try:


### PR DESCRIPTION
Avoid using python's / operator so that we do not create a floating
point value accidentally when python3 is used.