### PR TITLE
CSV formatted output to stdout for measurements

### DIFF
--- a/src/matrix/matrix-lib-speed-test.cc
+++ b/src/matrix/matrix-lib-speed-test.cc
@@ -27,11 +27,14 @@
 
 namespace kaldi {
 
-template<typename Real>
-std::string NameOf() {
+template<typename Real> std::string NameOf() {
   return (sizeof(Real) == 8 ? "<double>" : "<float>");
 }
 
+template<typename Real> static void CsvResult(std::string test, int dim, BaseFloat measure, std::string units) {
+    std::cout << test << "," << (sizeof(Real) == 8 ? "double" : "float") << "," << dim << "," << measure << "," << units << "\n";
+}
+    
 template<typename Real> static void UnitTestRealFftSpeed() {
   // First, test RealFftInefficient.
   Timer t;
@@ -41,7 +44,7 @@ template<typename Real> static void UnitTestRealFftSpeed() {
     Vector<Real> v(sz);
     RealFft(&v, true);
   }
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";
+  CsvResult<Real>(__func__, 512, t.Elapsed(), "seconds");
 }
 
 template<typename Real> static void UnitTestSplitRadixRealFftSpeed() {
@@ -54,7 +57,7 @@ template<typename Real> static void UnitTestSplitRadixRealFftSpeed() {
     Vector<Real> v(sz);
     srfft.Compute(v.Data(), true);
   }
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";
+  CsvResult<Real>(__func__, 512, t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -74,8 +77,7 @@ static void UnitTestSvdSpeed() {
       SpMatrix<Real> S(size);
       Vector<Real> l(size);
       S.Eig(&l);
-      KALDI_LOG << "For size " << size << ", Eig without eigenvectors took " << t1.Elapsed()
-                << " seconds.";
+      CsvResult<Real>("Eig w/o eigenvectors", size, t1.Elapsed(), "seconds");
     }
     {
       Timer t1;
@@ -84,8 +86,7 @@ static void UnitTestSvdSpeed() {
       Vector<Real> l(size);
       Matrix<Real> P(size, size);
       S.Eig(&l, &P);
-      KALDI_LOG << "For size " << size << ", Eig with eigenvectors took " << t1.Elapsed()
-                << " seconds.";
+      CsvResult<Real>("Eig with eigenvectors", size, t1.Elapsed(), "seconds");
     }
     {
       Timer t1;
@@ -93,8 +94,7 @@ static void UnitTestSvdSpeed() {
       M.SetRandn();
       Vector<Real> l(size);
       M.Svd(&l, NULL, NULL);
-      KALDI_LOG << "For size " << size << ", SVD without eigenvectors took " << t1.Elapsed()
-                << " seconds.";
+      CsvResult<Real>("SVD w/o eigenvectors", size, t1.Elapsed(), "seconds");
     }
     {
       Timer t1;
@@ -102,11 +102,10 @@ static void UnitTestSvdSpeed() {
       M.SetRandn();
       Vector<Real> l(size);
       M.Svd(&l, &U, &V);
-      KALDI_LOG << "For size " << size << ", SVD with eigenvectors took " << t1.Elapsed()
-                << " seconds.";
+      CsvResult<Real>("SVD with eigenvectors", size, t1.Elapsed(), "seconds");
     }
   }
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -127,11 +126,10 @@ static void UnitTestAddMatMatSpeed() {
         C.AddMatMat(1.0, A, kTrans, B, kNoTrans, 0.0); 
         C.AddMatMat(1.0, A, kTrans, B, kTrans, 0.0); 
       }
-      KALDI_LOG << "For size " << size << ", AddMatMat (2x) took " << t1.Elapsed()
-                << " seconds.";
+      CsvResult<Real>("AddMatMat", size, t1.Elapsed(), "seconds");
     }
   }
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -159,12 +157,9 @@ static void UnitTestAddRowSumMatSpeed() {
 
     BaseFloat fdim = size;
     BaseFloat gflops = (fdim * fdim * iter) / (t1.Elapsed() * 1.0e+09);
-    KALDI_LOG << "For AddRowSumMat" << NameOf<Real>()
-              << " , dim = " << size
-              << " , speed: " << gflops << " gigaflops.";
+    CsvResult<Real>("AddRowSumMat", size, gflops, "gigaflops");
   }
-
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";   
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -192,12 +187,9 @@ static void UnitTestAddColSumMatSpeed() {
  
     BaseFloat fdim = size;
     BaseFloat gflops = (fdim * fdim * iter) / (t1.Elapsed() * 1.0e+09);
-    KALDI_LOG << "For AddColSumMat" << NameOf<Real>()
-              << " , dim = " << size
-              << " , speed: " << gflops << " gigaflops.";
+    CsvResult<Real>("AddColSumMat", size, gflops, "gigaflops");
   }
-
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";   
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -226,12 +218,9 @@ static void UnitTestAddVecToRowsSpeed() {
 
     BaseFloat fdim = size;
     BaseFloat gflops = (fdim * fdim * iter) / (t1.Elapsed() * 1.0e+09);
-    KALDI_LOG << "For AddVecToRows" << NameOf<Real>()
-              << " , dim = " << size
-              << " , speed " << gflops << " gigaflops.";
+    CsvResult<Real>("AddVecToRows", size, gflops, "gigaflops");
   }
-
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";   
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real>
@@ -260,12 +249,9 @@ static void UnitTestAddVecToColsSpeed() {
 
     BaseFloat fdim = size;
     BaseFloat gflops = (fdim * fdim * iter) / (t1.Elapsed() * 1.0e+09);
-    KALDI_LOG << "For AddVecToCols" << NameOf<Real>() 
-              << ", dim = " << size
-              << ", speed: " << gflops << " gigaflops.";
+    CsvResult<Real>("AddVecToCols", size, gflops, "gigaflops");
   }
-
-  KALDI_LOG << __func__ << " finished in " << t.Elapsed() << " seconds.";   
+  CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
 template<typename Real> static void MatrixUnitSpeedTest() {


### PR DESCRIPTION
Changes to make metric output from matrix-lib-speed-test in CSV form, written to stdout instead of stderr. Here's sample output:

```UnitTestRealFftSpeed,float,512,0.209347,seconds
UnitTestSplitRadixRealFftSpeed,float,512,0.093781,seconds
Eig w/o eigenvectors,float,100,0.000247002,seconds
Eig with eigenvectors,float,100,0.00205898,seconds
SVD w/o eigenvectors,float,100,0.00100589,seconds
SVD with eigenvectors,float,100,0.00366497,seconds
Eig w/o eigenvectors,float,150,0.000362873,seconds
Eig with eigenvectors,float,150,0.00426292,seconds
SVD w/o eigenvectors,float,150,0.00202298,seconds
SVD with eigenvectors,float,150,0.009758,seconds
Eig w/o eigenvectors,float,200,0.000883102,seconds
Eig with eigenvectors,float,200,0.0083549,seconds
SVD w/o eigenvectors,float,200,0.00400209,seconds
SVD with eigenvectors,float,200,0.0207579,seconds
Eig w/o eigenvectors,float,300,0.0018189,seconds
Eig with eigenvectors,float,300,0.027554,seconds
SVD w/o eigenvectors,float,300,0.0113351,seconds
SVD with eigenvectors,float,300,0.0690949,seconds
UnitTestSvdSpeed,float,4,0.167302,seconds
AddMatMat,float,512,0.043648,seconds
AddMatMat,float,1024,0.199497,seconds
UnitTestAddMatMatSpeed,float,2,0.243168,seconds
AddRowSumMat,float,4,0.177579,gigaflops
AddRowSumMat,float,16,1.19981,gigaflops
AddRowSumMat,float,64,2.79826,gigaflops
AddRowSumMat,float,256,13.6124,gigaflops
AddRowSumMat,float,1024,12.6882,gigaflops
UnitTestAddRowSumMatSpeed,float,5,0.138748,seconds
AddColSumMat,float,4,0.151305,gigaflops
AddColSumMat,float,16,0.353519,gigaflops
AddColSumMat,float,64,0.39807,gigaflops
AddColSumMat,float,256,14.3805,gigaflops
AddColSumMat,float,1024,17.1856,gigaflops
UnitTestAddColSumMatSpeed,float,5,0.137279,seconds
AddVecToRows,float,4,0.193725,gigaflops
AddVecToRows,float,16,0.490396,gigaflops
AddVecToRows,float,64,0.491169,gigaflops
AddVecToRows,float,256,7.82305,gigaflops
AddVecToRows,float,1024,14.8705,gigaflops
UnitTestAddVecToRowsSpeed,float,5,0.136772,seconds
AddVecToCols,float,4,0.2088,gigaflops
AddVecToCols,float,16,0.541683,gigaflops
AddVecToCols,float,64,0.50573,gigaflops
AddVecToCols,float,256,7.84064,gigaflops
AddVecToCols,float,1024,14.6771,gigaflops
UnitTestAddVecToColsSpeed,float,5,0.136797,seconds
UnitTestRealFftSpeed,double,512,0.198586,seconds
UnitTestSplitRadixRealFftSpeed,double,512,0.0895569,seconds
Eig w/o eigenvectors,double,100,0.000277996,seconds
Eig with eigenvectors,double,100,0.00374389,seconds
SVD w/o eigenvectors,double,100,0.00104904,seconds
SVD with eigenvectors,double,100,0.005126,seconds
Eig w/o eigenvectors,double,150,0.000494957,seconds
Eig with eigenvectors,double,150,0.00606894,seconds
SVD w/o eigenvectors,double,150,0.00244904,seconds
SVD with eigenvectors,double,150,0.012903,seconds
Eig w/o eigenvectors,double,200,0.000825882,seconds
Eig with eigenvectors,double,200,0.0112691,seconds
SVD w/o eigenvectors,double,200,0.00525403,seconds
SVD with eigenvectors,double,200,0.0287721,seconds
Eig w/o eigenvectors,double,300,0.00263405,seconds
Eig with eigenvectors,double,300,0.039093,seconds
SVD w/o eigenvectors,double,300,0.0142691,seconds
SVD with eigenvectors,double,300,0.0867908,seconds
UnitTestSvdSpeed,double,4,0.221824,seconds
AddMatMat,double,512,0.055809,seconds
AddMatMat,double,1024,0.284975,seconds
UnitTestAddMatMatSpeed,double,2,0.340806,seconds
AddRowSumMat,double,4,0.178695,gigaflops
AddRowSumMat,double,16,0.931451,gigaflops
AddRowSumMat,double,64,3.12946,gigaflops
AddRowSumMat,double,256,4.38607,gigaflops
AddRowSumMat,double,1024,5.43007,gigaflops
UnitTestAddRowSumMatSpeed,double,5,0.14032,seconds
AddColSumMat,double,4,0.15847,gigaflops
AddColSumMat,double,16,0.403437,gigaflops
AddColSumMat,double,64,0.407699,gigaflops
AddColSumMat,double,256,4.75786,gigaflops
AddColSumMat,double,1024,9.19067,gigaflops
UnitTestAddColSumMatSpeed,double,5,0.140049,seconds
AddVecToRows,double,4,0.197304,gigaflops
AddVecToRows,double,16,0.481764,gigaflops
AddVecToRows,double,64,0.510415,gigaflops
AddVecToRows,double,256,2.19664,gigaflops
AddVecToRows,double,1024,5.91853,gigaflops
UnitTestAddVecToRowsSpeed,double,5,0.142902,seconds
AddVecToCols,double,4,0.210164,gigaflops
AddVecToCols,double,16,0.518222,gigaflops
AddVecToCols,double,64,0.454747,gigaflops
AddVecToCols,double,256,2.15529,gigaflops
AddVecToCols,double,1024,5.23633,gigaflops
UnitTestAddVecToColsSpeed,double,5,0.140687,seconds```
`