### PR TITLE
Check that the `which` command exists

### DIFF
--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -12,6 +12,11 @@ function add_packages {
   opensuse_packages="$opensuse_packages $3";
 }
 
+if ! which -v >/dev/null 2>&1; then
+  echo "$0: which is not installed."
+  add_packages which which which
+fi
+
 if ! which g++ >&/dev/null; then
   echo "$0: g++ is not installed."
   add_packages gcc-c++ g++ gcc-c++


### PR DESCRIPTION
check_dependencies.sh depends on `which`, but some distributions, such as those intended for use with Docker, do not include it. Check to see if is installed.