### PR TITLE
Storing phones.txt and add check_phones_compatible.sh

### DIFF
--- a/egs/wsj/s5/steps/align_basis_fmllr.sh
+++ b/egs/wsj/s5/steps/align_basis_fmllr.sh
@@ -57,6 +57,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 cp $srcdir/final.occs $dir;
 splice_opts=`cat $srcdir/splice_opts 2>/dev/null` # frame-splicing options.

--- a/egs/wsj/s5/steps/align_fmllr.sh
+++ b/egs/wsj/s5/steps/align_fmllr.sh
@@ -56,6 +56,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 cp $srcdir/final.alimdl $dir 2>/dev/null
 cp $srcdir/final.occs $dir;

--- a/egs/wsj/s5/steps/align_fmllr_lats.sh
+++ b/egs/wsj/s5/steps/align_fmllr_lats.sh
@@ -54,6 +54,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 cp $srcdir/final.alimdl $dir 2>/dev/null
 cp $srcdir/final.occs $dir;

--- a/egs/wsj/s5/steps/align_lvtln.sh
+++ b/egs/wsj/s5/steps/align_lvtln.sh
@@ -56,6 +56,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl,final.lvtln} $dir || exit 1;
 cp $srcdir/final.occs $dir;
 

--- a/egs/wsj/s5/steps/align_raw_fmllr.sh
+++ b/egs/wsj/s5/steps/align_raw_fmllr.sh
@@ -53,6 +53,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 cp $srcdir/final.occs $dir;
 splice_opts=`cat $srcdir/splice_opts 2>/dev/null` # frame-splicing options.

--- a/egs/wsj/s5/steps/align_sgmm.sh
+++ b/egs/wsj/s5/steps/align_sgmm.sh
@@ -59,6 +59,9 @@ cp $srcdir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 [ -f $srcdir/final.alimdl ] && cp $srcdir/final.alimdl $dir
 cp $srcdir/final.occs $dir;

--- a/egs/wsj/s5/steps/align_sgmm2.sh
+++ b/egs/wsj/s5/steps/align_sgmm2.sh
@@ -59,6 +59,9 @@ cp $srcdir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 [ -f $srcdir/final.alimdl ] && cp $srcdir/final.alimdl $dir
 cp $srcdir/final.occs $dir;

--- a/egs/wsj/s5/steps/align_si.sh
+++ b/egs/wsj/s5/steps/align_si.sh
@@ -61,6 +61,9 @@ cp $srcdir/delta_opts $dir 2>/dev/null
 
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 cp $srcdir/final.occs $dir;
 

--- a/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
+++ b/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
@@ -75,6 +75,8 @@ cp $srcdir/tree $dir
 cp $srcdir/cmvn_opts $dir
 cp $srcdir/{splice_opts,delta_opts,final.mat,final.alimdl} $dir 2>/dev/null || true
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 
 if [ $stage -le 1 ]; then
   echo "$0: Building biased-language-model decoding graphs..."

--- a/egs/wsj/s5/steps/cleanup/debug_lexicon.sh
+++ b/egs/wsj/s5/steps/cleanup/debug_lexicon.sh
@@ -44,6 +44,10 @@ for f in $data/feats.scp $lang/phones.txt $src/final.mdl $srcdict; do
   [ ! -f $f ] && echo "$0: expected file $f to exist" && exit 1;
 done
 
+mkdir -p $dir
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt
+cp $srcdir/phones.txt $dir
+
 if [ -z $alidir ]; then
   alidir=${src}_ali_$(basename $data)
   if [ $stage -le 1 ]; then

--- a/egs/wsj/s5/steps/cleanup/find_bad_utts.sh
+++ b/egs/wsj/s5/steps/cleanup/find_bad_utts.sh
@@ -63,6 +63,9 @@ cp $srcdir/splice_opts $dir 2>/dev/null # frame-splicing options.
 cmvn_opts=`cat $srcdir/cmvn_opts 2>/dev/null`
 cp $srcdir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
 cp $srcdir/{tree,final.mdl} $dir || exit 1;

--- a/egs/wsj/s5/steps/cleanup/find_bad_utts_nnet.sh
+++ b/egs/wsj/s5/steps/cleanup/find_bad_utts_nnet.sh
@@ -63,6 +63,9 @@ cp $srcdir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 #checking type of nnet
 if nnet-info 1>/dev/null 2>/dev/null $srcdir/final.mdl; then 
   nnet_type="nnet";

--- a/egs/wsj/s5/steps/cleanup/make_segmentation_graph.sh
+++ b/egs/wsj/s5/steps/cleanup/make_segmentation_graph.sh
@@ -54,6 +54,8 @@ for f in $data/text.orig $data/orig2utt $lang/L_disambig.fst \
   fi
 done
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $model_dir/phones.txt
+
 # If --ngram-order is larger than 1, we will have to use SRILM
 if [ $ngram_order -gt 1 ]; then
   ngram_count=`which ngram-count` || true

--- a/egs/wsj/s5/steps/cleanup/make_utterance_graph.sh
+++ b/egs/wsj/s5/steps/cleanup/make_utterance_graph.sh
@@ -55,6 +55,8 @@ done
 
 mkdir -p $graph_dir/sub_graphs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $model_dir/phones.txt
+
 # If --ngram-order is larger than 1, we will have to use SRILM
 if [ $ngram_order -gt 1 ]; then
   ngram_count=`which ngram-count` || true

