### PR TITLE
Add self-loop-scale warning

### DIFF
--- a/egs/wsj/s5/steps/lmrescore.sh
+++ b/egs/wsj/s5/steps/lmrescore.sh
@@ -98,6 +98,8 @@ case "$mode" in
      # grammar and transition weights.
     mdl=`dirname $indir`/final.mdl
     [ ! -f $mdl ] && echo No such model $mdl && exit 1;
+    [[ -f `dirname $indir`/frame_subsampling_factor && $self_loop_scale != 1.0 ]] && \
+      echo "$0: WARNING: chain models need '--self-loop-scale 1.0'";
     $cmd JOB=1:$nj $outdir/log/rescorelm.JOB.log \
       gunzip -c $indir/lat.JOB.gz \| \
       lattice-scale --lm-scale=0.0 ark:- ark:- \| \

--- a/egs/wsj/s5/utils/mkgraph.sh
+++ b/egs/wsj/s5/utils/mkgraph.sh
@@ -67,6 +67,9 @@ if [[ $context == mono && ($N != 1 || $P != 0) || \
   exit 1
 fi
 
+[[ -f $2/frame_subsampling_factor && $loopscale != 1.0 ]] && \
+  echo "$0: WARNING: chain models need '--self-loop-scale 1.0'";
+
 mkdir -p $lang/tmp
 # Note: [[ ]] is like [ ] but enables certain extra constructs, e.g. || in
 # place of -o


### PR DESCRIPTION
When using mkgraph or doing rescoring with chain models a self-loop-scale
of 1.0 should be used. Show a warning when chain models are used, but the
self-loop-scale is not set to 1.0.

Resolves #1049 