### PR TITLE
Cleanup segmentation perl fixes

### DIFF
--- a/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
+++ b/egs/wsj/s5/steps/cleanup/create_segments_from_ctm.pl
@@ -228,7 +228,7 @@ sub SplitLongSegment {
                            $aligned_ctm->[$seg_end_index]->[2] -
                            $aligned_ctm->[$seg_start_index]->[1];
   my $current_seg_index = $seg_start_index;
-  my $aligned_ctm_size = keys($aligned_ctm);    
+  my $aligned_ctm_size = scalar(@{$aligned_ctm});    
   while ($current_seg_length > 1.5 * $max_seg_length && $current_seg_index < $aligned_ctm_size-1) {
     my $split_point = GetSplitPoint($aligned_ctm, $current_seg_index,
                                     $seg_end_index, $max_seg_length);

--- a/egs/wsj/s5/steps/cleanup/split_long_utterance.sh
+++ b/egs/wsj/s5/steps/cleanup/split_long_utterance.sh
@@ -109,7 +109,7 @@ cat $output_dir/wav.scp | perl -e '
     @col == 2 || die "Error: bad line $_\n";
     $utt2spk{$col[0]} = $col[1];
   }
-  foreach $seg (keys %seg2wav) {
+  foreach $seg (sort keys %seg2wav) {
     $index = 0;
     $step = $slen - $olen;
     print UMAP "$seg";


### PR DESCRIPTION
Fixed two issues in the re-segmentation scripts caused by inconsistencies with different Perl versions. The first one makes sure that `data/train_split/orig2utt` (or similar) file will be sorted. Otherwise, the `steps/cleanup/decode_segmentation.sh` script might fail later, complaining that the utterances are not sorted.

The other commit changes the line that gets perl list size with another syntax. The old line used experimental syntax that only worked in some Perl versions.