### PR TITLE
Fixing lmrescore

### DIFF
--- a/egs/wsj/s5/steps/lmrescore.sh
+++ b/egs/wsj/s5/steps/lmrescore.sh
@@ -115,7 +115,7 @@ case "$mode" in
     ;;
 esac
 
-rm $outdir/Ldet.fst 2>/dev/null
+rm $outdir/Ldet.fst 2>/dev/null || true
 
 if ! $skip_scoring ; then
   [ ! -x local/score.sh ] && \


### PR DESCRIPTION
A user notified me that my earlier commit breaks other modes of lmrescore.sh then the default. This commit fixes that.

-f mode of rm is "ignore nonexistent files and arguments, never prompt"