### PR TITLE
Improved debug stride mode

### DIFF
--- a/src/chain/chain-supervision-test.cc
+++ b/src/chain/chain-supervision-test.cc
@@ -609,6 +609,7 @@ int main() {
 
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/cudamatrix/cu-array-test.cc
+++ b/src/cudamatrix/cu-array-test.cc
@@ -118,6 +118,7 @@ static void UnitTestCuArray() {
 int main() {
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/cudamatrix/cu-block-matrix-test.cc
+++ b/src/cudamatrix/cu-block-matrix-test.cc
@@ -182,6 +182,7 @@ template<typename Real> void CuBlockMatrixUnitTest() {
 int main() {
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/cudamatrix/cu-device-test.cc
+++ b/src/cudamatrix/cu-device-test.cc
@@ -101,6 +101,7 @@ void CudaMatrixResizeTest() {
 int main() {
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -563,8 +563,8 @@ void CuDevice::CheckGpuHealth() {
 */
 
 CuDevice::CuDevice() :
-    active_gpu_id_(-1), verbose_(true), random_stride_mode_(false),
-    allocator_(CuAllocatorOptions()) {
+    active_gpu_id_(-1), verbose_(true), debug_stride_mode_(false),
+    num_debug_stride_allocations_(0), allocator_(CuAllocatorOptions()) {
 }
 
 

--- a/src/cudamatrix/cu-math-test.cc
+++ b/src/cudamatrix/cu-math-test.cc
@@ -155,6 +155,7 @@ template<typename Real> void CudaMathUnitTest() {
 int main() {
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/cudamatrix/cu-matrix-test.cc
+++ b/src/cudamatrix/cu-matrix-test.cc
@@ -1432,7 +1432,7 @@ template<typename Real>
 static void UnitTestCuMatrixAddMatMatBatched() {
   // Random stride is disabled as AddMatMatBatched requires consistent stride
 #if HAVE_CUDA == 1
-  bool old_mode = CuDevice::Instantiate().SetRandomStrideMode(false);
+  bool old_mode = CuDevice::Instantiate().SetDebugStrideMode(false);
 #endif
   const int32 batchCount = 10;
   std::vector<Matrix<Real>* > Ha(batchCount), Hb(batchCount), Hc1(batchCount), Hc2(batchCount);
@@ -1497,7 +1497,7 @@ static void UnitTestCuMatrixAddMatMatBatched() {
     delete DA[i]; delete DB[i]; delete DC1[i]; delete DC2[i];
   }
 #if HAVE_CUDA == 1
-  CuDevice::Instantiate().SetRandomStrideMode(old_mode);
+  CuDevice::Instantiate().SetDebugStrideMode(old_mode);
 #endif
 }
 
@@ -2656,7 +2656,7 @@ template<typename Real> void CudaMatrixUnitTest() {
 int main() {
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
-    CuDevice::Instantiate().SetRandomStrideMode(true);
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/cudamatrix/cu-packed-matrix-test.cc
+++ b/src/cudamatrix/cu-packed-matrix-test.cc
@@ -243,6 +243,7 @@ template<typename Real> void CudaPackedMatrixUnitTest() {
 int main() {
   using namespace kaldi;
 #if HAVE_CUDA == 1
+  CuDevice::Instantiate().SetDebugStrideMode(true);
   // Select the GPU
   CuDevice::Instantiate().SelectGpuId("yes");
 #endif

--- a/src/cudamatrix/cu-sp-matrix-test.cc
+++ b/src/cudamatrix/cu-sp-matrix-test.cc
@@ -366,6 +366,7 @@ int main() {
 
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/cudamatrix/cu-sparse-matrix-test.cc
+++ b/src/cudamatrix/cu-sparse-matrix-test.cc
@@ -187,6 +187,7 @@ void CudaSparseMatrixUnitTest() {
 int main() {
   for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    kaldi::CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       kaldi::CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/cudamatrix/cu-tp-matrix-test.cc
+++ b/src/cudamatrix/cu-tp-matrix-test.cc
@@ -190,6 +190,7 @@ int main() {
 
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -758,7 +758,7 @@ int main(int argc, char *argv[]) {
 
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
-    CuDevice::Instantiate().SetRandomStrideMode(true);
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/nnet2/nnet-component-test.cc
+++ b/src/nnet2/nnet-component-test.cc
@@ -859,6 +859,8 @@ int main() {
 
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    //// Uncomment the following line to expose the bug in UnitTestDropoutComponent
+    //CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/nnet2/nnet-precondition-online-test.cc
+++ b/src/nnet2/nnet-precondition-online-test.cc
@@ -328,6 +328,7 @@ int main() {
   using namespace kaldi::nnet2;
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/nnet3/natural-gradient-online-test.cc
+++ b/src/nnet3/natural-gradient-online-test.cc
@@ -328,6 +328,7 @@ int main() {
   using namespace kaldi::nnet3;
   for (int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no"); // -1 means no GPU
     else

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -503,6 +503,7 @@ int main() {
   TestStringsApproxEqual();
   for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/nnet3/nnet-compute-test.cc
+++ b/src/nnet3/nnet-compute-test.cc
@@ -176,6 +176,7 @@ int main() {
 
   for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/nnet3/nnet-derivative-test.cc
+++ b/src/nnet3/nnet-derivative-test.cc
@@ -430,6 +430,7 @@ int main() {
 
   for (kaldi::int32 loop = 0; loop < 2; loop++) {
 #if HAVE_CUDA == 1
+    CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
     else

--- a/src/nnet3/nnet-optimize-test.cc
+++ b/src/nnet3/nnet-optimize-test.cc
@@ -232,6 +232,7 @@ int main() {
   //SetVerboseLevel(2);
 
 #if HAVE_CUDA == 1
+  CuDevice::Instantiate().SetDebugStrideMode(true);
   CuDevice::Instantiate().SelectGpuId("no");
   UnitTestNnetOptimize();
   CuDevice::Instantiate().SelectGpuId("yes");


### PR DESCRIPTION
This is a follow up of #1003. A counter ensues that adjacent allocations have different pitches so that the stride bugs are more likely to be detected in this debug stride mode. The mode is enabled in many CUDA tests including chain, nnet2 and nnet3 except for `nnet2/nnet-component-test`, as `nnet2::DropoutComponent` can not pass the test with unknown reason.
All CUDA tests have passed after disabling debug stride mode in `nnet2/nnet-component-test`.