### PR TITLE
Look in right location for new style subdirectories

### DIFF
--- a/egs/aspire/s5/local/fisher_data_prep.sh
+++ b/egs/aspire/s5/local/fisher_data_prep.sh
@@ -52,7 +52,7 @@ for subdir in fe_03_p1_sph1  fe_03_p1_sph3  fe_03_p1_sph5  fe_03_p1_sph7 \
       found_subdir=true
       ln -s $dir/$subdir data/local/data/links
     else
-      new_style_subdir=$(echo $subdir | sed s/fe_03_p2_sph/fisher_eng_tr_sp_d/)
+      new_style_subdir=$(echo $subdir | sed s/fe_03_p1_sph/fisher_eng_tr_sp_d/)
       if [ -d $dir/$new_style_subdir ]; then
         found_subdir=true
         ln -s $dir/$new_style_subdir data/local/data/links/$subdir


### PR DESCRIPTION
I tested this patch against `fisher_eng_tr_sp_LDC2004S13.zip`, which I downloaded from LDC today.

It looks like original committer mistyped the part number since LDC describes this dataset as "Fisher English Training Speech Data, Part 1."