### PR TITLE
Add Spatial Regularization Deriv

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -264,6 +264,10 @@ void cudaF_diff_log_softmax(dim3 Gr, dim3 Bl, const MatrixDim in_deriv_dim,
                             const float* out_value, const int out_value_stride,
                             const float* out_deriv, const int out_deriv_stride,
                             float* in_deriv);
+void cudaF_add_spatial_regularization_deriv(
+    dim3 Gr, dim3 Bl, const float* out_value, const MatrixDim out_value_dim,
+    float* out_deriv, const int out_deriv_stride, const float scale,
+    float* regularization_sumsq);
 void cudaF_one(int Gr, int Bl, float* x, int dim);
 void cudaF_copy(dim3 Gr, dim3 Bl, float *y, const float *x,
                 const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);
@@ -533,6 +537,10 @@ void cudaD_diff_log_softmax(dim3 Gr, dim3 Bl, const MatrixDim in_deriv_dim,
                             const double* out_value, const int out_value_stride,
                             const double* out_deriv, const int out_deriv_stride,
                             double* in_deriv);
+void cudaD_add_spatial_regularization_deriv(
+    dim3 Gr, dim3 Bl, const double* out_value, const MatrixDim out_value_dim,
+    double* out_deriv, const int out_deriv_stride, const double scale,
+    double* regularization_sumsq);
 void cudaD_one(int Gr, int Bl, double* x, int dim);
 void cudaD_copy(dim3 Gr, dim3 Bl, double *y, const double *x,
                 const int32_cuda *copy_from, MatrixDim d_out, MatrixDim d_in);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -548,15 +548,15 @@ inline void cuda_diff_tanh(dim3 Gr, dim3 Bl, float *eout, const float *e,
   cudaF_diff_tanh(Gr, Bl, eout, e, y, d, e_stride, y_stride);
 }
 inline void cuda_parametric_relu(dim3 Gr, dim3 Bl, float *y, const float *x,
-                                 MatrixDim d, int src_stride,
-                                 const float *a, const float *b) {
-  cudaF_parametric_relu(Gr,Bl,y,x,d,src_stride,a,b);
+                                 MatrixDim d, int src_stride, const float *a,
+                                 const float *b) {
+  cudaF_parametric_relu(Gr, Bl, y, x, d, src_stride, a, b);
 }
 inline void cuda_diff_parametric_relu(dim3 Gr, dim3 Bl, float *eout,
                                       const float *e, const float *y,
                                       MatrixDim d, int e_stride, int y_stride,
                                       const float *a, const float *b) {
-  cudaF_diff_parametric_relu(Gr,Bl,eout,e,y,d,e_stride,y_stride,a,b);
+  cudaF_diff_parametric_relu(Gr, Bl, eout, e, y, d, e_stride, y_stride, a, b);
 }
 inline void cuda_heaviside(dim3 Gr, dim3 Bl, float *y, const float *x,
                            MatrixDim d, int src_stride) {
@@ -603,6 +603,17 @@ inline void cuda_diff_log_softmax(dim3 Gr, dim3 Bl,
                                   const int out_deriv_stride, float* in_deriv) {
   cudaF_diff_log_softmax(Gr, Bl, in_deriv_dim, out_value, out_value_stride,
                          out_deriv, out_deriv_stride, in_deriv);
+}
+inline void cuda_add_spatial_regularization_deriv(dim3 Gr, dim3 Bl,
+                                                  const float* out_value,
+                                                  const MatrixDim out_value_dim,
+                                                  float* out_deriv,
+                                                  const int out_deriv_stride,
+                                                  const float scale,
+                                                  float* regularization_sumsq) {
+  cudaF_add_spatial_regularization_deriv(Gr, Bl, out_value, out_value_dim,
+                                         out_deriv, out_deriv_stride, scale,
+                                         regularization_sumsq);
 }
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, float *mat_out,
                                     MatrixDim d_out, const float *v_in) {
@@ -1087,15 +1098,15 @@ inline void cuda_diff_tanh(dim3 Gr, dim3 Bl, double *eout, const double *e,
   cudaD_diff_tanh(Gr, Bl, eout, e, y, d, e_stride, y_stride);
 }
 inline void cuda_parametric_relu(dim3 Gr, dim3 Bl, double *y, const double *x,
-                                 MatrixDim d, int src_stride,
-                                 const double *a, const double *b) {
-  cudaD_parametric_relu(Gr,Bl,y,x,d,src_stride,a,b);
+                                 MatrixDim d, int src_stride, const double *a,
+                                 const double *b) {
+  cudaD_parametric_relu(Gr, Bl, y, x, d, src_stride, a, b);
 }
 inline void cuda_diff_parametric_relu(dim3 Gr, dim3 Bl, double *eout,
                                       const double *e, const double *y,
                                       MatrixDim d, int e_stride, int y_stride,
                                       const double *a, const double *b) {
-  cudaD_diff_parametric_relu(Gr,Bl,eout,e,y,d,e_stride,y_stride,a,b);
+  cudaD_diff_parametric_relu(Gr, Bl, eout, e, y, d, e_stride, y_stride, a, b);
 }
 inline void cuda_heaviside(dim3 Gr, dim3 Bl, double *y, const double *x,
                            MatrixDim d, int src_stride) {
@@ -1140,6 +1151,14 @@ inline void cuda_diff_log_softmax(dim3 Gr, dim3 Bl,
                                   double* in_deriv) {
   cudaD_diff_log_softmax(Gr, Bl, in_deriv_dim, out_value, out_value_stride,
                          out_deriv, out_deriv_stride, in_deriv);
+}
+inline void cuda_add_spatial_regularization_deriv(
+    dim3 Gr, dim3 Bl, const double* out_value, const MatrixDim out_value_dim,
+    double* out_deriv, const int out_deriv_stride, const double scale,
+    double* regularization_sumsq) {
+  cudaD_add_spatial_regularization_deriv(Gr, Bl, out_value, out_value_dim,
+                                         out_deriv, out_deriv_stride, scale,
+                                         regularization_sumsq);
 }
 inline void cuda_copy_rows_from_vec(dim3 Gr, dim3 Bl, double *mat_out,
                                     MatrixDim d_out, const double *v_in) {

--- a/src/cudamatrix/cu-math-test.cc
+++ b/src/cudamatrix/cu-math-test.cc
@@ -139,6 +139,40 @@ static void UnitTestCuMathSplice() {
   }
 }
 
+template<typename Real>
+static void UnitTestCuMathAddSpatialRegularizationDeriv() {
+  for (int32 j = 17; j < 1030; j++) {
+    int32 row = 1 + Rand() % 50;
+    int32 col = j;
+
+    Real Hsumsq = Real(0);
+    Matrix<Real> Hoderiv(row, col);
+    Matrix<Real> Hovalue(row, col);
+    Hoderiv.SetRandn();
+    Hovalue.SetRandn();
+
+    Real Dsumsq = Real(0);
+    CuMatrix<Real> Doderiv(Hoderiv);
+    CuMatrix<Real> Dovalue(Hovalue);
+
+    Real scale = 0.12345;
+    bool compute_sumsq = (Rand() % 2 == 1);
+
+    cu::CpuAddSpatialRegularizationDeriv(Hovalue, scale, &Hoderiv,
+                                         compute_sumsq ? &Hsumsq : NULL);
+    cu::AddSpatialRegularizationDeriv(Dovalue, scale, &Doderiv,
+                                      compute_sumsq ? &Dsumsq : NULL);
+
+//    KALDI_LOG<< "row:" <<row << "  col:" << col;
+//    KALDI_LOG<< "Hsumsq:" <<Hsumsq << "  Dsumsq:" << Dsumsq;
+//    KALDI_LOG<< "ov:" << Hovalue << "Hod:" << Hoderiv << "Dod:" << Doderiv;
+
+    Matrix<Real> Hresult(Doderiv);
+    AssertEqual(Hsumsq, Dsumsq);
+    AssertEqual(Hoderiv, Hresult);
+  }
+}
+
 template<typename Real> void CudaMathUnitTest() {
   #if HAVE_CUDA == 1  
     if (CuDevice::Instantiate().DoublePrecisionSupported())
@@ -146,6 +180,7 @@ template<typename Real> void CudaMathUnitTest() {
   UnitTestCuMathRandomize<Real>();
   UnitTestCuMathSplice<Real>();
   UnitTestCuMathCopy<Real>();
+  UnitTestCuMathAddSpatialRegularizationDeriv<Real>();
 }
 
 

--- a/src/cudamatrix/cu-math.h
+++ b/src/cudamatrix/cu-math.h
@@ -78,7 +78,22 @@ void Group2norm(const CuMatrixBase<Real> &src,
                 CuMatrixBase<Real> *dest,
                 int32 group_stride);
 
-
+/// Add spatial regularization term to *deriv.
+/// The regularization derivative is calculated from `out_value`.
+/// Each row of `out_value` is first viewed as a 16*n grid,
+/// convoluted with the 3x3 kernel twice, scaled with `-scale`
+/// and then added to deriv.
+/// *deriv = *deriv - scale * Filter (X) (Filter (X) out_value)
+/// If regularization_sumsq is not NULL, the sum of the squared
+/// regularization term will be calculated and stored.
+template<typename Real>
+void AddSpatialRegularizationDeriv(const CuMatrixBase<Real>& out_value,
+                                   Real scale, CuMatrixBase<Real>* deriv,
+                                   Real* regularization_sumsq);
+template<typename Real>
+void CpuAddSpatialRegularizationDeriv(const MatrixBase<Real>& out_value,
+                                      Real scale, MatrixBase<Real>* deriv,
+                                      Real* regularization_sumsq);
 
 
 } // namespace cu

--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -977,6 +977,31 @@ template<typename Real> void TestCuMatrixAddRowRanges(int32 dim) {
             << dim << ", speed was " << gflops << " gigaflops.";
 }
 
+template<typename Real> void TestCuMatrixAddSpatialRegularizationDeriv(
+    int32 dim) {
+  BaseFloat time_in_secs = 0.025;
+  const int32 cols = dim > 16 ? dim : 17;
+  CuMatrix<Real> M(dim, cols), N(dim, cols);
+  Real sumsq;
+  Real scale = 0.12345;
+  M.SetRandn();
+  N.SetRandn();
+
+  Timer tim;
+  int32 iter = 0;
+  for (; tim.Elapsed() < time_in_secs; iter++) {
+//    cu::AddSpatialRegularizationDeriv(N, scale, &M, &sumsq);
+    cu::AddSpatialRegularizationDeriv(N, scale, &M, (Real*)NULL);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For AddSpatialRegularizationDeriv" << NameOf<Real>()
+            << ", for dim = " << dim << ", speed was " << gflops
+            << " gigaflops.";
+}
+
+
 template<typename Real> void CudaMatrixSpeedTest() {
   std::vector<int32> sizes;
   sizes.push_back(16);
@@ -1077,6 +1102,8 @@ template<typename Real> void CudaMatrixSpeedTest() {
     TestCuMatrixMax<Real>(sizes[s]);
   for (int32 s = 0; s < ns; s++)
     TestCuMatrixMin<Real>(sizes[s]);
+  for (int32 s = 0; s < ns; s++)
+    TestCuMatrixAddSpatialRegularizationDeriv<Real>(sizes[s]);
 }
 
 

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -1756,7 +1756,6 @@ void CuMatrixBase<Real>::DiffXent(const CuArray<int32> &tgt,
   }
 }
 
-
 template<typename Real>
 void CuMatrixBase<Real>::Cholesky(CuMatrixBase<Real> *inv_cholesky) {
   KALDI_ASSERT(this->NumRows() == this->NumCols());

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -2782,7 +2782,6 @@ void MatrixBase<Real>::DiffTanh(const MatrixBase<Real> &value,
   }
 }
 
-
 template<typename Real>
 template<typename OtherReal>
 void MatrixBase<Real>::AddVecToRows(const Real alpha, const VectorBase<OtherReal> &v) {

--- a/src/nnet3/nnet-component-itf.cc
+++ b/src/nnet3/nnet-component-itf.cc
@@ -147,6 +147,8 @@ Component* Component::NewComponentOfType(const std::string &component_type) {
     ans = new DropoutComponent();
   } else if (component_type == "BackpropTruncationComponent") {
     ans = new BackpropTruncationComponent();
+  } else if (component_type == "SpatialRegularizationComponent") {
+    ans = new SpatialRegularizationComponent();
   }
   if (ans != NULL) {
     KALDI_ASSERT(component_type == ans->Type());

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -532,9 +532,9 @@ void TestSpatialRegularizationComponentDataDerivative() {
   }
 
   int32 dim = 16 * RandInt(3, 30),
-      num_rows = RandInt(1, 100);
+      num_rows = RandInt(1, 50);
   BaseFloat regularization_scale = 0.5 * RandInt(1, 3);
-  BaseFloat perturb_delta = 1.0e-04;
+  BaseFloat perturb_delta = 5.0e-04;
 
   SpatialRegularizationComponent c;
   c.Init(dim, regularization_scale);
@@ -558,7 +558,7 @@ void TestSpatialRegularizationComponentDataDerivative() {
              NULL,
              &input_deriv);
 
-  int32 test_dim = 3;
+  int32 test_dim = 7;
   // note, sometimes we use input_data where we'd normally use output_data,
   // since in this case they are the same.
   BaseFloat original_objf = TraceMatMat(output_deriv, input_data, kTrans)
@@ -584,7 +584,7 @@ void TestSpatialRegularizationComponentDataDerivative() {
   }
   KALDI_LOG << "Predicted objf-change = " << predicted_objf_change;
   KALDI_LOG << "Measured objf-change = " << measured_objf_change;
-  BaseFloat threshold = 0.05;
+  BaseFloat threshold = 0.1;
   bool ans = ApproxEqual(predicted_objf_change, measured_objf_change, threshold);
   if (!ans)
     KALDI_ERR << "Data-derivative test for SpatialRegularizationComponent failed\n"

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -727,12 +727,11 @@ void SpatialRegularizationComponent::Backprop(
   if (in_deriv != &out_deriv)
     in_deriv->CopyFromMat(out_deriv);
   // accumulate stats only every other time.
-  bool compute_sumsq = (to_update_in != NULL && RandInt(0, 1) == 0);
+  bool compute_sumsq = (to_update_in != NULL && RandInt(0, 3) == 0);
 
   BaseFloat sumsq;
-  in_deriv->AddSpatialRegularizationDeriv(out_value,
-                                          regularization_scale_,
-                                          (compute_sumsq ? &sumsq : NULL));
+  cu::AddSpatialRegularizationDeriv(out_value, regularization_scale_, in_deriv,
+                                    (compute_sumsq ? &sumsq : NULL));
   if (compute_sumsq) {
     SpatialRegularizationComponent *to_update =
         dynamic_cast<SpatialRegularizationComponent*>(to_update_in);


### PR DESCRIPTION
WIP: Add Spatial Regularization DerivThis PR is working on the backprop of SpatialRegularizationComponent as described in #1128 .

Two things that I'm not sure about.

1. The paper mentioned that a 512-D layer output would be viewed as a 16x32 grid. What if the layer width is not 512, say 256 or 700? Should a layer with arbitrary width be partitioned into several 512-D sections?

2. What is the purpose for logarithmic reduction? It seems to me that after the 2-D convolution with the 3x3 kernel, the filtered `out_value` can be directly added to `out_deriv` and finish the whole thing. Do I miss something?

