### PR TITLE
WIP fixing the cantab lm links

### DIFF
--- a/egs/tedlium/s5/local/download_data.sh
+++ b/egs/tedlium/s5/local/download_data.sh
@@ -16,8 +16,8 @@ else
 fi
 # Language models (Cantab Research):
 if [ ! -d cantab-TEDLIUM ]; then
-    echo "Downloading \"http://cantabresearch.com/cantab-TEDLIUM.tar.bz2\". "
-    wget --no-verbose --output-document=- http://cantabresearch.com/cantab-TEDLIUM.tar.bz2 | bzcat | tar --extract --file=- || exit 1
+    echo "Downloading \"http://www.openslr.org/resources/27/cantab-TEDLIUM.tar.bz2\". "
+    wget --no-verbose --output-document=- http://www.openslr.org/resources/27/cantab-TEDLIUM.tar.bz2 | bzcat | tar --extract --file=- || exit 1
     gzip cantab-TEDLIUM/cantab-TEDLIUM-pruned.lm3
     gzip cantab-TEDLIUM/cantab-TEDLIUM-unpruned.lm4
 fi

--- a/egs/tedlium/s5_r2/local/download_data.sh
+++ b/egs/tedlium/s5_r2/local/download_data.sh
@@ -38,8 +38,6 @@ fi
 if [ ! -e cantab-TEDLIUM ]; then
   echo "$0: Downloading \"http://www.openslr.org/resources/27/cantab-TEDLIUM-partial.tar.bz2\". "
   wget --no-verbose --output-document=- http://www.openslr.org/resources/27/cantab-TEDLIUM-partial.tar.bz2 | bzcat | tar --extract --file=- || exit 1
-  gzip cantab-TEDLIUM/cantab-TEDLIUM-pruned.lm3
-  gzip cantab-TEDLIUM/cantab-TEDLIUM-unpruned.lm4
 else
   echo "$0: directory cantab-TEDLIUM already exists, not re-downloading."
 fi

--- a/egs/tedlium/s5_r2/local/download_data.sh
+++ b/egs/tedlium/s5_r2/local/download_data.sh
@@ -36,8 +36,8 @@ fi
 
 # Language models (Cantab Research):
 if [ ! -e cantab-TEDLIUM ]; then
-  echo "$0: Downloading \"http://cantabresearch.com/cantab-TEDLIUM.tar.bz2\". "
-  wget --no-verbose --output-document=- http://cantabresearch.com/cantab-TEDLIUM.tar.bz2 | bzcat | tar --extract --file=- || exit 1
+  echo "$0: Downloading \"http://www.openslr.org/resources/27/cantab-TEDLIUM-partial.tar.bz2\". "
+  wget --no-verbose --output-document=- http://www.openslr.org/resources/27/cantab-TEDLIUM-partial.tar.bz2 | bzcat | tar --extract --file=- || exit 1
   gzip cantab-TEDLIUM/cantab-TEDLIUM-pruned.lm3
   gzip cantab-TEDLIUM/cantab-TEDLIUM-unpruned.lm4
 else


### PR DESCRIPTION
My understanding from the brief scanning of the scripts is that "s5" needs the full archive and "s5_r2" is ok with the *-partial archive.