### PR TITLE
fix out-of-bound global read bug found by cuda-memcheck in cu-vector-…

### DIFF
--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -921,7 +921,7 @@ static void _add_diag_mat_mat_MTN(const Real alpha, const Real* M,
   const int tid = threadIdx.y * blockDim.x + threadIdx.x;
   const int j = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (j > dim_N.cols)
+  if (j >= dim_N.cols)
     return;
 
   // Loop along the matrix column.
@@ -1031,7 +1031,7 @@ static void _add_diag_mat_mat_MN(const Real alpha, const Real* M,
   }
 
   // output TileDim sums per thread block
-  if (tid < TileDim) {
+  if (tid < TileDim && j_n < dim_N.cols) {
     v[j_n] = alpha * smem.sum[tid] + beta * v[j_n];
   }
 }


### PR DESCRIPTION
Fix 2 out-of-bound global read bugs found by `$ cuda-memcheck cu-vector-test`

original bug msg:
```
========= Invalid __global__ read of size 4
=========     at 0x00000258 in /home/sykang/work/kaldi/src/cudamatrix/cu-kernels.cu:957:void _add_diag_mat_mat_MTN<int=16, float>(float, float const *, int, float const *, MatrixDim_, float, float*)
=========     by thread (5,0,0) in block (16,0,0)
=========     Address 0x1304ae7214 is out of bounds
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame:/usr/lib64/nvidia/libcuda.so.1 (cuLaunchKernel + 0x2cd) [0x15865d]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 [0x146ad]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 (cudaLaunch + 0x143) [0x2ece3]
=========     Host Frame:cu-vector-test [0xadb1a]
=========     Host Frame:cu-vector-test (cudaF_add_diag_mat_mat_MTN + 0xdc) [0xbb9bc]
=========     Host Frame:cu-vector-test (_ZN5kaldi12CuVectorBaseIfE13AddDiagMatMatEfRKNS_12CuMatrixBaseIfEENS_19MatrixTransposeTypeES5_S6_f + 0x16e) [0x929de]
=========     Host Frame:cu-vector-test (_ZN5kaldi27CuVectorUnitTestAddDiagMat2IfEEvv + 0x240) [0x497b0]
=========     Host Frame:cu-vector-test (_ZN5kaldi16CuVectorUnitTestIfEEvv + 0xc52) [0x4d572]
=========     Host Frame:cu-vector-test (main + 0x134) [0x3eb44]
=========     Host Frame:/lib64/libc.so.6 (__libc_start_main + 0xf5) [0x21b15]
=========     Host Frame:cu-vector-test [0x42275]
```
and 
```
========= Invalid __global__ read of size 4
=========     at 0x00000318 in /home/sykang/work/kaldi/src/cudamatrix/cu-kernels.cu:1035:void _add_diag_mat_mat_MN<int=16, float>(float, float const *, int, float const *, MatrixDim_, float, float*)
=========     by thread (15,0,0) in block (9,0,0)
=========     Address 0x13047ba67c is out of bounds
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame:/usr/lib64/nvidia/libcuda.so.1 (cuLaunchKernel + 0x2cd) [0x15865d]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 [0x146ad]
=========     Host Frame:/usr/local/cuda/lib64/libcudart.so.7.5 (cudaLaunch + 0x143) [0x2ece3]
=========     Host Frame:cu-vector-test [0xadd3a]
=========     Host Frame:cu-vector-test (cudaF_add_diag_mat_mat_MN + 0xdc) [0xbbaac]
=========     Host Frame:cu-vector-test (_ZN5kaldi12CuVectorBaseIfE13AddDiagMatMatEfRKNS_12CuMatrixBaseIfEENS_19MatrixTransposeTypeES5_S6_f + 0x557) [0x92dc7]
=========     Host Frame:cu-vector-test (_ZN5kaldi16CuVectorUnitTestIfEEvv + 0xe54) [0x4d774]
=========     Host Frame:cu-vector-test (main + 0x134) [0x3eb44]
=========     Host Frame:/lib64/libc.so.6 (__libc_start_main + 0xf5) [0x21b15]
=========     Host Frame:cu-vector-test [0x42275]
```
