### PR TITLE
Unk model

### DIFF
--- a/egs/tedlium/s5_r2/local/run_unk_model.sh
+++ b/egs/tedlium/s5_r2/local/run_unk_model.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+
+utils/lang/make_unk_lm.sh data/local/dict exp/unk_lang_model
+
+utils/prepare_lang.sh --unk-fst data/make_unk/unk_fst.txt data/local/dict "<unk>" data/local/lang data/lang_unk
+
+cp data/lang/G.fst data/lang_unk/G.fst
+
+utils/mkgraph.sh data/lang_unk exp/tri3 exp/tri3/graph_unk
+
+. ./cmd.sh
+
+## Caution: if you use this unk-model stuff, be sure that the scoring script
+## does not use lattice-align-words-lexicon, because it's not compatible with
+## the unk-model.  Instead you should use lattice-align-words (of course, this
+## only works if you have position-dependent phones).
+
+decode_nj=30
+for dset in dev test; do
+    steps/decode_fmllr.sh --nj $decode_nj --cmd "$decode_cmd"  --num-threads 4 \
+      exp/tri3/graph_unk data/${dset} exp/tri3/decode_${dset}_unk
+    steps/lmrescore_const_arpa.sh --cmd "$decode_cmd" data/lang data/lang_rescore \
+       data/${dset} exp/tri3/decode_${dset}_unk exp/tri3/decode_${dset}_unk_rescore
+done
+
+# for x in exp/tri3/decode*; do grep Sum $x/*/*ys | utils/best_wer.sh ; done | grep -v old | grep -v si
+
+# dev results.  unk-model helps slightly before rescoring.
+%WER 19.3 | 507 17783 | 83.7 11.6 4.7 3.0 19.3 91.5 | -0.076 | exp/tri3/decode_dev/score_17_0.0/ctm.filt.filt.sys
+%WER 18.2 | 507 17783 | 84.8 10.7 4.5 3.0 18.2 91.3 | -0.111 | exp/tri3/decode_dev_rescore/score_16_0.0/ctm.filt.filt.sys
+%WER 19.1 | 507 17783 | 83.7 11.3 5.1 2.8 19.1 91.9 | -0.044 | exp/tri3/decode_dev_unk/score_17_0.0/ctm.filt.filt.sys
+%WER 18.2 | 507 17783 | 84.5 10.6 4.9 2.8 18.2 91.5 | -0.047 | exp/tri3/decode_dev_unk_rescore/score_15_0.0/ctm.filt.filt.sys
+
+
+# dev results.  unk-model helps slightly after rescoring.
+%WER 17.3 | 1155 27500 | 85.0 11.5 3.5 2.4 17.3 86.9 | -0.035 | exp/tri3/decode_test/score_15_0.0/ctm.filt.filt.sys
+%WER 16.6 | 1155 27500 | 85.8 11.0 3.2 2.4 16.6 86.4 | -0.098 | exp/tri3/decode_test_rescore/score_14_0.0/ctm.filt.filt.sys
+%WER 17.3 | 1155 27500 | 84.9 11.3 3.8 2.2 17.3 87.4 | -0.015 | exp/tri3/decode_test_unk/score_15_0.0/ctm.filt.filt.sys
+%WER 16.5 | 1155 27500 | 85.7 10.7 3.6 2.2 16.5 86.7 | -0.075 | exp/tri3/decode_test_unk_rescore/score_14_0.0/ctm.filt.filt.sys

--- a/egs/tedlium/s5_r2/local/run_unk_model.sh
+++ b/egs/tedlium/s5_r2/local/run_unk_model.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 
 utils/lang/make_unk_lm.sh data/local/dict exp/unk_lang_model
 
-utils/prepare_lang.sh --unk-fst data/make_unk/unk_fst.txt data/local/dict "<unk>" data/local/lang data/lang_unk
+utils/prepare_lang.sh --unk-fst exp/unk_lang_model/unk_fst.txt data/local/dict "<unk>" data/local/lang data/lang_unk
 
 cp data/lang/G.fst data/lang_unk/G.fst
 

--- a/egs/tedlium/s5_r2/local/score_sclite.sh
+++ b/egs/tedlium/s5_r2/local/score_sclite.sh
@@ -66,8 +66,8 @@ if [ $stage -le 0 ]; then
       lattice-scale --inv-acoustic-scale=LMWT "ark:gunzip -c $dir/lat.*.gz|" ark:- \| \
       lattice-add-penalty --word-ins-penalty=$wip ark:- ark:- \| \
       lattice-prune --beam=$beam ark:- ark:- \| \
-      lattice-align-words-lexicon --output-error-lats=true --max-expand=10.0 --test=false \
-       $lang/phones/align_lexicon.int $model ark:- ark:- \| \
+      lattice-align-words --output-error-lats=true --max-expand=10.0 --test=false \
+       $lang/phones/word_boundary.int $model ark:- ark:- \| \
       lattice-to-ctm-conf --decode-mbr=$decode_mbr $frame_shift_opt ark:- - \| \
       utils/int2sym.pl -f 5 $lang/words.txt \| \
       utils/convert_ctm.pl $data/segments $data/reco2file_and_channel \| \

--- a/egs/tedlium/s5_r2/local/ted_train_lm.sh
+++ b/egs/tedlium/s5_r2/local/ted_train_lm.sh
@@ -97,15 +97,18 @@ if [ $stage -le 1 ]; then
   fi
   unpruned_lm_dir=${lm_dir}/${lm_name}.pocolm
   train_lm.py  --wordlist=${wordlist} --num-splits=10 --warm-start-ratio=20  \
+               --limit-unk-history=true \
                --fold-dev-into=ted ${bypass_metaparam_optim_opt} \
                --min-counts="${min_counts}" \
                ${dir}/data/text ${order} ${lm_dir}/work ${unpruned_lm_dir}
 
   get_data_prob.py ${dir}/data/real_dev_set.txt ${unpruned_lm_dir} 2>&1 | grep -F '[perplexity'
 
-  # currently (with min-counts), this is what we have:
+  # current results, after adding --limit-unk-history=true:
+  # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/wordlist_4.pocolm was -5.13486225358 per word [perplexity = 169.840923284] over 18290.0 words.
+  # older results (after adding min-counts):
   # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/wordlist_4.pocolm was -5.13902242865 per word [perplexity = 170.514153159] over 18290.0 words.
-  # before I added min-counts, this is what we had:
+  # even older results, before adding min-counts:
   # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4 was -5.10576291033 per word [perplexity = 164.969879761] over 18290.0 words.
 fi
 
@@ -117,7 +120,9 @@ if [ $stage -le 2 ]; then
 
   get_data_prob.py ${dir}/data/real_dev_set.txt ${dir}/data/lm_${order}_prune_big 2>&1 | grep -F '[perplexity'
 
-  # with min-counts:
+  # current results, after adding --limit-unk-history=true:
+  # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4_prune_big was -5.17558740241 per word [perplexity = 176.90049554] over 18290.0 words.
+  # older results, after adding min-counts:
   # get_data_prob.py ${dir}/data/real_dev_set.txt ${dir}/data/lm_${order}_prune_big 2>&1 | grep -F '[perplexity'
   # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4_prune_big was -5.17638942756 per word [perplexity = 177.006688203] over 18290.0 words.
 
@@ -134,9 +139,11 @@ if [ $stage -le 3 ]; then
 
   get_data_prob.py ${dir}/data/real_dev_set.txt ${dir}/data/lm_${order}_prune_small 2>&1 | grep -F '[perplexity'
 
-  # with min-counts:
+  # current results, after adding --limit-unk-history=true (needed for modeling OOVs and not blowing up LG.fst):
+  # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4_prune_small was -5.28036622198 per word [perplexity = 196.441803486] over 18290.0 words.
+  # older results, after adding min-counts:
   # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4_prune_small was -5.28346290049 per word [perplexity = 197.123843355] over 18290.0 words.
-  # before adding min-counts:
+  # even older results, before adding min-counts:
   # get_data_prob.py: log-prob of data/local/local_lm/data/real_dev_set.txt given model data/local/local_lm/data/lm_4_prune_small was -5.27623197813 per word [perplexity = 195.631341646] over 18290.0 words.
 
   format_arpa_lm.py ${dir}/data/lm_${order}_prune_small | gzip -c > ${dir}/data/arpa/${order}gram_small.arpa.gz

--- a/egs/tedlium/s5_r2/run.sh
+++ b/egs/tedlium/s5_r2/run.sh
@@ -168,6 +168,10 @@ if [ $stage -le 15 ]; then
   done
 fi
 
+# the following shows you how to insert a phone language model in place of <unk>
+# and decode with that.
+# local/run_unk_model.sh
+
 if [ $stage -le 16 ]; then
   # this does some data-cleaning.  It actually degrades the GMM-level results
   # slightly, but the cleaned data should be useful when we add the neural net and chain
@@ -190,16 +194,6 @@ fi
 
 # We removed the GMM+MMI stage that used to exist in the release-1 scripts,
 # since the neural net training is more of interest.
-
-
-
-
-
-
-
-
-
-
 
 echo "$0: success."
 exit 0

--- a/egs/wsj/s5/steps/cleanup/debug_lexicon.sh
+++ b/egs/wsj/s5/steps/cleanup/debug_lexicon.sh
@@ -58,7 +58,7 @@ fi
 phone_lang=data/$(basename $lang)_phone_bg
 
 if [ $stage -le 2 ]; then
-  utils/make_phone_bigram_lang.sh $lang $alidir $phone_lang
+  utils/lang/make_phone_bigram_lang.sh $lang $alidir $phone_lang
 fi
 
 if [ $stage -le 3 ]; then
@@ -201,4 +201,3 @@ if [ $stage -le 11 ]; then
 
 
 fi
-

--- a/egs/wsj/s5/steps/cleanup/internal/make_one_biased_lm.py
+++ b/egs/wsj/s5/steps/cleanup/internal/make_one_biased_lm.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2016  Johns Hopkins University (Author: Daniel Povey)
+# Apache 2.0.
+
 from __future__ import print_function
 import sys
 import argparse
@@ -50,7 +53,7 @@ class NgramCounts:
     ## We store n-gram counts as an array, indexed by (history-length == n-gram order minus one)
     ## (note: python calls arrays "lists")  of dicts from histories to counts, where
     ## histories are arrays of integers and "counts" are dicts from integer to float.
-    ## For instance, when accumulating the 4-gram count for the 'd' in the sequence '5 6 7 8',
+    ## For instance, when accumulating the 4-gram count for the '8' in the sequence '5 6 7 8',
     ## we'd do as follows:
     ##  self.counts[3][[5,6,7]][8] += 1.0
     ## where the [3] indexes an array, the [[5,6,7]] indexes a dict, and
@@ -58,7 +61,7 @@ class NgramCounts:
     def __init__(self, ngram_order):
         self.ngram_order = ngram_order
         # Integerized counts will never contain negative numbers, so
-        # inside this program, we use -1 and -2 for the BOS and EOS symbols
+        # inside this program, we use -3 and -2 for the BOS and EOS symbols
         # respectively.
         # Note: it's actually important that the bos-symbol is the most negative;
         # it helps ensure that we print the state with left-context <s> first

--- a/egs/wsj/s5/steps/info/chain_dir_info.pl
+++ b/egs/wsj/s5/steps/info/chain_dir_info.pl
@@ -145,6 +145,15 @@ sub get_combine_info {
   return "";
 }
 
