### PR TITLE
fix the bug on line 372 of wsj/s5/utils/prepare_lang.sh（issus 904）

### DIFF
--- a/egs/wsj/s5/utils/prepare_lang.sh
+++ b/egs/wsj/s5/utils/prepare_lang.sh
@@ -369,8 +369,7 @@ cat $dir/phones/align_lexicon.txt | utils/sym2int.pl -f 3- $dir/phones.txt | \
 if $silprob; then
   # Usually it's the same as having a fixed-prob L.fst
   # it matters a little bit in discriminative trainings
-  utils/make_lexicon_fst_silprob.pl $tmpdir/lexiconp_silprob_disambig.txt $srcdir/silprob.txt $silphone '#'$ndisambig | \
-     sed 's=\#[0-9][0-9]*=<eps>=g' | \
+  utils/make_lexicon_fst_silprob.pl $tmpdir/lexiconp_silprob.txt $srcdir/silprob.txt $silphone "<eps>" | \
      fstcompile --isymbols=$dir/phones.txt --osymbols=$dir/words.txt \
      --keep_isymbols=false --keep_osymbols=false |   \
      fstarcsort --sort_type=olabel > $dir/L.fst || exit 1;


### PR DESCRIPTION
Hi,@danpovey,@vijayaditya
I have already fix the bug on line 372 of wsj/s5/utils.prepare_lang.sh（issus 904）
The original command line
utils/make_lexicon_fst_silprob.pl $tmpdir/lexiconp_silprob_disambig.txt $srcdir/silprob.txt $silphone '#'$ndisambig | sed 's=\#[0-9][0-9]*=<eps>=g' | \
 is replaced by:
utils/make_lexicon_fst_silprob.pl $tmpdir/lexiconp_silprob.txt $srcdir/silprob.txt $silphone "<eps>" | \

At the same time, I have done some tests. The results are:
With the new L.fst, everything is going on smoothly when do alignment.
With the new alignment, I get the exp/tri4 in Switchboard and decode.
（1）In decode_eval2000_sw1_tg
The result is %WER 28.7 | 4459 42989 | 74.8 18.4 6.8 3.5 28.7 65.9 |
decode_eval2000_sw1_tg/score_14_1.0/eval2000.ctm.filt.sys
 (Original result:%WER 28.8 | 4459 42989 | 74.2 18.2 7.6 3.0 28.8 66.1 |
 exp/tri4/decode_eval2000_sw1_tg/score_14/eval2000.ctm.filt.sys)
（2）In decode_eval2000_sw1_tg.si
The result is %WER 36.5 | 4459 42989 | 68.2 24.2 7.6 4.7 36.5 71.3 |
 score_12_0.0/eval2000.ctm.filt.sys
 (Original result:%WER 36.8 | 4459 42989 | 67.2 24.0 8.8 4.1 36.8 71.0 |
exp/tri4/decode_eval2000_sw1_tg.si/score_12/eval2000.ctm.filt.sys)

Best Wishes
Hang
