### PR TITLE
Various SID Fixes

### DIFF
--- a/egs/sre08/v1/run.sh
+++ b/egs/sre08/v1/run.sh
@@ -243,7 +243,7 @@ trials=data/sre08_trials/short2-short3-female.trials
 ivector-compute-plda ark:data/train_female/spk2utt \
   'ark:ivector-normalize-length scp:exp/ivectors_train_female/ivector.scp  ark:- |' \
     exp/ivectors_train_female/plda 2>exp/ivectors_train_female/log/plda.log
-ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
+ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
    "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_female/plda - |" \
    "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp ark:- |" \
    "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
@@ -259,7 +259,7 @@ trials=data/sre08_trials/short2-short3-male.trials
 ivector-compute-plda ark:data/train_male/spk2utt \
   'ark:ivector-normalize-length scp:exp/ivectors_train_male/ivector.scp  ark:- |' \
     exp/ivectors_train_male/plda 2>exp/ivectors_train_male/log/plda.log
-ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
+ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
    "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_male/plda - |" \
    "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp ark:- |" \
    "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
@@ -276,7 +276,7 @@ ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utt
 # first, female.
 trials=data/sre08_trials/short2-short3-female.trials
 cat exp/ivectors_sre08_train_short2_female/spk_ivector.scp exp/ivectors_sre08_test_short3_female/ivector.scp > female.scp
-ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
+ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
    "ivector-adapt-plda $adapt_opts exp/ivectors_train_female/plda scp:female.scp -|" \
    scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp \
    "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- |" \
@@ -291,7 +291,7 @@ ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_u
 # next, male.
 trials=data/sre08_trials/short2-short3-male.trials
 cat exp/ivectors_sre08_train_short2_male/spk_ivector.scp exp/ivectors_sre08_test_short3_male/ivector.scp > male.scp
-ivector-plda-scoring --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
+ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
    "ivector-adapt-plda $adapt_opts exp/ivectors_train_male/plda scp:male.scp -|" \
    scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp \
    "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- |" \

--- a/egs/sre08/v1/run.sh
+++ b/egs/sre08/v1/run.sh
@@ -23,17 +23,17 @@ local/make_fisher.sh /export/corpora3/LDC/{LDC2005S13,LDC2005T19} data/fisher2
 
 local/make_sre_2005_test.pl /export/corpora5/LDC/LDC2011S04 data
 local/make_sre_2004_test.pl \
-    /export/corpora5/LDC/LDC2006S44/r93_5_1/sp04-05/test data/sre_2004_1
+  /export/corpora5/LDC/LDC2006S44/r93_5_1/sp04-05/test data/sre_2004_1
 local/make_sre_2004_test.pl \
-    /export/corpora5/LDC/LDC2006S44/r93_6_1/sp04-06/test data/sre_2004_2
+  /export/corpora5/LDC/LDC2006S44/r93_6_1/sp04-06/test data/sre_2004_2
 local/make_sre_2008_train.pl /export/corpora5/LDC/LDC2011S05 data
 local/make_sre_2008_test.sh  /export/corpora5/LDC/LDC2011S08 data
 local/make_sre_2006_train.pl /export/corpora5/LDC/LDC2011S09 data
 local/make_sre_2005_train.pl /export/corpora5/LDC/LDC2011S01 data
 local/make_swbd_cellular1.pl /export/corpora5/LDC/LDC2001S13 \
-                             data/swbd_cellular1_train
+  data/swbd_cellular1_train
 local/make_swbd_cellular2.pl /export/corpora5/LDC/LDC2004S07 \
-                             data/swbd_cellular2_train
+  data/swbd_cellular2_train
 
 utils/combine_data.sh data/train data/fisher1 data/fisher2 \
   data/swbd_cellular1_train data/swbd_cellular2_train \
@@ -106,7 +106,7 @@ sid/train_full_ubm.sh --nj 30 --remove-low-count-gaussians false \
   data/train_male_8k exp/full_ubm_2048 exp/full_ubm_2048_male &
 sid/train_full_ubm.sh --nj 30 --remove-low-count-gaussians false \
   --num-iters 1 --cmd "$train_cmd" \
- data/train_female_8k exp/full_ubm_2048 exp/full_ubm_2048_female &
+  data/train_female_8k exp/full_ubm_2048 exp/full_ubm_2048_female &
 wait
 
 # Train the iVector extractor for male speakers.
@@ -130,26 +130,26 @@ sid/gender_id.sh --cmd "$train_cmd" --nj 150 exp/full_ubm_2048{,_male,_female} \
 
 # Extract the iVectors for the training data.
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_male data/train_male exp/ivectors_train_male
+  exp/extractor_2048_male data/train_male exp/ivectors_train_male
 
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_female data/train_female exp/ivectors_train_female
+  exp/extractor_2048_female data/train_female exp/ivectors_train_female
 
 # .. and for the SRE08 training and test data. (We focus on the main
 # evaluation condition, the only required one in that eval, which is
 # the short2-short3 eval.)
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_female data/sre08_train_short2_female \
- exp/ivectors_sre08_train_short2_female
+  exp/extractor_2048_female data/sre08_train_short2_female \
+  exp/ivectors_sre08_train_short2_female
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_male data/sre08_train_short2_male \
- exp/ivectors_sre08_train_short2_male
+  exp/extractor_2048_male data/sre08_train_short2_male \
+  exp/ivectors_sre08_train_short2_male
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_female data/sre08_test_short3_female \
- exp/ivectors_sre08_test_short3_female
+  exp/extractor_2048_female data/sre08_test_short3_female \
+  exp/ivectors_sre08_test_short3_female
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
- exp/extractor_2048_male data/sre08_test_short3_male \
- exp/ivectors_sre08_test_short3_male
+  exp/extractor_2048_male data/sre08_test_short3_male \
+  exp/ivectors_sre08_test_short3_male
 
 ### Demonstrate simple cosine-distance scoring:
 
@@ -199,15 +199,15 @@ local/score_sre08.sh $trials foo
 
 ivector-compute-lda --dim=150  --total-covariance-factor=0.1 \
   'ark:ivector-normalize-length scp:exp/ivectors_train_female/ivector.scp ark:- |' \
-    ark:data/train_female/utt2spk \
-    exp/ivectors_train_female/transform.mat
+  ark:data/train_female/utt2spk \
+  exp/ivectors_train_female/transform.mat
 
 trials=data/sre08_trials/short2-short3-female.trials
 cat $trials | awk '{print $1, $2}' | \
   ivector-compute-dot-products - \
-    'ark:ivector-transform exp/ivectors_train_female/transform.mat scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |' \
-    'ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- | ivector-transform exp/ivectors_train_female/transform.mat ark:- ark:- | ivector-normalize-length ark:- ark:- |' \
-    foo
+  'ark:ivector-transform exp/ivectors_train_female/transform.mat scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |' \
+  'ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- | ivector-transform exp/ivectors_train_female/transform.mat ark:- ark:- | ivector-normalize-length ark:- ark:- |' \
+  foo
 local/score_sre08.sh $trials foo
 
 # Results for Female:
@@ -221,11 +221,11 @@ ivector-compute-lda --dim=150 --total-covariance-factor=0.1 \
   exp/ivectors_train_male/transform.mat
 
 trials=data/sre08_trials/short2-short3-male.trials
- cat $trials | awk '{print $1, $2}' | \
+  cat $trials | awk '{print $1, $2}' | \
   ivector-compute-dot-products - \
-    'ark:ivector-transform exp/ivectors_train_male/transform.mat scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |' \
-    'ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- | ivector-transform exp/ivectors_train_male/transform.mat ark:- ark:- | ivector-normalize-length ark:- ark:- |' \
-    foo
+  'ark:ivector-transform exp/ivectors_train_male/transform.mat scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |' \
+  'ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- | ivector-transform exp/ivectors_train_male/transform.mat ark:- ark:- | ivector-normalize-length ark:- ark:- |' \
+  foo
 local/score_sre08.sh $trials foo
 
 # Results for Male:
