### PR TITLE
quick fix for kaldi online decoder crash

### DIFF
--- a/src/nnet2/nnet-compute-online.cc
+++ b/src/nnet2/nnet-compute-online.cc
@@ -31,7 +31,7 @@ NnetOnlineComputer::NnetOnlineComputer(const Nnet &nnet, bool pad_input)
   data_.resize(nnet_.NumComponents() + 1);
   reusable_component_inputs_.resize(nnet_.NumComponents()+1);
 }
-void NnetOnlineComputer::getLastSeenInputFrameLength() {
+int NnetOnlineComputer::getLastSeenInputFrameLength() {
     return last_seen_input_frame_.Dim();
 }
 void NnetOnlineComputer::Compute(const CuMatrixBase<BaseFloat> &input,

--- a/src/nnet2/nnet-compute-online.cc
+++ b/src/nnet2/nnet-compute-online.cc
@@ -31,7 +31,9 @@ NnetOnlineComputer::NnetOnlineComputer(const Nnet &nnet, bool pad_input)
   data_.resize(nnet_.NumComponents() + 1);
   reusable_component_inputs_.resize(nnet_.NumComponents()+1);
 }
-
+void NnetOnlineComputer::getLastSeenInputFrameLength() {
+    return last_seen_input_frame_.Dim();
+}
 void NnetOnlineComputer::Compute(const CuMatrixBase<BaseFloat> &input,
                                  CuMatrix<BaseFloat> *output) {
   KALDI_ASSERT(output != NULL);

--- a/src/nnet2/nnet-compute-online.h
+++ b/src/nnet2/nnet-compute-online.h
@@ -69,7 +69,7 @@ class NnetOnlineComputer {
   // calling Flush.  It's valid to call Flush if no frames have been
   // input or if no frames have been output; this produces empty output.
   void Flush(CuMatrix<BaseFloat> *output);
-  void getLastSeenInputFrameLength();
+  int getLastSeenInputFrameLength();
 
  private:
   void Propagate();

--- a/src/nnet2/nnet-compute-online.h
+++ b/src/nnet2/nnet-compute-online.h
@@ -69,6 +69,7 @@ class NnetOnlineComputer {
   // calling Flush.  It's valid to call Flush if no frames have been
   // input or if no frames have been output; this produces empty output.
   void Flush(CuMatrix<BaseFloat> *output);
+  void getLastSeenInputFrameLength();
 
  private:
   void Propagate();

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -573,8 +573,13 @@ bool SingleUtteranceNnet2DecoderThreaded::RunNnetEvaluationInternal() {
         // which we check feature_buffer_finished_, and we'll exit the loop, so
         // if we reach here it must be the first time it was true.
         last_time = true;
-        computer.Flush(&cu_loglikes);
-        ProcessLoglikes(log_inv_prior, &cu_loglikes);
+        if (computer.getLastSeenInputFrameLength() != 0){
+            computer.Flush(&cu_loglikes);
+            ProcessLoglikes(log_inv_prior, &cu_loglikes);
+        }
+        else {
+            //KALDI_LOG << "WARNING\n";
+        }
       }
     } else {
       CuMatrix<BaseFloat> cu_feats;

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -576,10 +576,10 @@ bool SingleUtteranceNnet2DecoderThreaded::RunNnetEvaluationInternal() {
         if (computer.getLastSeenInputFrameLength() != 0){
             computer.Flush(&cu_loglikes);
         }
-        ProcessLoglikes(log_inv_prior, &cu_loglikes);
         else {
             //KALDI_LOG << "WARNING\n";
         }
+        ProcessLoglikes(log_inv_prior, &cu_loglikes);
       }
     } else {
       CuMatrix<BaseFloat> cu_feats;

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -575,8 +575,8 @@ bool SingleUtteranceNnet2DecoderThreaded::RunNnetEvaluationInternal() {
         last_time = true;
         if (computer.getLastSeenInputFrameLength() != 0){
             computer.Flush(&cu_loglikes);
-            ProcessLoglikes(log_inv_prior, &cu_loglikes);
         }
+        ProcessLoglikes(log_inv_prior, &cu_loglikes);
         else {
             //KALDI_LOG << "WARNING\n";
         }


### PR DESCRIPTION
From my experiment, in very rare cases, kaldi online decoder will crash due to last_seen_input_frames were not previously set. I made this quick fix and it can deal with this issue and decoder no longer crashed.