### PR TITLE
Speed up LogSoftmaxComponent::Backprop

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -240,8 +240,8 @@ void cudaF_tanh(dim3 Gr, dim3 Bl, float *y, const float *x, MatrixDim d,
 void cudaF_diff_tanh(dim3 Gr, dim3 Bl, float *eout, const float *e,
                      const float *y, MatrixDim d, int e_stride, int y_stride);
 void cudaF_parametric_relu(dim3 Gr, dim3 Bl, float *y, const float *x,
-                           MatrixDim d, int src_stride,
-                           const float *a, const float *b);
+                           MatrixDim d, int src_stride, const float *a,
+                           const float *b);
 void cudaF_diff_parametric_relu(dim3 Gr, dim3 Bl, float *eout, const float *e,
                                 const float *y, MatrixDim d, int e_stride,
                                 int y_stride, const float *a, const float *b);
@@ -263,6 +263,10 @@ void cudaF_randomize(dim3 Gr, dim3 Bl, float *y, const float *x,
                      MatrixDim d_in);
 void cudaF_splice(dim3 Gr, dim3 Bl, float *y, const float *x,
                   const int32_cuda *off, MatrixDim d_out, MatrixDim d_in);
+void cudaF_diff_log_softmax(dim3 Gr, dim3 Bl, const MatrixDim in_deriv_dim,
+                            const float* out_value, const int out_value_stride,
+                            const float* out_deriv, const int out_deriv_stride,
+                            float* in_deriv);
 void cudaF_one(int Gr, int Bl, float* x, int dim);
 void cudaF_copy(dim3 Gr, dim3 Bl, float *y, const float *x,
                 const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);
@@ -508,8 +512,8 @@ void cudaD_tanh(dim3 Gr, dim3 Bl, double *y, const double *x, MatrixDim d,
 void cudaD_diff_tanh(dim3 Gr, dim3 Bl, double *eout, const double *e,
                      const double *y, MatrixDim d, int e_stride, int y_stride);
 void cudaD_parametric_relu(dim3 Gr, dim3 Bl, double *y, const double *x,
-                           MatrixDim d, int src_stride,
-                           const double *a, const double *b);
+                           MatrixDim d, int src_stride, const double *a,
+                           const double *b);
 void cudaD_diff_parametric_relu(dim3 Gr, dim3 Bl, double *eout, const double *e,
                                 const double *y, MatrixDim d, int e_stride,
                                 int y_stride, const double *a, const double *b);
@@ -531,6 +535,10 @@ void cudaD_randomize(dim3 Gr, dim3 Bl, double *y, const double *x,
                      MatrixDim d_in);
 void cudaD_splice(dim3 Gr, dim3 Bl, double *y, const double *x,
                   const int32_cuda *off, MatrixDim d_out, MatrixDim d_in);
