### PR TITLE
Fix bugs with random stride mode

### DIFF
--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -56,7 +56,9 @@ class CuDevice {
 
   inline void* MallocPitch(size_t row_bytes, size_t num_rows, size_t *pitch) {
     if (random_stride_mode_) {
-      return allocator_.MallocPitch(row_bytes + 128 * (rand() & 1), num_rows,
+      // The pitch bucket size is hardware dependent.
+      // It is 512 on K40c with CUDA 7.5
+      return allocator_.MallocPitch(row_bytes + 512 * (rand() & 1), num_rows,
                                     pitch);
     } else {
       return allocator_.MallocPitch(row_bytes, num_rows, pitch);
@@ -113,7 +115,7 @@ class CuDevice {
 
   /// Call SetRandomStrideMode(true) to activate a mode where calls
   /// to MallocPitch will purposely allocate arrays with randomized pitch
-  /// (inconsistent between calls).  This is only useful testing code.
+  /// (inconsistent between calls).  This is only useful for testing code.
   /// This function returns the previous mode, where true means randomized
   /// pitch.  Note that you cannot ever rely on the strides from MallocPitch()
   /// being consistent for the same request, but in practice they tend to be

--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -119,8 +119,8 @@ void cudaF_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
                             int iv_stride, int ov_stride, int od_stride,
                             int group_size, float power);
 void cudaF_calc_group_max_deriv(dim3 Gr, dim3 Bl, float *y, const float *x1,
-                                const float *x2, MatrixDim d, int src_stride,
-                                int group_size);
+                                const float *x2, MatrixDim y_dim, int x1_stride,
+                                int x2_stride, int group_size);
 void cudaF_div_rows_vec(dim3 Gr, dim3 Bl, float *mat, const float *vec_div,
                         MatrixDim d);
 void cudaF_add_mat(dim3 Gr, dim3 Bl, float alpha, const float *src, float *dst,
@@ -377,8 +377,8 @@ void cudaD_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id, const double *iv,
                             MatrixDim id_dim, int iv_stride, int ov_stride,
                             int od_stride, int group_size, double power);
 void cudaD_calc_group_max_deriv(dim3 Gr, dim3 Bl, double *y, const double *x1,
-                                const double *x2, MatrixDim d, int src_stride,
-                                int group_size);
+                                const double *x2, MatrixDim y_dim,
+                                int x1_stride, int x2_stride, int group_size);
 void cudaD_div_rows_vec(dim3 Gr, dim3 Bl, double *mat, const double *vec_div,
                         MatrixDim d);
 void cudaD_add_mat(dim3 Gr, dim3 Bl, double alpha, const double *src,

--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -112,8 +112,8 @@ void cudaF_mul_rows_vec(dim3 Gr, dim3 Bl, float *mat, const float *scale,
 void cudaF_mul_rows_group_mat(dim3 Gr, dim3 Bl, float *y, const float *x,
                               MatrixDim d, int src_stride, int group_size);
 void cudaF_calc_pnorm_deriv(dim3 Gr, dim3 Bl, float *y, const float *x1,
-                            const float *x2, MatrixDim d, int src_stride,
-                            int group_size, float power);
+                            const float *x2, MatrixDim y_dim, int x1_stride,
+                            int x2_stride, int group_size, float power);
 void cudaF_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
                             const float *ov, const float* od, MatrixDim id_dim,
                             int iv_stride, int ov_stride, int od_stride,
@@ -370,8 +370,8 @@ void cudaD_mul_rows_vec(dim3 Gr, dim3 Bl, double *mat, const double *scale,
 void cudaD_mul_rows_group_mat(dim3 Gr, dim3 Bl, double *y, const double *x,
                               MatrixDim d, int src_stride, int group_size);
 void cudaD_calc_pnorm_deriv(dim3 Gr, dim3 Bl, double *y, const double *x1,
-                            const double *x2, MatrixDim d, int src_stride,
-                            int group_size, double power);
+                            const double *x2, MatrixDim y_dim, int x1_stride,
+                            int x2_stride, int group_size, double power);
 void cudaD_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id, const double *iv,
                             const double *ov, const double* od,
                             MatrixDim id_dim, int iv_stride, int ov_stride,

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -501,17 +501,19 @@ void _diff_group_pnorm(Real *id, const Real *iv, const Real *ov, const Real* od,
 template<typename Real>
 __global__
 static void _calc_group_max_deriv(Real *deriv, const Real *vec,
-                                  const Real *maxv, MatrixDim d, int src_stride,
+                                  const Real *maxv, MatrixDim deriv_dim,
+                                  int vec_stride, int maxv_stride,
                                   int group_size) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
-  if (j < d.rows && i < d.cols) {
-    int dst_index = i + j * d.stride, src_index = i / group_size
-        + j * src_stride;
-    Real vec_element = vec[dst_index], // The element of the original vector.
-        max_element = maxv[src_index]; // this is the max value
+  if (j < deriv_dim.rows && i < deriv_dim.cols) {
+    int deriv_index = i + j * deriv_dim.stride;
+    int vec_index = i + j * vec_stride;
+    int maxv_index = i / group_size + j * maxv_stride;
+    Real vec_element = vec[vec_index], // The element of the original vector.
+        max_element = maxv[maxv_index]; // this is the max value
     Real ans = (max_element == vec_element ? 1.0 : 0.0);
-    deriv[dst_index] = ans;
+    deriv[deriv_index] = ans;
   }
 }
 
@@ -2775,9 +2777,10 @@ void cudaF_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
 }
 
 void cudaF_calc_group_max_deriv(dim3 Gr, dim3 Bl, float *y, const float *x1,
-                                const float *x2, MatrixDim d, int src_stride,
-                                int group_size) {
-  _calc_group_max_deriv<<<Gr,Bl>>>(y, x1, x2, d, src_stride, group_size);
+                                const float *x2, MatrixDim y_dim, int x1_stride,
+                                int x2_stride, int group_size) {
+  _calc_group_max_deriv<<<Gr,Bl>>>(y, x1, x2, y_dim, x1_stride, x2_stride,
+      group_size);
 }
 
 void cudaF_div_rows_vec(dim3 Gr, dim3 Bl, float* mat, const float* vec_div,
@@ -3402,9 +3405,10 @@ void cudaD_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id, const double *iv,
 }
 
 void cudaD_calc_group_max_deriv(dim3 Gr, dim3 Bl, double*y, const double* x1,
-                                const double* x2, MatrixDim d, int src_stride,
-                                int group_size) {
-  _calc_group_max_deriv<<<Gr,Bl>>>(y, x1, x2, d, src_stride, group_size);
+                                const double* x2, MatrixDim y_dim,
+                                int x1_stride, int x2_stride, int group_size) {
+  _calc_group_max_deriv<<<Gr,Bl>>>(y, x1, x2, y_dim, x1_stride, x2_stride,
+      group_size);
 }
 
 void cudaD_div_rows_vec(dim3 Gr, dim3 Bl, double* mat, const double* vec_div,

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -429,15 +429,16 @@ static void _mul_rows_group_mat(Real *y, const Real *x, MatrixDim d,
 template<typename Real>
 __global__
 static void _calc_pnorm_deriv(Real *deriv, const Real *vec, const Real *norm,
-                              MatrixDim d, int src_stride, int group_size,
-                              Real power) {
+                              MatrixDim deriv_dim, int vec_stride,
+                              int norm_stride, int group_size, Real power) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
-  if (j < d.rows && i < d.cols) {
-    int dst_index = i + j * d.stride, src_index = i / group_size
-        + j * src_stride;
-    Real vec_element = vec[dst_index], // The element of the original vector.
-        norm_element = norm[src_index]; // this is the pnorm
+  if (j < deriv_dim.rows && i < deriv_dim.cols) {
+    int deriv_index = i + j * deriv_dim.stride;
+    int vec_index = i + j * vec_stride;
+    int norm_index = i / group_size + j * norm_stride;
+    Real vec_element = vec[vec_index], // The element of the original vector.
+        norm_element = norm[norm_index]; // this is the pnorm
     Real vec_element_sign = (vec_element > 0 ? 1 : -1);
     Real ans;
     if (norm_element <= 0.0)
@@ -445,7 +446,7 @@ static void _calc_pnorm_deriv(Real *deriv, const Real *vec, const Real *norm,
     else
       ans = vec_element_sign * pow(std::abs(vec_element), power - 1)
           * pow(norm_element, 1 - power);
-    deriv[dst_index] = ans;
+    deriv[deriv_index] = ans;
   }
 }
 
@@ -2763,9 +2764,10 @@ void cudaF_mul_rows_group_mat(dim3 Gr, dim3 Bl, float *y, const float *x,
 }
 
 void cudaF_calc_pnorm_deriv(dim3 Gr, dim3 Bl, float *y, const float *x1,
-                            const float *x2, MatrixDim d, int src_stride,
-                            int group_size, float power) {
-  _calc_pnorm_deriv<<<Gr,Bl>>>(y, x1, x2, d, src_stride, group_size, power);
+                            const float *x2, MatrixDim y_dim, int x1_stride,
+                            int x2_stride, int group_size, float power) {
+  _calc_pnorm_deriv<<<Gr,Bl>>>(y, x1, x2, y_dim, x1_stride, x2_stride,
+      group_size, power);
 }
 
 void cudaF_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
@@ -3391,9 +3393,10 @@ void cudaD_mul_rows_group_mat(dim3 Gr, dim3 Bl, double* y, const double* x,
 }
 
 void cudaD_calc_pnorm_deriv(dim3 Gr, dim3 Bl, double*y, const double* x1,
-                            const double* x2, MatrixDim d, int src_stride,
-                            int group_size, double power) {
-  _calc_pnorm_deriv<<<Gr,Bl>>>(y, x1, x2, d, src_stride, group_size, power);
+                            const double* x2, MatrixDim y_dim, int x1_stride,
+                            int x2_stride, int group_size, double power) {
+  _calc_pnorm_deriv<<<Gr,Bl>>>(y, x1, x2, y_dim, x1_stride, x2_stride,
+      group_size, power);
 }
 
 void cudaD_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id, const double *iv,

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -325,9 +325,10 @@ inline void cuda_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
 }
 inline void cuda_calc_group_max_deriv(dim3 Gr, dim3 Bl, float *y,
                                       const float *x1, const float *x2,
-                                      MatrixDim d, int src_stride,
-                                      int group_size) {
-  cudaF_calc_group_max_deriv(Gr, Bl, y, x1, x2, d, src_stride, group_size);
+                                      MatrixDim y_dim, int x1_stride,
+                                      int x2_stride, int group_size) {
+  cudaF_calc_group_max_deriv(Gr, Bl, y, x1, x2, y_dim, x1_stride, x2_stride,
+                             group_size);
 }
 inline void cuda_add_mat(dim3 Gr, dim3 Bl, float alpha, const float *src,
                          float *dst, MatrixDim d, int src_stride, int A_trans) {
@@ -842,9 +843,10 @@ inline void cuda_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id,
 }
 inline void cuda_calc_group_max_deriv(dim3 Gr, dim3 Bl, double *y,
                                       const double *x1, const double *x2,
-                                      MatrixDim d, int src_stride,
-                                      int group_size) {
-  cudaD_calc_group_max_deriv(Gr, Bl, y, x1, x2, d, src_stride, group_size);
+                                      MatrixDim y_dim, int x1_stride,
+                                      int x2_stride, int group_size) {
+  cudaD_calc_group_max_deriv(Gr, Bl, y, x1, x2, y_dim, x1_stride, x2_stride,
+                             group_size);
 }
 inline void cuda_add_mat(dim3 Gr, dim3 Bl, double alpha, const double *src,
                          double *dst, MatrixDim d, int src_stride,

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -311,9 +311,11 @@ inline void cuda_mul_rows_group_mat(dim3 Gr, dim3 Bl, float *y, const float *x,
   cudaF_mul_rows_group_mat(Gr, Bl, y, x, d, src_stride, group_size);
 }
 inline void cuda_calc_pnorm_deriv(dim3 Gr, dim3 Bl, float *y, const float *x1,
-                                  const float *x2, MatrixDim d, int src_stride,
-                                  int group_size, float power) {
-  cudaF_calc_pnorm_deriv(Gr, Bl, y, x1, x2, d, src_stride, group_size, power);
+                                  const float *x2, MatrixDim y_dim,
+                                  int x1_stride, int x2_stride, int group_size,
+                                  float power) {
+  cudaF_calc_pnorm_deriv(Gr, Bl, y, x1, x2, y_dim, x1_stride, x2_stride,
+                         group_size, power);
 }
 inline void cuda_diff_group_pnorm(dim3 Gr, dim3 Bl, float *id, const float *iv,
                                   const float *ov, const float* od,
@@ -829,9 +831,11 @@ inline void cuda_mul_rows_group_mat(dim3 Gr, dim3 Bl, double *y,
   cudaD_mul_rows_group_mat(Gr, Bl, y, x, d, src_stride, group_size);
 }
 inline void cuda_calc_pnorm_deriv(dim3 Gr, dim3 Bl, double *y, const double *x1,
-                                  const double *x2, MatrixDim d, int src_stride,
-                                  int group_size, double power) {
-  cudaD_calc_pnorm_deriv(Gr, Bl, y, x1, x2, d, src_stride, group_size, power);
+                                  const double *x2, MatrixDim y_dim,
+                                  int x1_stride, int x2_stride, int group_size,
+                                  double power) {
+  cudaD_calc_pnorm_deriv(Gr, Bl, y, x1, x2, y_dim, x1_stride, x2_stride,
+                         group_size, power);
 }
 inline void cuda_diff_group_pnorm(dim3 Gr, dim3 Bl, double *id,
                                   const double *iv, const double *ov,

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1432,7 +1432,7 @@ template<typename Real>
 static void UnitTestCuMatrixAddMatMatBatched() {
   // Random stride is disabled as AddMatMatBatched requires consistent stride
 #if HAVE_CUDA == 1
-  CuDevice::Instantiate().SetRandomStrideMode(false);
+  bool old_mode = CuDevice::Instantiate().SetRandomStrideMode(false);
 #endif
   const int32 batchCount = 10;
   std::vector<Matrix<Real>* > Ha(batchCount), Hb(batchCount), Hc1(batchCount), Hc2(batchCount);
@@ -1497,7 +1497,7 @@ static void UnitTestCuMatrixAddMatMatBatched() {
     delete DA[i]; delete DB[i]; delete DC1[i]; delete DC2[i];
   }
 #if HAVE_CUDA == 1
-  CuDevice::Instantiate().SetRandomStrideMode(true);
+  CuDevice::Instantiate().SetRandomStrideMode(old_mode);
 #endif
 }
 

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -811,7 +811,8 @@ void CuMatrixBase<Real>::GroupPnormDeriv(const CuMatrixBase<Real> &src1,
     dim3 dimGrid(n_blocks(NumCols(), CU2DBLOCK),
                  n_blocks(NumRows(), CU2DBLOCK));
     cuda_calc_pnorm_deriv(dimGrid, dimBlock, this->data_, src1.Data(),
-                          src2.Data(), Dim(), src2.Stride(), group_size, power);
+                          src2.Data(), Dim(), src1.Stride(), src2.Stride(),
+                          group_size, power);
     CU_SAFE_CALL(cudaGetLastError());
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -863,13 +864,13 @@ void CuMatrixBase<Real>::GroupMaxDeriv(const CuMatrixBase<Real> &src1,
   KALDI_ASSERT(this->NumCols() == src2.NumCols() * group_size);
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-   Timer tim;
+    Timer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(NumCols(), CU2DBLOCK),
                  n_blocks(NumRows(), CU2DBLOCK));
-    cuda_calc_group_max_deriv(dimGrid, dimBlock, this->data_,
-                              src1.Data(), src2.Data(), Dim(),
-                              src1.Stride(), src2.Stride(), group_size);
+    cuda_calc_group_max_deriv(dimGrid, dimBlock, this->data_, src1.Data(),
+                              src2.Data(), Dim(), src1.Stride(), src2.Stride(),
+                              group_size);
     CU_SAFE_CALL(cudaGetLastError());
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -869,7 +869,7 @@ void CuMatrixBase<Real>::GroupMaxDeriv(const CuMatrixBase<Real> &src1,
                  n_blocks(NumRows(), CU2DBLOCK));
     cuda_calc_group_max_deriv(dimGrid, dimBlock, this->data_,
                               src1.Data(), src2.Data(), Dim(),
-                              src2.Stride(), group_size);
+                              src1.Stride(), src2.Stride(), group_size);
     CU_SAFE_CALL(cudaGetLastError());
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -280,7 +280,7 @@ class CuMatrixBase {
                        const CuMatrixBase<Real> &output, Real power);
 
   /// Differentiate backward through the GroupPnorm function.
-  /// It is a combination of GroupPnormDeriv and MulRowsGroupMax.
+  /// It is a combination of GroupPnormDeriv and MulRowsGroupMat.
   void DiffGroupPnorm(const CuMatrixBase<Real> &in_value,
                       const CuMatrixBase<Real> &out_value,
                       const CuMatrixBase<Real> &out_deriv, Real power);


### PR DESCRIPTION
Fix random stride mode bug and typo mentioned in #997 

Fix stride bug in `_calc_group_max_deriv` detected by random stride mode.

Fix stride bug in `_calc_group_pnomr_deriv`. Random stride mode did not detect this but it uses the same code template as `_calc_group_max_deriv`. As `CuMatrixBase::GroupPnormDeriv` has been replaced by `CuMatrixBase::DiffGroupPnorm` in #897. This bug did not affect NNet3/2 since then.

All GPU tests have passed.