### PR TITLE
Speed up softmax

### DIFF
--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -1954,69 +1954,76 @@ static void _heaviside(Real*y, const Real*x, MatrixDim d, int src_stride) {
 template<typename Real>
 __global__
 static void _softmax_reduce(Real*y, const Real*x, MatrixDim d, int src_stride) {
-  int j = blockIdx.x;
-  int THREADS = blockDim.x;
-  if (j >= d.rows) return;
+  __shared__ Real smem[CU1DBLOCK];
+  const int i = blockIdx.x;
+  const int x_start = i * src_stride;
+  const int y_start = i * d.stride;
+  const int tid = threadIdx.x;
 
-  __shared__ Real aux[CU1DBLOCK];
-  int steps = (d.cols - 1) / THREADS + 1;
-
-  //copy input to aux
-  aux[threadIdx.x] = x[threadIdx.x+j*d.stride];
-  for(int i=1; i<steps; ++i) {
-    if(threadIdx.x+i*THREADS < d.cols && aux[threadIdx.x] < x[threadIdx.x+i*THREADS+j*d.stride])
-	aux[threadIdx.x] = x[threadIdx.x+i*THREADS+j*d.stride];
+  // find max element of the row
+  // reduce to CU1DBLOCK elements per row.
+  Real tmax = Real(-1.0 / 0.0);
+  for (int j = tid; j < d.cols; j += CU1DBLOCK) {
+    tmax = max(tmax, x[x_start + j]);
   }
-
-  //get the maximum value
-  int nTotalThreads = THREADS;
+  smem[tid] = tmax;
   __syncthreads();
-  while(nTotalThreads > 1) {
-    int halfPoint = ((1+nTotalThreads) >> 1);   // divide by two
-    // only the first half of the threads will be active.
-    if (threadIdx.x < halfPoint)  {
-      // Get the shared value stored by another thread
-      if(threadIdx.x+halfPoint < nTotalThreads && aux[threadIdx.x] < aux[threadIdx.x+halfPoint])
-        aux[threadIdx.x] = aux[threadIdx.x + halfPoint];
+
+  // reduce to 2x warpSize elements per row
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      smem[tid] = max(smem[tid], smem[tid + shift]);
     }
     __syncthreads();
-    nTotalThreads = ((1+nTotalThreads) >> 1);   // divide by two.
   }
-  Real max = aux[0];
-  __syncthreads();
 
-   // subtract max, apply exp, sum up...
-  y[threadIdx.x+j*d.stride] = exp(x[threadIdx.x+j*d.stride] - max);
-  aux[threadIdx.x] = y[threadIdx.x+j*d.stride];
-  for(int i=1; i<steps; i++) {
-    if(threadIdx.x+i*THREADS < d.cols) {
-      y[threadIdx.x+i*THREADS+j*d.stride] = exp(x[threadIdx.x+i*THREADS+j*d.stride] - max);
-      aux[threadIdx.x] += y[threadIdx.x+i*THREADS+j*d.stride];
+  // reduce to 1 element per row
+  if (tid < warpSize) {
+#   pragma unroll
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      smem[tid] = max(smem[tid], smem[tid + shift]);
     }
   }
-  nTotalThreads = THREADS;
+
+  // broadcast max to all threads
   __syncthreads();
-  while(nTotalThreads > 1) {
-    int halfPoint = ((1+nTotalThreads) >> 1);   // divide by two
-    // only the first half of the threads will be active.
-    if (threadIdx.x < halfPoint)  {
-      // Get the shared value stored by another thread
-      if(threadIdx.x+halfPoint < nTotalThreads)
-        aux[threadIdx.x] += aux[threadIdx.x + halfPoint];
+  Real max = smem[0];
+
+  // sum_j(exp(x(i,j)-max))
+  // reduce to CU1DBLOCK elements per row.
+  Real tsum = Real(0);
+  for (int j = tid; j < d.cols; j += CU1DBLOCK) {
+    tsum += exp(x[x_start + j] - max);
+  }
+  smem[tid] = tsum;
+  __syncthreads();
+
+  // reduce to 2x warpSize elements per row
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      smem[tid] += smem[tid + shift];
     }
     __syncthreads();
-    nTotalThreads = ((1+nTotalThreads) >> 1);   // divide by two.
   }
-  Real sum = aux[0];
-  __syncthreads();
 
-  //normalize by sum...
-  for(int i=0; i<steps; i++) {
-    if(threadIdx.x+i*THREADS < d.cols) {
-      y[threadIdx.x+i*THREADS+j*d.stride] = y[threadIdx.x+i*THREADS+j*d.stride] / sum;
+  // reduce to 1 element per row
+  if (tid < warpSize) {
+#   pragma unroll
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      smem[tid] += smem[tid + shift];
     }
   }
 
+  // broadcast sum to all threads
+  __syncthreads();
+  Real inv_sum = Real(1) / smem[0];
+
+  // normalize the row
+  for (int j = tid; j < d.cols; j += CU1DBLOCK) {
+    y[y_start + j] = exp(x[x_start + j] - max) * inv_sum;
+  }
 }
 
 template<typename Real>

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1424,7 +1424,7 @@ void CuMatrixBase<Real>::ApplySoftMaxPerRow(const CuMatrixBase<Real> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
-    size_t dimBlock = src.num_cols_ > CU1DBLOCK ? CU1DBLOCK : src.num_cols_;
+    size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = src.num_rows_;
     cuda_softmax_reduce(dimGrid, dimBlock, data_, src.data_, Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -300,7 +300,7 @@ void CuVectorBase<Real>::ApplySoftMax() {
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
     Timer tim;
-    size_t dimBlock = dim_ > CU1DBLOCK ? CU1DBLOCK : dim_; // for cuda_softmax_reduce function, dimBlock value is fixed min(CU1DBLOCK, dim) , represent CU1DBLOCK threads reduce a row at the same time.
+    size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = 1;       // dimGrid value represent the number of rows
     ::MatrixDim dim = { 1, this->dim_, this->dim_};
     cuda_softmax_reduce(dimGrid, dimBlock, data_, data_, dim, this->dim_);//actually dim is not stride...


### PR DESCRIPTION
Reduction on 2^n threads is faster. All GPU tests passed.

```
                            dim  old     new    speedup
CuMatrix::Softmax<float>,    16  0.0139  0.0154 1.11x
CuMatrix::Softmax<float>,    32  0.0507  0.0614 1.21x
CuMatrix::Softmax<float>,    64  0.2035  0.2358 1.16x
CuMatrix::Softmax<float>,   128  0.7255  0.7292 1.01x
CuMatrix::Softmax<float>,   256  1.7186  2.3013 1.34x
CuMatrix::Softmax<float>,   512  3.6966  5.0565 1.37x
CuMatrix::Softmax<float>,  1024  6.3834 10.2482 1.61x
CuMatrix::Softmax<double>,   16  0.0131  0.0143 1.09x
CuMatrix::Softmax<double>,   32  0.0495  0.0590 1.19x
CuMatrix::Softmax<double>,   64  0.1935  0.2286 1.18x
CuMatrix::Softmax<double>,  128  0.6764  0.6690 0.99x
CuMatrix::Softmax<double>,  256  1.5186  2.1013 1.38x
CuMatrix::Softmax<double>,  512  3.1547  4.1306 1.31x
CuMatrix::Softmax<double>, 1024  5.0297  6.4343 1.28x
```