### PR TITLE
New CUDA kernel for NormalizeComponet::propagate

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -220,6 +220,9 @@ void cudaF_soft_hinge(dim3 Gr, dim3 Bl, float *y, const float *x, MatrixDim d,
                       int src_stride);
 void cudaF_group_pnorm(dim3 Gr, dim3 Bl, float *y, const float *x, MatrixDim d,
                        int src_stride, int group_size, float power);
+void cudaF_normalize_per_row(size_t Gr, size_t Bl, float *y, int y_stride,
+                             const float *x, MatrixDim x_d, float tartget_rms,
+                             bool add_log_stddev);
 void cudaF_group_spec_pnorm(dim3 Gr, dim3 Bl, float *y, const float *x,
                             MatrixDim d, int src_stride, int group_size,
                             float power);
@@ -489,6 +492,9 @@ void cudaD_soft_hinge(dim3 Gr, dim3 Bl, double *y, const double *x, MatrixDim d,
 void cudaD_group_pnorm(dim3 Gr, dim3 Bl, double *y, const double *x,
                        MatrixDim d, int src_stride, int group_size,
                        double power);
+void cudaD_normalize_per_row(size_t Gr, size_t Bl, double *y, int y_stride,
+                             const double *x, MatrixDim x_d, double tartget_rms,
+                             bool add_log_stddev);
 void cudaD_group_spec_pnorm(dim3 Gr, dim3 Bl, double *y, const double *x,
                             MatrixDim d, int src_stride, int group_size,
                             double power);

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -2217,6 +2217,78 @@ static void _softmax_reduce(Real*y, const Real*x, MatrixDim d, int src_stride) {
   }
 }
 
+// The output y_i = scale * x_i,
+// and we want to RMS value of the y_i to equal target_rms,
+// so y^t y = D * target_rms^2 (if y is one row of the input).
+// we need to have scale = 1.0 / sqrt(x^t x / (D * target_rms^2)).
+// there is also flooring involved, to avoid division-by-zero
+// problems.  It's important for the backprop, that the floor's
+// square root is exactly representable as float.
+// If add_log_stddev is true, log(max(epsi, sqrt(x^t x / D)))
+// is an extra dimension of the output.
+//
+// 1D grid is used. Each 256-thread block works on 1 row of the data matrix.
+// The block is also of 1D. Strided memory access is used if the length of the
+// row is longer than 256.
+template<typename Real>
+__global__
+static void _normalize_per_row(Real *y, int y_stride, const Real *x,
+                               MatrixDim x_d, Real target_rms,
+                               bool add_log_stddev) {
+  const int i = blockIdx.x;
+  const int tid = threadIdx.x;
+  const Real* x_row = x + i * x_d.stride;
+  __shared__ Real ssum[CU1DBLOCK];
+
+  // Reduce x_j^2 to CU1DBLOCK elements per row
+  Real tsum = Real(0);
+  for (int j = tid; j < x_d.cols; j += CU1DBLOCK) {
+    tsum += x_row[j] * x_row[j];
+  }
+  ssum[tid] = tsum;
+  __syncthreads();
+
+  // Tree reduce to 2x warpSize elements per row
+# pragma unroll
+  for (int shift = CU1DBLOCK / 2; shift > warpSize; shift >>= 1) {
+    if (tid < shift) {
+      ssum[tid] += ssum[tid + shift];
+      __syncthreads();
+    }
+  }
+
+  // Reduce last warp to 1 element per row.
+  // Threads implicitly synchronized within a warp.
+  if (tid < warpSize) {
+#   pragma unroll
+    for (int shift = warpSize; shift > 0; shift >>= 1) {
+      ssum[tid] += ssum[tid + shift];
+    }
+  }
+
+  const Real kSquaredNormFloor = 1.35525271560688e-20; // 2^-66
+  if (tid == 0) {
+    ssum[0] = sqrt(
+        max(ssum[0] / (target_rms * target_rms * x_d.cols), kSquaredNormFloor));
+  }
+
+  // Broadcast floored stddev to all threads.
+  __syncthreads();
+  const Real stddev_div_target_rms = ssum[0];
+  const Real scale = Real(1) / stddev_div_target_rms;
+
+  // Store normalized input to output
+  Real* y_row = y + i * y_stride;
+  for (int j = tid; j < x_d.cols; j += CU1DBLOCK) {
+    y_row[j] = x_row[j] * scale;
+  }
+
+  if (tid == 0 && add_log_stddev) {
+    y_row[x_d.cols] = log(stddev_div_target_rms * target_rms);
+  }
+}
+
+
 // Per-row log-softmax operation on 'x', with writing to 'y'.
 // note, x and y may point to the same memory.  This is equivalent to setting
 // matrix y to matrix x and then, for each row of y, subtracting the offset that
