### PR TITLE
Try harder to find 2000 HUB5 transcripts

### DIFF
--- a/egs/swbd/s5c/local/eval2000_data_prep.sh
+++ b/egs/swbd/s5c/local/eval2000_data_prep.sh
@@ -30,6 +30,8 @@ sdir=$1
 tdir=$2
 [ ! -d $sdir/english ] \
   && echo Expecting directory $sdir/english to be present && exit 1;
+[ -d $tdir/2000_hub5_eng_eval_tr ] \
+  && tdir=$tdir/2000_hub5_eng_eval_tr
 [ ! -d $tdir/reference ] \
   && echo Expecting directory $tdir/reference to be present && exit 1;
 


### PR DESCRIPTION
Depending on how LDC2002T43.tgz is unpacked, the transcripts might be under `2000_hub5_eng_eval_tr`. As requested in #1169, we append it to `tdir` if that directory exists.