@@ -242,12 +242,12 @@ local/score_sre08.sh $trials foo
 trials=data/sre08_trials/short2-short3-female.trials
 ivector-compute-plda ark:data/train_female/spk2utt \
   'ark:ivector-normalize-length scp:exp/ivectors_train_female/ivector.scp  ark:- |' \
-    exp/ivectors_train_female/plda 2>exp/ivectors_train_female/log/plda.log
+  exp/ivectors_train_female/plda 2>exp/ivectors_train_female/log/plda.log
 ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
-   "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_female/plda - |" \
-   "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp ark:- |" \
-   "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
-   "cat '$trials' | awk '{print \$1, \$2}' |" foo
+  "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_female/plda - |" \
+  "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp ark:- |" \
+  "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
+  "cat '$trials' | awk '{print \$1, \$2}' |" foo
 local/score_sre08.sh $trials foo
 
 # Result for Female is below:
@@ -258,12 +258,12 @@ local/score_sre08.sh $trials foo
 trials=data/sre08_trials/short2-short3-male.trials
 ivector-compute-plda ark:data/train_male/spk2utt \
   'ark:ivector-normalize-length scp:exp/ivectors_train_male/ivector.scp  ark:- |' \
-    exp/ivectors_train_male/plda 2>exp/ivectors_train_male/log/plda.log
+  exp/ivectors_train_male/plda 2>exp/ivectors_train_male/log/plda.log
 ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
-   "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_male/plda - |" \
-   "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp ark:- |" \
-   "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
-   "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
+  "ivector-copy-plda --smoothing=0.0 exp/ivectors_train_male/plda - |" \
+  "ark:ivector-subtract-global-mean scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp ark:- |" \
+  "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- | ivector-subtract-global-mean ark:- ark:- |" \
+  "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
 
 # Result for Male is below:
 # Scoring against data/sre08_trials/short2-short3-male.trials
@@ -277,10 +277,10 @@ ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivect
 trials=data/sre08_trials/short2-short3-female.trials
 cat exp/ivectors_sre08_train_short2_female/spk_ivector.scp exp/ivectors_sre08_test_short3_female/ivector.scp > female.scp
 ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_female/num_utts.ark \
-   "ivector-adapt-plda $adapt_opts exp/ivectors_train_female/plda scp:female.scp -|" \
-   scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp \
-   "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- |" \
-   "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
+  "ivector-adapt-plda $adapt_opts exp/ivectors_train_female/plda scp:female.scp -|" \
+  scp:exp/ivectors_sre08_train_short2_female/spk_ivector.scp \
+  "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_female/ivector.scp ark:- |" \
+  "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
 # Results:
 #  Condition:      0      1      2      3      4      5      6      7      8
 #        EER:   5.45   6.73   1.19   6.79   7.06   6.61   6.32   4.18   4.74
@@ -292,10 +292,10 @@ ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivect
 trials=data/sre08_trials/short2-short3-male.trials
 cat exp/ivectors_sre08_train_short2_male/spk_ivector.scp exp/ivectors_sre08_test_short3_male/ivector.scp > male.scp
 ivector-plda-scoring --simple-length-normalization=true --num-utts=ark:exp/ivectors_sre08_train_short2_male/num_utts.ark \
-   "ivector-adapt-plda $adapt_opts exp/ivectors_train_male/plda scp:male.scp -|" \
-   scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp \
-   "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- |" \
-   "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
+  "ivector-adapt-plda $adapt_opts exp/ivectors_train_male/plda scp:male.scp -|" \
+  scp:exp/ivectors_sre08_train_short2_male/spk_ivector.scp \
+  "ark:ivector-normalize-length scp:exp/ivectors_sre08_test_short3_male/ivector.scp ark:- |" \
+  "cat '$trials' | awk '{print \$1, \$2}' |" foo; local/score_sre08.sh $trials foo
 
 # Results:
 #  Condition:      0      1      2      3      4      5      6      7      8

--- a/egs/sre08/v1/sid/train_diag_ubm.sh
+++ b/egs/sre08/v1/sid/train_diag_ubm.sh
@@ -29,7 +29,6 @@ cleanup=true
 min_gaussian_weight=0.0001
 remove_low_count_gaussians=true # set this to false if you need #gauss to stay fixed.
 num_threads=32
-parallel_opts="-pe smp 32"
 delta_window=3
 delta_order=2
 # End configuration section.
