### PR TITLE
"--extra-word-disambig-syms" for prepare_lang.sh

### DIFF
--- a/egs/wsj/s5/utils/lang/validate_disambig_sym_file.pl
+++ b/egs/wsj/s5/utils/lang/validate_disambig_sym_file.pl
@@ -19,20 +19,21 @@ This scripts checks if the entries of a file containing disambiguation symbols
 - must not be equal to '#-1' (disallowed because it is used internally in some
   FST stuff).
 
-In case the option '--extra-disambig-syms' is used with 'true', the symbols must
+In case the option '--allow-numeric' is used with 'false', the symbols must
 also be non-numeric (to avoid overlap with the automatically generated symbols).
 
 Allowed options:
-  --extra-disambig-syms  : Indicate extra symbols  (boolean,  default = "false")
+  --allow-numeric (true|false) : Default true. If false, disallow numeric
+                                 disambiguation symbols like #0, #1 and so on.
 
 EOU
 
 # Command line options
-my $extra_disambig_syms = "false";
+my $allow_numeric = "true";
 
 # Get the optional command line options
 GetOptions(
-    "extra-disambig-syms=s" => \$extra_disambig_syms,
+    "allow-numeric=s" => \$allow_numeric,
     ) or die ($Usage);
 
 if (@ARGV != 1) {
@@ -66,7 +67,7 @@ while (<SYMS>) {
     if ($sympart eq "-1") {
       print "$0: The disambiguation symbol \"$symbol\" is not allowed, exiting ...\n"; exit 1;
     }
-    if ($extra_disambig_syms eq "true" &&
+    if ($allow_numeric eq "false" &&
 	$sympart =~/^[0-9]+$/) {
       print "$0: Since \"$symbol\" is supposed to be an extra disambiguation symbol, it must not be numeric, exiting ...\n"; exit 1;
     }

--- a/egs/wsj/s5/utils/prepare_lang.sh
+++ b/egs/wsj/s5/utils/prepare_lang.sh
@@ -151,9 +151,9 @@ fi
 
 # In case there are extra word-level disambiguation symbols we need
 # to make sure that all symbols in the provided file are valid.
-if [[ ! -z $extra_word_disambig_syms ]]; then
-  if ! utils/validate_disambig_sym_file.pl --extra-disambig-syms $extra_word_disambig_syms; then
-    echo "Validation of disambiguation file \"$extra_word_disambig_syms\" failed."
+if [ ! -z "$extra_word_disambig_syms" ]; then
+  if ! utils/lang/validate_disambig_sym_file.pl --allow-numeric "false" $extra_word_disambig_syms; then
+    echo "$0: Validation of disambiguation file \"$extra_word_disambig_syms\" failed."
     exit 1;
   fi
 fi
@@ -292,10 +292,9 @@ echo $ndisambig > $tmpdir/lex_ndisambig
 
 # In case there are extra word-level disambiguation symbols they also
 # need to be added to the list of phone-level disambiguation symbols.
-if [[ ! -z $extra_word_disambig_syms ]]; then
+if [ ! -z "$extra_word_disambig_syms" ]; then
   # We expect a file containing valid word-level disambiguation symbols.
-  # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
-  cat $extra_word_disambig_syms | awk '/^#\w+$/ { print $1 }' >> $dir/phones/disambig.txt
+  cat $extra_word_disambig_syms | awk '{ print $1 }' >> $dir/phones/disambig.txt
 fi
 
 # Create phone symbol table.
@@ -359,17 +358,15 @@ cat $tmpdir/lexiconp.txt | awk '{print $1}' | sort | uniq  | awk '
 
 # In case there are extra word-level disambiguation symbols they also
 # need to be added to words.txt
-if [[ ! -z $extra_word_disambig_syms ]]; then
-  # Since words.txt already exist, we need to extract the current word count.
+if [ ! -z "$extra_word_disambig_syms" ]; then
+  # Since words.txt already exists, we need to extract the current word count.
   word_count=`tail -n 1 $dir/words.txt | awk '{ print $2 }'`
 
   # We expect a file containing valid word-level disambiguation symbols.
-  # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
-  cat $extra_word_disambig_syms | awk -v WC=$word_count '
-  /^#\w+$/
-  {
-    printf("%s %d\n", $1, ++WC);
-  }' >> $dir/words.txt || exit 1;
+  # The list of symbols is attached to the current words.txt (including
+  # a numeric identifier for each symbol).
+  cat $extra_word_disambig_syms | \
+    awk -v WC=$word_count '{ printf("%s %d\n", $1, ++WC); }' >> $dir/words.txt || exit 1;
 fi
 
 # format of $dir/words.txt:
@@ -439,10 +436,10 @@ echo '#0' >$dir/phones/wdisambig.txt
 
 # In case there are extra word-level disambiguation symbols they need
 # to be added to the existing word-level disambiguation symbols file.
-if [[ ! -z $extra_word_disambig_syms ]]; then
+if [ ! -z "$extra_word_disambig_syms" ]; then
   # We expect a file containing valid word-level disambiguation symbols.
   # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
-  cat $extra_word_disambig_syms | awk '/^#\w+$/ { print $1 }' >> $dir/phones/wdisambig.txt
+  cat $extra_word_disambig_syms | awk '{ print $1 }' >> $dir/phones/wdisambig.txt
 fi
 
 utils/sym2int.pl $dir/phones.txt <$dir/phones/wdisambig.txt >$dir/phones/wdisambig_phones.int

--- a/egs/wsj/s5/utils/prepare_lang.sh
+++ b/egs/wsj/s5/utils/prepare_lang.sh
@@ -3,6 +3,7 @@
 #                      Arnab Ghoshal
 #                2014  Guoguo Chen
 #                2015  Hainan Xu
+#                2016  FAU Erlangen (Author: Axel Horndasch)
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,6 +63,8 @@ unk_fst=        # if you want to model the unknown-word (<oov-dict-entry>)
                 # provide the text-form FST via this flag, e.g. <work-dir>/unk_fst.txt
                 # where <work-dir> was the 2nd argument of make_unk_lm.sh.
 phone_symbol_table=              # if set, use a specified phones.txt file.
+extra_word_disambig_syms=        # if set, add disambiguation symbols from this file (one per line)
+                                 # to phones/disambig.txt, phones/wdisambig.txt and words.txt
 # end configuration sections
 
 echo "$0 $@"  # Print the command line for logging
@@ -89,6 +92,9 @@ if [ $# -ne 4 ]; then
   echo "                                                     # This is for if you want to model the unknown word"
   echo "                                                     # via a phone-level LM rather than a special phone"
   echo "                                                     # (this should be more useful for test-time than train-time)."
+  echo "     --extra-word-disambig-syms <filename>           # default: \"\"; if not empty, add disambiguation symbols"
+  echo "                                                     # from this file (one per line) to phones/disambig.txt,"
+  echo "                                                     # phones/wdisambig.txt and words.txt"
   exit 1;
 fi
 
@@ -141,6 +147,15 @@ if [[ ! -z $phone_symbol_table ]]; then
   BEGIN { while ((getline < f) > 0) { sub(/_[BEIS]$/, "", $1); phones[$1] = 1; }}
   { for (x = 1; x <= NF; ++x) { if (!($x in phones)) {
       print "Phone appears in the lexicon but not in the provided phones.txt: "$x; exit 1; }}}' || exit 1;
+fi
+
+# In case there are extra word-level disambiguation symbols we need
+# to make sure that all symbols in the provided file are valid.
+if [[ ! -z $extra_word_disambig_syms ]]; then
+  if ! utils/validate_disambig_sym_file.pl --extra-disambig-syms $extra_word_disambig_syms; then
+    echo "Validation of disambiguation file \"$extra_word_disambig_syms\" failed."
+    exit 1;
+  fi
 fi
 
 if $position_dependent_phones; then
@@ -275,6 +290,14 @@ echo $ndisambig > $tmpdir/lex_ndisambig
 
 ( for n in `seq 0 $ndisambig`; do echo '#'$n; done ) >$dir/phones/disambig.txt
 
+# In case there are extra word-level disambiguation symbols they also
+# need to be added to the list of phone-level disambiguation symbols.
+if [[ ! -z $extra_word_disambig_syms ]]; then
+  # We expect a file containing valid word-level disambiguation symbols.
+  # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
+  cat $extra_word_disambig_syms | awk '/^#\w+$/ { print $1 }' >> $dir/phones/disambig.txt
+fi
+
 # Create phone symbol table.
 if [[ ! -z $phone_symbol_table ]]; then
   start_symbol=`grep \#0 $phone_symbol_table | awk '{print $2}'`
@@ -333,6 +356,21 @@ cat $tmpdir/lexiconp.txt | awk '{print $1}' | sort | uniq  | awk '
     printf("<s> %d\n", NR+2);
     printf("</s> %d\n", NR+3);
   }' > $dir/words.txt || exit 1;
+
+# In case there are extra word-level disambiguation symbols they also
+# need to be added to words.txt
+if [[ ! -z $extra_word_disambig_syms ]]; then
+  # Since words.txt already exist, we need to extract the current word count.
+  word_count=`tail -n 1 $dir/words.txt | awk '{ print $2 }'`
+
+  # We expect a file containing valid word-level disambiguation symbols.
+  # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
+  cat $extra_word_disambig_syms | awk -v WC=$word_count '
+  /^#\w+$/
+  {
+    printf("%s %d\n", $1, ++WC);
+  }' >> $dir/words.txt || exit 1;
+fi
 
 # format of $dir/words.txt:
 #<eps> 0
@@ -398,6 +436,15 @@ cat $dir/oov.txt | utils/sym2int.pl $dir/words.txt >$dir/oov.int || exit 1;
 # symbol table words.txt, and wdisambig_phones.int contains the corresponding
 # list interpreted by the symbol table phones.txt.
 echo '#0' >$dir/phones/wdisambig.txt
+
+# In case there are extra word-level disambiguation symbols they need
+# to be added to the existing word-level disambiguation symbols file.
+if [[ ! -z $extra_word_disambig_syms ]]; then
+  # We expect a file containing valid word-level disambiguation symbols.
+  # The regular expression for awk is just a paranoia filter (e.g. for empty lines).
+  cat $extra_word_disambig_syms | awk '/^#\w+$/ { print $1 }' >> $dir/phones/wdisambig.txt
+fi
+
 utils/sym2int.pl $dir/phones.txt <$dir/phones/wdisambig.txt >$dir/phones/wdisambig_phones.int
 utils/sym2int.pl $dir/words.txt <$dir/phones/wdisambig.txt >$dir/phones/wdisambig_words.int
 

--- a/egs/wsj/s5/utils/validate_disambig_sym_file.pl
+++ b/egs/wsj/s5/utils/validate_disambig_sym_file.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-#!/usr/bin/perl -w
+
 # Copyright 2016 FAU Erlangen (Author: Axel Horndasch)
 # Apache 2.0.
 #
@@ -16,8 +16,8 @@ This scripts checks if the entries of a file containing disambiguation symbols
 (word or phone level) are all valid. To be valid the symbols
 - must start with the hash mark '#',
 - must not contain any whitespace,
-- must not be equal to '#-1' (disallowed because it is used internally in some)
-  FST stuff.
+- must not be equal to '#-1' (disallowed because it is used internally in some
+  FST stuff).
 
 In case the option '--extra-disambig-syms' is used with 'true', the symbols must
 also be non-numeric (to avoid overlap with the automatically generated symbols).
@@ -27,7 +27,7 @@ Allowed options:
 
 EOU
 
-# command line options
+# Command line options
 my $extra_disambig_syms = "false";
 
 # Get the optional command line options
@@ -41,15 +41,16 @@ if (@ARGV != 1) {
 
 my $disambig_sym_file = shift @ARGV;
 
-print "$0: Checking $disambig_sym_file ...\n";
+print "$0: Checking validity of file \"$disambig_sym_file\" ...\n";
 if (-z $disambig_sym_file) {
-  print "$0: The file $disambig_sym_file is empty or does not exist, exiting ...\n"; exit 1;
+  print "$0: The file \"$disambig_sym_file\" is empty or does not exist, exiting ...\n"; exit 1;
 }
 
 if (not open(SYMS, "<$disambig_sym_file")) {
-  print "$0: Could not open file $disambig_sym_file, exiting ...\n"; exit 1;
+  print "$0: Could not open file \"$disambig_sym_file\", exiting ...\n"; exit 1;
 }
 
+# Go through the file containing disambiguation symbols line by line
 while (<SYMS>) {
   chomp;
   my $symbol = $_;
@@ -74,6 +75,6 @@ while (<SYMS>) {
   }
 }
 
-print "--> SUCCESS [validating disambiguation symbol file $disambig_sym_file]\n";
+print "--> SUCCESS [validating disambiguation symbol file \"$disambig_sym_file\"]\n";
 exit 0;
 

--- a/egs/wsj/s5/utils/validate_disambig_sym_file.pl
+++ b/egs/wsj/s5/utils/validate_disambig_sym_file.pl
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+#!/usr/bin/perl -w
+# Copyright 2016 FAU Erlangen (Author: Axel Horndasch)
+# Apache 2.0.
+#
+# Concept: Dan Povey
+
+use strict;
+use warnings;
+use Getopt::Long;
+
+my $Usage = <<EOU;
+Usage:  validate_disambig_sym_file.pl [options] disambig_syms.txt
+
+This scripts checks if the entries of a file containing disambiguation symbols
+(word or phone level) are all valid. To be valid the symbols
+- must start with the hash mark '#',
+- must not contain any whitespace,
+- must not be equal to '#-1' (disallowed because it is used internally in some)
+  FST stuff.
+
+In case the option '--extra-disambig-syms' is used with 'true', the symbols must
+also be non-numeric (to avoid overlap with the automatically generated symbols).
+
+Allowed options:
+  --extra-disambig-syms  : Indicate extra symbols  (boolean,  default = "false")
+
+EOU
+
+# command line options
+my $extra_disambig_syms = "false";
+
+# Get the optional command line options
+GetOptions(
+    "extra-disambig-syms=s" => \$extra_disambig_syms,
+    ) or die ($Usage);
+
+if (@ARGV != 1) {
+  die($Usage);
+}
+
+my $disambig_sym_file = shift @ARGV;
+
+print "$0: Checking $disambig_sym_file ...\n";
+if (-z $disambig_sym_file) {
+  print "$0: The file $disambig_sym_file is empty or does not exist, exiting ...\n"; exit 1;
+}
+
+if (not open(SYMS, "<$disambig_sym_file")) {
+  print "$0: Could not open file $disambig_sym_file, exiting ...\n"; exit 1;
+}
+
+while (<SYMS>) {
+  chomp;
+  my $symbol = $_;
+
+  if ($symbol =~ /^#(.*)$/) {
+    my $sympart = $1;
+    if ($sympart eq "") {
+      print "$0: Only \"$symbol\" is not allowed as a disambiguation symbol, exiting ...\n"; exit 1;
+    }
+    if ($sympart =~/\s+/) {
+      print "$0: The disambiguation symbol \"$symbol\" contains whitespace, exiting ...\n"; exit 1;
+    }
+    if ($sympart eq "-1") {
+      print "$0: The disambiguation symbol \"$symbol\" is not allowed, exiting ...\n"; exit 1;
+    }
+    if ($extra_disambig_syms eq "true" &&
+	$sympart =~/^[0-9]+$/) {
+      print "$0: Since \"$symbol\" is supposed to be an extra disambiguation symbol, it must not be numeric, exiting ...\n"; exit 1;
+    }
+  } else {
+    print "$0: The disambiguation symbol \"$symbol\" does not start with a '#', exiting ...\n"; exit 1;
+  }
+}
+
+print "--> SUCCESS [validating disambiguation symbol file $disambig_sym_file]\n";
+exit 0;
+


### PR DESCRIPTION
The new command line option '--extra-word-disambig-syms disambig_syms.txt'
for prepare_lang.sh adds the possibility to add extra word-level
disambiguation symbols to the list of automatic disambiguation symbols.

The extra disambiguation symbols can be used during the modification of
G.fst graphs, e.g. when embedding word classes (a word-class disambiguation
symbol can for example be transduced to <eps> when entering or leaving a
word-class sub-language model).