@@ -3182,6 +3254,12 @@ void cudaF_splice(dim3 Gr, dim3 Bl, float* y, const float* x,
   _splice<<<Gr,Bl>>>(y,x,off,d_out,d_in);
 }
 
+void cudaF_normalize_per_row(size_t Gr, size_t Bl, float *y, int y_stride,
+                             const float *x, MatrixDim x_d, float target_rms,
+                             bool add_log_stddev) {
+  _normalize_per_row<<<Gr, Bl>>>(y, y_stride, x, x_d, target_rms, add_log_stddev);
+}
+
 void cudaF_one(int Gr, int Bl, float* x, int dim) {
   _one<<<Gr,Bl>>>(x,dim);
 }
@@ -3809,6 +3887,12 @@ void cudaD_softmax_reduce(size_t Gr, size_t Bl, double* y, const double* x,
 void cudaD_log_softmax_reduce(size_t Gr, size_t Bl, double* y, const double* x,
                               MatrixDim y_dim, int x_stride) {
   _log_softmax_reduce<<<Gr,Bl>>>(y, x, y_dim, x_stride);
+}
+
+void cudaD_normalize_per_row(size_t Gr, size_t Bl, double *y, int y_stride,
+                             const double *x, MatrixDim x_d, double target_rms,
+                             bool add_log_stddev) {
+  _normalize_per_row<<<Gr, Bl>>>(y, y_stride, x, x_d, target_rms, add_log_stddev);
 }
 
 void cudaD_splice(dim3 Gr, dim3 Bl, double* y, const double* x,

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -590,6 +590,12 @@ inline void cuda_diff_xent(dim3 Gr, dim3 Bl, const int32_cuda *vec_tgt,
                            MatrixDim d) {
   cudaF_diff_xent(Gr, Bl, vec_tgt, mat_net_out, vec_log_post, d);
 }
+inline void cuda_normalize_per_row(size_t Gr, size_t Bl, float *y, int y_stride,
+                                   const float *x, MatrixDim x_d,
+                                   float target_rms, bool add_log_stddev) {
+  cudaF_normalize_per_row(Gr, Bl, y, y_stride, x, x_d, target_rms,
+                          add_log_stddev);
+}
 inline void cuda_diff_softmax(dim3 Gr, dim3 Bl, float* x, const MatrixDim dim,
                               const float* value, const int value_stride,
                               const float* diff, const int diff_stride) {
@@ -1109,6 +1115,12 @@ inline void cuda_log_softmax_reduce(size_t Gr, size_t Bl, double *y,
                                     const double *x, MatrixDim y_dim,
                                     int x_stride) {
   cudaD_log_softmax_reduce(Gr, Bl, y, x, y_dim, x_stride);
+}
+inline void cuda_normalize_per_row(size_t Gr, size_t Bl, double *y,
+                                   int y_stride, const double *x, MatrixDim x_d,
+                                   double target_rms, bool add_log_stddev) {
+  cudaD_normalize_per_row(Gr, Bl, y, y_stride, x, x_d, target_rms,
+                          add_log_stddev);
 }
 
 inline void cuda_regularize_l1(dim3 Gr, dim3 Bl, double *wei, double *grad,

--- a/src/cudamatrix/cu-math-test.cc
+++ b/src/cudamatrix/cu-math-test.cc
@@ -139,6 +139,76 @@ static void UnitTestCuMathSplice() {
   }
 }
 
+
+template<typename Real>
+static void UnitTestCuMathNormalizePerRow() {
+
+  for (int32 i = 0; i < 2; i++) {
+    int row = 10 + Rand() % 40;
+    int col = 10 + Rand() % 50;
+
+    Matrix<Real> Hi(row,col);
+    Matrix<Real> Ho(row,col+1);
+    Hi.SetRandn();
+    Hi.Scale(5.0);
+
+    CuMatrix<Real> Di(row, col);
+    CuMatrix<Real> Do(row, col+1);
+    Di.CopyFromMat(Hi);
+
+    Real target_rms = 0.3456;
+    bool add_log_stddev = true;
+    const Real kSquaredNormFloor = 1.35525271560688e-20; // 2^-66
+
+    //gpu
+    cu::NormalizePerRow(Di, target_rms, add_log_stddev, &Do);
+
+    //cpu
+    {
+      MatrixBase<Real>& in(Hi);
+      MatrixBase<Real>& out(Ho);
+      Real target_rms=0.3456;
+      SubMatrix<Real> out_no_log(out, 0, out.NumRows(), 0, in.NumCols());
+      if (in.Data() != out_no_log.Data())
+        out_no_log.CopyFromMat(in);
+      Vector<Real> in_norm(in.NumRows());
+      Real d_scaled = in.NumCols() * target_rms * target_rms;
+      in_norm.AddDiagMat2(1.0 / d_scaled, in, kNoTrans, 0.0);
+      in_norm.ApplyFloor(kSquaredNormFloor);
+      in_norm.ApplyPow(-0.5);
+      out_no_log.MulRowsVec(in_norm);
+      if (add_log_stddev) {
+        in_norm.ApplyLog();
+        in_norm.Scale(-1.0);
+        in_norm.Add(log(target_rms));
+        out.CopyColFromVec(in_norm, in.NumCols());
+      }
+    }
+
+    Matrix<Real> Ho2(Do);
+    AssertEqual(Ho,Ho2,0.00001);
+  }
+
+  for (int dim = 16; dim <= 1024; dim *= 2) {
+    BaseFloat time_in_secs = 0.025;
+    CuMatrix<Real> M(dim, dim), N(dim, dim + 1);
+    M.SetRandn();
+    N.SetRandn();
+    Timer tim;
+    int32 iter = 0;
+    for (; tim.Elapsed() < time_in_secs; iter++) {
+      cu::NormalizePerRow(M, Real(1), true, &N);
+    }
+
+    BaseFloat gflops = ((BaseFloat) dim * dim * iter)
+        / (tim.Elapsed() * 1.0e+09);
+    KALDI_LOG << "For CuMatrix::NormalizePerRow"
+              << (sizeof(Real)==8?"<double>":"<float>") << ", for dim = "
+              << dim << ", speed was " << gflops << " gigaflops.";
+  }
+}
+
+
 template<typename Real> void CudaMathUnitTest() {
   #if HAVE_CUDA == 1  
     if (CuDevice::Instantiate().DoublePrecisionSupported())
@@ -146,6 +216,7 @@ template<typename Real> void CudaMathUnitTest() {
   UnitTestCuMathRandomize<Real>();
   UnitTestCuMathSplice<Real>();
   UnitTestCuMathCopy<Real>();
+  UnitTestCuMathNormalizePerRow<Real>();
 }
 
 

--- a/src/cudamatrix/cu-math.cc
+++ b/src/cudamatrix/cu-math.cc
@@ -233,6 +233,57 @@ void Randomize(const CuMatrixBase<double> &src,
                const CuArray<int32> &copy_from_idx,
                CuMatrixBase<double> *tgt);
 
+// The output y_i = scale * x_i,
+// and we want to RMS value of the y_i to equal target_rms,
+// so y^t y = D * target_rms^2 (if y is one row of the input).
+// we need to have scale = 1.0 / sqrt(x^t x / (D * target_rms^2)).
+// there is also flooring involved, to avoid division-by-zero
+// problems.  It's important for the backprop, that the floor's
+// square root is exactly representable as float.
+// If add_log_stddev_ is true, log(max(epsi, sqrt(x^t x / D)))
+// is an extra dimension of the output.
+template<typename Real>
+void NormalizePerRow(const CuMatrixBase<Real>& in, const Real target_rms,
+                     const bool add_log_stddev, CuMatrixBase<Real>* out) {
+  const Real kSquaredNormFloor = 1.35525271560688e-20; // 2^-66
+
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    Timer tim;
+    size_t dimBlock = CU1DBLOCK;
+    size_t dimGrid = out->NumRows();
+    cuda_normalize_per_row(dimGrid, dimBlock, out->Data(), out->Stride(),
+                           in.Data(), in.Dim(), target_rms, add_log_stddev);
+    CU_SAFE_CALL(cudaGetLastError());
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+  } else
+#endif
+  {
+    CuSubMatrix<Real> out_no_log(*out, 0, out->NumRows(), 0, in.NumCols());
+    if (in.Data() != out_no_log.Data())
+      out_no_log.CopyFromMat(in);
+    CuVector<Real> in_norm(in.NumRows());
+    Real d_scaled = in.NumCols() * target_rms * target_rms;
+    in_norm.AddDiagMat2(1.0 / d_scaled, in, kNoTrans, 0.0);
+    in_norm.ApplyFloor(kSquaredNormFloor);
+    in_norm.ApplyPow(-0.5);
+    out_no_log.MulRowsVec(in_norm);
+    if (add_log_stddev) {
+      in_norm.ApplyLog();
+      in_norm.Scale(-1.0);
+      in_norm.Add(log(target_rms));
+      out->CopyColFromVec(in_norm, in.NumCols());
+    }
+  }
+}
+
+template
+void NormalizePerRow(const CuMatrixBase<float>& in, const float target_rms,
+                     const bool add_log_stddev, CuMatrixBase<float>* out);
+template
+void NormalizePerRow(const CuMatrixBase<double>& in, const double target_rms,
+                     const bool add_log_stddev, CuMatrixBase<double>* out);
+
 
 
 } //namespace cu

--- a/src/cudamatrix/cu-math.h
+++ b/src/cudamatrix/cu-math.h
@@ -78,6 +78,23 @@ void Group2norm(const CuMatrixBase<Real> &src,
                 CuMatrixBase<Real> *dest,
                 int32 group_stride);
 
+/// Normalize nonlinearity modifies the vector of activations
+/// by scaling it so that the root-mean-square equals 1.0.
+///
+/// The output y_i = scale * x_i,
+/// and we want to RMS value of the y_i to equal target_rms,
+/// so y^t y = D * target_rms^2 (if y is one row of the input).
+/// we need to have scale = 1.0 / sqrt(x^t x / (D * target_rms^2)).
+/// there is also flooring involved, to avoid division-by-zero
+/// problems.  It's important for the backprop, that the floor's
+/// square root is exactly representable as float.
+/// If add_log_stddev_ is true, log(max(epsi, sqrt(x^t x / D)))
+/// is an extra dimension of the output.
+template<typename Real>
+void NormalizePerRow(const CuMatrixBase<Real>& in, const Real target_rms,
+                     const bool add_log_stddev, CuMatrixBase<Real>* out);
+
+
 
 
 

--- a/src/nnet2/nnet-component.cc
+++ b/src/nnet2/nnet-component.cc
@@ -572,14 +572,7 @@ void NormalizeComponent::Propagate(const ChunkInfo &in_info,
                                    const ChunkInfo &out_info,
                                    const CuMatrixBase<BaseFloat> &in,
                                    CuMatrixBase<BaseFloat> *out) const  {
-  out->CopyFromMat(in);
-
-  CuVector<BaseFloat> in_norm(in.NumRows());
-  in_norm.AddDiagMat2(1.0 / in.NumCols(),
-                      in, kNoTrans, 0.0);
-  in_norm.ApplyFloor(kNormFloor);
-  in_norm.ApplyPow(-0.5);
-  out->MulRowsVec(in_norm);
+  cu::NormalizePerRow(in, BaseFloat(1), false, out);
 }
 
 /*

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -415,21 +415,7 @@ void NormalizeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                    const CuMatrixBase<BaseFloat> &in,
                                    CuMatrixBase<BaseFloat> *out) const {
   KALDI_ASSERT(out->NumCols() == in.NumCols() + (add_log_stddev_ ? 1 : 0));
-  CuSubMatrix<BaseFloat> out_no_log(*out, 0, out->NumRows(), 0, input_dim_);
-  if (in.Data() != out_no_log.Data())
-    out_no_log.CopyFromMat(in);
-  CuVector<BaseFloat> in_norm(in.NumRows());
-  BaseFloat d_scaled = in.NumCols() * target_rms_ * target_rms_;
-  in_norm.AddDiagMat2(1.0 / d_scaled, in, kNoTrans, 0.0);
-  in_norm.ApplyFloor(kSquaredNormFloor);
-  in_norm.ApplyPow(-0.5);
-  out_no_log.MulRowsVec(in_norm);
-  if (add_log_stddev_) {
-    in_norm.ApplyLog();
-    in_norm.Scale(-1.0);
-    in_norm.Add(log(target_rms_));
-    out->CopyColFromVec(in_norm, in.NumCols());
-  }
+  cu::NormalizePerRow(in, target_rms_, add_log_stddev_, out);
 }
 
 /*


### PR DESCRIPTION
Speed up by merging multiple kernel functions into one.  All GPU tests have passed.

```
benchmark(gflops)                   dim   new     old    speedup
CuMatrix::NormalizePerRow<float>,    16   0.015   0.001  13.16x
CuMatrix::NormalizePerRow<float>,    32   0.062   0.005  13.54x
CuMatrix::NormalizePerRow<float>,    64   0.239   0.019  12.77x
CuMatrix::NormalizePerRow<float>,   128   0.748   0.074  10.16x
CuMatrix::NormalizePerRow<float>,   256   2.255   0.289  7.79x
CuMatrix::NormalizePerRow<float>,   512   5.399   1.001  5.39x
CuMatrix::NormalizePerRow<float>,  1024  10.010   2.731  3.67x
CuMatrix::NormalizePerRow<double>,    16   0.015   0.001  12.45x
CuMatrix::NormalizePerRow<double>,    32   0.059   0.005  12.69x
CuMatrix::NormalizePerRow<double>,    64   0.236   0.018  12.81x
CuMatrix::NormalizePerRow<double>,   128   0.701   0.072  9.78x
CuMatrix::NormalizePerRow<double>,   256   1.738   0.279  6.23x
CuMatrix::NormalizePerRow<double>,   512   4.415   0.903  4.89x
CuMatrix::NormalizePerRow<double>,  1024   7.392   2.154  3.43x
```