### PR TITLE
Speed up log softmax

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -218,7 +218,7 @@ void cudaF_block_add_mat_mat(dim3 Gr, dim3 Bl, CuBlockMatrixData *B_cu_data,
 void cudaF_softmax_reduce(size_t Gr, size_t Bl, float *y, const float *x,
                           MatrixDim d, int src_stride);
 void cudaF_log_softmax_reduce(size_t Gr, size_t Bl, float *y, const float *x,
-                              MatrixDim d, int src_stride);
+                              MatrixDim y_dim, int x_stride);
 void cudaF_soft_hinge(dim3 Gr, dim3 Bl, float *y, const float *x, MatrixDim d,
                       int src_stride);
 void cudaF_group_pnorm(dim3 Gr, dim3 Bl, float *y, const float *x, MatrixDim d,
@@ -479,7 +479,7 @@ void cudaD_block_add_mat_mat(dim3 Gr, dim3 Bl, CuBlockMatrixData *B_cu_data,
 void cudaD_softmax_reduce(size_t Gr, size_t Bl, double *y, const double *x,
                           MatrixDim d, int src_stride);
 void cudaD_log_softmax_reduce(size_t Gr, size_t Bl, double *y, const double *x,
-                              MatrixDim d, int src_stride);
+                              MatrixDim y_dim, int x_stride);
 void cudaD_soft_hinge(dim3 Gr, dim3 Bl, double *y, const double *x, MatrixDim d,
                       int src_stride);
 void cudaD_group_pnorm(dim3 Gr, dim3 Bl, double *y, const double *x,

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -2214,88 +2214,86 @@ static void _softmax_reduce(Real*y, const Real*x, MatrixDim d, int src_stride) {
   }
 }
 
-/**
- This kernel implements the per-row log-softmax operation on 'x', with writing
- to 'y';
- note, x and my may point to the same memory.  This is equivalent to setting
- matrix y to matrix x and then, for each row of y, subtracting the offset that
- will make exp(y.row[j]) sum to 1 for each row j.
-
- It expects to be called with CU1DBLOCK threads if d.num_cols > CU1DBLOCK,
- otherwise with d.num_cols threads.  The number of blocks [i.e. the gridDim]
- equals d.rows, so one block of threads processes each row.  x and y are
- expected to have the same dimension, but possibly different row strides;
- d.stride is the row-stride of y and src_stride is the row-stride of x.
- */
+// Per-row log-softmax operation on 'x', with writing to 'y'.
+// note, x and y may point to the same memory.  This is equivalent to setting
+// matrix y to matrix x and then, for each row of y, subtracting the offset that
+// will make exp(y.row[j]) sum to 1 for each row j.
+//
+// It expects to be called with CU1DBLOCK threads.
+// The number of blocks [i.e. the gridDim] equals to y_dim.rows,
+// so one block of threads processes each row.  x and y are
+// expected to have the same dimension, but possibly different row strides.
 template<typename Real>
 __global__
-static void _log_softmax_reduce(Real *y, const Real *x, MatrixDim d,
-                                int src_stride) {
-  int j = blockIdx.x;
-  int THREADS = blockDim.x;
-  if (j >= d.rows)
-    return;
+static void _log_softmax_reduce(Real* y, const Real* x, MatrixDim y_dim,
+                                int x_stride) {
+  __shared__ Real smem[CU1DBLOCK];
+  const int i = blockIdx.x;
+  const int x_start = i * x_stride;
+  const int y_start = i * y_dim.stride;
+  const int tid = threadIdx.x;
 
-  __shared__ Real aux[CU1DBLOCK];
-  int steps = (d.cols - 1) / THREADS + 1;
-
-  // Maximum step 1: loads input data to <aux>. If <d.cols> is larger than
-  //                 <blockDim.x>, then we do a first pass filtering and only
-  //                 keep a <blockDim.x> size array.
-  aux[threadIdx.x] = x[threadIdx.x + j * src_stride];
-  for (int i = 1; i < steps; ++i) {
-    if (threadIdx.x + i * THREADS < d.cols
-        && aux[threadIdx.x] < x[threadIdx.x + i * THREADS + j * src_stride])
-      aux[threadIdx.x] = x[threadIdx.x + i * THREADS + j * src_stride];
+  // find max element of the row
+  // reduce to CU1DBLOCK elements per row.
+  Real tmax = -1e20;
+  for (int j = tid; j < y_dim.cols; j += CU1DBLOCK) {
+    tmax = max(tmax, x[x_start + j]);
   }
-
-  // Maximum step 2: the standard max reduce.
-  int nTotalThreads = THREADS;
+  smem[tid] = tmax;
   __syncthreads();
-  while (nTotalThreads > 1) {
-    int halfPoint = ((1 + nTotalThreads) >> 1);
-    if (threadIdx.x < halfPoint) {
-      if (threadIdx.x + halfPoint < nTotalThreads
-          && aux[threadIdx.x] < aux[threadIdx.x + halfPoint])
-        aux[threadIdx.x] = aux[threadIdx.x + halfPoint];
+
+  // reduce to 2x warpSize elements per row
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      smem[tid] = max(smem[tid], smem[tid + shift]);
     }
     __syncthreads();
-    nTotalThreads = ((1 + nTotalThreads) >> 1);
   }
-  Real max = aux[0];
-  __syncthreads();
 
-  // Log sum step 1: substracts max, and takes exponentials.
-  y[threadIdx.x + j * d.stride] = x[threadIdx.x + j * src_stride] - max;
-  aux[threadIdx.x] = exp(y[threadIdx.x + j * d.stride]);
-  for (int i = 1; i < steps; ++i) {
-    if (threadIdx.x + i * THREADS < d.cols) {
-      y[threadIdx.x + i * THREADS + j * d.stride] = x[threadIdx.x + i * THREADS
-          + j * src_stride] - max;
-      aux[threadIdx.x] += exp(y[threadIdx.x + i * THREADS + j * d.stride]);
+  // reduce to 1 element per row
+  if (tid < warpSize) {
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      smem[tid] = max(smem[tid], smem[tid + shift]);
     }
   }
 
-  // Log sum step 2: comptes summation and then takes logarithm.
-  nTotalThreads = THREADS;
+  // broadcast max to all threads
   __syncthreads();
-  while (nTotalThreads > 1) {
-    int halfPoint = ((1 + nTotalThreads) >> 1);
-    if (threadIdx.x < halfPoint) {
-      if (threadIdx.x + halfPoint < nTotalThreads)
-        aux[threadIdx.x] += aux[threadIdx.x + halfPoint];
+  Real max = smem[0];
+
+  // sum_j(exp(x(i,j)-max))
+  // reduce to CU1DBLOCK elements per row.
+  Real tsum = Real(0);
+  for (int j = tid; j < y_dim.cols; j += CU1DBLOCK) {
+    tsum += exp(x[x_start + j] - max);
+  }
+  smem[tid] = tsum;
+  __syncthreads();
+
+  // reduce to 2x warpSize elements per row
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      smem[tid] += smem[tid + shift];
     }
     __syncthreads();
-    nTotalThreads = ((1 + nTotalThreads) >> 1);
   }
-  Real log_sum = log(aux[0]);
-  __syncthreads();
 
-  // Computes log softmax.
-  for (int i = 0; i < steps; ++i) {
-    if (threadIdx.x + i * THREADS < d.cols) {
-      y[threadIdx.x + i * THREADS + j * d.stride] -= log_sum;
+  // reduce to 1 element per row
+  if (tid < warpSize) {
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      smem[tid] += smem[tid + shift];
     }
+  }
+
+  // broadcast sum to all threads
+  __syncthreads();
+  Real log_sum = log(smem[0]);
+
+  // normalize the row
+  for (int j = tid; j < y_dim.cols; j += CU1DBLOCK) {
+    y[y_start + j] = x[x_start + j] - max - log_sum;
   }
 }
 
@@ -3110,8 +3108,8 @@ void cudaF_softmax_reduce(size_t Gr, size_t Bl, float* y, const float* x,
 }
 
 void cudaF_log_softmax_reduce(size_t Gr, size_t Bl, float* y, const float* x,
-                              MatrixDim d, int src_stride) {
-  _log_softmax_reduce<<<Gr,Bl>>>(y, x, d, src_stride);
+                              MatrixDim y_dim, int x_stride) {
+  _log_softmax_reduce<<<Gr,Bl>>>(y, x, y_dim, x_stride);
 }
 
 void cudaF_splice(dim3 Gr, dim3 Bl, float* y, const float* x,
@@ -3731,8 +3729,8 @@ void cudaD_softmax_reduce(size_t Gr, size_t Bl, double* y, const double* x,
 }
 
 void cudaD_log_softmax_reduce(size_t Gr, size_t Bl, double* y, const double* x,
-                              MatrixDim d, int src_stride) {
-  _log_softmax_reduce<<<Gr,Bl>>>(y, x, d, src_stride);
+                              MatrixDim y_dim, int x_stride) {
+  _log_softmax_reduce<<<Gr,Bl>>>(y, x, y_dim, x_stride);
 }
 
 void cudaD_splice(dim3 Gr, dim3 Bl, double* y, const double* x,

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -565,9 +565,9 @@ inline void cuda_softmax_reduce(size_t Gr, size_t Bl, float *y, const float *x,
   cudaF_softmax_reduce(Gr, Bl, y, x, d, src_stride);
 }
 inline void cuda_log_softmax_reduce(size_t Gr, size_t Bl, float *y,
-                                    const float *x, MatrixDim d,
-                                    int src_stride) {
-  cudaF_log_softmax_reduce(Gr, Bl, y, x, d, src_stride);
+                                    const float *x, MatrixDim y_dim,
+                                    int x_stride) {
+  cudaF_log_softmax_reduce(Gr, Bl, y, x, y_dim, x_stride);
 }
 
 inline void cuda_regularize_l1(dim3 Gr, dim3 Bl, float *wei, float *grad,
@@ -1087,9 +1087,9 @@ inline void cuda_softmax_reduce(size_t Gr, size_t Bl, double *y,
   cudaD_softmax_reduce(Gr, Bl, y, x, d, src_stride);
 }
 inline void cuda_log_softmax_reduce(size_t Gr, size_t Bl, double *y,
-                                    const double *x, MatrixDim d,
-                                    int src_stride) {
-  cudaD_log_softmax_reduce(Gr, Bl, y, x, d, src_stride);
+                                    const double *x, MatrixDim y_dim,
+                                    int x_stride) {
+  cudaD_log_softmax_reduce(Gr, Bl, y, x, y_dim, x_stride);
 }
 
 inline void cuda_regularize_l1(dim3 Gr, dim3 Bl, double *wei, double *grad,

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1482,7 +1482,7 @@ void CuMatrixBase<Real>::ApplyLogSoftMaxPerRow(const CuMatrixBase<Real> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
-    size_t dimBlock = src.num_cols_ > CU1DBLOCK ? CU1DBLOCK : src.num_cols_;
+    size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = src.num_rows_;
     cuda_log_softmax_reduce(dimGrid, dimBlock,
                             data_, src.data_, Dim(), src.Stride());

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1012,6 +1012,8 @@ void CuMatrixBase<Real>::AddMatBlocks(Real alpha, const CuMatrixBase<Real> &A,
   }
 }
 
+/// dst = a * b / c (by element; when c = 0, dst = a)
+/// dst can be an alias of a, b or c safely and get expected result.
 template<typename Real>
 void CuMatrixBase<Real>::AddMatMatDivMat(const CuMatrixBase<Real> &A,
                     const CuMatrixBase<Real> &B, const CuMatrixBase<Real> &C) {

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -416,6 +416,7 @@ class CuMatrixBase {
   /// A = alpha * x * y^T + A .
   void AddVecVec(Real alpha, const CuVectorBase<Real> &x, const CuVectorBase<Real> &y);
   /// *this = a * b / c (by element; when c = 0, *this = a)
+  /// *this can be an alias of a, b or c safely and get expected result.
   void AddMatMatDivMat(const CuMatrixBase<Real> &A, const CuMatrixBase<Real> &B, const CuMatrixBase<Real> &C);
 
   /// *this = beta * *this + alpha * M M^T, for symmetric matrices.  It only


### PR DESCRIPTION
Speed up by reducing global memory access and faster tree reduction.

```
Benchmark (gflops)            dim  old     new    speedup
CuMatrix::LogSoftmax<float>,   16  0.0134  0.0138 1.03x
CuMatrix::LogSoftmax<float>,   32  0.0521  0.0562 1.08x
CuMatrix::LogSoftmax<float>,   64  0.1863  0.2278 1.22x
CuMatrix::LogSoftmax<float>,  128  0.6507  0.6564 1.01x
CuMatrix::LogSoftmax<float>,  256  1.6489  2.1527 1.31x
CuMatrix::LogSoftmax<float>,  512  3.8514  5.1179 1.33x
CuMatrix::LogSoftmax<float>, 1024  6.7696 10.8209 1.60x
CuMatrix::LogSoftmax<double>,   16  0.0114  0.0134 1.17x
CuMatrix::LogSoftmax<double>,   32  0.0528  0.0534 1.01x
CuMatrix::LogSoftmax<double>,   64  0.1701  0.2027 1.19x
CuMatrix::LogSoftmax<double>,  128  0.7222  0.6272 0.87x
CuMatrix::LogSoftmax<double>,  256  1.4448  1.8999 1.31x
CuMatrix::LogSoftmax<double>,  512  3.3797  4.1481 1.23x
CuMatrix::LogSoftmax<double>, 1024  4.9666  6.7085 1.35x
```

Also add comments about aliasing in AddMatMatDivMat as discussed in #1008.

All GPU tests have passed.
