### PR TITLE
linux_x86_64_mkl.mk now show respect to --static-fst=yes

### DIFF
--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -53,8 +53,8 @@ MKL_DYN_MUL = -L$(MKLLIB) -lmkl_solver_lp64 -Wl,--start-group -lmkl_intel_lp64 \
 
 # MKLFLAGS = $(MKL_DYN_MUL)
 
-LDFLAGS = -rdynamic -L$(FSTROOT)/lib -Wl,-R$(FSTROOT)/lib
-LDLIBS =  $(EXTRA_LDLIBS) -lfst -ldl $(MKLFLAGS) -lm -lpthread
+LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(MKLFLAGS) -lm -lpthread -ldl
 CC = g++
 CXX = g++
 AR = ar


### PR DESCRIPTION
linux_x86_64_mkl.mk is hard-coded to link openfst dynamically.

It should use ``$(OPENFSTLDFLAGS)`` and ``$(OPENFSTLIBS)`` instead, just like in `linux_atlas.mk`, `linux_clapack.mk` and `linux_openblas.mk`