### PR TITLE
nnet3 reporting : Added code to summarize the timing info from nnet3*…

### DIFF
--- a/egs/wsj/s5/steps/nnet3/report/summarize_compute_debug_timing.py
+++ b/egs/wsj/s5/steps/nnet3/report/summarize_compute_debug_timing.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+
+# Copyright 2016 Vijayaditya Peddinti.
+# Apache 2.0.
+
+
+# we're using python 3.x style print but want it to work in python 2.x,
+from __future__ import print_function
+import sys
+import re
+import argparse
+
+# expects the output of nnet3*train with --computation-debug=true
+# will run faster if just the lines with "DebugAfterExecute" are provided
+# <train-command> |grep DebugAfterExecute | steps/nnet3/report/summarize_compute_debug_timing.py
+
+def GetArgs():
+    parser = argparse.ArgumentParser(description="Summarizes the timing info from nnet3-*-train --computation.debug=true commands ")
+    parser.add_argument("--node-prefixes", type=str,
+                        help="list of prefixes. Execution times from nnet3 components with the same prefix"
+                        " will be accumulated. Still distinguishes Propagate and BackPropagate commands"
+                        " --node-prefixes Lstm1,Lstm2,Layer1", default=None)
+
+    print(' '.join(sys.argv), file=sys.stderr)
+
+    args = parser.parse_args()
+    if args.node_prefixes is not None:
+        raise NotImplementedError
+        # this will be implemented after https://github.com/kaldi-asr/kaldi/issues/944
+        args.node_prefixes = args.node_prefixes.split(',')
+    else:
+        args.node_prefixes = []
+
+    return args
+# get opening bracket position corresponding to the last closing bracket
+def FindOpenParanthesisPosition(string):
+    string = string.strip()
+    if string[-1] != ")":
+        # we don't know how to deal with these strings
+        return None
+
+    string_index = len(string) - 1
+    closing_parans = []
+    closing_parans.append(string_index)
+    string_index -= 1
+    while string_index >= 0:
+        if string[string_index] == "(":
+            if len(closing_parans) == 1:
+                # this opening bracket corresponds to the last closing bracket
+                return string_index
+            else:
+                closing_parans.pop()
+        elif string[string_index] == ")":
+            closing_parans.append(string_index)
+        string_index -= 1
+
+    raise Exception("Malformed string: Could not find opening paranthesis\n\t{0}".format(string))
+
+# input : LOG (nnet3-chain-train:DebugAfterExecute():nnet-compute.cc:144) c68: BLstm1_backward_W_i-xr.Propagate(NULL, m6212(3136:3199, 0:555), &m31(0:63, 0:1023))
+# output : BLstm1_backward_W_i-xr.Propagate
+def ExtractCommandName(command_string):
+    # create a concise representation for the the command
+    # strip off : LOG (nnet3-chain-train:DebugAfterExecute():nnet-compute.cc:144)
+    command = " ".join(command_string.split()[2:])
+    # command = c68: BLstm1_backward_W_i-xr.Propagate(NULL, m6212(3136:3199, 0:555), &m31(0:63, 0:1023))
+    end_position = FindOpenParanthesisPosition(command)
+    if end_position is not None:
+        command = command[:end_position]
+    # command = c68: BLstm1_backward_W_i-xr.Propagate
+    command = ":".join(command.split(":")[1:]).strip()
+    # command = BLstm1_backward_W_i-xr.Propagate
+    return command
+
+def Main():
+    # Sample Line
+    # LOG (nnet3-chain-train:DebugAfterExecute():nnet-compute.cc:144) c128: m19 = []  |               |        time: 0.0007689 secs
+
+    debug_regex = re.compile("DebugAfterExecute")
+    command_times = {}
+    for line in sys.stdin:
+        parts = line.split("|")
+        if len(parts) != 3:
+            # we don't know how to deal with these lines
+            continue
+        if debug_regex.search(parts[0]) is not None:
+            # this is a line printed in the DebugAfterExecute method
+
+            # get the timing info
+            time_parts = parts[-1].split()
+            assert(len(time_parts) == 3 and time_parts[-1] == "secs" and time_parts[0] == "time:" )
+            time = float(time_parts[1])
+
+            command = ExtractCommandName(parts[0])
+           # store the time
+            try:
+                command_times[command] += time
+            except KeyError:
+                command_times[command] = time
+
+    total_time = sum(command_times.values())
+    sorted_commands = sorted(command_times.items(), key = lambda x: x[1], reverse = True)
+    for item in sorted_commands:
+        print("{c} : time {t} : fraction {f}".format(c=item[0], t=item[1], f=item[1] / total_time))
+
+
+if __name__ == "__main__":
+    args = GetArgs()
+    Main()
+
+


### PR DESCRIPTION
…train --computation.debug=true outputs


generates summary like this

```
c86: Final-xent_affine.Backprop : time 2.8047679 : fraction 0.233143034181
c76: Final_affine.Backprop : time 2.784232 : fraction 0.231436011637
c73: Final_affine.Propagate : time 1.4015891 : fraction 0.116505446118
c64: Final-xent_affine.Propagate : time 1.396891 : fraction 0.116114922079
c146: Mrtdnn_1_3_affine.Backprop : time 0.4918523 : fraction 0.040884644177
c130: Mrtdnn_1_9_PDA.Backprop : time 0.37513207 : fraction 0.0311824122838
c33: Mrtdnn_1_9_PDA.Propagate : time 0.35927334 : fraction 0.0298641739973
c108: Mrtdnn_1_6_affine.Backprop : time 0.29575168 : fraction 0.0245840106909
c13: Affine_0_relu.StoreStats : time 0.2215809585 : fraction 0.0184186566672
c122: Mrtdnn_1_9_affine.Backprop : time 0.21220477 : fraction 0.0176392720215
c21: Mrtdnn_1_3_affine.Propagate : time 0.14906101 : fraction 0.0123905212083
c158: Affine_0_affine.Backprop : time 0.14536951 : fraction 0.0120836696109
c49: Mrtdnn_1_6_affine.Propagate : time 0.07736396 : fraction 0.00643078821981
c83: Final-xent_log_softmax.Backprop : time 0.06955433 : fraction 0.00578162190768
```