### PR TITLE
Array job submission for train_ivector_extractor.sh

### DIFF
--- a/egs/wsj/s5/steps/online/nnet2/train_ivector_extractor.sh
+++ b/egs/wsj/s5/steps/online/nnet2/train_ivector_extractor.sh
@@ -142,19 +142,26 @@ while [ $x -lt $num_iters ]; do
   if [ $stage -le $x ]; then
     rm $dir/.error 2>/dev/null
 
-    Args=() # bash array of training commands for 1:nj, that put accs to stdout.
-    for j in $(seq $nj_full); do
-      Args[$j]=`echo "ivector-extractor-acc-stats --num-threads=$num_threads $dir/$x.ie '$feats' 'ark,s,cs:gunzip -c $dir/post.JOB.gz|' -|" | sed s/JOB/$j/g`
-    done
+    if [ $num_processes -eq 1 ] && [ $num_threads -eq 1 ]; then #submit as an array
+        $cmd --num-threads 1 JOB=1:$nj_full $dir/log/acc.$x.JOB.log \
+            ivector-extractor-sum-accs --parallel=true \
+                "ivector-extractor-acc-stats --num-threads=1 $dir/$x.ie '$feats' 'ark,s,cs:gunzip -c $dir/post.JOB.gz|' -|"  $dir/acc.$x.JOB || touch $dir/.error
+    else
+         Args=() # bash array of training commands for 1:nj, that put accs to stdout.
+         for j in $(seq $nj_full); do
+           Args[$j]=`echo "ivector-extractor-acc-stats --num-threads=$num_threads $dir/$x.ie '$feats' 'ark,s,cs:gunzip -c $dir/post.JOB.gz|' -|" | sed s/JOB/$j/g`
+         done
 
-    echo "Accumulating stats (pass $x)"
-    for g in $(seq $nj); do
-      start=$[$num_processes*($g-1)+1]
-      $cmd --num-threads $[$num_threads*$num_processes] $dir/log/acc.$x.$g.log \
-        ivector-extractor-sum-accs --parallel=true "${Args[@]:$start:$num_processes}" \
-          $dir/acc.$x.$g || touch $dir/.error &
-    done
-    wait
+        echo "Accumulating stats (pass $x)"
+        for g in $(seq $nj); do
+            start=$[$num_processes*($g-1)+1]
+            $cmd --num-threads $[$num_threads*$num_processes] $dir/log/acc.$x.$g.log \
+                ivector-extractor-sum-accs --parallel=true "${Args[@]:$start:$num_processes}" \
+                $dir/acc.$x.$g || touch $dir/.error &
+        done
+        wait
+    fi
+
     [ -f $dir/.error ] && echo "Error accumulating stats on iteration $x" && exit 1;
 	accs=""
 	for j in $(seq $nj); do


### PR DESCRIPTION
Now train_ivector_extractor.sh executes the acc estimation as an
array job when num_processes and num_threads are equal to one. The
problem is that when nj is high, a huge number of queue.pl are submitted
resulting a huge load in the exec machine.

This could be done also for the case that num_processes and num_threads
are distinct to one, but I would recommend doing it using an new script for sake of clarity.