--- a/egs/wsj/s5/steps/combine_ali_dirs.sh
+++ b/egs/wsj/s5/steps/combine_ali_dirs.sh
@@ -34,6 +34,8 @@ first_src=$1;
 mkdir -p $dest;
 rm $dest/{ali.*.gz,num_jobs} 2>/dev/null
 
+cp $first_src/phones.txt $dest || exit 1;
+
 export LC_ALL=C
 
 for dir in $*; do

--- a/egs/wsj/s5/steps/get_fmllr_basis.sh
+++ b/egs/wsj/s5/steps/get_fmllr_basis.sh
@@ -48,7 +48,7 @@ for f in $data/feats.scp $dir/final.mdl $dir/ali.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done
 
-
+utils/lang/check_phones_compatible.sh $lang/phones.txt $dir/phones.txt || exit 1;
 # Set up the unadapted features "$sifeats".
 if [ -f $dir/final.mat ]; then feat_type=lda; else feat_type=delta; fi
 echo "$0: feature type is $feat_type";

--- a/egs/wsj/s5/steps/get_lexicon_probs.sh
+++ b/egs/wsj/s5/steps/get_lexicon_probs.sh
@@ -58,6 +58,8 @@ mkdir -p $dir/log
 utils/split_data.sh $data $nj # Make sure split data-dir exists.
 sdata=$data/split$nj
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir/phones.txt || exit 1;
 
 mkdir -p $dir/log
 

--- a/egs/wsj/s5/steps/kl_hmm/build_tree.sh
+++ b/egs/wsj/s5/steps/kl_hmm/build_tree.sh
@@ -63,6 +63,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata=$data/split$nj;
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/make_denlats.sh
+++ b/egs/wsj/s5/steps/make_denlats.sh
@@ -59,6 +59,9 @@ mkdir -p $dir/log
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 oov=`cat $lang/oov.int` || exit 1;
 
 mkdir -p $dir

--- a/egs/wsj/s5/steps/make_denlats_sgmm.sh
+++ b/egs/wsj/s5/steps/make_denlats_sgmm.sh
@@ -54,6 +54,9 @@ mkdir -p $dir/log
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 oov=`cat $lang/oov.int` || exit 1;
 
 mkdir -p $dir

--- a/egs/wsj/s5/steps/make_denlats_sgmm2.sh
+++ b/egs/wsj/s5/steps/make_denlats_sgmm2.sh
@@ -66,6 +66,9 @@ oov=`cat $lang/oov.int` || exit 1;
 
 mkdir -p $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 cp -RH $lang $dir/
 
 # Compute grammar FST which corresponds to unigram decoding graph.

--- a/egs/wsj/s5/steps/make_phone_graph.sh
+++ b/egs/wsj/s5/steps/make_phone_graph.sh
@@ -65,6 +65,9 @@ set -e # exit on error status
 
 mkdir -p $dir/phone_graph
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 if [ $stage -le 0 ]; then
   echo "$0: creating phone LM-training data"
   gunzip -c $alidir/ali.*gz | ali-to-phones $alidir/final.mdl ark:- ark,t:- | \

--- a/egs/wsj/s5/steps/mixup.sh
+++ b/egs/wsj/s5/steps/mixup.sh
@@ -54,6 +54,9 @@ cp $srcdir/final.mat $dir
 echo $nj > $dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/tree $dir
 
 

--- a/egs/wsj/s5/steps/nnet/align.sh
+++ b/egs/wsj/s5/steps/nnet/align.sh
@@ -50,6 +50,9 @@ echo $nj > $dir/num_jobs
 sdata=$data/split$nj
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp $srcdir/{tree,final.mdl} $dir || exit 1;
 
 # Select default locations to model files

--- a/egs/wsj/s5/steps/nnet/make_denlats.sh
+++ b/egs/wsj/s5/steps/nnet/make_denlats.sh
@@ -60,6 +60,9 @@ oov=`cat $lang/oov.int` || exit 1;
 
 mkdir -p $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 cp -r $lang $dir/
 
 # Compute grammar FST which corresponds to unigram decoding graph.

--- a/egs/wsj/s5/steps/nnet/train.sh
+++ b/egs/wsj/s5/steps/nnet/train.sh
@@ -122,6 +122,10 @@ echo
 
 mkdir -p $dir/{log,nnet}
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir_cv/phones.txt
+cp $alidir/phones.txt $dir
+
 # skip when already trained,
 if [ -e $dir/final.nnet ]; then
   echo "SKIPPING TRAINING... ($0)"

