### PR TITLE
Set -o pipefail for lmrescore.sh

### DIFF
--- a/egs/wsj/s5/steps/lmrescore.sh
+++ b/egs/wsj/s5/steps/lmrescore.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 # Begin configuration section.
 mode=4
 cmd=run.pl


### PR DESCRIPTION
Prevent silenced errors in lmrescore.sh

See email thread "Differences between normal and const-arpa rescoring"