### PR TITLE
Fix get_ctm_edits.py to be not too greedy with id's

### DIFF
--- a/egs/wsj/s5/steps/cleanup/internal/get_ctm_edits.py
+++ b/egs/wsj/s5/steps/cleanup/internal/get_ctm_edits.py
@@ -336,7 +336,7 @@ def ProcessData():
         utterance_id = a[0]
         utterance_id_len = len(utterance_id)
         this_utterance_ctm_lines = []
-        while pending_ctm_line[0:utterance_id_len] == utterance_id:
+        while len(pending_ctm_line.strip()) > 0 and pending_ctm_line.split()[0] == utterance_id:
             this_utterance_ctm_lines.append(pending_ctm_line)
             pending_ctm_line = ctm_in.readline()
         ProcessOneUtterance(utterance_id, this_edits_line,

--- a/egs/wsj/s5/steps/cleanup/lattice_oracle_align.sh
+++ b/egs/wsj/s5/steps/cleanup/lattice_oracle_align.sh
@@ -111,6 +111,7 @@ if [ $stage -le 2 ]; then
     $cmd JOB=1:$nj $dir/log/get_ctm.JOB.log \
       set -o pipefail '&&' \
       lattice-align-words-lexicon $lang/phones/align_lexicon.int $model  "ark:gunzip -c $dir/lat.JOB.gz|" ark:- \| \
+      lattice-1best ark:- ark:- \| \
       nbest-to-ctm --frame-shift=$frame_shift --print-silence=$print_silence ark:- - \| \
       utils/int2sym.pl -f 5 $lang/words.txt '>' $dir/ctm.JOB || exit 1;
   else


### PR DESCRIPTION
It is not too pretty this way (and possibly wasteful), but the whole function would need reorganization to do this in a nicer way. (See also email thread "Problems with cleanup, can't align in get_ctm_edits.py")