+void cudaD_diff_log_softmax(dim3 Gr, dim3 Bl, const MatrixDim in_deriv_dim,
+                            const double* out_value, const int out_value_stride,
+                            const double* out_deriv, const int out_deriv_stride,
+                            double* in_deriv);
 void cudaD_one(int Gr, int Bl, double* x, int dim);
 void cudaD_copy(dim3 Gr, dim3 Bl, double *y, const double *x,
                 const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -601,6 +601,15 @@ inline void cuda_diff_softmax(dim3 Gr, dim3 Bl, float* x, const MatrixDim dim,
                               const float* diff, const int diff_stride) {
   cudaF_diff_softmax(Gr, Bl, x, dim, value, value_stride, diff, diff_stride);
 }
+inline void cuda_diff_log_softmax(dim3 Gr, dim3 Bl,
+                                  const MatrixDim in_deriv_dim,
+                                  const float* out_value,
+                                  const int out_value_stride,
+                                  const float* out_deriv,
+                                  const int out_deriv_stride, float* in_deriv) {
+  cudaF_diff_log_softmax(Gr, Bl, in_deriv_dim, out_value, out_value_stride,
+                         out_deriv, out_deriv_stride, in_deriv);
+}
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, float *mat_out,
                                     MatrixDim d_out, const float *v_in) {
   cudaF_copy_rows_from_vec(Gr, Bl, mat_out, d_out, v_in);
@@ -1133,6 +1142,16 @@ inline void cuda_diff_softmax(dim3 Gr, dim3 Bl, double* x, const MatrixDim dim,
                               const double* value, const int value_stride,
                               const double* diff, const int diff_stride) {
   cudaD_diff_softmax(Gr, Bl, x, dim, value, value_stride, diff, diff_stride);
+}
+inline void cuda_diff_log_softmax(dim3 Gr, dim3 Bl,
+                                  const MatrixDim in_deriv_dim,
+                                  const double* out_value,
+                                  const int out_value_stride,
+                                  const double* out_deriv,
+                                  const int out_deriv_stride,
+                                  double* in_deriv) {
+  cudaD_diff_log_softmax(Gr, Bl, in_deriv_dim, out_value, out_value_stride,
+                         out_deriv, out_deriv_stride, in_deriv);
 }
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, double *mat_out,
                                     MatrixDim d_out, const double *v_in) {

--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -458,7 +458,6 @@ template<typename Real> void TestCuMatrixMulRowsGroupMat(int32 dim) {
             << dim << ", speed was " << gflops << " gigaflops.";
 }
 
-
 template<typename Real> void TestCuMatrixDiffSoftmax(int32 dim) {
   BaseFloat time_in_secs = 0.025;
   CuMatrix<Real> M(dim, dim), N(dim, dim), L(dim, dim);
@@ -474,6 +473,24 @@ template<typename Real> void TestCuMatrixDiffSoftmax(int32 dim) {
   BaseFloat fdim = dim;
   BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
   KALDI_LOG << "For CuMatrix::DiffSoftmaxPerRow" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+}
+
+template<typename Real> void TestCuMatrixDiffLogSoftmax(int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  CuMatrix<Real> M(dim, dim), N(dim, dim), L(dim, dim);
+  M.SetRandn();
+  N.SetRandn();
+  L.SetRandn();
+  Timer tim;
+  int32 iter = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+    N.DiffLogSoftmaxPerRow(M, L);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuMatrix::DiffLogSoftmaxPerRow" << NameOf<Real>() << ", for dim = "
             << dim << ", speed was " << gflops << " gigaflops.";
 }
 
@@ -1021,6 +1038,8 @@ template<typename Real> void CudaMatrixSpeedTest() {
     TestCuMatrixSoftmax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixDiffSoftmax<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixDiffLogSoftmax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixLogSoftmax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1690,7 +1690,6 @@ void CuMatrixBase<Real>::DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
         value.Stride(), diff.Data(), diff.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1708,6 +1707,50 @@ void CuMatrixBase<Real>::DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
   }
 }
 
+template<typename Real>
+void CuMatrixBase<Real>::DiffLogSoftmaxPerRow(const CuMatrixBase<Real> &value,
+                                              const CuMatrixBase<Real> &diff) {
+
+  KALDI_ASSERT(SameDim(value, diff) && SameDim(value, *this));
+
+//#if HAVE_CUDA == 1
+//  if (CuDevice::Instantiate().Enabled()) {
+//    Timer tim;
+//
+//    // CUDA thread layout: one thread block per matrix-row.
+//    dim3 dimBlock(CU1DBLOCK);
+//    dim3 dimGrid(num_rows_);
+//    cuda_diff_log_softmax(dimGrid, dimBlock, data_, this->Dim(), value.Data(),
+//        value.Stride(), diff.Data(), diff.Stride());
+//    CU_SAFE_CALL(cudaGetLastError());
+//
+//    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+//  } else
+//#endif
+  {
+    /*
+     Let the output be y, then
+     y_i = x_i - log(sum_i exp(x_i))
+     where x_i is the input to the component. The Jacobian matrix of this
+     function is
+     J = I - 1 exp(y^T)
+     where 1 is a vector of ones. Let the derivative vector at the output be e,
+     and at the input be d, then we have
+     d = e - exp(y) Sum(e)
+     d_i = e_i - exp(y_i) Sum(e)
+     */
+    const CuMatrixBase<Real> &Y(value), &E(diff);
+    CuMatrixBase<Real> &D(*this);
+
+    D.CopyFromMat(Y);
+    D.ApplyExp();                           // exp(y)
+    CuVector<Real> E_sum(D.NumRows()); // Initializes to zero
+    E_sum.AddColSumMat(1.0, E);             // Sum(e)
+    D.MulRowsVec(E_sum);                    // exp(y) Sum(e)
+    D.Scale(-1.0);                          // - exp(y) Sum(e)
+    D.AddMat(1.0, E, kNoTrans);             // e - exp(y_i) Sum(e)
+  }
+}
 
 template<typename Real>
 void CuMatrixBase<Real>::DiffXent(const CuArray<int32> &tgt,

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -336,6 +336,13 @@ class CuMatrixBase {
   void DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
                          const CuMatrixBase<Real> &diff);
 
+  /// Differentiate backward through the log softmax function.  Here, "value" is the
+  /// log softmax output. Does, for each row i,
+  /// *this(i) =  diff(i) - sum(diff(i)) .* exp(value(i))
+  /// xxxx(i) is row-vector.
+  void DiffLogSoftmaxPerRow(const CuMatrixBase<Real> &value,
+                            const CuMatrixBase<Real> &diff);
+
   /// Differentiate the block [softmax+cross-entropy] :
   /// dE/da = posterior_mat - target_mat,
   /// 'E' is error function, 'a' is activation on softmax input

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -336,12 +336,12 @@ class CuMatrixBase {
   void DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
                          const CuMatrixBase<Real> &diff);
 
-  /// Differentiate backward through the log softmax function.  Here, "value" is the
-  /// log softmax output. Does, for each row i,
-  /// *this(i) =  diff(i) - sum(diff(i)) .* exp(value(i))
+  /// Differentiate backward through the log softmax function.
+  /// Here, "out_value" is the log softmax output. Does, for each row i,
+  /// *this(i) =  out_deriv(i) - sum(out_deriv(i)) .* exp(out_value(i))
   /// xxxx(i) is row-vector.
-  void DiffLogSoftmaxPerRow(const CuMatrixBase<Real> &value,
-                            const CuMatrixBase<Real> &diff);
+  void DiffLogSoftmaxPerRow(const CuMatrixBase<Real> &out_value,
+                            const CuMatrixBase<Real> &out_deriv);
 
   /// Differentiate the block [softmax+cross-entropy] :
   /// dE/da = posterior_mat - target_mat,

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -1003,16 +1003,8 @@ void LogSoftmaxComponent::Backprop(const ChunkInfo &in_info,
   */
   in_deriv->Resize(out_deriv.NumRows(), out_deriv.NumCols());
   KALDI_ASSERT(SameDim(out_value, out_deriv) && SameDim(out_value, *in_deriv));
-  const CuMatrixBase<BaseFloat> &Y(out_value), &E(out_deriv);
-  CuMatrixBase<BaseFloat> &D (*in_deriv);
 
-  D.CopyFromMat(Y);
-  D.ApplyExp();                           // exp(y)
-  CuVector<BaseFloat> E_sum(D.NumRows()); // Initializes to zero
-  E_sum.AddColSumMat(1.0, E);             // Sum(e)
-  D.MulRowsVec(E_sum);                    // exp(y) Sum(e)
-  D.Scale(-1.0);                          // - exp(y) Sum(e)
-  D.AddMat(1.0, E, kNoTrans);             // e - exp(y_i) Sum(e)
+  in_deriv->DiffLogSoftmaxPerRow(out_value, out_deriv);
 
   // Updates stats.
   if (to_update != NULL) {

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -3018,28 +3018,7 @@ void LogSoftmaxComponent::Backprop(const std::string &debug_info,
                                    CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv == NULL)
     return;
-
-  /*
-    Let the output be y, then
-      y_i = x_i - log(sum_i exp(x_i))
-    where x_i is the input to the component. The Jacobian matrix of this
-    function is
-      J = I - 1 exp(y^T)
-    where 1 is a vector of ones. Let the derivative vector at the output be e,
-    and at the input be d, then we have
-      d = e - exp(y) Sum(e)
-      d_i = e_i - exp(y_i) Sum(e)
-  */
-  const CuMatrixBase<BaseFloat> &Y(out_value), &E(out_deriv);
-  CuMatrixBase<BaseFloat> &D (*in_deriv);
-
-  D.CopyFromMat(Y);
-  D.ApplyExp();                           // exp(y)
-  CuVector<BaseFloat> E_sum(D.NumRows()); // Initializes to zero
-  E_sum.AddColSumMat(1.0, E);             // Sum(e)
-  D.MulRowsVec(E_sum);                    // exp(y) Sum(e)
-  D.Scale(-1.0);                          // - exp(y) Sum(e)
-  D.AddMat(1.0, E, kNoTrans);             // e - exp(y_i) Sum(e)
+  in_deriv->DiffLogSoftmaxPerRow(out_value, out_deriv);
 }
 
 


### PR DESCRIPTION
Speed up by merging multiple kernels into one.
All GPU tests have passed.

```
Benchmark (gflops)                      dim  old     new    speedup
CuMatrix::DiffLogSoftmaxPerRow<float>,   16  0.0022  0.0153 7.03x
CuMatrix::DiffLogSoftmaxPerRow<float>,   32  0.0087  0.0577 6.66x
CuMatrix::DiffLogSoftmaxPerRow<float>,   64  0.0353  0.2678 7.59x
CuMatrix::DiffLogSoftmaxPerRow<float>,  128  0.1347  0.8785 6.52x
CuMatrix::DiffLogSoftmaxPerRow<float>,  256  0.4920  2.8799 5.85x
CuMatrix::DiffLogSoftmaxPerRow<float>,  512  1.3416  6.2052 4.63x
CuMatrix::DiffLogSoftmaxPerRow<float>, 1024  2.4438 10.4197 4.26x
CuMatrix::DiffLogSoftmaxPerRow<double>,   16  0.0019  0.0140 7.22x
CuMatrix::DiffLogSoftmaxPerRow<double>,   32  0.0073  0.0573 7.83x
CuMatrix::DiffLogSoftmaxPerRow<double>,   64  0.0282  0.1971 6.98x
CuMatrix::DiffLogSoftmaxPerRow<double>,  128  0.1113  0.7518 6.75x
CuMatrix::DiffLogSoftmaxPerRow<double>,  256  0.3945  2.4320 6.16x
CuMatrix::DiffLogSoftmaxPerRow<double>,  512  0.9307  4.5303 4.87x
CuMatrix::DiffLogSoftmaxPerRow<double>, 1024  1.5232  5.4336 3.57x
```