### PR TITLE
Fix "last index out of range" exception

### DIFF
--- a/egs/swbd/s5c/local/format_acronyms_dict.py
+++ b/egs/swbd/s5c/local/format_acronyms_dict.py
@@ -31,6 +31,10 @@ fin_Letter.close()
 
 for lex in fin_lex:
     items = lex.split()
+
+    if items == []:
+        continue
+
     word = items[0]
     lexicon = lex[len(items[0])+1:].strip()
     # find acronyms from words with only letters and '


### PR DESCRIPTION
This skips blank lines in input files, for example, the first line of
lexicon3.txt.