### PR TITLE
Fix phone is not in {, non}silence.txt

### DIFF
--- a/egs/swbd/s5c/local/dict.patch
+++ b/egs/swbd/s5c/local/dict.patch
@@ -1,3 +1,5 @@
+1d0
+<  file: $SWB/data/dictionary/sw-ms98-dict.text
 8645a8646
 > uh-hum ah m hh ah m
 9006c9007


### PR DESCRIPTION
The latest version of `sw-ms98-dict.text` from http://www.openslr.org/resources/5/switchboard_word_alignments.tar.gz contains the following header on line 1:

>   file: $SWB/data/dictionary/sw-ms98-dict.text

This ends up in `lexicon0.txt`, which causes `utils/validate_dict_dir.pl` to
fail with the following error:

> --> ERROR: phone "$swb/data/dictionary/sw-ms98-dict.text" is not in {,  non}silence.txt (line 10399)

This in turn causes `utils/prepare_lang.sh` to fail.

Update `dict.patch` so that it removes the file header from `sw-ms98-dict.text`.