### PR TITLE
removing direct links for subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ For HOT news about Kaldi see [the project site](http://kaldi-asr.org/).
 [Kaldi forums and mailing lists](http://kaldi-asr.org/forums.html):
 - User list kaldi-help:
     [Web interface/archive](https://groups.google.com/forum/#!forum/kaldi-help) ||
-    [Subscribe] (mailto:kaldi-help+subscribe@googlegroups.com) ||
-    [Post] (mailto:kaldi-help@googlegroups.com)
 - Developer list kaldi-developers:
     [Web interface/archive](https://groups.google.com/forum/#!forum/kaldi-developers) ||
-    [Subscribe] (mailto:kaldi-developers+subscribe@googlegroups.com) ||
-    [Post] (mailto:kaldi-developers@googlegroups.com)
 - Also try luck and search in [SourceForge archives](https://sourceforge.net/p/kaldi/discussion/).
 
 Development pattern for contributors

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ For HOT news about Kaldi see [the project site](http://kaldi-asr.org/).
 - Doxygen reference of the C++ code.
 
 [Kaldi forums and mailing lists](http://kaldi-asr.org/forums.html):
-- User list kaldi-help:
-    [Web interface/archive](https://groups.google.com/forum/#!forum/kaldi-help) ||
+We have two different lists
+- User list kaldi-help
 - Developer list kaldi-developers:
-    [Web interface/archive](https://groups.google.com/forum/#!forum/kaldi-developers) ||
-- Also try luck and search in [SourceForge archives](https://sourceforge.net/p/kaldi/discussion/).
+
+To sign up to any of those mailing lists, go to
+[http://kaldi-asr.org/forums.html](http://kaldi-asr.org/forums.html):
+
 
 Development pattern for contributors
 ------------------------------------


### PR DESCRIPTION
I'm proposing to remove the direct links for emailing the group and subscription.
So far, I get around 80 percent of the requests without reason filled out, despite the fact it's explicitly mentioned in bold on the kaldi-asr.org/forums.html.
I'm hoping that this percentage is this high just because there is some other way how to create the subscription request :(