@@ -51,7 +50,7 @@ if [ $# != 3 ]; then
   echo "  --stage <stage|-2>                               # stage to do partial re-run from."
   echo "  --num-gselect <n|30>                             # Number of Gaussians per frame to"
   echo "                                                   # limit computation to, for speed"
-  echo " --subsample <n|5>                                 # In main E-M phase, use every n" 
+  echo " --subsample <n|5>                                 # In main E-M phase, use every n"
   echo "                                                   # frames (a speedup)"
   echo "  --num-frames <n|500000>                          # Maximum num-frames to keep in memory"
   echo "                                                   # for model initialization"
@@ -86,6 +85,7 @@ for f in $data/feats.scp $data/vad.scp; do
    [ ! -f $f ] && echo "$0: expecting file $f to exist" && exit 1
 done
 
+parallel_opts="-pe smp $num_threads"
 delta_opts="--delta-window=$delta_window --delta-order=$delta_order"
 echo $delta_opts > $dir/delta_opts
 

--- a/egs/sre10/v1/local/cosine_scoring.sh
+++ b/egs/sre10/v1/local/cosine_scoring.sh
@@ -20,9 +20,10 @@ test_ivec_dir=$4
 trials=$5
 scores_dir=$6
 
-mkdir -p $scores_dir
-cat $trials | awk '{print $1, $2}' | \
+mkdir -p $scores_dir/log
+run.pl $scores_dir/log/cosine_scoring.log \
+  cat $trials \| awk '{print $1, $2}' \| \
  ivector-compute-dot-products - \
   scp:${enroll_ivec_dir}/spk_ivector.scp \
-  scp:${test_ivec_dir}/ivector.scp \
-   $scores_dir/cosine_scores
+  'ark:ivector-normalize-length scp:${test_ivec_dir}/ivector.scp ark:- |' \
+   $scores_dir/cosine_scores || exit 1;

--- a/egs/sre10/v1/local/lda_scoring.sh
+++ b/egs/sre10/v1/local/lda_scoring.sh
@@ -2,7 +2,7 @@
 # Copyright 2015   David Snyder
 # Apache 2.0.
 #
-# This script trains an LDA transform, applies it to the enroll and 
+# This script trains an LDA transform, applies it to the enroll and
 # test i-vectors and does cosine scoring.
 
 use_existing_models=false
@@ -32,14 +32,18 @@ if [ "$use_existing_models" == "true" ]; then
     [ ! -f $f ] && echo "No such file $f" && exit 1;
   done
 else
-ivector-compute-lda --dim=$lda_dim  --total-covariance-factor=$covar_factor \
+
+mkdir -p ${lda_ivec_dir}/log
+run.pl ${lda_ivec_dir}/log/lda.log \
+  ivector-compute-lda --dim=$lda_dim  --total-covariance-factor=$covar_factor \
   "ark:ivector-normalize-length scp:${lda_ivec_dir}/ivector.scp ark:- |" \
     ark:${lda_data_dir}/utt2spk \
-    ${lda_ivec_dir}/transform.mat 2>${lda_ivec_dir}/log/lda.log
+    ${lda_ivec_dir}/transform.mat || exit 1;
 fi
 
-mkdir -p $scores_dir
-ivector-compute-dot-products  "cat '$trials' | awk '{print \$1, \$2}' |"  \
+mkdir -p $scores_dir/log
+run.pl $scores_dir/log/lda_scoring.log \
+  ivector-compute-dot-products  "cat '$trials' | cut -d\  --fields=1,2 |"  \
   "ark:ivector-transform ${lda_ivec_dir}/transform.mat scp:${enroll_ivec_dir}/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |" \
-  "ark:ivector-transform ${lda_ivec_dir}/transform.mat scp:${test_ivec_dir}/ivector.scp ark:- | ivector-normalize-length ark:- ark:- |" \
-  $scores_dir/lda_scores
+  "ark:ivector-normalize-length scp:${test_ivec_dir}/ivector.scp ark:- | ivector-transform ${lda_ivec_dir}/transform.mat ark:- ark:- | ivector-normalize-length ark:- ark:- |" \
+  $scores_dir/lda_scores || exit 1;

--- a/egs/sre10/v1/local/plda_scoring.sh
+++ b/egs/sre10/v1/local/plda_scoring.sh
@@ -29,15 +29,18 @@ if [ "$use_existing_models" == "true" ]; then
     [ ! -f $f ] && echo "No such file $f" && exit 1;
   done
 else
-  ivector-compute-plda ark:$plda_data_dir/spk2utt \
+  run.pl $plda_ivec_dir/log/plda.log \
+    ivector-compute-plda ark:$plda_data_dir/spk2utt \
     "ark:ivector-normalize-length scp:${plda_ivec_dir}/ivector.scp  ark:- |" \
-      $plda_ivec_dir/plda 2>$plda_ivec_dir/log/plda.log
+    $plda_ivec_dir/plda || exit 1;
 fi
 
-mkdir -p $scores_dir
+mkdir -p $scores_dir/log
 
-ivector-plda-scoring --num-utts=ark:${enroll_ivec_dir}/num_utts.ark \
+run.pl $scores_dir/log/plda_scoring.log \
+   ivector-plda-scoring --normalize-length=true \
+   --num-utts=ark:${enroll_ivec_dir}/num_utts.ark \
    "ivector-copy-plda --smoothing=0.0 ${plda_ivec_dir}/plda - |" \
-   "ark:ivector-subtract-global-mean ${plda_ivec_dir}/mean.vec scp:${enroll_ivec_dir}/spk_ivector.scp ark:- |" \
-   "ark:ivector-subtract-global-mean ${plda_ivec_dir}/mean.vec scp:${test_ivec_dir}/ivector.scp ark:- |" \
-   "cat '$trials' | awk '{print \$1, \$2}' |" $scores_dir/plda_scores
+   "ark:ivector-subtract-global-mean ${plda_ivec_dir}/mean.vec scp:${enroll_ivec_dir}/spk_ivector.scp ark:- | ivector-normalize-length ark:- ark:- |" \
+   "ark:ivector-normalize-length scp:${test_ivec_dir}/ivector.scp ark:- | ivector-subtract-global-mean ${plda_ivec_dir}/mean.vec ark:- ark:- | ivector-normalize-length ark:- ark:- |" \
+   "cat '$trials' | cut -d\  --fields=1,2 |" $scores_dir/plda_scores || exit 1;

--- a/egs/sre10/v1/local/scoring_common.sh
+++ b/egs/sre10/v1/local/scoring_common.sh
@@ -12,7 +12,7 @@ plda_ivec_dir=${4%/}
 enroll_ivec_dir=${5%/}
 test_ivec_dir=${6%/}
 
-if [ ! -f ${test_data_dir}/trials ]; then 
+if [ ! -f ${test_data_dir}/trials ]; then
   echo "${test_data_dir} needs a trial file."
   exit;
 fi
@@ -81,8 +81,14 @@ utils/filter_scp.pl ${plda_data_dir}_female/spk2utt \
   ${plda_ivec_dir}/num_utts.ark > ${plda_ivec_dir}_female/num_utts.ark
 
 # Compute gender independent and dependent i-vector means.
-ivector-mean scp:${plda_ivec_dir}/ivector.scp ${plda_ivec_dir}/mean.vec
-ivector-mean scp:${plda_ivec_dir}_male/ivector.scp ${plda_ivec_dir}_male/mean.vec
-ivector-mean scp:${plda_ivec_dir}_female/ivector.scp ${plda_ivec_dir}_female/mean.vec
+run.pl ${plda_ivec_dir}/log/compute_mean.log \
+  ivector-normalize-length scp:${plda_ivec_dir}/ivector.scp \
+  ark:- \| ivector-mean ark:- ${plda_ivec_dir}/mean.vec || exit 1;
+run.pl ${plda_ivec_dir}_male/log/compute_mean.log \
+  ivector-normalize-length scp:${plda_ivec_dir}_male/ivector.scp \
+  ark:- \| ivector-mean ark:- ${plda_ivec_dir}_male/mean.vec || exit 1;
+run.pl ${plda_ivec_dir}_female/log/compute_mean.log \
+  ivector-normalize-length scp:${plda_ivec_dir}_female/ivector.scp \
+  ark:- \| ivector-mean ark:- ${plda_ivec_dir}_female/mean.vec || exit 1;
 
 rm -rf local/.tmp

--- a/egs/sre10/v1/run.sh
+++ b/egs/sre10/v1/run.sh
@@ -72,7 +72,6 @@ utils/subset_data_dir.sh data/train 32000 data/train_32k
 
 # Train UBM and i-vector extractor.
 sid/train_diag_ubm.sh --cmd "$train_cmd -l mem_free=20G,ram_free=20G" \
-  --stage 0 \
   --nj 20 --num-threads 8 \
   data/train_16k $num_components \
   exp/diag_ubm_$num_components
@@ -82,7 +81,6 @@ sid/train_full_ubm.sh --nj 40 --remove-low-count-gaussians false \
   exp/diag_ubm_$num_components exp/full_ubm_$num_components
 
 sid/train_ivector_extractor.sh --cmd "$train_cmd -l mem_free=35G,ram_free=35G" \
-  --stage 0 \
   --ivector-dim 600 \
   --num-iters 5 exp/full_ubm_$num_components/final.ubm data/train \
   exp/extractor

--- a/egs/sre10/v1/run.sh
+++ b/egs/sre10/v1/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Copyright 2015   David Snyder
-#           2015   Johns Hopkins University (Author: Daniel Garcia-Romero)
-#           2015   Johns Hopkins University (Author: Daniel Povey)
+# Copyright 2015-2016   David Snyder
+#                2015   Johns Hopkins University (Author: Daniel Garcia-Romero)
+#                2015   Johns Hopkins University (Author: Daniel Povey)
 # Apache 2.0.
 #
 # See README.txt for more info on data required.
@@ -28,39 +28,39 @@ local/make_sre.sh data
 
 # Prepare SWB for UBM and i-vector extractor training.
 local/make_swbd2_phase2.pl /export/corpora5/LDC/LDC99S79 \
-                           data/swbd2_phase2_train
+  data/swbd2_phase2_train
 local/make_swbd2_phase3.pl /export/corpora5/LDC/LDC2002S06 \
-                           data/swbd2_phase3_train
+  data/swbd2_phase3_train
 local/make_swbd_cellular1.pl /export/corpora5/LDC/LDC2001S13 \
-                             data/swbd_cellular1_train
+  data/swbd_cellular1_train
 local/make_swbd_cellular2.pl /export/corpora5/LDC/LDC2004S07 \
-                             data/swbd_cellular2_train
+  data/swbd_cellular2_train
 
 utils/combine_data.sh data/train \
   data/swbd_cellular1_train data/swbd_cellular2_train \
   data/swbd2_phase2_train data/swbd2_phase3_train data/sre
 
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/train exp/make_mfcc $mfccdir
+  data/train exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre exp/make_mfcc $mfccdir
+  data/sre exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre10_train exp/make_mfcc $mfccdir
+  data/sre10_train exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre10_test exp/make_mfcc $mfccdir
+  data/sre10_test exp/make_mfcc $mfccdir
 
 for name in sre sre10_train sre10_test train; do
   utils/fix_data_dir.sh data/${name}
 done
 
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/train exp/make_vad $vaddir
+  data/train exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre exp/make_vad $vaddir
+  data/sre exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre10_train exp/make_vad $vaddir
+  data/sre10_train exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre10_test exp/make_vad $vaddir
+  data/sre10_test exp/make_vad $vaddir
 
 for name in sre sre10_train sre10_test train; do
   utils/fix_data_dir.sh data/${name}
@@ -71,31 +71,34 @@ utils/subset_data_dir.sh data/train 16000 data/train_16k
 utils/subset_data_dir.sh data/train 32000 data/train_32k
 
 # Train UBM and i-vector extractor.
-sid/train_diag_ubm.sh --nj 40 --cmd "$train_cmd -l mem_free=20G,ram_free=20G"\
-    data/train_16k $num_components \
-    exp/diag_ubm_$num_components
+sid/train_diag_ubm.sh --cmd "$train_cmd -l mem_free=20G,ram_free=20G" \
+  --stage 0 \
+  --nj 20 --num-threads 8 \
+  data/train_16k $num_components \
+  exp/diag_ubm_$num_components
 
 sid/train_full_ubm.sh --nj 40 --remove-low-count-gaussians false \
-    --cmd "$train_cmd -l mem_free=25G,ram_free=25G" data/train_32k \
-    exp/diag_ubm_$num_components exp/full_ubm_$num_components
+  --cmd "$train_cmd -l mem_free=25G,ram_free=25G" data/train_32k \
+  exp/diag_ubm_$num_components exp/full_ubm_$num_components
 
 sid/train_ivector_extractor.sh --cmd "$train_cmd -l mem_free=35G,ram_free=35G" \
+  --stage 0 \
   --ivector-dim 600 \
   --num-iters 5 exp/full_ubm_$num_components/final.ubm data/train \
   exp/extractor
 
 # Extract i-vectors.
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
-   exp/extractor data/sre10_train \
-   exp/ivectors_sre10_train
+  exp/extractor data/sre10_train \
+  exp/ivectors_sre10_train
 
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
-   exp/extractor data/sre10_test \
-   exp/ivectors_sre10_test
+  exp/extractor data/sre10_test \
+  exp/ivectors_sre10_test
 
 sid/extract_ivectors.sh --cmd "$train_cmd -l mem_free=6G,ram_free=6G" --nj 50 \
-   exp/extractor data/sre \
-   exp/ivectors_sre
+  exp/extractor data/sre \
+  exp/ivectors_sre
 
 # Separate the i-vectors into male and female partitions and calculate
 # i-vector means used by the scoring scripts.
@@ -103,7 +106,7 @@ local/scoring_common.sh data/sre data/sre10_train data/sre10_test \
   exp/ivectors_sre exp/ivectors_sre10_train exp/ivectors_sre10_test
 
 # The commented out scripts show how to do cosine scoring with and without
-# first reducing the i-vector dimensionality with LDA. PLDA tends to work 
+# first reducing the i-vector dimensionality with LDA. PLDA tends to work
 # best, so we don't focus on the scores obtained here.
 #
 # local/cosine_scoring.sh data/sre10_train data/sre10_test \
@@ -130,12 +133,12 @@ cat local/scores_gmm_2048_dep_male/plda_scores local/scores_gmm_2048_dep_female/
   > local/scores_gmm_2048_dep_pooled/plda_scores
 
 # GMM-2048 PLDA EER
-# ind pooled: 2.49
-# ind female: 2.35
-# ind male:   2.51
-# dep female: 2.33
+# ind pooled: 2.26
+# ind female: 2.33
+# ind male:   2.05
+# dep female: 2.30
 # dep male:   1.59
-# dep pooled: 2.16
+# dep pooled: 2.00
 echo "GMM-$num_components EER"
 for x in ind dep; do
   for y in female male pooled; do

--- a/egs/sre10/v2/README.txt
+++ b/egs/sre10/v2/README.txt
@@ -1,7 +1,17 @@
- Data required for system development (on top of the data for testing described
- in ../README.txt).  We use SWBD and the older (prior to 2010) SREs to train the
- supervised-GMM and iVector extractor. To create an in-domain system, the SREs
- are needed to train the PLDA backend.  The TDNN is trained on Fisher English.
+ This recipe replaces the standard unsupervised GMM of the v1 recipe with a 
+ UBM that uses a time-delay deep neural network (TDNN).  Posteriors from the
+ TDNN are used in conjunction with features extracted using a standard approach
+ for speaker recognition, to create the sufficient statistics for i-vector
+ extraction.  The recipe also demonstrates a lightweight alternative in which
+ a supervised GMM is derived from the TDNN posteriors. The recipe is based on
+ http://www.danielpovey.com/files/2015_asru_tdnn_ubm.pdf. See run.sh for 
+ updated results.
+
+ The following describes data required for system development (on top of the 
+ data for testing described in ../README.txt).  We use SWBD and the older 
+ (prior to 2010) SREs to train the supervised-GMM and iVector extractor. To 
+ create an in-domain system, the SREs are needed to train the PLDA backend.
+ The TDNN is trained on Fisher English.
  
      Corpus              LDC Catalog No.
      SWBD2 Phase 2       LDC99S79

--- a/egs/sre10/v2/run.sh
+++ b/egs/sre10/v2/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Copyright 2015   David Snyder
-#           2015   Johns Hopkins University (Author: Daniel Garcia-Romero)
-#           2015   Johns Hopkins University (Author: Daniel Povey)
+# Copyright 2015-2016   David Snyder
+#                2015   Johns Hopkins University (Author: Daniel Garcia-Romero)
+#                2015   Johns Hopkins University (Author: Daniel Povey)
 # Apache 2.0.
 #
 # See README.txt for more info on data required.
@@ -35,13 +35,13 @@ local/make_sre.sh data
 
 # Prepare SWB for UBM and i-vector extractor training.
 local/make_swbd2_phase2.pl /export/corpora5/LDC/LDC99S79 \
-                           data/swbd2_phase2_train
+  data/swbd2_phase2_train
 local/make_swbd2_phase3.pl /export/corpora5/LDC/LDC2002S06 \
-                           data/swbd2_phase3_train
+  data/swbd2_phase3_train
 local/make_swbd_cellular1.pl /export/corpora5/LDC/LDC2001S13 \
-                             data/swbd_cellular1_train
+  data/swbd_cellular1_train
 local/make_swbd_cellular2.pl /export/corpora5/LDC/LDC2004S07 \
-                             data/swbd_cellular2_train
+  data/swbd_cellular2_train
 
 utils/combine_data.sh data/train \
   data/swbd_cellular1_train data/swbd_cellular2_train \
@@ -54,38 +54,38 @@ cp -r data/sre10_test data/sre10_test_dnn
 
 # Extract speaker recogntion features.
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/train exp/make_mfcc $mfccdir
+  data/train exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre exp/make_mfcc $mfccdir
+  data/sre exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre10_train exp/make_mfcc $mfccdir
+  data/sre10_train exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \
-    data/sre10_test exp/make_mfcc $mfccdir
+  data/sre10_test exp/make_mfcc $mfccdir
 
 # Extract DNN features.
 steps/make_mfcc.sh --mfcc-config conf/mfcc_hires.conf --nj 40 \
-    --cmd "$train_cmd" data/train_dnn exp/make_mfcc $mfccdir
+  --cmd "$train_cmd" data/train_dnn exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc_hires.conf --nj 40 \
-    --cmd "$train_cmd" data/sre_dnn exp/make_mfcc $mfccdir
+  --cmd "$train_cmd" data/sre_dnn exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc_hires.conf --nj 40 \
-    --cmd "$train_cmd" data/sre10_train_dnn exp/make_mfcc $mfccdir
+  --cmd "$train_cmd" data/sre10_train_dnn exp/make_mfcc $mfccdir
 steps/make_mfcc.sh --mfcc-config conf/mfcc_hires.conf --nj 40 \
-    --cmd "$train_cmd" data/sre10_test_dnn exp/make_mfcc $mfccdir
+  --cmd "$train_cmd" data/sre10_test_dnn exp/make_mfcc $mfccdir
 
 for name in sre_dnn sre10_train_dnn sre10_test_dnn train_dnn sre \
-    sre10_train sre10_test train; do
+  sre10_train sre10_test train; do
   utils/fix_data_dir.sh data/${name}
 done
 
 # Compute VAD decisions. These will be shared across both sets of features.
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/train exp/make_vad $vaddir
+  data/train exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre exp/make_vad $vaddir
+  data/sre exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre10_train exp/make_vad $vaddir
+  data/sre10_train exp/make_vad $vaddir
 sid/compute_vad_decision.sh --nj 40 --cmd "$train_cmd" \
-    data/sre10_test exp/make_vad $vaddir
+  data/sre10_test exp/make_vad $vaddir
 
 for name in sre sre10_train sre10_test train; do
   cp data/${name}/vad.scp data/${name}_dnn/vad.scp
@@ -98,8 +98,8 @@ done
 # Subset training data for faster sup-GMM initialization.
 utils/subset_data_dir.sh data/train_dnn 32000 data/train_dnn_32k
 utils/fix_data_dir.sh data/train_dnn_32k
-utils/subset_data_dir.sh --utt-list data/train_dnn_32k/utt2spk data/train \
-    data/train_32k
+utils/subset_data_dir.sh --utt-list data/train_dnn_32k/utt2spk \
+  data/train data/train_32k
 utils/fix_data_dir.sh data/train_32k
 
 # Initialize a full GMM from the DNN posteriors and speaker recognition
@@ -128,44 +128,44 @@ sid/train_ivector_extractor_dnn.sh \
 
 # Extract i-vectors from the extractor with the sup-GMM UBM.
 sid/extract_ivectors.sh \
-   --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
-   exp/extractor_sup_gmm data/sre10_train \
-   exp/ivectors_sre10_train_sup_gmm
+  --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
+  exp/extractor_sup_gmm data/sre10_train \
+  exp/ivectors_sre10_train_sup_gmm
 
 sid/extract_ivectors.sh \
-   --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
-   exp/extractor_sup_gmm data/sre10_test \
-   exp/ivectors_sre10_test_sup_gmm
+  --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
+  exp/extractor_sup_gmm data/sre10_test \
+  exp/ivectors_sre10_test_sup_gmm
 
 sid/extract_ivectors.sh \
-   --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
-   exp/extractor_sup_gmm data/sre \
-   exp/ivectors_sre_sup_gmm
+  --cmd "$train_cmd -l mem_free=8G,ram_free=8G" --nj 40 \
+  exp/extractor_sup_gmm data/sre \
+  exp/ivectors_sre_sup_gmm
 
 # Extract i-vectors using the extractor with the DNN-UBM.
 sid/extract_ivectors_dnn.sh \
-   --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
-   exp/extractor_dnn \
-   $nnet \
-   data/sre10_test \
-   data/sre10_test_dnn \
-   exp/ivectors10_test_dnn
+  --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
+  exp/extractor_dnn \
+  $nnet \
+  data/sre10_test \
+  data/sre10_test_dnn \
+  exp/ivectors10_test_dnn
 
 sid/extract_ivectors_dnn.sh
-   --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
-   exp/extractor_dnn \
-   $nnet \
-   data/sre10_train \
-   data/sre10_train_dnn \
-   exp/ivectors10_train_dnn
+  --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
+  exp/extractor_dnn \
+  $nnet \
+  data/sre10_train \
+  data/sre10_train_dnn \
+  exp/ivectors10_train_dnn
 
 sid/extract_ivectors_dnn.sh
-   --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
-   exp/extractor_dnn \
-   $nnet \
-   data/sre \
-   data/sre_dnn \
-   exp/ivectors_sre_dnn
+  --cmd "$train_cmd -l mem_free=10G,ram_free=10G" --nj 40 \
+  exp/extractor_dnn \
+  $nnet \
+  data/sre \
+  data/sre_dnn \
+  exp/ivectors_sre_dnn
 
 # Separate the i-vectors into male and female partitions and calculate
 # i-vector means used by the scoring scripts.
@@ -182,14 +182,16 @@ local/scoring_common.sh data/sre data/sre10_train data/sre10_test \
 # best, so we don't focus on the scores obtained here.
 #
 # local/cosine_scoring.sh data/sre10_train data/sre10_test \
-#  exp/ivectors_sre10_train exp/ivectors_sre10_test $trials local/scores_gmm_2048_ind_pooled
+#   exp/ivectors_sre10_train exp/ivectors_sre10_test $trials \
+#   local/scores_gmm_2048_ind_pooled
 # local/lda_scoring.sh data/sre data/sre10_train data/sre10_test \
-#  exp/ivectors_sre exp/ivectors_sre10_train exp/ivectors_sre10_test $trials local/scores_gmm_2048_ind_pooled
+#   exp/ivectors_sre exp/ivectors_sre10_train exp/ivectors_sre10_test \
+#   $trials local/scores_gmm_2048_ind_pooled
 
 # Create a gender independent PLDA model and do scoring with the sup-GMM system.
 local/plda_scoring.sh data/sre data/sre10_train data/sre10_test \
-  exp/ivectors_sre_test_sup_gmm exp/ivectors_sre10_train_sup_gmm \
-   exp/ivectors_sre10_test_sup_gmm $trials local/scores_sup_gmm_ind_pooled
+  exp/ivectors_sre_sup_gmm exp/ivectors_sre10_train_sup_gmm \
+  exp/ivectors_sre10_test_sup_gmm $trials local/scores_sup_gmm_ind_pooled
 local/plda_scoring.sh --use-existing-models true data/sre data/sre10_train_female data/sre10_test_female \
   exp/ivectors_sre_sup_gmm exp/ivectors_sre10_train_sup_gmm_female \
   exp/ivectors_sre10_test_sup_gmm_female $trials_female local/scores_sup_gmm_ind_female
@@ -203,15 +205,15 @@ local/plda_scoring.sh data/sre_female data/sre10_train_female data/sre10_test_fe
   exp/ivectors_sre10_test_sup_gmm_female $trials_female local/scores_sup_gmm_dep_female
 local/plda_scoring.sh data/sre_male data/sre10_train_male data/sre10_test_male \
   exp/ivectors_sre_sup_gmm exp/ivectors_sre10_train_sup_gmm_male \
-   exp/ivectors_sre10_test_sup_gmm_male $trials_male local/scores_sup_gmm_dep_male
+  exp/ivectors_sre10_test_sup_gmm_male $trials_male local/scores_sup_gmm_dep_male
 mkdir -p local/scores_sup_gmm_dep_pooled
 cat local/scores_sup_gmm_dep_male/plda_scores local/scores_sup_gmm_dep_female/plda_scores \
   > local/scores_sup_gmm_dep_pooled/plda_scores
 
 # Create a gender independent PLDA model and do scoring with the DNN system.
 local/plda_scoring.sh data/sre data/sre10_train data/sre10_test \
-  exp/ivectors_sre_test_dnn exp/ivectors_sre10_train_dnn \
-   exp/ivectors_sre10_test_dnn $trials local/scores_dnn_ind_pooled
+  exp/ivectors_sre_dnn exp/ivectors_sre10_train_dnn \
+  exp/ivectors_sre10_test_dnn $trials local/scores_dnn_ind_pooled
 local/plda_scoring.sh --use-existing-models true data/sre data/sre10_train_female data/sre10_test_female \
   exp/ivectors_sre_dnn exp/ivectors_sre10_train_dnn_female \
   exp/ivectors_sre10_test_dnn_female $trials_female local/scores_dnn_ind_female
@@ -225,18 +227,17 @@ local/plda_scoring.sh data/sre_female data/sre10_train_female data/sre10_test_fe
   exp/ivectors_sre10_test_dnn_female $trials_female local/scores_dnn_dep_female
 local/plda_scoring.sh data/sre_male data/sre10_train_male data/sre10_test_male \
   exp/ivectors_sre_dnn exp/ivectors_sre10_train_dnn_male \
-   exp/ivectors_sre10_test_dnn_male $trials_male local/scores_dnn_dep_male
+  exp/ivectors_sre10_test_dnn_male $trials_male local/scores_dnn_dep_male
 mkdir -p local/scores_dnn_dep_pooled
 cat local/scores_dnn_dep_male/plda_scores local/scores_dnn_dep_female/plda_scores \
   > local/scores_dnn_dep_pooled/plda_scores
 
-
 # Sup-GMM PLDA EER
-# ind pooled: 1.94
-# ind female: 1.98
-# ind male:   1.79
-# dep female: 1.87
-# dep male:   1.30
+# ind pooled: 1.72
+# ind female: 1.81
+# ind male:   1.56
+# dep female: 1.89
+# dep male:   1.39
 # dep pooled: 1.65
 echo "Sup-GMM-$num_components EER"
 for x in ind dep; do
@@ -247,12 +248,12 @@ for x in ind dep; do
 done
 
 # DNN PLDA EER
-# ind pooled: 1.20
-# ind female: 1.46
-# ind male:   0.87
-# dep female: 1.43
-# dep male:   0.72
-# dep pooled: 1.09
+# ind pooled: 1.05
+# ind female: 1.33
+# ind male:   0.75
+# dep female: 1.41
+# dep male:   0.64
+# dep pooled: 1.02
 echo "DNN-$num_components EER"
 for x in ind dep; do
   for y in female male pooled; do
@@ -264,9 +265,9 @@ done
 # In comparison, here is the EER for an unsupervised GMM-based system
 # with 5297 components (the same as the number of senones in the DNN):
 # GMM-5297 PLDA EER
-# ind pooled: 2.42
-# ind female: 2.43
-# ind male:   2.40
-# dep female: 2.16
-# dep male:   1.53
-# dep pooled: 2.00
+# ind pooled: 2.25
+# ind female: 2.33
+# ind male:   2.08
+# dep female: 2.25
+# dep male:   1.50
+# dep pooled: 1.91

--- a/src/ivector/plda.cc
+++ b/src/ivector/plda.cc
@@ -83,36 +83,64 @@ void Plda::ComputeDerivedVars() {
 
  */
 
+double Plda::GetNormalizationFactor(
+    const VectorBase<double> &transformed_ivector,
+    int32 num_examples) const {
+  KALDI_ASSERT(num_examples > 0);
+  // Work out the normalization factor.  The covariance for an average over
+  // "num_examples" training iVectors equals \Psi + I/num_examples.
+  Vector<double> transformed_ivector_sq(transformed_ivector);
+  transformed_ivector_sq.ApplyPow(2.0);
+  // inv_covar will equal 1.0 / (\Psi + I/num_examples).
+  Vector<double> inv_covar(psi_);
+  inv_covar.Add(1.0 / num_examples);
+  inv_covar.InvertElements();
+  // "transformed_ivector" should have covariance (\Psi + I/num_examples), i.e.
+  // within-class/num_examples plus between-class covariance.  So
+  // transformed_ivector_sq . (I/num_examples + \Psi)^{-1} should be equal to
+  //  the dimension.
+  double dot_prod = VecVec(inv_covar, transformed_ivector_sq);
+  return sqrt(Dim() / dot_prod);
+}
+
+
 double Plda::TransformIvector(const PldaConfig &config,
                               const VectorBase<double> &ivector,
+                              int32 num_examples,
                               VectorBase<double> *transformed_ivector) const {
   KALDI_ASSERT(ivector.Dim() == Dim() && transformed_ivector->Dim() == Dim());
+  double normalization_factor;
   transformed_ivector->CopyFromVec(offset_);
   transformed_ivector->AddMatVec(1.0, transform_, kNoTrans, ivector, 1.0);
-  double normalization_factor = sqrt(transformed_ivector->Dim()) 
-                                / transformed_ivector->Norm(2.0);
+  if (config.simple_length_norm)
+    normalization_factor = sqrt(transformed_ivector->Dim())
+      / transformed_ivector->Norm(2.0);
+  else
+    normalization_factor = GetNormalizationFactor(*transformed_ivector,
+                                                       num_examples);
   if (config.normalize_length)
-      transformed_ivector->Scale(normalization_factor);
+    transformed_ivector->Scale(normalization_factor);
   return normalization_factor;
 }
 
 // "float" version of TransformIvector.
 float Plda::TransformIvector(const PldaConfig &config,
                              const VectorBase<float> &ivector,
+                             int32 num_examples,
                              VectorBase<float> *transformed_ivector) const {
   Vector<double> tmp(ivector), tmp_out(ivector.Dim());
-  float ans = TransformIvector(config, tmp, &tmp_out);
+  float ans = TransformIvector(config, tmp, num_examples, &tmp_out);
   transformed_ivector->CopyFromVec(tmp_out);
   return ans;
 }
 
 
-// There is an extended comment within this file, referencing a paper by Ioffe, that
-// may clarify what this function is doing.
+// There is an extended comment within this file, referencing a paper by
+// Ioffe, that may clarify what this function is doing.
 double Plda::LogLikelihoodRatio(
     const VectorBase<double> &transformed_train_ivector,
     int32 n, // number of training utterances.
-    const VectorBase<double> &transformed_test_ivector) const {
+    const VectorBase<double> &transformed_test_ivector) {
   int32 dim = Dim();
   double loglike_given_class, loglike_without_class;
   { // work out loglike_given_class.
@@ -123,7 +151,8 @@ double Plda::LogLikelihoodRatio(
     Vector<double> mean(dim, kUndefined);
     Vector<double> variance(dim, kUndefined);
     for (int32 i = 0; i < dim; i++) {
-      mean(i) = n * psi_(i) / (n * psi_(i) + 1.0) * transformed_train_ivector(i);
+      mean(i) = n * psi_(i) / (n * psi_(i) + 1.0)
+        * transformed_train_ivector(i);
       variance(i) = 1.0 + psi_(i) / (n * psi_(i) + 1.0);
     }
     double logdet = variance.SumLog();
@@ -223,7 +252,7 @@ void PldaStats::Init(int32 dim) {
   example_weight_ = 0.0;
   sum_.Resize(dim);
   offset_scatter_.Resize(dim);
-  KALDI_ASSERT(class_info_.empty());  
+  KALDI_ASSERT(class_info_.empty());
 }
 
 
@@ -242,7 +271,7 @@ double PldaEstimator::ComputeObjfPart1() const {
   // #examples) separate samples, each with the within-class covariance.. the
   // argument is a little complicated and involves an orthogonal complement of a
   // matrix whose first row computes the mean.
-  
+
   double within_class_count = stats_.example_weight_ - stats_.class_weight_,
       within_logdet, det_sign;
   SpMatrix<double> inv_within_var(within_var_);
@@ -256,12 +285,12 @@ double PldaEstimator::ComputeObjfPart1() const {
 
 double PldaEstimator::ComputeObjfPart2() const {
   double tot_objf = 0.0;
-  
+
   int32 n = -1; // the number of examples for the current class
   SpMatrix<double> combined_inv_var(Dim());
   // combined_inv_var = (between_var_ + within_var_ / n)^{-1}
   double combined_var_logdet;
-  
+
   for (size_t i = 0; i < stats_.class_info_.size(); i++) {
     const ClassInfo &info = stats_.class_info_[i];
     if (info.num_examples != n) {
@@ -338,9 +367,9 @@ void PldaEstimator::GetStatsFromIntraClass() {
             = C - 0.5 x^T (between_var^{-1} + n within_var^{-1}) x + x^T z
 
             where z = n within_var^{-1} m, and we can write this as:
-            
+
    log p(x) = C - 0.5 (x-w)^T (between_var^{-1} + n within_var^{-1}) (x-w)
-     
+
     where x^T (between_var^{-1} + n within_var^{-1}) w = x^T z, i.e.
        (between_var^{-1} + n within_var^{-1}) w = z = n within_var^{-1} m, so
 
@@ -353,7 +382,7 @@ void PldaEstimator::GetStatsFromIntraClass() {
        between-var-stats += w w^T + (between_var^{-1} + n within_var^{-1})^{-1}.
     and the update to the within-var stats will be:
        within-var-stats += n ( (m-w) (m-w)^T (between_var^{-1} + n within_var^{-1})^{-1} ).
-    
+
     The drawback of this formulation is that each time we encounter a different
     value of n (number of examples) we will have to do a different matrix
     inversion.  We'll try to improve on this later using a suitable transform.
@@ -365,7 +394,7 @@ void PldaEstimator::GetStatsFromClassMeans() {
   SpMatrix<double> within_var_inv(within_var_);
   within_var_inv.Invert();
   // mixed_var will equal (between_var^{-1} + n within_var^{-1})^{-1}.
-  SpMatrix<double> mixed_var(Dim()); 
+  SpMatrix<double> mixed_var(Dim());
   int32 n = -1; // the current number of examples for the class.
 
   for (size_t i = 0; i < stats_.class_info_.size(); i++) {
@@ -442,7 +471,7 @@ void PldaEstimator::GetOutput(Plda *plda) {
   plda->mean_.Scale(1.0 / stats_.class_weight_);
   KALDI_LOG << "Norm of mean of iVector distribution is "
             << plda->mean_.Norm(2.0);
-  
+
   Matrix<double> transform1(Dim(), Dim());
   ComputeNormalizingTransform(within_var_, &transform1);
   // now transform is a matrix that if we project with it,
@@ -456,7 +485,7 @@ void PldaEstimator::GetOutput(Plda *plda) {
   Vector<double> s(Dim());
   // Do symmetric eigenvalue decomposition between_var_proj = U diag(s) U^T,
   // where U is orthogonal.
-  between_var_proj.Eig(&s, &U); 
+  between_var_proj.Eig(&s, &U);
 
   KALDI_ASSERT(s.Min() >= 0.0);
   int32 n = s.ApplyFloor(0.0);
@@ -466,7 +495,7 @@ void PldaEstimator::GetOutput(Plda *plda) {
   }
   // Sort from greatest to smallest eigenvalue.
   SortSvd(&s, &U);
-  
+
   // The transform U^T will make between_var_proj diagonal with value s
   // (i.e. U^T U diag(s) U U^T = diag(s)).  The final transform that
   // makes within_var_ unit and between_var_ diagonal is U^T transform1,
@@ -539,7 +568,7 @@ void PldaUnsupervisedAdaptor::UpdatePlda(const PldaUnsupervisedAdaptorConfig &co
   // plda->transform_ transforms into a space where the within-class covar is
   // 1.0 and the the between-class covar is diag(plda->psi_), we need to scale
   // each dimension i by 1.0 / sqrt(1.0 + plda->psi_(i))
-  
+
   Matrix<double> transform_mod(plda->transform_);
   for (int32 i = 0; i < dim; i++)
     transform_mod.Row(i).Scale(1.0 / sqrt(1.0 + plda->psi_(i)));
@@ -564,7 +593,7 @@ void PldaUnsupervisedAdaptor::UpdatePlda(const PldaUnsupervisedAdaptorConfig &co
   // transform_mod.
   SpMatrix<double> W(dim), B(dim);
   for (int32 i = 0; i < dim; i++) {
-    W(i, i) =           1.0 / (1.0 + plda->psi_(i)), 
+    W(i, i) =           1.0 / (1.0 + plda->psi_(i)),
     B(i, i) = plda->psi_(i) / (1.0 + plda->psi_(i));
   }
 
@@ -576,7 +605,7 @@ void PldaUnsupervisedAdaptor::UpdatePlda(const PldaUnsupervisedAdaptorConfig &co
   // First let's compute these projected variances... we call the "proj2" because
   // it's after the data has been projected twice (actually, transformed, as there is no
   // dimension loss), by transform_mod and then P^T.
-  
+
   SpMatrix<double> Wproj2(dim), Bproj2(dim);
   Wproj2.AddMat2Sp(1.0, P, kTrans, W, 0.0);
   Bproj2.AddMat2Sp(1.0, P, kTrans, B, 0.0);
@@ -584,7 +613,7 @@ void PldaUnsupervisedAdaptor::UpdatePlda(const PldaUnsupervisedAdaptorConfig &co
   Matrix<double> Ptrans(P, kTrans);
 
   SpMatrix<double> Wproj2mod(Wproj2), Bproj2mod(Bproj2);
-  
+
   for (int32 i = 0; i < dim; i++) {
     // For this eigenvalue, compute the within-class covar projected with this direction,
     // and the same for between.
@@ -626,20 +655,20 @@ void PldaUnsupervisedAdaptor::UpdatePlda(const PldaUnsupervisedAdaptorConfig &co
   SpMatrix<double> Wmod(dim), Bmod(dim);
   Wmod.AddMat2Sp(1.0, combined_trans_inv, kNoTrans, Wproj2mod, 0.0);
   Bmod.AddMat2Sp(1.0, combined_trans_inv, kNoTrans, Bproj2mod, 0.0);
-  
+
   TpMatrix<double> C(dim);
   // Do Cholesky Wmod = C C^T.  Now if we use C^{-1} as a transform, we have
   // C^{-1} W C^{-T} = I, so it makes the within-class covar unit.
   C.Cholesky(Wmod);
   TpMatrix<double> Cinv(C);
   Cinv.Invert();
-  
+
   // Bmod_proj is Bmod projected by Cinv.
   SpMatrix<double> Bmod_proj(dim);
   Bmod_proj.AddTp2Sp(1.0, Cinv, kNoTrans, Bmod, 0.0);
   Vector<double> psi_new(dim);
   Matrix<double> Q(dim, dim);
-  // Do symmetric eigenvalue decomposition of Bmod_proj, so 
+  // Do symmetric eigenvalue decomposition of Bmod_proj, so
   // Bmod_proj = Q diag(psi_new) Q^T
   Bmod_proj.Eig(&psi_new, &Q);
   SortSvd(&psi_new, &Q);

--- a/src/ivector/plda.cc
+++ b/src/ivector/plda.cc
@@ -140,7 +140,7 @@ float Plda::TransformIvector(const PldaConfig &config,
 double Plda::LogLikelihoodRatio(
     const VectorBase<double> &transformed_train_ivector,
     int32 n, // number of training utterances.
-    const VectorBase<double> &transformed_test_ivector) {
+    const VectorBase<double> &transformed_test_ivector) const {
   int32 dim = Dim();
   double loglike_given_class, loglike_without_class;
   { // work out loglike_given_class.

--- a/src/ivector/plda.cc
+++ b/src/ivector/plda.cc
@@ -117,7 +117,7 @@ double Plda::TransformIvector(const PldaConfig &config,
       / transformed_ivector->Norm(2.0);
   else
     normalization_factor = GetNormalizationFactor(*transformed_ivector,
-                                                       num_examples);
+                                                  num_examples);
   if (config.normalize_length)
     transformed_ivector->Scale(normalization_factor);
   return normalization_factor;

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -34,9 +34,8 @@
 
 namespace kaldi {
 
-/* This code
-   implements Probabilistic Linear Discriminant Analysis: see
-    "Probabilistic Linear Discriminant Analysis" by Sergey Ioffe, ECCV 2006.
+/* This code implements Probabilistic Linear Discriminant Analysis: see
+   "Probabilistic Linear Discriminant Analysis" by Sergey Ioffe, ECCV 2006.
    At least, that was the inspiration.  The E-M is an efficient method
    that I derived myself (note: it could be made even more efficient but
    it doesn't seem to be necessary as it's already very fast).
@@ -52,12 +51,22 @@ struct PldaConfig {
   // This config is for the application of PLDA as a transform to iVectors,
   // prior to dot-product scoring.
   bool normalize_length;
-  PldaConfig(): normalize_length(true) { }
+  bool simple_length_norm;
+  PldaConfig(): normalize_length(true), simple_length_norm(false) { }
   void Register(OptionsItf *opts) {
     opts->Register("normalize-length", &normalize_length,
-                   "If true, do length normalization as part of PLDA.  This "
-                   "normalizes the length of the iVectors to be equal to the "
-                   "square root of the iVector dimension.");
+                   "If true, do length normalization as part of PLDA (see "
+                   "code for details).  This does not set the length unit; "
+                   "by default it instead ensures that the inner product "
+                   "with the PLDA model's inverse variance (which is a "
+                   "function of how many utterances the iVector was averaged "
+                   "over) has the expected value, equal to the iVector "
+                   "dimension.");
+
+    opts->Register("simple-length-normalization", &simple_length_norm,
+                   "If true, replace the default length normalization by an "
+                   "alternative that normalizes the length of the iVectors to "
+                   "be equal to the square root of the iVector dimension.");
   }
 };
 
@@ -67,26 +76,33 @@ class Plda {
   Plda() { }
 
 
-  /// Transforms iVector into the space where the within-class variance
+  /// Transforms an iVector into a space where the within-class variance
   /// is unit and between-class variance is diagonalized.  The only
   /// anticipated use of this function is to pre-transform iVectors
   /// before giving them to the function LogLikelihoodRatio (it's
   /// done this way for efficiency because a given iVector may be
   /// used multiple times in LogLikelihoodRatio and we don't want
-  /// to repeat the matrix multiplication
+  /// do repeat the matrix multiplication
   ///
-  /// If config.normalize_length == true, it will also normalize the length of
-  /// the iVector so that it is equal to the sqrt(dim).  The normalization
+  /// If config.normalize_length == true, it will also normalize the iVector's
+  /// length by multiplying by a scalar that ensures that ivector^T inv_var
+  /// ivector = dim.  In this case, "num_examples" comes into play because it
+  /// affects the expected covariance matrix of the iVector.  The normalization
   /// factor is returned, even if config.normalize_length == false, in which
   /// case the normalization factor is computed but not applied.
+  /// If config.simple_length_normalization == true, then an alternative
+  /// normalization factor is computed that causes the iVector length
+  /// to be equal to the square root of the iVector dimension.
   double TransformIvector(const PldaConfig &config,
                           const VectorBase<double> &ivector,
+                          int32 num_examples,
                           VectorBase<double> *transformed_ivector) const;
 
   /// float version of the above (not BaseFloat because we'd be implementing it
   /// twice for the same type if BaseFloat == double).
   float TransformIvector(const PldaConfig &config,
                          const VectorBase<float> &ivector,
+                         int32 num_examples,
                          VectorBase<float> *transformed_ivector) const;
 
   /// Returns the log-likelihood ratio
@@ -98,7 +114,7 @@ class Plda {
   /// the transformed iVectors.
   double LogLikelihoodRatio(const VectorBase<double> &transformed_train_ivector,
                             int32 num_train_utts,
-                            const VectorBase<double> &transformed_test_ivector) const;
+                            const VectorBase<double> &transformed_test_ivector);
 
 
   /// This function smooths the within-class covariance by adding to it,
@@ -128,6 +144,15 @@ class Plda {
 
  private:
   KALDI_DISALLOW_COPY_AND_ASSIGN(Plda);
+  /// This returns a normalization factor, which is a quantity we
+  /// must multiply "transformed_ivector" by so that it has the length
+  /// that it "should" have.  We assume "transformed_ivector" is an
+  /// iVector in the transformed space (i.e., mean-subtracted, and
+  /// multiplied by transform_).  The covariance it "should" have
+  /// in this space is \Psi + I/num_examples.
+  double GetNormalizationFactor(const VectorBase<double> &transformed_ivector,
+                                int32 num_examples) const;
+
 };
 
 
@@ -156,12 +181,12 @@ class PldaStats {
 
   int32 dim_;
   int64 num_classes_;
-  int64 num_examples_; // total number of examples, sumed over classes.
+  int64 num_examples_; // total number of examples, summed over classes.
   double class_weight_; // total over classes, of their weight.
   double example_weight_; // total over classes, of weight times #examples.
 
-  Vector<double> sum_; // Weighted sum of class means (normalize by class_weight_
-                       // to get mean).
+  Vector<double> sum_; // Weighted sum of class means (normalize by
+                       // class_weight_ to get mean).
 
   SpMatrix<double> offset_scatter_; // Sum over all examples, of the weight
                                     // times (example - class-mean).
@@ -247,7 +272,6 @@ private:
 
   KALDI_DISALLOW_COPY_AND_ASSIGN(PldaEstimator);
 };
-
 
 
 struct PldaUnsupervisedAdaptorConfig {

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -82,7 +82,7 @@ class Plda {
   /// before giving them to the function LogLikelihoodRatio (it's
   /// done this way for efficiency because a given iVector may be
   /// used multiple times in LogLikelihoodRatio and we don't want
-  /// do repeat the matrix multiplication
+  /// to repeat the matrix multiplication
   ///
   /// If config.normalize_length == true, it will also normalize the iVector's
   /// length by multiplying by a scalar that ensures that ivector^T inv_var
@@ -114,7 +114,8 @@ class Plda {
   /// the transformed iVectors.
   double LogLikelihoodRatio(const VectorBase<double> &transformed_train_ivector,
                             int32 num_train_utts,
-                            const VectorBase<double> &transformed_test_ivector);
+                            const VectorBase<double> &transformed_test_ivector)
+                            const;
 
 
   /// This function smooths the within-class covariance by adding to it,


### PR DESCRIPTION
This addresses several issues in the SID examples, mostly related to length normalization. Also includes some cosmetic improvements. 

## PLDA Length Normalization
* Addresses Issue #376 
* This restores the original PLDA length normalization as the default when the option `--normalize-length=true` is set in the binary `ivector-plda-scoring`
* However, the simple length normalization (which is currently used and is the same as `ivector-normalize-length`) works better for the SRE08 eval, so the option `--simple-length-normalization` is added to provide an option that retains that approach. When set to `true` the default length normalization is replaced with the simple alternative.
* _Using the original PLDA length normalization results in improved SRE10 results_  (search for "EER"). The SRE08 results are unchanged, because `--simple-length-normalization=true` is set in that example.

## Informative Error Messages
* This addresses Issue #504 
* The sre10 scoring now uses run.pl and || exit 1

## Cosmetic Changes
* Removing trailing whitespace
* Using 2 space indent in run.sh scripts, etc