+sub format_float_as_string {
+  my $float = shift @_;
+  if (abs($float) >= 1.0) {
+    return sprintf("%.2f", $float);
+  } else {
+    return sprintf("%.3f", $float);
+  }
+}
+
 # this is used in get_loglike_and_accuracy to format
 # strings like ' loglike[32,48,final],train/valid=(-2.43,-2.32,-2.21/-2.84,-2.71,-2.68)'.
 sub get_printed_string {
@@ -159,8 +168,8 @@ sub get_printed_string {
   foreach my $iter (@iters_array) {
     if (defined($train_hash{$iter}) && defined($valid_hash{$iter})) {
       push @iters_to_print, $iter;
-      push @train_values_to_print, sprintf("%.2f", $train_hash{$iter});
-      push @valid_values_to_print, sprintf("%.2f", $valid_hash{$iter});
+      push @train_values_to_print, format_float_as_string($train_hash{$iter});
+      push @valid_values_to_print, format_float_as_string($valid_hash{$iter});
     }
   }
   if (@iters_to_print == 0) {  return ""; }

--- a/egs/wsj/s5/utils/add_lex_disambig.pl
+++ b/egs/wsj/s5/utils/add_lex_disambig.pl
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
-# Copyright 2010-2011  Microsoft Corporation
-#                2013  Johns Hopkins University (author: Daniel Povey)
-#                2015  Hainan Xu
-#                2015  Guoguo Chen
+#  Copyright 2010-2011  Microsoft Corporation
+#            2013-2016  Johns Hopkins University (author: Daniel Povey)
+#                 2015  Hainan Xu
+#                 2015  Guoguo Chen
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,27 +20,59 @@
 
 # Adds disambiguation symbols to a lexicon.
 # Outputs still in the normal lexicon format.
-# Disambig syms are numbered #1, #2, #3, etc. (#0 
+# Disambig syms are numbered #1, #2, #3, etc. (#0
 # reserved for symbol in grammar).
 # Outputs the number of disambig syms to the standard output.
 # With the --pron-probs option, expects the second field
 # of each lexicon line to be a pron-prob.
+# With the --sil-probs option, expects three additional
+# fields after the pron-prob, representing various components
+# of the silence probability model.
 
 $pron_probs = 0;
 $sil_probs = 0;
+$first_allowed_disambig = 1;
 
-if ($ARGV[0] eq "--pron-probs") {
-  $pron_probs = 1;
-  shift @ARGV;
+for ($n = 1; $n <= 3 && @ARGV > 0; $n++) {
+  if ($ARGV[0] eq "--pron-probs") {
+    $pron_probs = 1;
+    shift @ARGV;
+  }
+  if ($ARGV[0] eq "--sil-probs") {
+    $sil_probs = 1;
+    shift @ARGV;
+  }
+  if ($ARGV[0] eq "--first-allowed-disambig") {
+    $first_allowed_disambig = 0 + $ARGV[1];
+    if ($first_allowed_disambig < 1) {
+      die "add_lex_disambig.pl: invalid --first-allowed-disambig option: $first_allowed_disambig\n";
+    }
+    shift @ARGV;
+    shift @ARGV;
+  }
 }
 
-if ($ARGV[0] eq "--sil-probs") {
-  $sil_probs = 1;
-  shift @ARGV;
-}
-
-if(@ARGV != 2) {
-    die "Usage: add_lex_disambig.pl [--pron-probs] [--sil-probs] lexicon.txt lexicon_disambig.txt "
+if (@ARGV != 2) {
+  die "Usage: add_lex_disambig.pl [opts] <lexicon-in> <lexicon-out>\n" .
+    "This script adds disambiguation symbols to a lexicon in order to\n" .
+    "make decoding graphs determinizable; it adds pseudo-phone\n" .
+    "disambiguation symbols #1, #2 and so on at the ends of phones\n" .
+    "to ensure that all pronunciations are different, and that none\n" .
+    "is a prefix of another.\n" .
+    "It prints to the standard output the number of the largest-numbered" .
+    "disambiguation symbol that was used.\n" .
+    "\n" .
+    "Options:   --pron-probs       Expect pronunciation probabilities in the 2nd field\n" .
+    "           --sil-probs        [should be with --pron-probs option]\n" .
+    "                              Expect 3 extra fields after the pron-probs, for aspects of\n" .
+    "                              the silence probability model\n" .
+    "           --first-allowed-disambig <n>  The number of the first disambiguation symbol\n" .
+    "                              that this script is allowed to add.  By default this is\n" .
+    "                              #1, but you can set this to a larger value using this option.\n" .
+    "e.g.:\n" .
+    " add_lex_disambig.pl lexicon.txt lexicon_disambig.txt\n" .
+    " add_lex_disambig.pl --pron-probs lexiconp.txt lexiconp_disambig.txt\n" .
+    " add_lex_disambig.pl --pron-probs --sil-probs lexiconp_silprob.txt lexiconp_silprob_disambig.txt\n";
 }
 
 
@@ -81,7 +113,7 @@ foreach $l (@L) {
 }
 
 # (3) For each left sub-sequence of each phone-sequence, note down
-# that exists (for identifying prefixes of longer strings).
+# that it exists (for identifying prefixes of longer strings).
 
 foreach $l (@L) {
     @A = split(" ", $l);
@@ -106,48 +138,58 @@ foreach $l (@L) {
 
 open(O, ">$lexoutfn") || die "Opening lexicon file $lexoutfn for writing.\n";
 
-$max_disambig = 0;
+# max_disambig will always be the highest-numbered disambiguation symbol that
+# has been used so far.
+$max_disambig = $first_allowed_disambig - 1;
+
 foreach $l (@L) {
-    @A = split(" ", $l);
-    $word = shift @A;
-    if ($pron_probs) { $pron_prob = shift @A; }
-    if ($sil_probs) {
-      $sil_word_prob = shift @A;
-      $word_sil_correction = shift @A;
-      $prev_nonsil_correction = shift @A
-    }
-    $phnseq = join(" ",@A);
-    if(!defined $issubseq{$phnseq}
-       && $count{$phnseq} == 1) {
-        ; # Do nothing.
+  @A = split(" ", $l);
+  $word = shift @A;
+  if ($pron_probs) {
+    $pron_prob = shift @A;
+  }
+  if ($sil_probs) {
+    $sil_word_prob = shift @A;
+    $word_sil_correction = shift @A;
+    $prev_nonsil_correction = shift @A
+  }
+  $phnseq = join(" ", @A);
+  if (!defined $issubseq{$phnseq}
+      && $count{$phnseq} == 1) {
+    ;                           # Do nothing.
+  } else {
+    if ($phnseq eq "") {        # need disambig symbols for the empty string
+      # that are not use anywhere else.
+      $max_disambig++;
+      $reserved_for_the_empty_string{$max_disambig} = 1;
+      $phnseq = "#$max_disambig";
     } else {
-        if($phnseq eq "") { # need disambig symbols for the empty string
-            # that are not use anywhere else.
-            $max_disambig++;
-            $reserved{$max_disambig} = 1;
-            $phnseq = "#$max_disambig";
-        } else {
-            $curnumber = $disambig_of{$phnseq};
-            if(!defined{$curnumber}) { $curnumber = 0; }
-            $curnumber++; # now 1 or 2, ... 
-            while(defined $reserved{$curnumber} ) { $curnumber++; } # skip over reserved symbols
-            if($curnumber > $max_disambig) {
-                $max_disambig = $curnumber;
-            }
-            $disambig_of{$phnseq} = $curnumber;
-            $phnseq = $phnseq . " #" . $curnumber;
-         }
-    }
-    if ($pron_probs) {  
-      if ($sil_probs) {
-        print O "$word\t$pron_prob\t$sil_word_prob\t$word_sil_correction\t$prev_nonsil_correction\t$phnseq\n"; 
+      $cur_disambig = $last_used_disambig_symbol_of{$phnseq};
+      if (!defined $cur_disambig) {
+        $cur_disambig = $first_allowed_disambig;
+      } else {
+        $cur_disambig++;           # Get a number that has not been used yet for
+                                   # this phone sequence.
       }
-      else {
-        print O "$word\t$pron_prob\t$phnseq\n"; 
+      while (defined $reserved_for_the_empty_string{$cur_disambig}) {
+        $cur_disambig++;
       }
+      if ($cur_disambig > $max_disambig) {
+        $max_disambig = $cur_disambig;
+      }
+      $last_used_disambig_symbol_of{$phnseq} = $cur_disambig;
+      $phnseq = $phnseq . " #" . $cur_disambig;
     }
-    else {  print O "$word\t$phnseq\n"; }
+  }
+  if ($pron_probs) {
+    if ($sil_probs) {
+      print O "$word\t$pron_prob\t$sil_word_prob\t$word_sil_correction\t$prev_nonsil_correction\t$phnseq\n";
+    } else {
+      print O "$word\t$pron_prob\t$phnseq\n";
+    }
+  } else {
+    print O "$word\t$phnseq\n";
+  }
 }
 
 print $max_disambig . "\n";
-

--- a/egs/wsj/s5/utils/lang/internal/apply_unk_lm.sh
+++ b/egs/wsj/s5/utils/lang/internal/apply_unk_lm.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright      2016 Johns Hopkins University (Author: Daniel Povey);
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Begin configuration section.
+
+# end configuration sections
+
+echo "$0 $@"  # Print the command line for logging
+[ -f path.sh ] && . ./path.sh
+
+
+. utils/parse_options.sh
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 [options] <input-unk-lm-fst> <lang-dir>"
+  echo "e.g.: $0 exp/make_unk/unk_fst.txt data/lang_unk"
+  echo ""
+  echo "This script, which is called from the end of prepare_lang.sh,"
+  echo "inserts the unknown-word LM FST into the lexicon FSTs"
+  echo "<lang-dir>/L.fst and <lang-dir>/L_disambig.fst in place of"
+  echo "the special disambiguation symbol #2 (which was inserted by"
+  echo "add_lex_disambig.pl as a placeholder for this FST)."
+  echo ""
+  echo "  <input-unk-lm-fst>:  A text-form FST, typically with the name"
+  echo "                unk_fst.txt.  We will remove all symbols from the"
+  echo "                output before applying it."
+  echo "  <lang-dir>:  A partially built lang/ directory.  We modify"
+  echo "               L.fst and L_disambig.fst, and read only words.txt."
+  exit 1;
+fi
+
+
+unk_lm_fst=$1
+lang=$2
+
+set -e
+
+for f in "$unk_lm_fst" $lang/L.fst $lang/L_disambig.fst $lang/words.txt $lang/oov.int; do
+  [ ! -f $f ] && echo "$0: expected file $f to exist" && exit 1;
+done
+
+unused_phone_label=$(tail -n 1 $lang/phones.txt | awk '{print $2 + 1}')
+label_to_replace=$(awk '{if ($1 == "#2") {print $2;}}' <$lang/phones.txt)
+! [ "$unused_phone_label" -eq "$unused_phone_label" -a "$label_to_replace" -eq "$label_to_replace" ] && \
+   echo "$0: error getting unused phone label or label for #2" && exit 1
+
+
+# OK, now fstreplace works based on olabels, but we actually want to deal with ilabels,
+# so we need to invert all the FSTs before and after doing fstreplace.
+awk '{if(NF>=4) $4 = "<eps>"; print }' <$unk_lm_fst | \
+  fstcompile --isymbols=$lang/phones.txt --osymbols=$lang/words.txt | \
+  fstinvert > $lang/unk_temp.fst
+
+num_states_unk=$(fstinfo $lang/unk_temp.fst | grep '# of states' | awk '{print $NF}')
+
+# fstreplace usage is:
+# Usage: fstreplace root.fst rootlabel [rule1.fst label1 ...] [out.fst]
+# ... the rootlabel should just be an otherwise unused symbol.
+# all the labels are olabels (word labels).. that is hardcoded in fstreplace.
+
+for f in L.fst L_disambig.fst; do
+
+  # with OpenFst tools, to refer to the standard input/output you need to use
+  # the empty string '' and not '-'.
+  fstinvert $lang/$f | fstreplace '' "$unused_phone_label" $lang/unk_temp.fst "$label_to_replace" | fstinvert > $lang/${f}.temp
+
+  num_states_old=$(fstinfo $lang/$f | grep '# of states' | awk '{print $NF}')
+  num_states_new=$(fstinfo $lang/${f}.temp | grep '# of states' | awk '{print $NF}')
+  num_states_added=$[$num_states_new-$num_states_old]
+  echo "$0: in $f, substituting in the unknown-word LM (which had $num_states_unk states) added $num_states_added new FST states."
+  mv -f $lang/${f}.temp $lang/$f
+done
+
+rm $lang/unk_temp.fst
+
+exit 0;

--- a/egs/wsj/s5/utils/lang/internal/arpa2fst_constrained.py
+++ b/egs/wsj/s5/utils/lang/internal/arpa2fst_constrained.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python
+
+# Copyright 2016  Johns Hopkins University (Author: Daniel Povey)
+# Apache 2.0.
+
+from __future__ import print_function
+import sys
+import argparse
+import math
+from collections import defaultdict
+
+# note, this was originally based
+
+parser = argparse.ArgumentParser(description="""
+This script converts an ARPA-format language model to FST format
+(like the C++ program arpa2fst), but does so while applying bigram
+constraints supplied in a separate file.  The resulting language
+model will have no unigram state, and there will be no backoff from
+the bigram level.
+This is useful for phone-level language models in order to keep
+graphs small and impose things like linguistic constraints on
+allowable phone sequences.
+This script writes it output to the stdout.  It is a text-form FST,
+suitable for compilation by fstcompile.
+""")
+
+
+parser.add_argument('--disambig-symbol', type = str, default = "#0",
+                    help = 'Disambiguation symbol (e.g. #0), '
+                    'that is printed on the input side only of backoff '
+                    'arcs (output side would be epsilon)')
+parser.add_argument('arpa_in', type = str,
+                    help = 'The input ARPA file (must not be gzipped)')
+parser.add_argument('allowed_bigrams_in', type = str,
+                    help = "A file containing the list of allowed bigram pairs.  "
+                    "Must include pairs like '<s> foo' and 'foo </s>', as well as "
+                    "pairs like 'foo bar'.")
+parser.add_argument('--verbose', type = int, default = 0,
+                    choices=[0,1,2,3,4,5], help = 'Verbose level')
+
+args = parser.parse_args()
+
+if args.verbose >= 1:
+    print(' '.join(sys.argv), file = sys.stderr)
+
+
+class HistoryState:
+    def __init__(self):
+        # note: neither backoff_prob nor the floats
+        # in word_to_prob are in log space.
+        self.backoff_prob = 1.0
+        # will be a dict from string to float.  the prob is
+        # the actual probability of the word, including any probability
+        # mass from backoff (they get added together while writing out
+        # the arpa, and these probs are read in from the arpa).
+        self.word_to_prob = dict()
+
+
+class ArpaModel:
+    def __init__(self):
+        # self.orders is indexed by history-length [i.e. 0 for unigram,
+        # 1 for bigram and so on], and is then a dict indexed
+        # by tuples of history-words.  E.g. for trigrams, we'd index
+        # it as self.orders[2][('a', 'b')].
+        # The value-type of the dict is HistoryState.  E.g. to set the
+        # probability of the trigram a b -> c to 0.2, we'd do
+        # self.orders[2][('a', 'b')].word_to_prob['c'] = 0.2
+        self.orders = []
+
+    def Read(self, arpa_in):
+        assert len(self.orders) == 0
+        log10 = math.log(10.0)
+        if arpa_in == "" or arpa_in == "-":
+            arpa_in = "/dev/stdin"
+        try:
+            f = open(arpa_in, "r")
+        except:
+            sys.exit("{0}: error opening ARPA file {1}".format(
+                     sys.argv[0], arpa_in))
+        # first read till the \data\ marker.
+        while True:
+            line = f.readline()
+            if line == '':
+                sys.exit("{0}: reading {1}, got EOF looking for \\data\\ marker.".format(
+                    sys.argv[0], arpa_in))
+            if line[0:6] == '\\data\\':
+                break
+        while True:
+            # read, and ignore, the lines like 'ngram 1=1264'...
+            line = f.readline()
+            if line == '\n' or line == '\r\n':
+                break
+            if line[0:5] != 'ngram':
+                sys.exit("{0}: reading {1}, read something unexpected in header: {2}".format(
+                    sys.argv[0], arpa_in, line[:-1]))
+            rest=line[5:]
+            a = rest.split('=')  # e.g. a = [ '1', '1264] ]
+            if len(a) != 2:
+                sys.exit("{0}: reading {1}, read something unexpected in header: {2}".format(
+                    sys.argv[0], arpa_in, line[:-1]))
+            max_order = int(a[0])
+
+
+        for n in range(max_order):
+            # self.orders[n], indexed by history-length (length of the
+            # history-vector, == order-1), is a map from history as a tuple
+            # of strings, to class HistoryState.
+            self.orders.append(defaultdict(lambda: HistoryState()))
+
+        cur_order = 0
+        while True:
+            line = f.readline()
+            if line == '':
+                sys.exit("{0}: reading {1}, found EOF while looking for \\end\\ marker.".format(
+                    sys.argv[0], arpa_in))
+            elif line[0:5] == '\\end\\':
+                if len(self.orders) == 0:
+                    sys.exit("{0}: reading {1}, read no n-grams.".format(sys.argv[0], arpa_in))
+                break
+            else:
+                cur_order += 1
+                expected_line = '\\{0}-grams:'.format(cur_order)
+                if not expected_line in line:  # e.g. allow trailing whitespace and newline
+                    sys.exit("{0}: reading {1}, expected line {1}, got {2}".format(arpa_in, expected_line, line[:-1]))
+                if args.verbose >= 2:
+                    print("{0}: reading {1}-grams".format(
+                        sys.argv[0], cur_order), file = sys.stderr)
+
+                # now read all the n-grams from this order.
+                while True:
+                    line = f.readline()
+                    # the section of n-grams is terminated by a blank line.
+                    if line == '\n' or line == '\r\n':
+                        break
+                    a = line.split()
+                    l = len(a)
+                    if l != cur_order + 1 and l != cur_order + 2:
+                        sys.exit("{0}: reading {1}: in {2}-grams section, got bad line: {3}".format(
+                            sys.argv[0], arpa_in, cur_order, line[:-1]))
+                    try:
+                        prob = math.exp(float(a[0]) * log10)
+                        hist = tuple(a[1:cur_order])  # tuple of strings
+                        word = a[cur_order]  # a string
+                        backoff_prob = math.exp(float(a[cur_order+1]) * log10) if l == cur_order + 2 else None
+                    except Exception as e:
+                        sys.exit("{0}: reading {1}: in {2}-grams section, got bad "
+                                 "line (exception is: {3}): {4}".format(
+                                     sys.argv[0], arpa_in, cur_order,
+                                     str(type(e)) + ',' + str(e), line[:-1]))
+                    self.orders[cur_order-1][hist].word_to_prob[word] = prob
+                    if backoff_prob != None:
+                        self.orders[cur_order][hist + (word,)].backoff_prob = backoff_prob
+
+        if args.verbose >= 2:
+            print("{0}: read {1}-gram model from {2}".format(
+                sys.argv[0], cur_order, arpa_in), file = sys.stderr)
+        if cur_order < 2:
+            # we'd have to have some if-statements in the code to make this work,
+            # and I don't want to have to test it.
+            sys.exit("{0}: this script does not work when the ARPA language model "
+                     "is unigram.".format(sys.argv[0]))
+
+    # Returns the probability of word 'word' in history-state 'hist'.
+    # Dies with error if this word is not predicted at all by the LM (not in vocab).
+    # history-state does not exist.
+    def GetProb(self, hist, word):
+        assert len(hist) < len(self.orders)
+        if len(hist) == 0:
+            word_to_prob = self.orders[0][()].word_to_prob
+            if not word in word_to_prob:
+                sys.exit("{0}: no probability in unigram for word {1}".format(
+                    sys.argv[0], word))
+            return word_to_prob[word]
+        else:
+            if hist in self.orders[len(hist)]:
+                hist_state = self.orders[len(hist)][hist]
+                if word in hist_state.word_to_prob:
+                    return hist_state.word_to_prob[word]
+                else:
+                    return hist_state.backoff_prob * self.GetProb(hist[1:], word)
+            else:
+                return self.GetProb(hist[1:], word)
+
+    # This gets the state corresponding to 'hist' in 'hist_to_state', but backs
+    # off for us if there is no such state.
+    def GetStateForHist(self, hist_to_state, hist):
+        if hist in hist_to_state:
+            return hist_to_state[hist]
+        else:
+            if len(hist) <= 1:
+                # this would likely be a code error, but possibly an error
+                # in the ARPA file
+                sys.exit("{0}: error processing histories: history-state {1} "
+                         "does not exist.".format(sys.argv[0], hist))
+            return self.GetStateForHist(hist_to_state, hist[1:])
+
+
+    def GetHistToStateMap(self):
+        # This function, called from PrintAsFst, returns (hist_to_state,
+        # state_to_hist), which map from history (as a tuple of strings) to
+        # integer FST-state and vice versa.
+
+        hist_to_state = dict()
+        state_to_hist = []
+
+        # Make sure the initial bigram state comes first (and that
+        # we have such a state even if it was completely pruned
+        # away in the bigram LM.. which is unlikely of course)
+        hist = ('<s>',)
+        hist_to_state[hist] = len(state_to_hist)
+        state_to_hist.append(hist)
+
+        # create a bigram state for each of the 'real' words...  even if the LM
+        # didn't naturally have such bigram states, we'll create them so that we
+        # can enforce the bigram constraints supplied in 'bigrams_file' by the
+        # user.
+        for word in self.orders[0][()].word_to_prob:
+            if word != '<s>' and word != '</s>':
+                hist = (word,)
+                hist_to_state[hist] = len(state_to_hist)
+                state_to_hist.append(hist)
+
+        # note: we do not allocate an FST state for the unigram state, because
+        # we don't have a unigram state in the output FST, only bigram states; and
+        # we don't iterate over bigram histories because we covered them all above;
+        # that's why we start 'n' from 2 below instead of from 0.
+        for n in range(2, len(self.orders)):
+            for hist in self.orders[n].keys():
+                # note: hist is a tuple of strings.
+                assert not hist in hist_to_state
+                hist_to_state[hist] = len(state_to_hist)
+                state_to_hist.append(hist)
+
+        return (hist_to_state, state_to_hist)
+
+    # This function prints the estimated language model as an FST.
+    # disambig_symbol will be something like '#0' (a symbol introduced
+    # to make the result determinizable).
+    # bigram_map represent the allowed bigrams (left-word, right-word): it's a map
+    # from left-word to a set of right-words (both are strings).
+    def PrintAsFst(self, disambig_symbol, bigram_map):
+        # History will map from history (as a tuple) to integer FST-state.
+        (hist_to_state, state_to_hist) = self.GetHistToStateMap()
+
+
+        # The following 3 things are just for diagnostics.
+        normalization_stats = [ [0, 0.0] for x in range(len(self.orders)) ]
+        num_ngrams_allowed = 0
+        num_ngrams_disallowed = 0
+
+        for state in range(len(state_to_hist)):
+            hist = state_to_hist[state]
+            hist_len = len(hist)
+            assert hist_len > 0
+            if hist_len == 1:  # it's a bigram state...
+                context_word = hist[0]
+                if not context_word in bigram_map:
+                    print("{0}: warning: word {1} appears in ARPA but is not listed "
+                          "as a left context in the bigram map".format(
+                              sys.argv[0], context_word), file = sys.stderr)
+                    continue
+                # word list is a list of words that can follow this word.  It must be nonempty.
+                word_list = list(bigram_map[context_word])
+
+                normalization_stats[hist_len][0] += 1
+
+                for word in word_list:
+                    prob = self.GetProb((context_word,), word)
+                    assert prob != 0
+                    normalization_stats[hist_len][1] += prob
+                    cost = -math.log(prob)
+                    if abs(cost) < 0.01 and args.verbose >= 3:
+                        print("{0}: warning: very small cost {1} for {2}->{3}".format(
+                            sys.argv[0], cost, context_word, word), file=sys.stderr)
+                    if word == '</s>':
+                        # print the final-prob of this state.
+                        print("%d %.3f" % (state, cost))
+                    else:
+                        next_state = self.GetStateForHist(hist_to_state,
+                                                          (context_word, word))
+                        print("%d %d %s %s %.3f" %
+                              (state, next_state, word, word, cost))
+            else:  # it's a higher-order than bigram state.
+                assert hist in self.orders[hist_len]
+                hist_state = self.orders[hist_len][hist]
+                most_recent_word = hist[-1]
+
+                normalization_stats[hist_len][0] += 1
+                normalization_stats[hist_len][1] += \
+                  sum([ self.GetProb(hist, word) for word in bigram_map[most_recent_word]])
+
+                for word, prob in hist_state.word_to_prob.items():
+                    cost = -math.log(prob)
+                    if word in bigram_map[most_recent_word]:
+                        num_ngrams_allowed += 1
+                    else:
+                        num_ngrams_disallowed += 1
+                        continue
+                    if word == '</s>':
+                        # print the final-prob of this state.
+                        print("%d %.3f" % (state, cost))
+                    else:
+                        next_state = self.GetStateForHist(hist_to_state,
+                                                          (hist) + (word,))
+                        print("%d %d %s %s %.3f" %
+                              (state, next_state, word, word, cost))
+                # Now deal with the backoff probability of this state (back off
+                # to the lower-order state).
+                assert hist in self.orders[hist_len]
+                backoff_prob = self.orders[hist_len][hist].backoff_prob
+                assert backoff_prob != 0.0
+                cost = -math.log(backoff_prob)
+                backoff_hist = hist[1:]
+                backoff_state = self.GetStateForHist(hist_to_state, backoff_hist)
+                # note: we only print the disambig symbol on the input side.
+                if args.verbose >= 3 and abs(cost) < 0.001:
+                    print("{0}: very low backoff cost {1} for history {2}, state = {3}".format(
+                        sys.argv[0], cost, str(hist), state), file = sys.stderr)
+
+                print("%d %d %s <eps> %.3f" %
+                      (state, backoff_state, disambig_symbol, cost))
+        if args.verbose >= 1:
+            for hist_len in range(1, len(self.orders)):
+                num_states = normalization_stats[hist_len][0]
+                avg_prob_sum = normalization_stats[hist_len][1] / num_states if num_states > 0 else 0.0
+                print("{0}: for {1}-gram states, over {2} states the average sum of "
+                      "probs was {3} (would be 1.0 if properly normalized).".format(
+                          sys.argv[0], hist_len + 1, num_states, avg_prob_sum),
+                      file = sys.stderr)
+            if num_ngrams_disallowed != 0:
+                print("{0}: for explicit n-grams higher than bigram from the ARPA model, {0} "
+                      "were allowed by the bigram constraints and {1} were disallowed (we "
+                      "normally expect all or almost all of them to be allowed).".format(
+                          num_ngrams_allowed, num_ngrams_disallowed), file = sys.stderr)
+
+
+
+# returns a map which is a dict [indexed by left-hand word] of sets [containing
+# the right-hand word].
+def ReadBigramMap(bigrams_file):
+    ans = defaultdict(lambda: set())
+
+    have_one_bos = False
+    have_one_eos = False
+    have_one_regular = False
+
+    try:
+        f = open(bigrams_file, "r")
+    except:
+        sys.exit("utils/lang/internal/arpa2fst_constrained.py: error opening "
+                 "bigrams file " + bigrams_file)
+    while True:
+        line = f.readline()
+        if line == '':
+            break
+        a = line.split()
+        if len(a) != 2:
+            sys.exit("utils/lang/internal/arpa2fst_constrained.py: bad line in "
+                     "bigrams file {0} (expect 2 fields): {1}".format(
+                         bigrams_file, line[:-1]))
+        [word1, word2] = a
+        if word1 in ans and word2 in ans[word1]:
+            sys.exit("{0}: bigrams file contained duplicate entry: {1} {2}".format(
+                sys.argv[0], word1, word2), file = sys.stderr)
+        if word2 == '<s>' or word1 == '</s>':
+            sys.exit("{0}: bad sequence of BOS/EOS symbols: {1} {2}".format(
+                sys.argv[0], word1, word2))
+        if word1 == '<s>':
+            have_one_bos = True
+        elif word2 == '</s>':
+            have_one_eos = True
+        else:
+            have_one_regular = True
+        ans[word1].add(word2)
+    # check for at least one pair with BOS
+    if len(ans) == 0:
+        sys.exit("{0}: no data found in bigrams file {1}".format(
+            sys.argv[0], bigrams_file))
+    elif not (have_one_bos and have_one_eos and have_one_regular):
+        sys.exit("{0}: the bigrams file {1} does not look right "
+                 "(make sure BOS and EOS symbols are there)".format(
+            sys.argv[0], bigrams_file))
+    return ans
+
+arpa_model = ArpaModel()
+arpa_model.Read(args.arpa_in)
+bigrams_map = ReadBigramMap(args.allowed_bigrams_in)
+if len(args.disambig_symbol.split()) != 1:
+    sys.exit("{0}: invalid option --disambig-symbol={1}".format(
+        sys.argv[0], args.disambig_symbol))
+arpa_model.PrintAsFst(args.disambig_symbol, bigrams_map)

--- a/egs/wsj/s5/utils/lang/internal/modify_unk_pron.py
+++ b/egs/wsj/s5/utils/lang/internal/modify_unk_pron.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+# Copyright 2016  Johns Hopkins University (Author: Daniel Povey)
+# Apache 2.0.
+
+from __future__ import print_function
+import sys
+import os
+import argparse
+from collections import defaultdict
+
+# note, this was originally based
+
+parser = argparse.ArgumentParser(description="""
+This script replaces the existing pronunciation of the
+unknown word in the provided lexicon, with a pronunciation
+consisting of two disambiguation symbols: #1 followed by #2.
+The #2 will later be replaced by a phone-level LM by
+apply_unk_lm.sh (called later on by prepare_lang.sh).
+Caution: this script is sensitive to the basename of the
+lexicon: it should be called either lexiconp.txt, in which
+case the format is 'word pron-prob p1 p2 p3 ...'
+or lexiconp_silprob.txt, in which case the format is
+'word pron-prob sil-prob1 sil-prob2 sil-prob3 p1 p2 p3....'.
+It is an error if there is not exactly one pronunciation of
+the unknown word in the lexicon.""",
+epilog="""E.g.: modify_unk_pron.py data/local/lang/lexiconp.txt '<unk>'.
+This script is called from prepare_lang.sh.""")
+
+parser.add_argument('lexicon_file', type = str,
+                    help = 'Filename of the lexicon file to operate on (this is '
+                    'both an input and output of this script).')
+parser.add_argument('unk_word', type = str,
+                    help = "The printed form of the unknown/OOV word, normally '<unk>'.")
+
+args = parser.parse_args()
+
+if len(args.unk_word.split()) != 1:
+    sys.exit("{0}: invalid unknown-word '{1}'".format(
+        sys.argv[0], args.unk_word))
+
+basename = os.path.basename(args.lexicon_file)
+if basename != 'lexiconp.txt' and basename != 'lexiconp_silprob.txt':
+    sys.exit("{0}: expected the basename of the lexicon file to be either "
+             "'lexiconp.txt' or 'lexiconp_silprob.txt', got: {1}".format(
+                 sys.argv[0], args.lexicon_file))
+# the lexiconp.txt format is: word pron-prob p1 p2 p3...
+# lexiconp_silprob.txt has 3 extra real-valued fields after the pron-prob.
+num_fields_before_pron = 2 if basename == 'lexiconp.txt' else 5
+
+print(' '.join(sys.argv), file = sys.stderr)
+
+try:
+    lexicon_in = open(args.lexicon_file, 'r')
+except:
+    sys.exit("{0}: failed to open lexicon file {1}".format(
+        sys.argv[0], args.lexicon_file))
+
+split_lines = []
+unk_index = -1
+while True:
+    line = lexicon_in.readline()
+    if line == '':
+        break
+    this_split_line = line.split()
+    if this_split_line[0] == args.unk_word:
+        if unk_index != -1:
+            sys.exit("{0}: expected there to be exactly one pronunciation of the "
+                     "unknown word {1} in {2}, but there are more than one.".format(
+                         sys.argv[0], args.lexicon_file, args.unk_word))
+        unk_index = len(split_lines)
+    if len(this_split_line) <= num_fields_before_pron:
+        sys.exit("{0}: input file {1} had a bad line (too few fields): {2}".format(
+            sys.argv[0], args.lexicon_file, line[:-1]))
+    split_lines.append(this_split_line)
+
+if len(split_lines) == 0:
+    sys.exit("{0}: read no data from lexicon file {1}.".format(
+        sys.argv[0], args.lexicon_file))
+
+
+if unk_index == -1:
+    sys.exit("{0}: expected there to be exactly one pronunciation of the "
+             "unknown word {1} in {2}, but there are none.".format(
+                 sys.argv[0], args.unk_word, args.lexicon_file))
+
+lexicon_in.close()
+
+# now modify the pron.
+split_lines[unk_index] = split_lines[unk_index][0:num_fields_before_pron] + [ '#1', '#2' ]
+
+
+try:
+    # write to the same file.
+    lexicon_out = open(args.lexicon_file, 'w')
+except:
+    sys.exit("{0}: failed to open lexicon file {1} for writing (permissions probleM?)".format(
+        sys.argv[0], args.lexicon_file))
+
+for split_line in split_lines:
+    print(' '.join(split_line), file = lexicon_out)
+
+try:
+    lexicon_out.close()
+except:
+    sys.exit("{0}: failed to close lexicon file {1} after writing (disk full?)".format(
+        sys.argv[0], args.lexicon_file))

--- a/egs/wsj/s5/utils/lang/make_phone_bigram_lang.sh
+++ b/egs/wsj/s5/utils/lang/make_phone_bigram_lang.sh
@@ -20,8 +20,8 @@ echo "$0 $@"  # Print the command line for logging
 
 
 if [ $# != 3 ]; then
-  echo "Usage: utils/make_phone_bigram_lang.sh [options] <lang-dir> <ali-dir> <output-lang-dir>"
-  echo "e.g.: utils/make_phone_bigram_lang.sh data/lang exp/tri3b_ali data/lang_phone_bg"
+  echo "Usage: $0: [options] <lang-dir> <ali-dir> <output-lang-dir>"
+  echo "e.g.: $0: data/lang exp/tri3b_ali data/lang_phone_bg"
   exit 1;
 fi
 

--- a/egs/wsj/s5/utils/lang/make_phone_lm.py
+++ b/egs/wsj/s5/utils/lang/make_phone_lm.py
@@ -1,0 +1,885 @@
+#!/usr/bin/env python
+
+# Copyright 2016  Johns Hopkins University (Author: Daniel Povey)
+# Apache 2.0.
+
+from __future__ import print_function
+import sys
+import argparse
+import math
+from collections import defaultdict
+
+# note, this was originally based
+
+parser = argparse.ArgumentParser(description="""
+This script creates a language model that's intended to be used in modeling
+phone sequences (either of sentences or of dictionary entries), although of
+course it will work for any type of data.  The easiest way
+to describe it is as a a Kneser-Ney language model (unmodified, with addition)
+with a fixed discounting constant equal to 1, except with no smoothing of the
+bigrams (and hence no unigram state).  This is (a) because we want to keep the
+graph after context expansion small, (b) because languages tend to have
+constraints on which phones can follow each other, and (c) in order to get valid
+sequences of word-position-dependent phones so that lattice-align-words can
+work.  It also includes have a special entropy-based pruning technique that
+backs off the statistics of pruned n-grams to lower-order states.
+
+This script reads lines from its standard input, each
+consisting of a sequence of integer symbol-ids (which should be > 0),
+representing the phone sequences of a sentence or dictionary entry.
+This script outputs a backoff language model in FST format""",
+                                 epilog="See also utils/lang/make_phone_bigram_lang.sh")
+
+
+parser.add_argument("--phone-disambig-symbol", type = int, required = False,
+                    help = "Integer corresponding to an otherwise-unused "
+                    "phone-level disambiguation symbol (e.g. #5).  This is "
+                    "inserted at the beginning of the phone sequence and "
+                    "whenever we back off.")
+parser.add_argument("--ngram-order", type = int, default = 4,
+                    choices = [2,3,4,5,6,7],
+                    help = "Order of n-gram to use (but see also --num-extra-states;"
+                    "the effective order after pruning may be less.")
+parser.add_argument("--num-extra-ngrams", type = int, default = 20000,
+                    help = "Target number of n-grams in addition to the n-grams in "
+                    "the bigram LM states which can't be pruned away.  n-grams "
+                    "will be pruned to reach this target.")
+parser.add_argument("--no-backoff-ngram-order", type = int, default = 2,
+                    choices = [1,2,3,4,5],
+                    help = "This specifies the n-gram order at which (and below which) "
+                    "no backoff or pruning should be done.  This is expected to normally "
+                    "be bigram, but for testing purposes you may want to set it to "
+                    "1.")
+parser.add_argument("--print-as-arpa", type = str, default = "false",
+                    choices = ["true", "false"],
+                    help = "If true, print LM in ARPA format (default is to print "
+                    "as FST).  You must also set --no-backoff-ngram-order=1 or "
+                    "this is not allowed.")
+parser.add_argument("--verbose", type = int, default = 0,
+                    choices=[0,1,2,3,4,5], help = "Verbose level")
+
+args = parser.parse_args()
+
+if args.verbose >= 1:
+    print(' '.join(sys.argv), file = sys.stderr)
+
+
+
+class CountsForHistory:
+    ## This class (which is more like a struct) stores the counts seen in a
+    ## particular history-state.  It is used inside class NgramCounts.
+    ## It really does the job of a dict from int to float, but it also
+    ## keeps track of the total count.
+    def __init__(self):
+        # The 'lambda: defaultdict(float)' is an anonymous function taking no
+        # arguments that returns a new defaultdict(float).
+        self.word_to_count = defaultdict(int)
+        self.total_count = 0
+
+    def Words(self):
+        return self.word_to_count.keys()
+
+    def __str__(self):
+        # e.g. returns ' total=12 3->4 4->6 -1->2'
+        return ' total={0} {1}'.format(
+            str(self.total_count),
+            ' '.join(['{0} -> {1}'.format(word, count)
+                      for word, count in self.word_to_count.items()]))
+
+
+    ## Adds a certain count (expected to be integer, but might be negative).  If
+    ## the resulting count for this word is zero, removes the dict entry from
+    ## word_to_count.
+    ## [note, though, that in some circumstances we 'add back' zero counts
+    ## where the presence of n-grams would be structurally required by the arpa,
+    ## specifically if a higher-order history state has a nonzero count,
+    ## we need to structurally have the count there in the states it backs
+    ## off to.
+    def AddCount(self, predicted_word, count):
+        self.total_count += count
+        assert self.total_count >= 0
+        old_count = self.word_to_count[predicted_word]
+        new_count = old_count + count
+        if new_count < 0:
+            print("predicted-word={0}, old-count={1}, count={2}".format(
+                    predicted_word, old_count, count))
+        assert new_count >= 0
+        if new_count == 0:
+            del self.word_to_count[predicted_word]
+        else:
+            self.word_to_count[predicted_word] = new_count
+
+class NgramCounts:
+    ## A note on data-structure.  Firstly, all words are represented as
+    ## integers.  We store n-gram counts as an array, indexed by (history-length
+    ## == n-gram order minus one) (note: python calls arrays "lists") of dicts
+    ## from histories to counts, where histories are arrays of integers and
+    ## "counts" are dicts from integer to float.  For instance, when
+    ## accumulating the 4-gram count for the '8' in the sequence '5 6 7 8', we'd
+    ## do as follows: self.counts[3][[5,6,7]][8] += 1.0 where the [3] indexes an
+    ## array, the [[5,6,7]] indexes a dict, and the [8] indexes a dict.
+    def __init__(self, ngram_order):
+        assert ngram_order >= 2
+        # Integerized counts will never contain negative numbers, so
+        # inside this program, we use -3 and -2 for the BOS and EOS symbols
+        # respectively.
+        # Note: it's actually important that the bos-symbol is the most negative;
+        # it helps ensure that we print the state with left-context <s> first
+        # when we print the FST, and this means that the start-state will have
+        # the correct value.
+        self.bos_symbol = -3
+        self.eos_symbol = -2
+        # backoff_symbol is kind of a pseudo-word, it's used in keeping track of
+        # the backoff counts in each state.
+        self.backoff_symbol = -1
+        self.total_num_words = 0  # count includes EOS but not BOS.
+        self.counts = []
+        for n in range(ngram_order):
+            self.counts.append(defaultdict(lambda: CountsForHistory()))
+
+    # adds a raw count (called while processing input data).
+    # Suppose we see the sequence '6 7 8 9' and ngram_order=4, 'history'
+    # would be (6,7,8) and 'predicted_word' would be 9; 'count' would be
+    # 1.
+    def AddCount(self, history, predicted_word, count):
+        self.counts[len(history)][history].AddCount(predicted_word, count)
+
+
+    # 'line' is a string containing a sequence of integer word-ids.
+    # This function adds the un-smoothed counts from this line of text.
+    def AddRawCountsFromLine(self, line):
+        try:
+            words = [self.bos_symbol] + [ int(x) for x in line.split() ] + [self.eos_symbol]
+        except:
+            sys.exit("make_one_biased_lm.py: bad input line {0} (expected a sequence "
+                     "of integers)".format(line))
+
+        for n in range(1, len(words)):
+            predicted_word = words[n]
+            history_start = max(0, n + 1 - args.ngram_order)
+            history = tuple(words[history_start:n])
+            self.AddCount(history, predicted_word, 1)
+            self.total_num_words += 1
+
+    def AddRawCountsFromStandardInput(self):
+        lines_processed = 0
+        while True:
+            line = sys.stdin.readline()
+            if line == '':
+                break
+            self.AddRawCountsFromLine(line)
+            lines_processed += 1
+        if lines_processed == 0 or args.verbose > 0:
+            print("make_one_biased_lm.py: processed {0} lines of input".format(
+                    lines_processed), file = sys.stderr)
+
+
+    # This backs off the counts by subtracting 1 and assigning the subtracted
+    # count to the backoff state.  It's like a special case of Kneser-Ney with D
+    # = 1.  The optimal D would likely be something like 0.9, but we plan to
+    # later do entropy-pruning, and the remaining small counts of 0.1 would
+    # essentially all get pruned away anyway, so we don't lose much by doing it
+    # like this.
+    def ApplyBackoff(self):
+        # note: in the normal case where args.no_backoff_ngram_order == 2 we
+        # don't do backoff for history-length = 1 (i.e. for bigrams)... this is
+        # a kind of special LM where we're not going to back off to unigram,
+        # there will be no unigram.
+        if args.verbose >= 1:
+            initial_num_ngrams = self.GetNumNgrams()
+        for n in reversed(range(args.no_backoff_ngram_order, args.ngram_order)):
+            this_order_counts = self.counts[n]
+            for hist, counts_for_hist in this_order_counts.items():
+                backoff_hist = hist[1:]
+                backoff_counts_for_hist = self.counts[n-1][backoff_hist]
+                this_discount_total = 0
+                for word in counts_for_hist.Words():
+                    counts_for_hist.AddCount(word, -1)
+                    # You can interpret the following line as incrementing the
+                    # count-of-counts for the next-lower order.  Note, however,
+                    # that later when we remove n-grams, we'll also add their
+                    # counts to the next-lower-order history state, so the
+                    # resulting counts won't strictly speaking be
+                    # counts-of-counts.
+                    backoff_counts_for_hist.AddCount(word, 1)
+                    this_discount_total += 1
+                counts_for_hist.AddCount(self.backoff_symbol, this_discount_total)
+
+        if args.verbose >= 1:
+            # Note: because D == 1, we completely back off singletons.
+            print("make_phone_lm.py: ApplyBackoff() reduced the num-ngrams from "
+                  "{0} to {1}".format(initial_num_ngrams, self.GetNumNgrams()),
+                  file = sys.stderr)
+
+
+    # This function prints out to stderr the n-gram counts stored in this
+    # object; it's used for debugging.
+    def Print(self, info_string):
+        print(info_string, file=sys.stderr)
+        # these are useful for debug.
+        total = 0.0
+        total_excluding_backoff = 0.0
+        for this_order_counts in self.counts:
+            for hist, counts_for_hist in this_order_counts.items():
+                print(str(hist) + str(counts_for_hist), file = sys.stderr)
+                total += counts_for_hist.total_count
+                total_excluding_backoff += counts_for_hist.total_count
+                if self.backoff_symbol in counts_for_hist.word_to_count:
+                    total_excluding_backoff -= counts_for_hist.word_to_count[self.backoff_symbol]
+        print('total count = {0}, excluding backoff = {1}'.format(
+                total, total_excluding_backoff), file = sys.stderr)
+
+    def GetHistToStateMap(self):
+        # This function, called from PrintAsFst, returns a map from
+        # history to integer FST-state.
+        hist_to_state = dict()
+        fst_state_counter = 0
+        for n in range(0, args.ngram_order):
+            for hist in self.counts[n].keys():
+                hist_to_state[hist] = fst_state_counter
+                fst_state_counter += 1
+        return hist_to_state
+
+    # Returns the probability of word 'word' in history-state 'hist'.
+    # If 'word' is self.backoff_symbol, returns the backoff prob
+    # of this history-state.
+    # Returns None if there is no such word in this history-state, or this
+    # history-state does not exist.
+    def GetProb(self, hist, word):
+        if len(hist) >= args.ngram_order or not hist in self.counts[len(hist)]:
+            return None
+        counts_for_hist = self.counts[len(hist)][hist]
+        total_count = float(counts_for_hist.total_count)
+        if not word in counts_for_hist.word_to_count:
+            print("make_phone_lm.py: no prob for {0} -> {1} "
+                  "[no such count]".format(hist, word),
+                  file = sys.stderr)
+            return None
+        prob = float(counts_for_hist.word_to_count[word]) / total_count
+        if len(hist) > 0 and word != self.backoff_symbol and \
+          self.backoff_symbol in counts_for_hist.word_to_count:
+            prob_in_backoff = self.GetProb(hist[1:], word)
+            backoff_prob = float(counts_for_hist.word_to_count[self.backoff_symbol]) / total_count
+            try:
+                prob += backoff_prob * prob_in_backoff
+            except:
+                sys.exit("problem, hist is {0}, word is {1}".format(hist, word))
+        return prob
+
+    def PruneEmptyStates(self):
+        # Removes history-states that have no counts.
+
+        # It's possible in principle for history-states to have no counts and
+        # yet they cannot be pruned away because a higher-order version of the
+        # state exists with nonzero counts, so we have to keep track of this.
+        protected_histories = set()
+
+        states_removed_per_hist_len = [ 0 ] * args.ngram_order
+
+        for n in reversed(range(args.no_backoff_ngram_order,
+                                args.ngram_order)):
+            num_states_removed = 0
+            for hist, counts_for_hist in self.counts[n].items():
+                l = len(counts_for_hist.word_to_count)
+                assert l > 0 and self.backoff_symbol in counts_for_hist.word_to_count
+                if l == 1 and not hist in protected_histories:  # only the backoff symbol has a count.
+                    del self.counts[n][hist]
+                    num_states_removed += 1
+                else:
+                    # if this state was not pruned away, then the state that
+                    # it backs off to may not be pruned away either.
+                    backoff_hist = hist[1:]
+                    protected_histories.add(backoff_hist)
+            states_removed_per_hist_len[n] = num_states_removed
+        if args.verbose >= 1:
+            print("make_phone_lm.py: in PruneEmptyStates(), num states removed for "
+                  "each history-length was: " + str(states_removed_per_hist_len),
+                  file = sys.stderr)
+
+    def EnsureStructurallyNeededNgramsExist(self):
+        # makes sure that if an n-gram like (6, 7, 8) -> 9 exists,
+        # then counts exist for (7, 8) -> 9 and (8,) -> 9.  It does so
+        # by adding zero counts where such counts were absent.
+        # [note: () -> 9 is guaranteed anyway by the backoff method, if
+        # we have a unigram state].
+        if args.verbose >= 1:
+            num_ngrams_initial = self.GetNumNgrams()
+        for n in reversed(range(args.no_backoff_ngram_order,
+                                args.ngram_order)):
+
+            for hist, counts_for_hist in self.counts[n].items():
+                # This loop ensures that if we have an n-gram like (6, 7, 8) -> 9,
+                # then, say, (7, 8) -> 9 and (8) -> 9 exist.
+                reduced_hist = hist
+                for m in reversed(range(args.no_backoff_ngram_order, n)):
+                    reduced_hist = reduced_hist[1:]  # shift an element off
+                                                     # the history.
+                    counts_for_backoff_hist = self.counts[m][reduced_hist]
+                    for word in counts_for_hist.word_to_count.keys():
+                        counts_for_backoff_hist.word_to_count[word] += 0
+                # This loop ensures that if we have an n-gram like (6, 7, 8) -> 9,
+                # then, say, (6, 7) -> 8 and (6) -> 7 exist.  This will be needed
+                # for FST representations of the ARPA LM.
+                reduced_hist = hist
+                for m in reversed(range(args.no_backoff_ngram_order, n)):
+                    this_word = reduced_hist[-1]
+                    reduced_hist = reduced_hist[:-1]  # pop an element off the
+                                                      # history
+                    counts_for_backoff_hist = self.counts[m][reduced_hist]
+                    counts_for_backoff_hist.word_to_count[this_word] += 0
+        if args.verbose >= 1:
+            print("make_phone_lm.py: in EnsureStructurallyNeededNgramsExist(), "
+                  "added {0} n-grams".format(self.GetNumNgrams() - num_ngrams_initial),
+                  file = sys.stderr)
+
+
+
+    # This function prints the estimated language model as an FST.
+    def PrintAsFst(self, word_disambig_symbol):
+        # n is the history-length (== order + 1).  We iterate over the
+        # history-length in the order 1, 0, 2, 3, and then iterate over the
+        # histories of each order in sorted order.  Putting order 1 first
+        # and sorting on the histories
+        # ensures that the bigram state with <s> as the left context comes first.
+        # (note: self.bos_symbol is the most negative symbol)
+
+        # History will map from history (as a tuple) to integer FST-state.
+        hist_to_state = self.GetHistToStateMap()
+
+        for n in [ 1, 0 ] + range(2, args.ngram_order):
+            this_order_counts = self.counts[n]
+            # For order 1, make sure the keys are sorted.
+            keys = this_order_counts.keys() if n != 1 else sorted(this_order_counts.keys())
+            for hist in keys:
+                word_to_count = this_order_counts[hist].word_to_count
+                this_fst_state = hist_to_state[hist]
+
+                for word in word_to_count.keys():
+                    # work out this_cost.  Costs in OpenFst are negative logs.
+                    this_cost = -math.log(self.GetProb(hist, word))
+
+                    if word > 0: # a real word.
+                        next_hist = hist + (word,)  # appending tuples
+                        while not next_hist in hist_to_state:
+                            next_hist = next_hist[1:]
+                        next_fst_state = hist_to_state[next_hist]
+                        print(this_fst_state, next_fst_state, word, word,
+                              this_cost)
+                    elif word == self.eos_symbol:
+                        # print final-prob for this state.
+                        print(this_fst_state, this_cost)
+                    else:
+                        assert word == self.backoff_symbol
+                        backoff_fst_state = hist_to_state[hist[1:len(hist)]]
+                        print(this_fst_state, backoff_fst_state,
+                              word_disambig_symbol, 0, this_cost)
+
+    # This function returns a set of n-grams that cannot currently be pruned
+    # away, either because a higher-order form of the same n-gram already exists,
+    # or because the n-gram leads to an n-gram state that exists.
+    # [Note: as we prune, we remove any states that can be removed; see that
+    # PruneToIntermediateTarget() calls PruneEmptyStates().
+
+    def GetProtectedNgrams(self):
+        ans = set()
+        for n in range(args.no_backoff_ngram_order + 1, args.ngram_order):
+            for hist, counts_for_hist in self.counts[n].items():
+                # If we have an n-gram (6, 7, 8) -> 9, the following loop will
+                # add the backed-off n-grams (7, 8) -> 9 and (8) -> 9 to
+                # 'protected-ngrams'.
+                reduced_hist = hist
+                for m in reversed(range(args.no_backoff_ngram_order, n)):
+                    reduced_hist = reduced_hist[1:]  # shift an element off
+                                                     # the history.
+
+                    for word in counts_for_hist.word_to_count.keys():
+                        if word != self.backoff_symbol:
+                            ans.add(reduced_hist + (word,))
+                # The following statement ensures that if we are in a
+                # history-state (6, 7, 8), then n-grams (6, 7, 8) and (6, 7) are
+                # protected.  This assures that the FST states are accessible.
+                reduced_hist = hist
+                for m in reversed(range(args.no_backoff_ngram_order, n)):
+                    ans.add(reduced_hist)
+                    reduced_hist = reduced_hist[:-1]  # pop an element off the
+                                                      # history
+        return ans
+
+    def PruneNgram(self, hist, word):
+        counts_for_hist = self.counts[len(hist)][hist]
+        assert word != self.backoff_symbol and word in counts_for_hist.word_to_count
+        count = counts_for_hist.word_to_count[word]
+        del counts_for_hist.word_to_count[word]
+        counts_for_hist.word_to_count[self.backoff_symbol] += count
+        # the next call adds the count to the symbol 'word' in the backoff
+        # history-state, and also updates its 'total_count'.
+        self.counts[len(hist) - 1][hist[1:]].AddCount(word, count)
+
+    # The function PruningLogprobChange is the same as the same-named
+    # function in float-counts-prune.cc in pocolm.  Note, it doesn't access
+    # any class members.
+
+    # This function computes the log-likelihood change (<= 0) from backing off
+    # a particular symbol to the lower-order state.
+    # The value it returns can be interpreted as a lower bound the actual log-likelihood
+    # change.  By "the actual log-likelihood change" we mean of data generated by
+    # the model itself before making the change, then modeled with the changed model
+    # [and comparing the log-like with the log-like before changing the model].  That is,
+    # it's a K-L divergence, but with the caveat that we don't normalize by the
+    # overall count of the data, so it's a K-L divergence multiplied by the training-data
+    # count.
+
+    #  'count' is the count of the word (call it 'a') in this state.  It's an integer.
+    #  'discount' is the discount-count in this state (represented as the count
+    #         for the symbol self.backoff_symbol).  It's an integer.
+    #  [note: we don't care about the total-count in this state, it cancels out.]
+    #  'backoff_count' is the count of word 'a' in the lower-order state.
+    #                 [actually it is the augmented count, treating any
+    #                  extra probability from even-lower-order states as
+    #                  if it were a count].  It's a float.
+    #  'backoff_total' is the total count in the lower-order state.  It's a float.
+    def PruningLogprobChange(self, count, discount, backoff_count, backoff_total):
+        if count == 0:
+            return 0.0
+
+        assert discount > 0 and backoff_total >= backoff_count and backoff_total >= 0.99 * discount
+
+
+        # augmented_count is like 'count', but with the extra count for symbol
+        # 'a' due to backoff included.
+        augmented_count = count + discount * backoff_count / backoff_total
+
+        # We imagine a phantom symbol 'b' that represents all symbols other than
+        # 'a' appearing in this history-state that are accessed via backoff.  We
+        # treat these as being distinct symbols from the same symbol if accessed
+        # not-via-backoff.  (Treating same symbols as distinct gives an upper bound
+        # on the divergence).  We also treat them as distinct from the same symbols
+        # that are being accessed via backoff from other states.  b_count is the
+        # observed count of symbol 'b' in this state (the backed-off count is
+        # zero).  b_count is also the count of symbol 'b' in the backoff state.
+        # Note: b_count will not be negative because backoff_total >= backoff_count.
+        b_count = discount * ((backoff_total - backoff_count) / backoff_total)
+        assert b_count >= -0.001 * backoff_total
+
+        # We imagine a phantom symbol 'c' that represents all symbols other than
+        # 'a' and 'b' appearing in the backoff state, which got there from
+        # backing off other states (other than 'this' state).  Again, we imagine
+        # the symbols are distinct even though they may not be (i.e. that c and
+        # b represent disjoint sets of symbol, even though they might not really
+        # be disjoint), and this gives us an upper bound on the divergence.
+        c_count = backoff_total - backoff_count - b_count
+        assert c_count >= -0.001 * backoff_total
+
+        # a_other is the count of 'a' in the backoff state that comes from
+        # 'other sources', i.e. it was backed off from history-states other than
+        # the current history state.
+        a_other_count = backoff_count - discount * backoff_count / backoff_total
+        assert a_other_count >= -0.001 * backoff_count
+
+        # the following sub-expressions are the 'new' versions of certain
+        # quantities after we assign the total count 'count' to backoff.  it
+        # increases the backoff count in 'this' state, and also the total count
+        # in the backoff state, and the count of symbol 'a' in the backoff
+        # state.
+        new_backoff_count = backoff_count + count  # new count of symbol 'a' in
+                                                    # backoff state
+        new_backoff_total = backoff_total + count  # new total count in
+                                                    # backoff state.
+        new_discount = discount + count  # new discount-count in 'this' state.
+
+
+        # all the loglike changes below are of the form
+        # count-of-symbol * log(new prob / old prob)
+        # which can be more conveniently written (by canceling the denominators),
+        # count-of-symbol * log(new count / old count).
+
+        # this_a_change is the log-like change of symbol 'a' coming from 'this'
+        # state.  bear in mind that
+        # augmented_count = count + discount * backoff_count / backoff_total,
+        # and the 'count' term is zero in the numerator part of the log expression,
+        # because symbol 'a' is completely backed off in 'this' state.
+        this_a_change = augmented_count * \
+            math.log((new_discount * new_backoff_count / new_backoff_total) / \
+                         augmented_count)
+
+        # other_a_change is the log-like change of symbol 'a' coming from all
+        # other states than 'this'.  For speed reasons we don't examine the
+        # direct (non-backoff) counts of symbol 'a' in all other states than
+        # 'this' that back off to the backoff state-- it would be slower.
+        # Instead we just treat the direct part of the prob for symbol 'a' as a
+        # distinct symbol when it comes from those other states... as usual,
+        # doing so gives us an upper bound on the divergence.
+        other_a_change = \
+            a_other_count * math.log((new_backoff_count / new_backoff_total) / \
+                                         (backoff_count / backoff_total))
+
+        # b_change is the log-like change of phantom symbol 'b' coming from
+        # 'this' state (and note: it only comes from this state, that's how we
+        # defined it).
+        # note: the expression below could be more directly written as a
+        # ratio of pseudo-counts as follows, by converting the backoff probabilities
+        # into pseudo-counts in 'this' state:
+        #  b_count * logf((new_discount * b_count / new_backoff_total) /
+        #                 (discount * b_count / backoff_total),
+        # but we cancel b_count to give us the expression below.
+        b_change = b_count * math.log((new_discount / new_backoff_total) / \
+                                          (discount / backoff_total))
+
+        # c_change is the log-like change of phantom symbol 'c' coming from
+        # all other states that back off to the backoff sate (and all prob. mass of
+        # 'c' comes from those other states).  The expression below could be more
+        # directly written as a ratio of counts, as c_count * logf((c_count /
+        # new_backoff_total) / (c_count / backoff_total)), but we simplified it to
+        # the expression below.
+        c_change = c_count * math.log(backoff_total / new_backoff_total)
+
+        ans = this_a_change + other_a_change + b_change + c_change
+        # the answer should not be positive.
+        assert ans <= 0.0001 * (count + discount + backoff_count + backoff_total)
+        if args.verbose >= 4:
+            print("pruning-logprob-change for {0},{1},{2},{3} is {4}".format(
+                    count, discount, backoff_count, backoff_total, ans),
+                  file = sys.stderr)
+        return ans
+
+
+    def GetLikeChangeFromPruningNgram(self, hist, word):
+        counts_for_hist = self.counts[len(hist)][hist]
+        counts_for_backoff_hist = self.counts[len(hist) - 1][hist[1:]]
+        assert word != self.backoff_symbol and word in counts_for_hist.word_to_count
+        count = counts_for_hist.word_to_count[word]
+        discount = counts_for_hist.word_to_count[self.backoff_symbol]
+        backoff_total = counts_for_backoff_hist.total_count
+        # backoff_count is a pseudo-count: it's like the count of 'word' in the
+        # backoff history-state, but adding something to account for further
+        # levels of backoff.
+        try:
+            backoff_count = self.GetProb(hist[1:], word) * backoff_total
+        except:
+            print("problem getting backoff count: hist = {0}, word = {1}".format(hist, word),
+                  file = sys.stderr)
+            sys.exit(1)
+
+        return self.PruningLogprobChange(float(count), float(discount),
+                                         backoff_count, float(backoff_total))
+
+    # note: returns loglike change per word.
+    def PruneToIntermediateTarget(self, num_extra_ngrams):
+        protected_ngrams = self.GetProtectedNgrams()
+        initial_num_extra_ngrams = self.GetNumExtraNgrams()
+        num_ngrams_to_prune = initial_num_extra_ngrams - num_extra_ngrams
+        assert num_ngrams_to_prune > 0
+
+        num_candidates_per_order = [ 0 ] * args.ngram_order
+        num_pruned_per_order = [ 0 ] * args.ngram_order
+
+
+        # like_change_and_ngrams this will be a list of tuples consisting
+        # of the likelihood change as a float and then the words of the n-gram
+        # that we're considering pruning,
+        # e.g. (-0.164, 7, 8, 9)
+        # meaning that pruning the n-gram (7, 8) -> 9 leads to
+        # a likelihood change of -0.164.  We'll later sort this list
+        # so we can prune the n-grams that made the least-negative
+        # likelihood change.
+        like_change_and_ngrams = []
+        for n in range(args.no_backoff_ngram_order, args.ngram_order):
+            for hist, counts_for_hist in self.counts[n].items():
+                for word, count in counts_for_hist.word_to_count.items():
+                    if word != self.backoff_symbol:
+                        if not hist + (word,) in protected_ngrams:
+                            like_change = self.GetLikeChangeFromPruningNgram(hist, word)
+                            like_change_and_ngrams.append((like_change,) + hist + (word,))
+                            num_candidates_per_order[len(hist)] += 1
+
+        like_change_and_ngrams.sort(reverse = True)
+
+        if num_ngrams_to_prune > len(like_change_and_ngrams):
+            print('make_phone_lm.py: aimed to prune {0} n-grams but could only '
+                  'prune {1}'.format(num_ngrams_to_prune, len(like_change_and_ngrams)),
+                  file = sys.stderr)
+            num_ngrams_to_prune = len(like_change_and_ngrams)
+
+        total_loglike_change = 0.0
+
+        for i in range(num_ngrams_to_prune):
+            total_loglike_change += like_change_and_ngrams[i][0]
+            hist = like_change_and_ngrams[i][1:-1]  # all but 1st and last elements
+            word = like_change_and_ngrams[i][-1]  # last element
+            num_pruned_per_order[len(hist)] += 1
+            self.PruneNgram(hist, word)
+
+        like_change_per_word = total_loglike_change / self.total_num_words
+
+        if args.verbose >= 1:
+            effective_threshold = (like_change_and_ngrams[num_ngrams_to_prune - 1][0]
+                                   if num_ngrams_to_prune >= 0 else 0.0)
+            print("Pruned from {0} ngrams to {1}, with threshold {2}.  Candidates per order were {3}, "
+                  "num-ngrams pruned per order were {4}.  Like-change per word was {5}".format(
+                    initial_num_extra_ngrams,
+                    initial_num_extra_ngrams - num_ngrams_to_prune,
+                    '%.4f' % effective_threshold,
+                    num_candidates_per_order,
+                    num_pruned_per_order,
+                    like_change_per_word), file = sys.stderr)
+
+        if args.verbose >= 3:
+            print("Pruning: like_change_and_ngrams is:\n" +
+                  '\n'.join([str(x) for x in like_change_and_ngrams[:num_ngrams_to_prune]]) +
+                  "\n-------- stop pruning here: ----------\n" +
+                  '\n'.join([str(x) for x in like_change_and_ngrams[num_ngrams_to_prune:]]),
+                  file = sys.stderr)
+            self.Print("Counts after pruning to num-extra-ngrams={0}".format(
+                    initial_num_extra_ngrams - num_ngrams_to_prune))
+
+        self.PruneEmptyStates()
+        if args.verbose >= 3:
+            ngram_counts.Print("Counts after removing empty states [inside pruning algorithm]:")
+        return like_change_per_word
+
+
+
+    def PruneToFinalTarget(self, num_extra_ngrams):
+        # prunes to a specified num_extra_ngrams.  The 'extra_ngrams' refers to
+        # the count of n-grams of order higher than args.no_backoff_ngram_order.
+        # We construct a sequence of targets that gradually approaches
+        # this value.  Doing it iteratively like this is a good way
+        # to deal with the fact that sometimes we can't prune a certain
+        # n-gram before certain other n-grams are pruned (because
+        # they lead to a state that must be kept, or an n-gram exists
+        # that backs off to this n-gram).
+
+        current_num_extra_ngrams = self.GetNumExtraNgrams()
+
+        if num_extra_ngrams >= current_num_extra_ngrams:
+            print('make_phone_lm.py: not pruning since target num-extra-ngrams={0} is >= '
+                  'current num-extra-ngrams={1}'.format(num_extra_ngrams, current_num_extra_ngrams),
+                  file=sys.stderr)
+            return
+
+        target_sequence = [num_extra_ngrams]
+        # two final iterations where the targets differ by factors of 1.1,
+        # preceded by two iterations where the targets differ by factors of 1.2.
+        for this_factor in [ 1.1, 1.2 ]:
+            for n in range(0,2):
+                if int((target_sequence[-1]+1) * this_factor) < current_num_extra_ngrams:
+                    target_sequence.append(int((target_sequence[-1]+1) * this_factor))
+        # then change in factors of 1.3
+        while True:
+            this_factor = 1.3
+            if int((target_sequence[-1]+1) * this_factor) < current_num_extra_ngrams:
+                target_sequence.append(int((target_sequence[-1]+1) * this_factor))
+            else:
+                break
+
+        target_sequence = list(set(target_sequence))  # only keep unique targets.
+        target_sequence.sort(reverse = True)
+
+        print('make_phone_lm.py: current num-extra-ngrams={0}, pruning with '
+              'following sequence of targets: {1}'.format(current_num_extra_ngrams,
+                                                          target_sequence),
+              file = sys.stderr)
+        total_like_change_per_word = 0.0
+        for target in target_sequence:
+            total_like_change_per_word += self.PruneToIntermediateTarget(target)
+
+        if args.verbose >= 1:
+            print('make_phone_lm.py: K-L divergence from pruning (upper bound) is '
+                  '%.4f' % total_like_change_per_word, file = sys.stderr)
+
+
+    # returns the number of n-grams on top of those that can't be pruned away
+    # because their order is <= args.no_backoff_ngram_order.
+    def GetNumExtraNgrams(self):
+        ans = 0
+        for hist_len in range(args.no_backoff_ngram_order, args.ngram_order):
+            # note: hist_len + 1 is the actual order.
+            ans += self.GetNumNgrams(hist_len)
+        return ans
+
+
+    def GetNumNgrams(self, hist_len = None):
+        ans = 0
+        if hist_len == None:
+            for hist_len in range(args.ngram_order):
+                # note: hist_len + 1 is the actual order.
+                ans += self.GetNumNgrams(hist_len)
+            return ans
+        else:
+            for counts_for_hist in self.counts[hist_len].values():
+                ans += len(counts_for_hist.word_to_count)
+                if self.backoff_symbol in counts_for_hist.word_to_count:
+                    ans -= 1  # don't count the backoff symbol, it doesn't produce
+                              # its own n-gram line.
+            return ans
+
+
+    # this function, used in PrintAsArpa, converts an integer to
+    # a string by either printing it as a string, or for self.bos_symbol
+    # and self.eos_symbol, printing them as "<s>" and "</s>" respectively.
+    def IntToString(self, i):
+        if i == self.bos_symbol:
+            return '<s>'
+        elif i == self.eos_symbol:
+            return '</s>'
+        else:
+            assert i != self.backoff_symbol
+            return str(i)
+
+
+
+    def PrintAsArpa(self):
+        # Prints out the FST in ARPA format.
+        assert args.no_backoff_ngram_order == 1  # without unigrams we couldn't
+                                                 # print as ARPA format.
+
+        print('\\data\\');
+        for hist_len in range(args.ngram_order):
+            # print the number of n-grams.  Add 1 for the 1-gram
+            # section because of <s>, we print -99 as the prob so we
+            # have a place to put the backoff prob.
+            print('ngram {0}={1}'.format(
+                    hist_len + 1,
+                    self.GetNumNgrams(hist_len) + (1 if hist_len == 0 else 0)))
+
+        print('')
+
+        for hist_len in range(args.ngram_order):
+            print('\\{0}-grams:'.format(hist_len + 1))
+
+            # print fake n-gram for <s>, for its backoff prob.
+            if hist_len == 0:
+                backoff_prob = self.GetProb((self.bos_symbol,), self.backoff_symbol)
+                if backoff_prob != None:
+                    print('-99\t<s>\t{0}'.format('%.5f' % math.log10(backoff_prob)))
+
+            for hist in self.counts[hist_len].keys():
+                for word in self.counts[hist_len][hist].word_to_count.keys():
+                    if word != self.backoff_symbol:
+                        prob = self.GetProb(hist, word)
+                        assert prob != None and prob > 0
+                        backoff_prob = self.GetProb((hist)+(word,), self.backoff_symbol)
+                        line = '{0}\t{1}'.format('%.5f' % math.log10(prob),
+                                                 ' '.join(self.IntToString(x) for x in hist + (word,)))
+                        if backoff_prob != None:
+                            line += '\t{0}'.format('%.5f' % math.log10(backoff_prob))
+                        print(line)
+            print('')
+        print('\\end\\')
+
+
+
+ngram_counts = NgramCounts(args.ngram_order)
+ngram_counts.AddRawCountsFromStandardInput()
+
+if args.verbose >= 3:
+    ngram_counts.Print("Raw counts:")
+ngram_counts.ApplyBackoff()
+if args.verbose >= 3:
+    ngram_counts.Print("Counts after applying Kneser-Ney discounting:")
+ngram_counts.EnsureStructurallyNeededNgramsExist()
+if args.verbose >= 3:
+    ngram_counts.Print("Counts after adding structurally-needed n-grams (1st time):")
+ngram_counts.PruneEmptyStates()
+if args.verbose >= 3:
+    ngram_counts.Print("Counts after removing empty states:")
+ngram_counts.PruneToFinalTarget(args.num_extra_ngrams)
+
+ngram_counts.EnsureStructurallyNeededNgramsExist()
+if args.verbose >= 3:
+    ngram_counts.Print("Counts after adding structurally-needed n-grams (2nd time):")
+
+
+
+
+if args.print_as_arpa == "true":
+    ngram_counts.PrintAsArpa()
+else:
+    if args.phone_disambig_symbol == None:
+        sys.exit("make_phone_lm.py: --phone-disambig-symbol must be provided (unless "
+                 "you are writing as ARPA")
+    ngram_counts.PrintAsFst(args.phone_disambig_symbol)
+
+
+## Below are some little test commands that can be used to look at the detailed stats
+## for a kind of sanity check.
+# test comand:
+# (echo 6 7 8 4; echo 7 8 9; echo 7 8; echo 7 4; echo 8 4 ) | utils/lang/make_phone_lm.py --phone-disambig-symbol=400  --verbose=3
+#  (echo 6 7 8 4; echo 7 8 9; echo 7 8; echo 7 4; echo 8 4 ) | utils/lang/make_phone_lm.py --phone-disambig-symbol=400  --verbose=3 --num-extra-ngrams=0
+# (echo 6 7 8 4; echo 6 7 ) | utils/lang/make_phone_lm.py --print-as-arpa=true --no-backoff-ngram-order=1  --verbose=3
+
+
+## The following shows how we created some data suitable to do comparisons with
+## other language modeling toolkits.  Note: we're running in a configuration
+## where --no-backoff-ngram-order=1 (i.e. we have a unigram LM state) because
+## it's the only way to get perplexity calculations and to write an ARPA file.
+##
+# cd egs/tedlium/s5_r2
+# . ./path.sh
+# mkdir -p lm_test
+# ali-to-phones exp/tri3/final.mdl "ark:gunzip -c exp/tri3/ali.*.gz|" ark,t:-  | awk '{$1 = ""; print}' > lm_test/phone_seqs
+# wc lm_test/phone_seqs
+# 92464  8409563 27953288 lm_test/phone_seqs
+# head -n 20000 lm_test/phone_seqs > lm_test/train.txt
+# tail -n 1000 lm_test/phone_seqs > lm_test/test.txt
+
+## This shows make_phone_lm.py with the default number of extra-lm-states (20k)
+## You have to have SRILM on your path to ger perplexities [note: it should be on the
+## path if you installed it and you sourced the tedlium s5b path.sh, as above.]
+# utils/lang/make_phone_lm.py --print-as-arpa=true --no-backoff-ngram-order=1 --verbose=1 < lm_test/train.txt > lm_test/arpa_pr20k
+# ngram -order 4 -unk -lm lm_test/arpa_pr20k -ppl lm_test/test.txt
+# file lm_test/test.txt: 1000 sentences, 86489 words, 3 OOVs
+# 0 zeroprobs, logprob= -80130.1 ppl=*8.23985* ppl1= 8.44325
+# on training data: 0 zeroprobs, logprob= -1.6264e+06 ppl= 7.46947 ppl1= 7.63431
+
+## This shows make_phone_lm.py without any pruning (make --num-extra-ngrams very large).
+# utils/lang/make_phone_lm.py --print-as-arpa=true --num-extra-ngrams=1000000 --no-backoff-ngram-order=1 --verbose=1 < lm_test/train.txt > lm_test/arpa
+# ngram -order 4 -unk -lm lm_test/arpa -ppl lm_test/test.txt
+# file lm_test/test.txt: 1000 sentences, 86489 words, 3 OOVs
+# 0 zeroprobs, logprob= -74976 ppl=*7.19459* ppl1= 7.36064
+# on training data: 0 zeroprobs, logprob= -1.44198e+06 ppl= 5.94659 ppl1= 6.06279
+
+## This is SRILM without pruning (c.f. the 7.19 above, it's slightly better).
+# ngram-count -text lm_test/train.txt -order 4 -kndiscount2 -kndiscount3 -kndiscount4 -interpolate -lm lm_test/arpa_srilm
+# ngram -order 4 -unk -lm lm_test/arpa_srilm -ppl lm_test/test.txt
+# file lm_test/test.txt: 1000 sentences, 86489 words, 3 OOVs
+# 0 zeroprobs, logprob= -74742.2 ppl= *7.15044* ppl1= 7.31494
+
+
+## This is SRILM with a pruning beam tuned to get 20k n-grams above unigram
+##  (c.f. the 8.23 above, it's a lot worse).
+# ngram-count -text lm_test/train.txt -order 4 -kndiscount2 -kndiscount3 -kndiscount4 -interpolate -prune 1.65e-05 -lm lm_test/arpa_srilm.pr1.65e-5
+# the model has 20249 n-grams above unigram [c.f. our 20k]
+# ngram -order 4 -unk -lm lm_test/arpa_srilm.pr1.65e-5 -ppl lm_test/test.txt
+# file lm_test/test.txt: 1000 sentences, 86489 words, 3 OOVs
+# 0 zeroprobs, logprob= -86803.7 ppl=*9.82202* ppl1= 10.0849
+
+
+## This is pocolm..
+## Note: we have to hold out some of the training data as dev to
+## estimate the hyperparameters, but we'll fold it back in before
+## making the final LM. [--fold-dev-into=train]
+# mkdir -p lm_test/data/text
+# head -n 1000 lm_test/train.txt > lm_test/data/text/dev.txt
+# tail -n +1001 lm_test/train.txt > lm_test/data/text/train.txt
+## give it a 'large' num-words so it picks them all.
+# export PATH=$PATH:../../../tools/pocolm/scripts
+# train_lm.py --num-word=100000 --fold-dev-into=train lm_test/data/text 4 lm_test/data/lm_unpruned
+# get_data_prob.py lm_test/test.txt lm_test/data/lm_unpruned/100000_4.pocolm
+## compute-probs: average log-prob per word was -1.95956 (perplexity = *7.0962*) over 87489 words.
+## Note: we can compare this perplexity with 7.15 with SRILM and 7.19 with make_phone_lm.py.
+
+#   pruned_lm_dir=${lm_dir}/${num_word}_${order}_prune${threshold}.pocolm
+# prune_lm_dir.py --target-num-ngrams=20100 lm_test/data/lm_unpruned/100000_4.pocolm lm_test/data/lm_unpruned/100000_4_pr20k.pocolm
+# get_data_prob.py lm_test/test.txt lm_test/data/lm_unpruned/100000_4_pr20k.pocolm
+## compute-probs: average log-prob per word was -2.0409 (perplexity = 7.69757) over 87489 words.
+## note: the 7.69 can be compared with 9.82 from SRILM and 8.23 from pocolm.
+## format_arpa_lm.py lm_test/data/lm_unpruned/100000_4_pr20k.pocolm | head
+## .. it has 20488 n-grams above unigram.  More than 20k but not enough to explain the difference
+## .. in perplexity.
+
+## OK... if I reran after modifying prune_lm_dir.py to comment out the line
+## 'steps += 'EM EM'.split()' which adds the two EM stages per step, and got the
+## perplexity again, I got the following:
+## compute-probs: average log-prob per word was -2.09722 (perplexity = 8.14353) over 87489 words.
+## .. so it turns out the E-M is actually important.

--- a/egs/wsj/s5/utils/lang/make_unk_lm.sh
+++ b/egs/wsj/s5/utils/lang/make_unk_lm.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+
+# Copyright      2016 Johns Hopkins University (Author: Daniel Povey);
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Begin configuration section.
+cmd=run.pl
+ngram_order=4
+num_extra_ngrams=10000
+position_dependent_phones=true
+use_pocolm=true
+min_word_length=2
+stage=0
+phone_disambig_symbol="#1"
+
+# end configuration sections
+
+[ -f path.sh ] && . ./path.sh
+. utils/parse_options.sh
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 [options] <input-dict-dir> <work-dir>"
+  echo "e.g.: $0 data/local/dict exp/make_unk"
+  echo ""
+  echo "This script creates, as an FST, a phone language model suitable for modeling"
+  echo "the unknown word.  It first trains a language model on the phone sequences of the"
+  echo "provided dictionary entries (which should be without any word-position-dependency"
+  echo "tags); it then creates an FST from it, while, for compactness after context-dependency"
+  echo "limiting the transitions to seen bigram pairs of phones.  Then, by composing with"
+  echo "a separate FST it converts it into word-position-dependent phones if applicable,"
+  echo "while imposing a minimum-number-of-phones constraint."
+  echo ""
+  echo "  <input-dict-dir>:  A dictionary directory (as validated by validate_dict_dir.pl);"
+  echo "             the dictionary from this location (lexicon.txt, lexiconp.txt, or"
+  echo "             lexiconp_silprob.txt) will be used to train the language model on"
+  echo "             phones.  The files silence_phones.txt and nonsilence_phones.txt will"
+  echo "             be used to construct a symbol table used internally, and to"
+  echo "             exclude lexicon entries containing silences."
+  echo " <work-dir>:    A place to put logs and the output of this script.  The output of"
+  echo "                this script will be written to <work-dir>/unk_fst.txt (we write in"
+  echo "                text form so that it's independent of the phones.txt)."
+  echo "Options:"
+  echo "    --ngram-order <n>                 # (default: 4)  N-gram order of the phone-level language"
+  echo "                                      # model.  Must be in range [2, 7]"
+  echo "    --num-extra-ngrams <n>            # (default: 10000).  The maximum the number of n-grams"
+  echo "                                      # that may be present in the language model in addition"
+  echo "                                      # to the unigrams.  The LM will be pruned to achieve this."
+  echo "    --use-pocolm <true|false>         # (default: true).  If true, use pocolm to estimate the"
+  echo "                                      # language model; you will be prompted to install it if"
+  echo "                                      # needed.  (If false, we use the script make_phone_lm.py,"
+  echo "                                      # which is simpler but the perplexity is not as good)."
+  echo "    --position-dependent-phones <true|false>  # (default: true).  If true, assume position-dependent"
+  echo "                                      # phones (although in any case the lexicon should use position-"
+  echo "                                      # independent phones).  If position-dependent phones are used,"
+  echo "                                      # after creating the LM we compose with an FST that converts"
+  echo "                                      # into position-dependent phones while enforcing the natural"
+  echo "                                      # constraints that they form a single word."
+  echo "    --min-word-length <1|2>           # (default: 2).  May only be 1 or 2.  The minimum word length"
+  echo "                                      # (in number of phones) that is allowed"
+  echo "    --phone-disambig-symbol <symbol>  # default: '#1'.  This is the symbol that will be put on the"
+  echo "                                      # input side of backoff arcs.  You won't normally have to change"
+  echo "                                      # this because prepare_lang.sh expects '#1' there."
+  exit 1;
+fi
+
+
+dict_dir=$1
+dir=$2
+
+set -e
+
+mkdir -p $dir/log
+
+if [ $stage -le 0 ]; then
+  if ! utils/validate_dict_dir.pl $dict_dir >&$dir/log/validate_dict_dir.log; then
+    cat $dir/log/validate_dict_dir.log
+    echo "$0: failed to validate input dict-dir $dict_dir"
+    exit 1
+  fi
+fi
+
+if ! [ $ngram_order -ge 2 ] || ! [ $ngram_order -le 7 ]; then
+  echo "$0: invalid --ngram-order $ngram_order (must be in [2,7])"
+  exit 1
+fi
+
+if ! [ $min_word_length -ge 1 ] || ! [ $min_word_length -le 2 ]; then
+  echo "$0: invalid --min-word-length $min_word_length (must be in [1,2])"
+  exit 1
+fi
+
+# The next command creates a symbol table that will cover all the symbols we might
+# possibly need in this script.  The word-position-dependent suffixes (_B and so on
+# won't be needed if --position-dependent-phones is false, but it won't hurt.
+cat $dict_dir/silence_phones.txt $dict_dir/nonsilence_phones.txt | \
+  awk '{for(n=1;n<=NF;n++) print $n; }' | \
+  awk '{print $1; print $1 "_B"; print $1 "_I"; print $1 "_S"; print $1 "_E";}' | \
+      cat - <(echo "$phone_disambig_symbol") | \
+  awk 'BEGIN{print "<eps> 0";} {print $1, NR;}' > $dir/phones.txt
+
+phone_disambig_int=$(tail -n 1 <$dir/phones.txt | awk '{print $2}')
+if ! [ $phone_disambig_int == $phone_disambig_int ]; then
+  echo "$0: problem working out integer form of phone-disambig symbol."
+  exit 1;
+fi
+
+if [ -e $dict_dir/lexicon.txt ]; then
+  src_dict=$dict_dir/lexicon.txt
+  first_phone_field=2
+elif [ -e $dict_dir/lexiconp.txt ]; then
+  src_dict=$dict_dir/lexiconp.txt
+  first_phone_field=3
+else
+  [ ! -e $dict_dir/lexiconp_silprob.txt ] && \
+    echo "$0: expected file $dict_dir/lexiconp_silprob.txt to exist" && exit 1
+  src_dict=$dict_dir/lexiconp_silprob.tt
+  first_phone_field=6
+fi
+
+cat $dict_dir/silence_phones.txt | awk '{for(n=1;n<=NF;n++) print $n; }' > $dir/silence_phones.txt
+
+# prepare the cleaned up version of the dictionary (to train our phone LM), with
+# the first field (the word) removed, with prons that have silence phones in
+# them removed, and with empty prons (which should not be allowed anyway, but
+# just in case..) removed.
+awk -v dir=$dir -v ff=$first_phone_field \
+   'BEGIN{ while ((getline <(dir"/silence_phones.txt")) > 0) sil[$1]=1;  }
+         { ok=1; for (n=ff; n<=NF; n++) { if ($n in sil) ok=0; }
+           if (ok && NF>=ff) { for (n=ff;n<=NF;n++) printf("%s ",$n); print ""; } else {
+            print("make_unk_lm.sh: info: not including dict line: ", $0) >"/dev/stderr" }}' <$src_dict >$dir/training.txt
+
+num_dict_lines=$(wc -l <$src_dict)
+num_train_lines=$(wc -l < $dir/training.txt)
+if ! [ $num_train_lines -gt 0 ]; then
+  echo "$0: something went wrong getting text to train phone-level LM."
+  exit 1
+fi
+echo "$0: training on $num_train_lines words out of $num_dict_lines in the "
+echo "     ... original dictionary (excluding words with silence phones)."
+
+
+if [ $num_train_lines -lt 2000 ] && $use_pocolm; then
+  echo "$0: the number of lines of training data is very small [$num_train_lines]."
+  echo "    Setting --use-pocolm to false since it probably won't work well"
+  echo "    on so little data (e.g. hard to estimate the discounting parameters)"
+  echo "    Using make_phone_lm.py instead."
+  use_pocolm=false
+fi
+
+if $use_pocolm; then
+  if [ ! -e $KALDI_ROOT/tools/pocolm ]; then
+    echo "$0: $KALDI_ROOT/tools/pocolm does not exist:"
+    echo " ... please do:   cd $KALDI_ROOT; extras/install_pocolm.sh"
+    echo " ... and then rerun this script."
+    exit 1
+  fi
+
+  PATH=$KALDI_ROOT/tools/pocolm/scripts:$PATH
+
+  if [ $stage -le 1 ]; then
+    echo "$0: training $ngram_order-gram LM with pocolm"
+
+    mkdir -p $dir/pocolm/text
+    heldout_ratio=5  # hold out one fifth of the data as validation to estimate
+    # metaparameters; we'll fold it back in before estimating the
+    # final LM.
+    cat $dir/training.txt | awk -v h=$heldout_ratio '{if(NR%h == 0) print; }' > $dir/pocolm/text/dev.txt
+    cat $dir/training.txt | awk -v h=$heldout_ratio '{if(NR%h != 0) print; }' > $dir/pocolm/text/train.txt
+
+    cat $dir/training.txt | awk '{for(n=1;n<=NF;n++) seen[$n]=1; } END{for (k in seen) print k;}' > $dir/all_nonsil_phones
+
+    # the following options are because we expect the amount of data to be small,
+    # all the data subsampling isn't really needed and will increase the chance of
+    # something going wrong.
+
+    small_data_opts="--num-splits 4 --warm-start-ratio 1"
+    $cmd $dir/log/train_lm.log \
+         train_lm.py --wordlist $dir/all_nonsil_phones $small_data_opts \
+         --fold-dev-into=train $dir/pocolm/text $ngram_order $dir/pocolm
+  fi
+
+  if [ $stage -le 2 ]; then
+    echo "$0: pruning LM with pocolm"
+    num_words=$(wc -l <$dir/all_nonsil_phones)
+    num_ngrams=$[$num_extra_ngrams+$num_words]
+
+
+    $cmd $dir/log/prune_lm_dir.log \
+         prune_lm_dir.py --target-num-ngrams=$num_ngrams \
+         $dir/pocolm/all_nonsil_phones_${ngram_order}.pocolm $dir/poclm/lm_pruned
+
+    # format as arpa.
+    format_arpa_lm.py $dir/poclm/lm_pruned > $dir/pocolm.arpa
+  fi
+
+  if [ $stage -le 3 ]; then
+    echo "$0: applying bigram constraints and converting from ARPA to FST"
+    # now get bigram constraints: we want to get an FST that only allows phone
+    # bigrams that we've seen (this may enforce certain linguistic constraints,
+    # and also stops the graph from blowing up too much once we introduce
+    # phonetic context.
+    cat $dir/training.txt | awk '{ printf("<s> %s </s>\n", $0); }' | \
+      awk '{for(n=1;n<NF;n++) { m=n+1; seen[ $n " " $m ] = 1; }} END{for(k in seen) print k;}' \
+          > $dir/allowed_bigrams
+
+    $cmd $dir/log/arpa2fst.log \
+         utils/lang/internal/arpa2fst_constrained.py --verbose=3 \
+           --disambig-symbol="$phone_disambig_symbol" \
+         $dir/pocolm.arpa $dir/allowed_bigrams '>' $dir/unk_fst_orig.txt
+  fi
+else
+
+  if [ $stage -le 1 ]; then
+    echo "$0: using make_phone_lm.py to create $ngram_order-gram language-model FST"
+    $cmd $dir/log/make_phone_lm.log \
+         utils/sym2int.pl $dir/phones.txt $dir/training.txt '|' \
+         utils/lang/make_phone_lm.py --verbose=2 \
+         --phone-disambig-symbol=$phone_disambig_int \
+         --num-extra-ngrams=$num_extra_ngrams \
+         --ngram-order=$ngram_order '|' \
+         utils/int2sym.pl -f 3-4 $dir/phones.txt '>'$dir/unk_fst_orig.txt
+  fi
+fi
+
+
+sym_opts="--isymbols=$dir/phones.txt --osymbols=$dir/phones.txt"
+
+if ! $position_dependent_phones; then
+  if  [ $min_word_length == 1 ]; then
+    echo "$0: no word-length constraint or word-position-dependency, so exiting."
+    # There is no need to compose unk_fst_orig.txt with a separate FST: because of
+    # the bigram constraints and because we ensure that there were no empty prons
+    # in the dictionary (no empty lines in training.txt), the FST wouldn't allow
+    # length-zero words anyway.
+    cp $dir/unk_fst_orig.txt $dir/unk_fst.txt
+    fstcompile $sym_opts <$dir/unk_fst.txt >$dir/unk.fst
+    exit 0;
+  else
+    echo "$0: creating constraint_fst.txt for min-word-length=2 constraint."
+    # min-word-length is 2; we need to apply that constraint.  A note on the FST
+    # states: 0 is start state, 1 is "seen one phone", 2 is "seen two or more
+    # phones".
+    # We don't need to take into account the disambig symbol because we compose on
+    # the right with this FST, and it doesn't appear on the output side.
+    cat $dir/all_nonsil_phones | \
+      awk -v '{ph[$1]=1} END{ for (p in ph) { print 0,1,p,p; print 1,2,p,p; print 2,2,p,p; }
+                 print 2,0.0; }' > $dir/constraint_fst.txt
+  fi
+else
+  echo "$0: creating constraint_fst.txt for min-word-length=$min_word_length constraint, plus word-position-dependency conversion."
+
+  # Add constraints and convert phones without tags into phones with the _B, _E, _I and _S
+  # tags (begin, end, internal, singleton).
+
+  # States:
+  # 0 is start state,
+  # 1 is "seen initial phone (and maybe internal phones) of multi-phone word",
+  # 2 is "seen final phone of multi-phone word".
+  # 3 is "seen phone of single-phone word"; note, if --min-word-length is 2,
+  #      then state 3 will not exist.
+
+  cat $dir/all_nonsil_phones | \
+    awk -v mwl=$min_word_length -v "disambig=$phone_disambig_symbol" \
+ '{ph[$1]=1} END{ for (n=0; n<3; n++) print n,n,disambig,disambig;
+                  for (p in ph) { printf("0 1 %s %s_B\n", p, p); printf("1 1 %s %s_I\n", p, p);
+                                  printf("1 2 %s %s_E\n", p, p); if (mwl==1) printf("0 3 %s %s_S\n", p, p);  }
+                 print 2,0.0; if (mwl==1) print 3,0.0; }' >$dir/constraint_fst.txt
+fi
+
+
+echo "$0: creating final FST via composition, etc."
+
+fstcompile $sym_opts <$dir/constraint_fst.txt | fstarcsort > $dir/constraint.fst
+fstcompile $sym_opts <$dir/unk_fst_orig.txt >$dir/unk_orig.fst
+
+# The first 'fstproject' below projects on the input; it makes sure the
+# disambiguation symbol appears on the output side also.
+# The fstcompose actually applies the constraints and does the conversion, but
+# after this the "correct" phones appear only on the output side.
+# The second 'fstproject' copies the word-position-dependent phones to
+# the input side.
+# The 'fstpushspecial' pushes the weights, as the composition with the
+#  constraint FST makes the FST quite non-stochastic [weights per state do not
+#  sum up to one].
+# The 'fstrmsymbols' command makes sure the disambiguation symbol appears only
+# on the input side.
+# 'fstminimizeencoded' combines states that are the same as far as their output
+# arcs are concerned; in the case where --min-word-length is 1, this combines
+# a lot of final-states that have no transitions out of them.
+fstproject $dir/unk_orig.fst | \
+  fstcompose - $dir/constraint.fst | \
+  fstproject --project_output=true | \
+  fstpushspecial | \
+  fstminimizeencoded | \
+  fstrmsymbols --remove-from-output=true <(echo $phone_disambig_int) >$dir/unk.fst
+
+fstprint $sym_opts <$dir/unk.fst >$dir/unk_fst.txt
+
+
+exit 0;

--- a/egs/wsj/s5/utils/validate_dict_dir.pl
+++ b/egs/wsj/s5/utils/validate_dict_dir.pl
@@ -8,7 +8,8 @@
 
 
 if(@ARGV != 1) {
-  die "Usage: validate_dict_dir.pl dict_directory\n";
+  die "Usage: validate_dict_dir.pl <dict-dir>\n" .
+      "e.g.: validate_dict_dir.pl data/local/dict\n";
 }
 
 $dict = shift @ARGV;
@@ -45,12 +46,17 @@ while(<S>) {
   }
   foreach(0 .. @col-1) {
     my $p = $col[$_];
-    if($silence{$p}) {set_to_fail(); print "--> ERROR: phone \"$p\" duplicates in $dict/silence_phones.txt (line $idx)\n"; }
-    else {$silence{$p} = 1;}
-    if ($p =~ m/#(\d)+/ || $p =~ m/_[BESI]$/){
+    if($silence{$p}) {
+      set_to_fail(); print "--> ERROR: phone \"$p\" duplicates in $dict/silence_phones.txt (line $idx)\n";
+    } else {
+      $silence{$p} = 1;
+    }
+    # disambiguation symbols; phones ending in _B, _E, _S or _I will cause
+    # problems with word-position-dependent systems, and <eps> is obviously
+    # confusable with epsilon.
+    if ($p =~ m/^#/ || $p =~ m/_[BESI]$/ || $p eq "<eps>"){
       set_to_fail();
       print "--> ERROR: phone \"$p\" has disallowed written form\n";
-
     }
   }
   $idx ++;
@@ -112,12 +118,18 @@ while(<NS>) {
   }
   foreach(0 .. @col-1) {
     my $p = $col[$_];
-    if($nonsilence{$p}) {set_to_fail(); print "--> ERROR: phone \"$p\" duplicates in $dict/nonsilence_phones.txt (line $idx)\n"; }
-    else {$nonsilence{$p} = 1;}
-    if ($p =~ m/#(\d)+/ || $p =~ m/_[BESI]$/){
+    if($nonsilence{$p}) {
+      set_to_fail(); print "--> ERROR: phone \"$p\" duplicates in $dict/nonsilence_phones.txt (line $idx)\n";
+    } else {
+      $nonsilence{$p} = 1;
+    }
+    # phones that start with the pound sign/hash may be mistaken for
+    # disambiguation symbols; phones ending in _B, _E, _S or _I will cause
+    # problems with word-position-dependent systems, and <eps> is obviously
+    # confusable with epsilon.
+    if ($p =~ m/^#/ || $p =~ m/_[BESI]$/ || $p eq "<eps>"){
       set_to_fail();
       print "--> ERROR: phone \"$p\" has disallowed written form\n";
-
     }
   }
   $idx ++;

--- a/egs/wsj/s5/utils/validate_lang.pl
+++ b/egs/wsj/s5/utils/validate_lang.pl
@@ -754,7 +754,10 @@ if (-s "$lang/phones/word_boundary.int") {
     $cur_state = "bos";
     $num_words = 0;
     foreach $phone (split (" ", "$phoneseq <<eos>>")) {
-      if (!($fst == "L_disambig.fst" && defined $is_disambig{$phone})) {
+      # Note: now that we support unk-LMs (see the --unk-fst option to
+      # prepare_lang.sh), the regular L.fst may contain some disambiguation
+      # symbols.
+      if (! defined $is_disambig{$phone}) {
         if ($phone == "<<eos>>") {
           $state = "eos";
         } else {

--- a/src/chain/language-model.cc
+++ b/src/chain/language-model.cc
@@ -200,7 +200,7 @@ BaseFloat LanguageModelEstimator::BackoffLogLikelihoodChange(
   LmState sum_state(backoff_lm_state);
   sum_state.Add(lm_state);
   BaseFloat log_like_change =
-      sum_state.LogLike() - 
+      sum_state.LogLike() -
       lm_state.LogLike() -
       backoff_lm_state.LogLike();
   // log-like change should not be positive... give it a margin for round-off
@@ -272,7 +272,7 @@ void LanguageModelEstimator::BackOffState(int32 l) {
   lm_state.Clear();
   backoff_lm_state.backoff_allowed = BackoffAllowed(
       lm_state.backoff_lmstate_index);
-  
+
   if (!backoff_state_had_backoff_allowed &&
       backoff_lm_state.backoff_allowed) {
     // the backoff state would not have been in the queue, but is now allowed in
@@ -357,7 +357,7 @@ void LanguageModelEstimator::OutputToFst(
   for (int32 i = 0; i < num_states; i++)
     fst->AddState();
   fst->SetStart(FindInitialFstState());
-  
+
   int64 tot_count = 0;
   double tot_logprob = 0.0;
 
@@ -402,7 +402,8 @@ void LanguageModelEstimator::OutputToFst(
   KALDI_ASSERT(num_states_connected == num_states);
   // arc-sort.  ilabel or olabel doesn't matter, it's an acceptor.
   fst::ArcSort(fst, fst::ILabelCompare<fst::StdArc>());
-  KALDI_LOG << "Created phone language model with " << num_states << " states.";
+  KALDI_LOG << "Created phone language model with " << num_states
+            << " states and " << fst::NumArcs(*fst) << " arcs.";
 }
 
 }  // namespace chain

--- a/src/lm/arpa-lm-compiler-test.cc
+++ b/src/lm/arpa-lm-compiler-test.cc
@@ -130,6 +130,8 @@ bool CoverageTest(bool seps, const string &infile) {
     if (seps)
       AddSelfLoops(&sentence);
 
+    fst::ArcSort(lm_compiler->MutableFst(), fst::StdOLabelCompare());
+
     // The past must successfullycompose with the LM FST.
     fst::StdVectorFst composition;
     Compose(sentence, lm_compiler->Fst(), &composition);

--- a/src/lm/arpa-lm-compiler.h
+++ b/src/lm/arpa-lm-compiler.h
@@ -47,7 +47,12 @@ class ArpaLmCompiler : public ArpaFileParser {
   virtual void ConsumeNGram(const NGram& ngram);
   virtual void ReadComplete();
 
+
  private:
+  // this function removes states that only have a backoff arc coming
+  // out of them.
+  void RemoveRedundantStates();
+
   int sub_eps_;
   ArpaLmCompilerImplInterface* impl_;  // Owned.
   fst::StdVectorFst fst_;


### PR DESCRIPTION
This pull request implements using a phone language model to model the unknown-word `<unk>` in test time.  (It could be used in train time too, if you wanted; it might be useful for figuring out pronunciations of unseen words; @xiaohui-zhang, you should probably eventually test whether this is a better way to get the candidates in your lexicon-learning stuff, but this is not time-sensitive and can be done later).

There is an example in the tedlium s5_r2 recipe; it helps WER very slightly (even without making any attempt to map `<unk>` to real words via g2p-like methods).  

@xiaohui-zhang and/or @keli78, can you please check this out, and run the tedlium s5_r2 recipe up to and until the part (commented out) where it runs the unk-related stuff.  The reason for this is two-fold: I want you to do the g2p aspects of it; but also, I want you to test it to make sure I haven't broken anything and that it does work.  Once you have checked it I can merge this PR.  When you are ready, you can work on g2p-type things to figure out what word, or words, were really there each time `<unk>` was decoded.  

Note: to get the pronunciations, of `<unk>`, the easiest method is probably to use lattice-1best to get the 1-best of the lattice, then use lattice-arc-post (with suitable options) to get the information about each arc in the lattice.  This would replace the steps lattice-prune | lattice-align-words | lattice-to-ctm-conf in local/score_sclite.sh... you should score the baseline without minimum bayes risk decoding (--decode-mbr false) to get the appropriate baseline WERs.

Even if WER is degraded when we replace `<unk>` with guessed words, this could still be a useful method, as it's better to have (say) a misspelled name than no name at all or a sequence of wrong words.

