### PR TITLE
fix the bug about seq (issue #947)

### DIFF
--- a/egs/wsj/s5/steps/combine_ali_dirs.sh
+++ b/egs/wsj/s5/steps/combine_ali_dirs.sh
@@ -68,9 +68,9 @@ echo "$0: dumping alignments in each source directory as single archive and inde
 for dir in $*; do
   src_id=$((src_id + 1))
   cur_num_jobs=$(cat $dir/num_jobs) || exit 1;
-  all_ids=$(seq -s, $cur_num_jobs)
+  alis=$(for n in $(seq $cur_num_jobs); do echo $dir/ali.$n.gz; done)
   $cmd $dir/log/copy_alignments.log \
-    copy-int-vector "ark:gunzip -c $dir/ali.{$all_ids}.gz|" \
+    copy-int-vector "ark:gunzip -c $alis|" \
     ark,scp:$temp_dir/ali.$src_id.ark,$temp_dir/ali.$src_id.scp || exit 1;
 done
 sort -m $temp_dir/ali.*.scp > $temp_dir/ali.scp || exit 1;

--- a/egs/wsj/s5/steps/get_ctm.sh
+++ b/egs/wsj/s5/steps/get_ctm.sh
@@ -63,7 +63,7 @@ if [ $stage -le 0 ]; then
   fi
 
   nj=$(cat $dir/num_jobs)
-  lats=$(eval echo $dir/lat.{$(seq -s, $nj)}.gz)
+  lats=$(for n in $(seq $nj); do echo $dir/lat.$n.gz; done)
   if [ -f $lang/phones/word_boundary.int ]; then
     $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring/log/get_ctm.LMWT.log \
       set -o pipefail '&&' mkdir -p $dir/score_LMWT/ '&&' \

--- a/egs/wsj/s5/steps/nnet2/get_egs.sh
+++ b/egs/wsj/s5/steps/nnet2/get_egs.sh
@@ -199,7 +199,6 @@ if [ $stage -le 2 ]; then
     gzip -c >$dir/ali_special.gz || exit 1;
   set +o pipefail; # unset the pipefail option.
 
-  all_ids=$(seq -s, $nj)  # e.g. 1,2,...39,40
   $cmd $dir/log/create_valid_subset.log \
     nnet-get-egs $ivectors_opt $nnet_context_opts "$valid_feats" \
     "ark,s,cs:gunzip -c $dir/ali_special.gz | ali-to-pdf $alidir/final.mdl ark:- ark:- | ali-to-post ark:- ark:- |" \

--- a/egs/wsj/s5/steps/nnet2/relabel_egs.sh
+++ b/egs/wsj/s5/steps/nnet2/relabel_egs.sh
@@ -53,7 +53,7 @@ echo $num_jobs_nnet > $dir/num_jobs_nnet
 echo $iters_per_epoch > $dir/iters_per_epoch
 echo $samples_per_iter_real > $dir/samples_per_iter
 
-alignments=`eval echo $alidir/ali.{$(seq -s ',' $num_jobs_align)}.gz`
+alignments=$(for n in $(seq $num_jobs_align); do echo $alidir/ali.$n.gz; done)
 
 if [ $stage -le 0 ]; then
   egs_in=

--- a/egs/wsj/s5/steps/nnet2/relabel_egs2.sh
+++ b/egs/wsj/s5/steps/nnet2/relabel_egs2.sh
@@ -59,7 +59,7 @@ mkdir -p $dir/log
 mkdir -p $dir/info
 cp -r $egs_in_dir/info/*  $dir/info
 
-alignments=`eval echo $alidir/ali.{$(seq -s ',' $num_jobs_align)}.gz`
+alignments=$(for n in $(seq $num_jobs_align); do echo $alidir/ali.$n.gz; done)
 
 if [ $stage -le 0 ]; then
   for x in $(seq $num_archives); do

--- a/egs/wsj/s5/steps/nnet3/get_egs_discriminative.sh
+++ b/egs/wsj/s5/steps/nnet3/get_egs_discriminative.sh
@@ -102,9 +102,6 @@ done
 
 mkdir -p $dir/log $dir/info || exit 1;
 
-[ "$(readlink /bin/sh)" == dash ] && \
-  echo "This script won't work if /bin/sh points to dash.  make it point to bash." && exit 1
-
 nj=$(cat $denlatdir/num_jobs) || exit 1;
 
 sdata=$data/split$nj
@@ -132,9 +129,9 @@ awk '{print $1}' $data/utt2spk | utils/filter_scp.pl --exclude $dir/valid_uttlis
 
 if [ $stage -le 1 ]; then
   nj_ali=$(cat $alidir/num_jobs)
-  all_ids=$(seq -s, $nj_ali)
+  alis=$(for n in $(seq $nj_ali); do echo $alidir/ali.$n.gz; done)
   $cmd $dir/log/copy_alignments.log \
-    copy-int-vector "ark:gunzip -c $alidir/ali.{$all_ids}.gz|" \
+    copy-int-vector "ark:gunzip -c $alis|" \
     ark,scp:$dir/ali.ark,$dir/ali.scp || exit 1;
 fi
 
@@ -324,9 +321,9 @@ fi
   if $adjust_priors && [ $stage -le 10 ]; then
     if [ ! -f $dir/ali.scp ]; then
       nj_ali=$(cat $alidir/num_jobs)
-      all_ids=$(seq -s, $nj_ali)
+      alis=$(for n in $(seq $nj_ali); do echo $alidir/ali.$n.gz; done)
       $cmd $dir/log/copy_alignments.log \
-        copy-int-vector "ark:gunzip -c $alidir/ali.{$all_ids}.gz|" \
+        copy-int-vector "ark:gunzip -c $alis|" \
         ark,scp:$dir/ali.ark,$dir/ali.scp || exit 1;
     fi
 

--- a/egs/wsj/s5/steps/online/nnet2/get_egs_discriminative2.sh
+++ b/egs/wsj/s5/steps/online/nnet2/get_egs_discriminative2.sh
@@ -85,9 +85,9 @@ else
   ali_rspecifier="scp:$dir/ali.scp"
   if [ $stage -le 1 ]; then
     echo "$0: number of jobs in den-lats versus alignments differ: dumping them as single archive and index."
-    all_ids=$(seq -s, $nj_ali)
+    alis=$(for n in $(seq $nj_ali); do echo $alidir/ali.$n.gz; done)
     copy-int-vector --print-args=false \
-      "ark:gunzip -c $alidir/ali.{$all_ids}.gz|" ark,scp:$dir/ali.ark,$dir/ali.scp || exit 1;
+      "ark:gunzip -c $alis|" ark,scp:$dir/ali.ark,$dir/ali.scp || exit 1;
   fi
 fi
 


### PR DESCRIPTION
@danpovey @vince62s 
This pull request is about issue #947 
1.I think vince62s's problem is mainly caused by the difference between 'dash' and 'bash' when they try to  interpret `{}` , rather than ‘seq’.
For example, the command "lat.{1,2,3}.gz" will be replaced by "lat.1.gz lat.2.gz lat.3.gz" in bash, but nothing will be done in dash.
2.I submit a solution and I have tested them in both dash and bash. Meanwhile, I did some tests on Switchboard. I think everything goes smoothly.
  ```C++
 - lats=$(eval echo $dir/lat.{$(seq -s, $nj)}.gz)
 + for n in $(seq $nj); do
 +   lats=$(eval echo "$lats $dir/lat.$n.gz")
 + done
  ```
3.I still have a doubt. At the begining of "get_ctm.sh" file, there is a command "#!/bin/bash ". I think the script will be conducted in bash circumstance. Why vince62s's problem will happen? I'm not very clear about it. 

If the code has any questions, please contect me as soon as possible. I would appreciate it very much.
Hang