### PR TITLE
Fix "error" on checking dash

### DIFF
--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -80,7 +80,7 @@ if which apt-get >&/dev/null && ! which zypper >/dev/null; then
   fi
   # Debian systems generally link /bin/sh to dash, which doesn't work
   # with some scripts as it doesn't expand x.{1,2}.y to x.1.y x.2.y
-  if [ $(readlink /bin/sh) == "dash" ]; then
+  if [ "$(readlink /bin/sh)" == "dash" ]; then
     echo "/bin/sh is linked to dash, and currently some of the scripts will not run"
     echo "properly.  We recommend to run:"
     echo " sudo ln -s -f bash /bin/sh"


### PR DESCRIPTION
Original result when launching command

```
$ ./check_dependencies.sh 
./check_dependencies.sh: line 83: [: ==: unary operator expected
./check_dependencies.sh: all OK.
$
```