--- a/egs/wsj/s5/steps/nnet/train_mmi.sh
+++ b/egs/wsj/s5/steps/nnet/train_mmi.sh
@@ -68,6 +68,11 @@ if ! $skip_cuda_check; then cuda-compiled || { echo "Error, CUDA not compiled-in
 
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt
+utils/lang/check_phones_compatible.sh $lang/phones.txt $denlatdir/phones.txt
+cp $alidir/phones.txt $dir
+
 cp $alidir/{final.mdl,tree} $dir
 
 silphonelist=`cat $lang/phones/silence.csl`

--- a/egs/wsj/s5/steps/nnet/train_mpe.sh
+++ b/egs/wsj/s5/steps/nnet/train_mpe.sh
@@ -72,6 +72,11 @@ if ! $skip_cuda_check; then cuda-compiled || { echo "Error, CUDA not compiled-in
 
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt
+utils/lang/check_phones_compatible.sh $lang/phones.txt $denlatdir/phones.txt
+cp $alidir/phones.txt $dir
+
 cp $alidir/{final.mdl,tree} $dir
 
 silphonelist=`cat $lang/phones/silence.csl`

--- a/egs/wsj/s5/steps/nnet2/align.sh
+++ b/egs/wsj/s5/steps/nnet2/align.sh
@@ -53,6 +53,9 @@ for f in $srcdir/tree $srcdir/${iter}.mdl $data/feats.scp $lang/L.fst $extra_fil
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt  $dir || exit 1;
+
 cp $srcdir/{tree,${iter}.mdl} $dir || exit 1;
 
 

--- a/egs/wsj/s5/steps/nnet2/convert_lda_to_raw.sh
+++ b/egs/wsj/s5/steps/nnet2/convert_lda_to_raw.sh
@@ -44,7 +44,7 @@ for f in $src/final.mdl $src/final.mat $src/splice_opts $src/cmvn_opts; do
   [ ! -f $f ] && echo "$0: expected file $f to exist" && exit 1
 done
 
-
+cp $src/phones.txt $dir/phones.txt || exit 1;
 mkdir -p $dir/log
 
 # nnet.config will be a config for a few trivial neural-network layers

--- a/egs/wsj/s5/steps/nnet2/convert_nnet1_to_nnet2.sh
+++ b/egs/wsj/s5/steps/nnet2/convert_nnet1_to_nnet2.sh
@@ -32,7 +32,7 @@ for f in $src/final.mdl $src/final.feature_transform $src/ali_train_pdf.counts; 
   [ ! -f $f ] && echo "$0: expected file $f to exist" && exit 1
 done
 
-
+cp $src/phones.txt $dir/phones.txt || exit 1;
 $cmd $dir/log/convert_feature_transform.log \
   nnet1-to-raw-nnet $src/final.feature_transform $dir/0.raw || exit 1;
 

--- a/egs/wsj/s5/steps/nnet2/get_egs.sh
+++ b/egs/wsj/s5/steps/nnet2/get_egs.sh
@@ -88,6 +88,8 @@ utils/split_data.sh $data $nj
 mkdir -p $dir/log
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 
 # Get list of validation utterances. 
 awk '{print $1}' $data/utt2spk | utils/shuffle_list.pl | head -$num_utts_subset \

--- a/egs/wsj/s5/steps/nnet2/get_egs_discriminative2.sh
+++ b/egs/wsj/s5/steps/nnet2/get_egs_discriminative2.sh
@@ -76,6 +76,7 @@ done
 
 mkdir -p $dir/log $dir/info || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
 
 nj=$(cat $denlatdir/num_jobs) || exit 1; # $nj is the number of
                                          # splits of the denlats and alignments.

--- a/egs/wsj/s5/steps/nnet2/get_lda.sh
+++ b/egs/wsj/s5/steps/nnet2/get_lda.sh
@@ -83,6 +83,10 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 [ -z "$transform_dir" ] && transform_dir=$alidir
 if [ -z "$cmvn_opts" ]; then
   cmvn_opts=`cat $alidir/cmvn_opts 2>/dev/null`

--- a/egs/wsj/s5/steps/nnet2/get_lda_block.sh
+++ b/egs/wsj/s5/steps/nnet2/get_lda_block.sh
@@ -65,6 +65,9 @@ echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 cmvn_opts=`cat $alidir/cmvn_opts 2>/dev/null`
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 ## Set up features.  Note: these are different from the normal features
 ## because we have one rspecifier that has the features for the entire
 ## training set, not separate ones for each batch.

--- a/egs/wsj/s5/steps/nnet2/make_denlats.sh
+++ b/egs/wsj/s5/steps/nnet2/make_denlats.sh
@@ -70,6 +70,9 @@ mkdir -p $dir/log
 split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 oov=`cat $lang/oov.int` || exit 1;
 
 cp -rH $lang $dir/

--- a/egs/wsj/s5/steps/nnet2/retrain_fast.sh
+++ b/egs/wsj/s5/steps/nnet2/retrain_fast.sh
@@ -145,6 +145,9 @@ echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 if [ $stage -le -3 ] && [ -z "$egs_dir" ]; then
   echo "$0: calling get_egs.sh"
   steps/nnet2/get_egs.sh --feat-type raw --cmvn-opts "--norm-means=false --norm-vars=false" \

--- a/egs/wsj/s5/steps/nnet2/retrain_simple2.sh
+++ b/egs/wsj/s5/steps/nnet2/retrain_simple2.sh
@@ -150,6 +150,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 
 
 if [ $stage -le -3 ] && [ -z "$egs_dir" ]; then

--- a/egs/wsj/s5/steps/nnet2/retrain_tanh.sh
+++ b/egs/wsj/s5/steps/nnet2/retrain_tanh.sh
@@ -99,6 +99,7 @@ num_jobs_nnet=`cat $egs_dir/num_jobs_nnet` || exit 1;
 iters_per_epoch=`cat $egs_dir/iters_per_epoch`  || exit 1;
 
 mkdir -p $dir/log
+cp $nnet_dir/phones.txt $dir || exit 1;
 
 cp $nnet_dir/splice_opts $dir 2>/dev/null
 cp $nnet_dir/final.mat $dir 2>/dev/null # any LDA matrix...

--- a/egs/wsj/s5/steps/nnet2/train_block.sh
+++ b/egs/wsj/s5/steps/nnet2/train_block.sh
@@ -150,6 +150,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 
 # Get list of validation utterances. 
 awk '{print $1}' $data/utt2spk | utils/shuffle_list.pl | head -$num_utts_subset \

--- a/egs/wsj/s5/steps/nnet2/train_convnet_accel2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_convnet_accel2.sh
@@ -207,6 +207,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_discriminative.sh
+++ b/egs/wsj/s5/steps/nnet2/train_discriminative.sh
@@ -122,6 +122,9 @@ fi
 mkdir -p $dir/log || exit 1;
 [ -z "$degs_dir" ] && mkdir -p $dir/degs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata=$data/split$nj
 utils/split_data.sh $data $nj
 

--- a/egs/wsj/s5/steps/nnet2/train_discriminative2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_discriminative2.sh
@@ -103,6 +103,7 @@ for f in $degs_dir/degs.1.ark $degs_dir/info/{num_archives,silence.csl,frames_pe
 done
 
 mkdir -p $dir/log || exit 1;
+cp $degs_dir/phones.txt $dir || exit 1;
 
 # copy some things
 for f in splice_opts cmvn_opts tree final.mat; do

--- a/egs/wsj/s5/steps/nnet2/train_pnorm.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm.sh
@@ -171,6 +171,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_accel2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_accel2.sh
@@ -184,6 +184,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_bottleneck_fast.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_bottleneck_fast.sh
@@ -169,6 +169,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_ensemble.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_ensemble.sh
@@ -157,6 +157,9 @@ splice_opts=`cat $alidir/splice_opts 2>/dev/null`
 cp $alidir/splice_opts $dir 2>/dev/null
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 if [ $stage -le -4 ]; then
   echo "$0: calling get_lda.sh"
   steps/nnet2/get_lda.sh $lda_opts --splice-width $splice_width --cmd "$cmd" $data $lang $alidir $dir || exit 1;

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_fast.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_fast.sh
@@ -170,6 +170,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_multisplice.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_multisplice.sh
@@ -182,6 +182,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 # process the splice_inds string, to get a layer-wise context string
 # to be processed by the nnet-components
 # this would be mainly used by SpliceComponent|SpliceMaxComponent

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_multisplice2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_multisplice2.sh
@@ -175,6 +175,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 # process the splice_inds string, to get a layer-wise context string
 # to be processed by the nnet-components
 # this would be mainly used by SpliceComponent|SpliceMaxComponent

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_simple.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_simple.sh
@@ -177,6 +177,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_pnorm_simple2.sh
+++ b/egs/wsj/s5/steps/nnet2/train_pnorm_simple2.sh
@@ -187,6 +187,9 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_tanh.sh
+++ b/egs/wsj/s5/steps/nnet2/train_tanh.sh
@@ -148,6 +148,9 @@ utils/split_data.sh $data $nj
 mkdir -p $dir/log
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/train_tanh_bottleneck.sh
+++ b/egs/wsj/s5/steps/nnet2/train_tanh_bottleneck.sh
@@ -158,6 +158,9 @@ cmvn_opts=`cat $alidir/cmvn_opts 2>/dev/null`
 cp $alidir/cmvn_opts $dir 2>/dev/null
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 truncate_comp_num=$[2*$num_hidden_layers+1]
 if [ $stage -le -4 ]; then
   echo "$0: calling get_lda.sh"

--- a/egs/wsj/s5/steps/nnet2/train_tanh_fast.sh
+++ b/egs/wsj/s5/steps/nnet2/train_tanh_fast.sh
@@ -162,6 +162,9 @@ utils/split_data.sh $data $nj
 mkdir -p $dir/log
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 extra_opts=()
 [ ! -z "$cmvn_opts" ] && extra_opts+=(--cmvn-opts "$cmvn_opts")
 [ ! -z "$feat_type" ] && extra_opts+=(--feat-type $feat_type)

--- a/egs/wsj/s5/steps/nnet2/update_nnet.sh
+++ b/egs/wsj/s5/steps/nnet2/update_nnet.sh
@@ -130,6 +130,9 @@ splice_opts=`cat $alidir/splice_opts 2>/dev/null`
 cp $alidir/splice_opts $dir 2>/dev/null
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 [ -z "$transform_dir" ] && transform_dir=$alidir
 
 if [ $stage -le -3 ] && [ -z "$egs_dir" ]; then

--- a/egs/wsj/s5/steps/nnet3/align.sh
+++ b/egs/wsj/s5/steps/nnet3/align.sh
@@ -69,7 +69,8 @@ done
 
 cp $srcdir/{tree,${iter}.mdl} $dir || exit 1;
 
-
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 ## Set up features.  Note: these are different from the normal features
 ## because we have one rspecifier that has the features for the entire
 ## training set, not separate ones for each batch.

--- a/egs/wsj/s5/steps/nnet3/chain/build_tree.sh
+++ b/egs/wsj/s5/steps/nnet3/chain/build_tree.sh
@@ -66,6 +66,9 @@ cp $alidir/splice_opts $dir 2>/dev/null # frame-splicing options.
 cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 cp $alidir/delta_opts $dir 2>/dev/null # delta option.
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/nnet3/get_egs_discriminative.sh
+++ b/egs/wsj/s5/steps/nnet3/get_egs_discriminative.sh
@@ -102,6 +102,9 @@ done
 
 mkdir -p $dir/log $dir/info || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 nj=$(cat $denlatdir/num_jobs) || exit 1;
 
 sdata=$data/split$nj

--- a/egs/wsj/s5/steps/nnet3/lstm/train.sh
+++ b/egs/wsj/s5/steps/nnet3/lstm/train.sh
@@ -224,7 +224,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
-
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 # First work out the feature and iVector dimension, needed for tdnn config creation.
 case $feat_type in
   raw) feat_dim=$(feat-to-dim --print-args=false scp:$data/feats.scp -) || \

--- a/egs/wsj/s5/steps/nnet3/make_denlats.sh
+++ b/egs/wsj/s5/steps/nnet3/make_denlats.sh
@@ -83,6 +83,9 @@ mkdir -p $dir/log
 split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 oov=`cat $lang/oov.int` || exit 1;
 
 cp -rH $lang $dir/

--- a/egs/wsj/s5/steps/nnet3/tdnn/train.sh
+++ b/egs/wsj/s5/steps/nnet3/tdnn/train.sh
@@ -162,7 +162,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
-
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 # First work out the feature and iVector dimension, needed for tdnn config creation.
 case $feat_type in
   raw) feat_dim=$(feat-to-dim --print-args=false scp:$data/feats.scp -) || \

--- a/egs/wsj/s5/steps/nnet3/train_tdnn.sh
+++ b/egs/wsj/s5/steps/nnet3/train_tdnn.sh
@@ -160,6 +160,8 @@ mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 cp $alidir/tree $dir
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 
 # First work out the feature and iVector dimension, needed for tdnn config creation.
 case $feat_type in

--- a/egs/wsj/s5/steps/online/nnet2/align.sh
+++ b/egs/wsj/s5/steps/online/nnet2/align.sh
@@ -52,6 +52,8 @@ for f in $srcdir/tree $srcdir/${iter}.mdl $data/wav.scp $lang/L.fst \
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 cp $srcdir/{tree,${iter}.mdl} $dir || exit 1;
 
 grep -v '^--endpoint' $srcdir/conf/online_nnet2_decoding.conf >$dir/feature.conf || exit 1;

--- a/egs/wsj/s5/steps/online/nnet2/get_egs_discriminative2.sh
+++ b/egs/wsj/s5/steps/online/nnet2/get_egs_discriminative2.sh
@@ -66,6 +66,8 @@ done
 
 mkdir -p $dir/log $dir/info || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
 
 nj=$(cat $denlatdir/num_jobs) || exit 1; # $nj is the number of
                                          # splits of the denlats and alignments.

--- a/egs/wsj/s5/steps/online/nnet2/make_denlats.sh
+++ b/egs/wsj/s5/steps/online/nnet2/make_denlats.sh
@@ -62,6 +62,9 @@ mkdir -p $dir/log
 split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 oov=`cat $lang/oov.int` || exit 1;
 
 

--- a/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding.sh
+++ b/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding.sh
@@ -76,6 +76,8 @@ if [ ! -z "$iedir" ]; then
   done
 fi
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 
 dir=$(readlink -f $dir) # Convert $dir to an absolute pathname, so that the
                         # configuration files we write will contain absolute

--- a/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding_transfer.sh
+++ b/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding_transfer.sh
@@ -44,6 +44,8 @@ dir=$(readlink -f $dir) # Convert $dir to an absolute pathname, so that the
                         # pathnames.
 mkdir -p $dir/conf $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $nnet_src/phones.txt || exit 1;
+cp $nnet_src/phones.txt $dir || exit 1;
 
 cp $nnet_src/tree $dir/ || exit 1;
 

--- a/egs/wsj/s5/steps/online/nnet3/prepare_online_decoding.sh
+++ b/egs/wsj/s5/steps/online/nnet3/prepare_online_decoding.sh
@@ -82,6 +82,8 @@ dir=$(readlink -f $dir) # Convert $dir to an absolute pathname, so that the
                         # pathnames.
 mkdir -p $dir/conf
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 
 cp $srcdir/${iter}.mdl $dir/final.mdl || exit 1;
 cp $srcdir/tree $dir/ || exit 1;

--- a/egs/wsj/s5/steps/online/prepare_online_decoding.sh
+++ b/egs/wsj/s5/steps/online/prepare_online_decoding.sh
@@ -77,6 +77,9 @@ sdata=$data/split$nj;
 mkdir -p $dir/log
 echo $nj >$dir/num_jobs || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 splice_opts=`cat $srcdir/splice_opts 2>/dev/null` 
 cmvn_opts=`cat $srcdir/cmvn_opts 2>/dev/null` 
 silphonelist=`cat $lang/phones/silence.csl` || exit 1;

--- a/egs/wsj/s5/steps/resegment_data.sh
+++ b/egs/wsj/s5/steps/resegment_data.sh
@@ -41,6 +41,9 @@ rm $data_out/* 2>/dev/null # Old stuff that's partial can cause problems later i
                            # thrown out.
 mkdir -p $dir/log || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $lang/phones.txt $alidir/ali.1.gz $alidir/num_jobs; do
   if [ ! -f $f ]; then 
     echo "$0: no such file $f"

--- a/egs/wsj/s5/steps/tandem/align_fmllr.sh
+++ b/egs/wsj/s5/steps/tandem/align_fmllr.sh
@@ -55,6 +55,9 @@ silphonelist=`cat $lang/phones/silence.csl` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj
 sdata2=$data2/split$nj
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/align_sgmm.sh
+++ b/egs/wsj/s5/steps/tandem/align_sgmm.sh
@@ -55,6 +55,9 @@ silphonelist=`cat $lang/phones/silence.csl` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 ## Set up features.
 
 sdata1=$data1/split$nj

--- a/egs/wsj/s5/steps/tandem/align_sgmm2.sh
+++ b/egs/wsj/s5/steps/tandem/align_sgmm2.sh
@@ -55,6 +55,9 @@ silphonelist=`cat $lang/phones/silence.csl` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj
 sdata2=$data2/split$nj
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/align_si.sh
+++ b/egs/wsj/s5/steps/tandem/align_si.sh
@@ -48,6 +48,8 @@ oov=`cat $lang/oov.int` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
 # Set up the features
 
 sdata1=$data1/split$nj

--- a/egs/wsj/s5/steps/tandem/make_denlats.sh
+++ b/egs/wsj/s5/steps/tandem/make_denlats.sh
@@ -50,6 +50,9 @@ dir=$5
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj
 sdata2=$data2/split$nj
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/make_denlats_sgmm.sh
+++ b/egs/wsj/s5/steps/tandem/make_denlats_sgmm.sh
@@ -52,6 +52,9 @@ splice_opts=`cat $srcdir/splice_opts 2>/dev/null`
 normft2=`cat $srcdir/normft2 2>/dev/null`
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj
 sdata2=$data2/split$nj
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/make_denlats_sgmm2.sh
+++ b/egs/wsj/s5/steps/tandem/make_denlats_sgmm2.sh
@@ -51,6 +51,9 @@ dir=$5
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+cp $srcdir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj
 sdata2=$data2/split$nj
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/train_deltas.sh
+++ b/egs/wsj/s5/steps/tandem/train_deltas.sh
@@ -56,6 +56,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 # Set up features
 
 sdata1=$data1/split$nj;

--- a/egs/wsj/s5/steps/tandem/train_lda_mllt.sh
+++ b/egs/wsj/s5/steps/tandem/train_lda_mllt.sh
@@ -74,6 +74,9 @@ ciphonelist=`cat $lang/phones/context_indep.csl` || exit 1;
 mkdir -p $dir/log
 echo $nj >$dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 
 # Set up features.
 

--- a/egs/wsj/s5/steps/tandem/train_mllt.sh
+++ b/egs/wsj/s5/steps/tandem/train_mllt.sh
@@ -74,6 +74,9 @@ ciphonelist=`cat $lang/phones/context_indep.csl` || exit 1;
 mkdir -p $dir/log
 echo $nj >$dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 
 # Set up features.
 

--- a/egs/wsj/s5/steps/tandem/train_mmi.sh
+++ b/egs/wsj/s5/steps/tandem/train_mmi.sh
@@ -48,6 +48,9 @@ dir=$6
 
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data1/feats.scp $data2/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/tandem/train_mmi_sgmm.sh
+++ b/egs/wsj/s5/steps/tandem/train_mmi_sgmm.sh
@@ -43,6 +43,9 @@ denlatdir=$5
 dir=$6
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data1/feats.scp $data2/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/tandem/train_mmi_sgmm2.sh
+++ b/egs/wsj/s5/steps/tandem/train_mmi_sgmm2.sh
@@ -42,6 +42,9 @@ denlatdir=$5
 dir=$6
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data1/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/tandem/train_mono.sh
+++ b/egs/wsj/s5/steps/tandem/train_mono.sh
@@ -49,6 +49,7 @@ oov_sym=`cat $lang/oov.int` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+cp $lang/phones.txt $dir || exit 1;
 
 # Set up features.
 

--- a/egs/wsj/s5/steps/tandem/train_sat.sh
+++ b/egs/wsj/s5/steps/tandem/train_sat.sh
@@ -65,6 +65,9 @@ ciphonelist=`cat $lang/phones/context_indep.csl` || exit 1;
 
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 
 sdata1=$data1/split$nj;

--- a/egs/wsj/s5/steps/tandem/train_sgmm.sh
+++ b/egs/wsj/s5/steps/tandem/train_sgmm.sh
@@ -82,6 +82,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj;
 sdata2=$data2/split$nj;
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/train_sgmm2.sh
+++ b/egs/wsj/s5/steps/tandem/train_sgmm2.sh
@@ -95,6 +95,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj;
 sdata2=$data2/split$nj;
 [[ -d $sdata1 && $data1/feats.scp -ot $sdata1 ]] || split_data.sh $data1 $nj || exit 1;

--- a/egs/wsj/s5/steps/tandem/train_ubm.sh
+++ b/egs/wsj/s5/steps/tandem/train_ubm.sh
@@ -59,6 +59,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata1=$data1/split$nj;
 sdata2=$data2/split$nj;
 

--- a/egs/wsj/s5/steps/train_deltas.sh
+++ b/egs/wsj/s5/steps/train_deltas.sh
@@ -58,6 +58,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata=$data/split$nj;
 split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_diag_ubm.sh
+++ b/egs/wsj/s5/steps/train_diag_ubm.sh
@@ -58,6 +58,9 @@ mkdir -p $dir/log
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 if [ -f $alidir/final.mat ]; then feat_type=lda; else feat_type=delta; fi
 echo "$0: feature type is $feat_type"
 

--- a/egs/wsj/s5/steps/train_lda_mllt.sh
+++ b/egs/wsj/s5/steps/train_lda_mllt.sh
@@ -70,6 +70,10 @@ silphonelist=`cat $lang/phones/silence.csl` || exit 1;
 ciphonelist=`cat $lang/phones/context_indep.csl` || exit 1;
 
 mkdir -p $dir/log
+
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 echo "$splice_opts" >$dir/splice_opts # keep track of frame-splicing options
            # so that later stages of system building can know what they were.

--- a/egs/wsj/s5/steps/train_lvtln.sh
+++ b/egs/wsj/s5/steps/train_lvtln.sh
@@ -78,6 +78,9 @@ splice_opts=`cat $alidir/splice_opts 2>/dev/null`
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata=$data/split$nj;
 split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_map.sh
+++ b/egs/wsj/s5/steps/train_map.sh
@@ -60,6 +60,9 @@ delta_opts=`cat $alidir/delta_opts 2>/dev/null`
 
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 cp $alidir/tree $dir
 # link ali.*.gz from $alidir to dest directory.
 utils/ln.pl $alidir/ali.*.gz $dir

--- a/egs/wsj/s5/steps/train_mmi.sh
+++ b/egs/wsj/s5/steps/train_mmi.sh
@@ -47,6 +47,9 @@ denlatdir=$4
 dir=$5
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/train_mmi_fmmi.sh
+++ b/egs/wsj/s5/steps/train_mmi_fmmi.sh
@@ -65,6 +65,9 @@ dir=$6
 silphonelist=`cat $lang/phones/silence.csl`
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $lang/phones.txt $dubmdir/final.dubm $alidir/final.mdl \
     $alidir/ali.1.gz $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "Expected file $f to exist" && exit 1;

--- a/egs/wsj/s5/steps/train_mmi_fmmi_indirect.sh
+++ b/egs/wsj/s5/steps/train_mmi_fmmi_indirect.sh
@@ -63,6 +63,9 @@ dir=$6
 silphonelist=`cat $lang/phones/silence.csl`
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $lang/phones.txt $dubmdir/final.dubm $alidir/final.mdl \
   $alidir/ali.1.gz $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "Expected file $f to exist" && exit 1;

--- a/egs/wsj/s5/steps/train_mmi_sgmm.sh
+++ b/egs/wsj/s5/steps/train_mmi_sgmm.sh
@@ -41,6 +41,9 @@ denlatdir=$4
 dir=$5
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/train_mmi_sgmm2.sh
+++ b/egs/wsj/s5/steps/train_mmi_sgmm2.sh
@@ -41,6 +41,9 @@ denlatdir=$4
 dir=$5
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/train_mono.sh
+++ b/egs/wsj/s5/steps/train_mono.sh
@@ -50,6 +50,7 @@ echo $nj > $dir/num_jobs
 sdata=$data/split$nj;
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+cp $lang/phones.txt $dir || exit 1;
 
 $norm_vars && cmvn_opts="--norm-vars=true $cmvn_opts"
 echo $cmvn_opts  > $dir/cmvn_opts # keep track of options to CMVN.

--- a/egs/wsj/s5/steps/train_mpe.sh
+++ b/egs/wsj/s5/steps/train_mpe.sh
@@ -46,6 +46,9 @@ denlatdir=$4
 dir=$5
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/train_quick.sh
+++ b/egs/wsj/s5/steps/train_quick.sh
@@ -68,6 +68,9 @@ cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 cp $alidir/delta_opts $dir 2>/dev/null
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 ## Set up features.
 if [ -f $alidir/final.mat ]; then feat_type=lda; else feat_type=delta; fi
 echo "$0: feature type is $feat_type"

--- a/egs/wsj/s5/steps/train_raw_sat.sh
+++ b/egs/wsj/s5/steps/train_raw_sat.sh
@@ -75,6 +75,9 @@ mkdir -p $dir/log
 cp $alidir/splice_opts $dir 2>/dev/null # frame-splicing options.
 cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_sat.sh
+++ b/egs/wsj/s5/steps/train_sat.sh
@@ -81,6 +81,9 @@ cp $alidir/splice_opts $dir 2>/dev/null # frame-splicing options.
 cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 cp $alidir/delta_opts $dir 2>/dev/null # delta option.
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_sat_basis.sh
+++ b/egs/wsj/s5/steps/train_sat_basis.sh
@@ -70,6 +70,9 @@ cp $alidir/splice_opts $dir 2>/dev/null # frame-splicing options.
 cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 cp $alidir/delta_opts $dir 2>/dev/null
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 echo $nj >$dir/num_jobs
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_segmenter.sh
+++ b/egs/wsj/s5/steps/train_segmenter.sh
@@ -54,6 +54,9 @@ nj=`cat $alidir/num_jobs` || exit 1;
 mkdir -p $dir/log
 echo $nj > $dir/num_jobs
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 sdata=$data/split$nj;
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 

--- a/egs/wsj/s5/steps/train_sgmm.sh
+++ b/egs/wsj/s5/steps/train_sgmm.sh
@@ -85,6 +85,9 @@ cmvn_opts=`cat $alidir/cmvn_opts 2>/dev/null`
 cp $alidir/splice_opts $dir 2>/dev/null
 cp $alidir/cmvn_opts $dir 2>/dev/null # cmn/cmvn option.
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
 spkvecs_opt=  # Empty option for now, until we estimate the speaker vectors.

--- a/egs/wsj/s5/steps/train_sgmm2.sh
+++ b/egs/wsj/s5/steps/train_sgmm2.sh
@@ -99,6 +99,9 @@ echo $nj > $dir/num_jobs
 sdata=$data/split$nj;
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 spkvecs_opt=  # Empty option for now, until we estimate the speaker vectors.
 gselect_opt="--gselect=ark,s,cs:gunzip -c $dir/gselect.JOB.gz|"
 

--- a/egs/wsj/s5/steps/train_sgmm2_group.sh
+++ b/egs/wsj/s5/steps/train_sgmm2_group.sh
@@ -104,6 +104,9 @@ echo $nj > $dir/num_jobs
 sdata=$data/split$nj;
 [[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 spkvecs_opt=  # Empty option for now, until we estimate the speaker vectors.
 gselect_opt="--gselect=ark,s,cs:gunzip -c $dir/gselect.JOB.gz|"
 

--- a/egs/wsj/s5/steps/train_smbr.sh
+++ b/egs/wsj/s5/steps/train_smbr.sh
@@ -46,6 +46,9 @@ denlatdir=$4
 dir=$5
 mkdir -p $dir/log
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 for f in $data/feats.scp $alidir/{tree,final.mdl,ali.1.gz} $denlatdir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: no such file $f" && exit 1;
 done

--- a/egs/wsj/s5/steps/train_ubm.sh
+++ b/egs/wsj/s5/steps/train_ubm.sh
@@ -65,6 +65,9 @@ splice_opts=`cat $alidir/splice_opts 2>/dev/null` # frame-splicing options.
 cmvn_opts=`cat $alidir/cmvn_opts 2>/dev/null`
 delta_opts=`cat $alidir/delta_opts 2>/dev/null`
 
+utils/lang/check_phones_compatible.sh $lang/phones.txt $alidir/phones.txt || exit 1;
+cp $alidir/phones.txt $dir || exit 1;
+
 ## Set up features.
 if [ -f $alidir/final.mat ]; then feat_type=lda; else feat_type=delta; fi
 echo "$0: feature type is $feat_type"

--- a/egs/wsj/s5/utils/lang/check_phones_compatible.sh
+++ b/egs/wsj/s5/utils/lang/check_phones_compatible.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright 2016 Hang Lyu
+
+# Licensed udner the Apache License, Version 2.0 (the "Lincense");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OF IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+# This script exits with status zero if the phone symbols tables are the same
+# except for possible differences in disambiguation symbols (meaning that all
+# symbols except those beginning with a # are mapped to the same values).
+# Otherwise it prints a warning and exits with status 1.
+# For the sake of compatibility with other scripts that did not write the 
+# phones.txt to model directories, this script exits silently with status 0 
+# if one of the phone symbol tables does not exist.
+# For the sake of compatibility with other scripts that did not write the 
+# phones.txt to model directories, this script exits silently with status 0 
+# if one of the phone symbol tables does not exist.
+
+. utils/parse_options.sh || exit 1;
+
+if [ $# -ne 2 ]; then
+  echo "Usage: utils/lang/check_phones_compatible.sh <phones-symbol-table1> <phones-symbol-table2>"
+  echo "e.g.: utils/lang/check_phones_compatible.sh data/lang/phones.txt exp/tri3/phones.txt"
+  exit 1;
+fi
+
+table_first=$1
+table_second=$2
+
+# check the files exist or not 
+if [ ! -f $table_first ]; then
+  if [ ! -f $table_second ]; then
+    echo "$0: Error! Both of the two phones-symbol tables are absent."
+    echo "Please check your command"
+    exit 1;
+  else
+    #The phones-symbol-table1 is absent. The model directory maybe created by old script.
+    #For back compatibility, this script exits silently with status 0.
+    exit 0;
+  fi
+elif [ ! -f $table_second ]; then
+  #The phones-symbol-table2 is absent. The model directory maybe created by old script.
+  #For back compatibility, this script exits silently with status 0.
+  exit 0;
+fi
+
+#Check the two tables are same or not (except for possible difference in disambiguation symbols).
+if ! cmp -s <(grep -v "^#" $table_first) <(grep -v "^#" $table_second); then
+  echo "$0: phone symbol tables $table_first and $table_second are not compatible."
+  exit 1;
+fi
+
+exit 0;


### PR DESCRIPTION
@danpovey 
I have fininshed the shell script-- utils/lang/check_phones_compatible.sh. Firstly, this script will check the arguments in different conditions. Then, This script can judge whether the two phone symbol tables are same or not (except for possible differences in disambiguation symbols). 
I have tested it with four different phones.txt. (swbd_phones.txt; swbd_phones_withoutdisam.txt; swbd_phones_fewdisam.txt and timit_phones.txt). All  branches of the script were tested. Everything goes smoothly.

After that, I traverse all the files in wsj/s5/steps 
and add the command
utils/lang/check_phones_compatible.sh $lang/phones.txt $dir/phones.txt if set -e was done,
or utils/lang/check_phones_compatible.sh $lang/phones.txt $dir/phones.txt || exit 1 otherwise.
if any scripts that take a lang directory and a model or alignment directory.

At the same time, I will copy the phones.txt to the new directory if the scripts create new directory.
The command looks like: cp $alidir/phones.txt $dir || exit 1;

I'm not sure if this can accord with your standard. Thank you for your advice and guidance.
Hang 
 