### PR TITLE
nnet3: lstm/make_configs.py : Removed a bug where label_delay was not…

### DIFF
--- a/egs/wsj/s5/steps/nnet3/lstm/make_configs.py
+++ b/egs/wsj/s5/steps/nnet3/lstm/make_configs.py
@@ -253,7 +253,7 @@ def MakeConfigs(config_dir, feat_dim, ivector_dim, num_targets,
 
         if xent_regularize != 0.0:
             nodes.AddFinalLayer(config_lines, prev_layer_output, num_targets,
-                                include_log_softmax = True,
+                                include_log_softmax = True, label_delay = label_delay,
                                 name_affix = 'xent')
 
         config_files['{0}/layer{1}.config'.format(config_dir, i+1)] = config_lines
@@ -269,7 +269,7 @@ def MakeConfigs(config_dir, feat_dim, ivector_dim, num_targets,
 
         if xent_regularize != 0.0:
             nodes.AddFinalLayer(config_lines, prev_layer_output, num_targets,
-                                include_log_softmax = True,
+                                include_log_softmax = True, label_delay = label_delay,
                                 name_affix = 'xent')
 
         config_files['{0}/layer{1}.config'.format(config_dir, i+1)] = config_lines


### PR DESCRIPTION
… being added to the xentropy branch in chain models.

This most probably affects none of the current recipes as we do not have chain+lstm recipes and the blstm+chain recipes do not use label_delay.