### PR TITLE
Remove gawk dependency from s5c swbd1_prepare_dict.sh

### DIFF
--- a/egs/swbd/s5c/local/swbd1_data_prep.sh
+++ b/egs/swbd/s5c/local/swbd1_data_prep.sh
@@ -49,8 +49,8 @@ sph2pipe=$KALDI_ROOT/tools/sph2pipe_v2.5/sph2pipe
 find $SWBD_DIR -iname '*.sph' | sort > $dir/sph.flist
 
 n=`cat $dir/sph.flist | wc -l`
-[ $n -ne 2435 ] && \
-  echo Warning: expected 2435 data data files, found $n
+[ $n -ne 2438 ] && \
+  echo Warning: expected 2438 data data files, found $n
 
 
 # (1a) Transcriptions preparation

--- a/egs/swbd/s5c/local/swbd1_data_prep.sh
+++ b/egs/swbd/s5c/local/swbd1_data_prep.sh
@@ -49,8 +49,8 @@ sph2pipe=$KALDI_ROOT/tools/sph2pipe_v2.5/sph2pipe
 find $SWBD_DIR -iname '*.sph' | sort > $dir/sph.flist
 
 n=`cat $dir/sph.flist | wc -l`
-[ $n -ne 2438 ] && \
-  echo Warning: expected 2438 data data files, found $n
+[ $n -ne 2435 ] && [ $n -ne 2438 ] && \
+  echo Warning: expected 2435 or 2438 data data files, found $n
 
 
 # (1a) Transcriptions preparation

--- a/egs/swbd/s5c/local/swbd1_prepare_dict.sh
+++ b/egs/swbd/s5c/local/swbd1_prepare_dict.sh
@@ -22,10 +22,8 @@ cp $srcdict $dir/lexicon0.txt || exit 1;
 patch <local/dict.patch $dir/lexicon0.txt || exit 1;
 
 #(2a) Dictionary preparation:
-# Pre-processing (Upper-case, remove comments)
-awk 'BEGIN{getline}($0 !~ /^#/) {print}' \
-  $dir/lexicon0.txt | sort | awk '($0 !~ /^[[:space:]]*$/) {print}' \
-   > $dir/lexicon1.txt || exit 1;
+# Pre-processing (remove comments, remove empty lines)
+grep -v '^#' $dir/lexicon0.txt | awk 'NF>0' | sort > $dir/lexicon1.txt || exit 1;
 
 
 cat $dir/lexicon1.txt | awk '{ for(n=2;n<=NF;n++){ phones[$n] = 1; }} END{for (p in phones) print p;}' | \

--- a/egs/swbd/s5c/local/swbd1_prepare_dict.sh
+++ b/egs/swbd/s5c/local/swbd1_prepare_dict.sh
@@ -89,6 +89,6 @@ cat $dir/acronyms_raw.map | sort -u > $dir/acronyms.map
 pushd $dir >&/dev/null
 ln -sf lexicon5.txt lexicon.txt # This is the final lexicon.
 popd >&/dev/null
-rm -f $dir/lexiconp.txt
+rm $dir/lexiconp.txt 2>/dev/null
 echo Prepared input dictionary and phone-sets for Switchboard phase 1.
 

--- a/egs/swbd/s5c/local/swbd1_prepare_dict.sh
+++ b/egs/swbd/s5c/local/swbd1_prepare_dict.sh
@@ -89,6 +89,6 @@ cat $dir/acronyms_raw.map | sort -u > $dir/acronyms.map
 pushd $dir >&/dev/null
 ln -sf lexicon5.txt lexicon.txt # This is the final lexicon.
 popd >&/dev/null
-rm $dir/lexiconp.txt
+rm -f $dir/lexiconp.txt
 echo Prepared input dictionary and phone-sets for Switchboard phase 1.
 


### PR DESCRIPTION
* Remove gawk dependency from s5c swbd1_prepare_dict.sh
* Suppress warning about non-existent lexiconp.txt
* Check for 2,435 or 2,438 data files in LDC97S62 corpus