### PR TITLE
Specify full path to 2000 HUB5 transcripts

### DIFF
--- a/egs/swbd/s5c/run.sh
+++ b/egs/swbd/s5c/run.sh
@@ -70,7 +70,7 @@ fi
 # local/eval2000_data_prep.sh /mnt/matylda2/data/HUB5_2000/ /mnt/matylda2/data/HUB5_2000/2000_hub5_eng_eval_tr
 # local/eval2000_data_prep.sh /exports/work/inf_hcrc_cstr_general/corpora/switchboard/hub5/2000 /exports/work/inf_hcrc_cstr_general/corpora/switchboard/hub5/2000/transcr
 # local/eval2000_data_prep.sh /home/dpovey/data/LDC2002S09/hub5e_00 /home/dpovey/data/LDC2002T43
-local/eval2000_data_prep.sh /export/corpora2/LDC/LDC2002S09/hub5e_00 /export/corpora2/LDC/LDC2002T43
+local/eval2000_data_prep.sh /export/corpora2/LDC/LDC2002S09/hub5e_00 /export/corpora2/LDC/LDC2002T43/2000_hub5_eng_eval_tr
 
 # Now make MFCC features.
 # mfccdir should be some place with a largish disk where you


### PR DESCRIPTION
The top-level directory inside LDC2002T43.tgz is 2000_hub5_eng_eval_tr, so this needs to be passed to eval2000_data_prep.sh. Otherwise the script will give the error, "Expecting directory /export/corpora2/LDC/LDC2002T43/reference to be present".