### PR TITLE
wer_per_spk_details.pl reads utt2spk containing unicode

### DIFF
--- a/egs/wsj/s5/utils/scoring/wer_per_spk_details.pl
+++ b/egs/wsj/s5/utils/scoring/wer_per_spk_details.pl
@@ -28,6 +28,7 @@ use utf8;
 use List::Util qw[max];
 use Getopt::Long;
 use Pod::Usage;
+use open qw(:std :encoding(UTF-8));
 
 
 #use Data::Dumper;


### PR DESCRIPTION
`utils/scoring/wer_per_spk_details.pl` deals with `STDIN`, `STDOUT` and `$ARGV[0]`, three I/Os.
The origin script set `STDIN` ad `STDOUT` only.

```
binmode STDIN, ":utf8";
binmode STDOUT, ":utf8";
```

So `$ARGV[0]` should be set.
The code `use open qw(:std :encoding(UTF-8));` was copied from [stackoverflow](http://stackoverflow.com/a/14566813/3640653).

PS: I found this problem because I got the warnings below:

```
Use of uninitialized value $SPK in hash element at utils/scoring/wer_per_spk_details.pl line 118, <STDIN> line 4.
Use of uninitialized value $SPK in hash element at utils/scoring/wer_per_spk_details.pl line 119, <STDIN> line 4.
Use of uninitialized value $SPK in hash element at utils/scoring/wer_per_spk_details.pl line 120, <STDIN> line 4.
Use of uninitialized value $SPK in hash element at utils/scoring/wer_per_spk_details.pl line 121, <STDIN> line 4.
Use of uninitialized value $SPK in hash element at utils/scoring/wer_per_spk_details.pl line 122, <STDIN> line 4.
...
```
