### PR TITLE
Add PowerPC64le in Kaldi build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ Development pattern for contributors
    You can use the [Google's cpplint.py]
    (https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py)
    to verify that your code is free of basic mistakes.
+
+Platform specific notes
+-----------------------
+
+PowerPC 64bits little-endian (ppc64le):
+- Kaldi is expected to work out of the box in RHEL >= 7 and Ubuntu >= 16.04 with
+  OpenBLAS, ATLAS, or CUDA.
+- CUDA drivers for ppc64le can be found at [https://developer.nvidia.com/cuda-downloads]
+  (https://developer.nvidia.com/cuda-downloads).
+- An [IBM Redbook] (https://www.redbooks.ibm.com/abstracts/redp5169.html) is
+  available as a guide to install and configure CUDA.

--- a/src/configure
+++ b/src/configure
@@ -462,6 +462,8 @@ function configure_cuda {
       else
         cat makefiles/cuda_64bit.mk >> kaldi.mk
       fi
+    elif [ "`uname -m`" == "ppc64le" ]; then
+      cat makefiles/cuda_ppc64le.mk >> kaldi.mk
     else
       cat makefiles/cuda_32bit.mk >> kaldi.mk
     fi
@@ -526,6 +528,8 @@ function linux_atlas_failure { # function we use when we couldn't find
    echo ATLASLIBS = [somewhere]/liblapack.a [somewhere]/libcblas.a [somewhere]/libatlas.a [somewhere]/libf77blas.a $ATLASLIBDIR >> kaldi.mk
    if [[ "`uname -m`" == arm* ]]; then
      cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+   elif [[ "`uname -m`" == ppc64le ]]; then
+     cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
    else
      cat makefiles/linux_atlas.mk >> kaldi.mk
    fi
@@ -581,6 +585,8 @@ function linux_configure_debian_ubuntu {
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+   elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -604,6 +610,8 @@ function linux_configure_debian_ubuntu3 {
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -630,6 +638,8 @@ function linux_configure_debian7 {
   echo
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -653,6 +663,8 @@ function linux_configure_redhat {
   echo
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -678,6 +690,8 @@ function linux_configure_redhat_fat {
   echo
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -735,6 +749,8 @@ function linux_configure_static {
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -818,6 +834,8 @@ function linux_configure_dynamic {
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
   if [[ "`uname -m`" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk
+  elif [[ "`uname -m`" == ppc64le ]]; then
+    cat makefiles/linux_atlas_ppc64le.mk >> kaldi.mk
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
@@ -1104,6 +1122,8 @@ if [ "`uname`" == "Linux" ]; then
     echo "OPENBLASROOT = $OPENBLASROOT" >> kaldi.mk
     if [[ "`uname -m`" == arm* ]]; then
       cat makefiles/linux_openblas_arm.mk >> kaldi.mk
+    elif [[ "`uname -m`" == ppc64le ]]; then
+      cat makefiles/linux_openblas_ppc64le.mk >> kaldi.mk
     else
       cat makefiles/linux_openblas.mk >> kaldi.mk
     fi

--- a/src/makefiles/cuda_ppc64le.mk
+++ b/src/makefiles/cuda_ppc64le.mk
@@ -1,0 +1,12 @@
+
+ifndef DOUBLE_PRECISION
+$(error DOUBLE_PRECISION not defined.)
+endif
+
+
+CUDA_INCLUDE= -I$(CUDATKDIR)/include
+CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA \
+             -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION)
+CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include
+CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
+CUDA_LDLIBS += -lcublas -lcudart -lcurand #LDLIBS : The libs are loaded later than static libs in implicit rule

--- a/src/makefiles/linux_atlas_ppc64le.mk
+++ b/src/makefiles/linux_atlas_ppc64le.mk
@@ -1,0 +1,37 @@
+# You have to make sure ATLASLIBS is set...
+
+ifndef FSTROOT
+$(error FSTROOT not defined.)
+endif
+
+ifndef ATLASINC
+$(error ATLASINC not defined.)
+endif
+
+ifndef ATLASLIBS
+$(error ATLASLIBS not defined.)
+endif
+
+
+DOUBLE_PRECISION = 0
+CXXFLAGS = -m64 -maltivec -mcpu=power8 -Wall -I.. \
+	   -mtune=power8 -mpower8-vector -mvsx -pthread \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
+      -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
+      -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
+      -DHAVE_ATLAS -I$(ATLASINC) \
+      -I$(FSTROOT)/include \
+      $(EXTRA_CXXFLAGS) \
+      -g # -O0 -DKALDI_PARANOID 
+
+ifeq ($(KALDI_FLAVOR), dynamic)
+CXXFLAGS += -fPIC
+endif
+
+LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl
+CC = g++
+CXX = g++
+AR = ar
+AS = as
+RANLIB = ranlib

--- a/src/makefiles/linux_openblas_ppc64le.mk
+++ b/src/makefiles/linux_openblas_ppc64le.mk
@@ -1,0 +1,37 @@
+# You have to make sure FSTROOT,OPENBLASROOT,OPENBLASLIBS are set...
+
+ifndef FSTROOT
+$(error FSTROOT not defined.)
+endif
+
+ifndef OPENBLASLIBS
+$(error OPENBLASLIBS not defined.)
+endif
+
+ifndef OPENBLASROOT
+$(error OPENBLASROOT not defined.)
+endif
+
+
+DOUBLE_PRECISION = 0
+CXXFLAGS = -m64 -maltivec -mcpu=power8 -Wall -I.. \
+           -mtune=power8 -mpower8-vector -mvsx -pthread \
+      -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
+      -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self \
+      -DHAVE_EXECINFO_H=1 -rdynamic -DHAVE_CXXABI_H \
+      -DHAVE_OPENBLAS -I $(OPENBLASROOT)/include \
+      -I $(FSTROOT)/include \
+      $(EXTRA_CXXFLAGS) \
+      -g # -O0 -DKALDI_PARANOID
+
+ifeq ($(KALDI_FLAVOR), dynamic)
+CXXFLAGS += -fPIC
+endif
+
+LDFLAGS = -rdynamic $(OPENFSTLDFLAGS)
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(OPENBLASLIBS) -lm -lpthread -ldl
+CC = g++
+CXX = g++
+AR = ar
+AS = as
+RANLIB = ranlib

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -85,6 +85,10 @@ ifeq ($(OSTYPE),cygwin)
 else ifeq ($(OS),Windows_NT)
 	cd openfst-$(OPENFST_VERSION)/; ./configure --prefix=`pwd` --enable-static --enable-shared --enable-far --enable-ngram-fsts CXX=$(CXX) CXXFLAGS="$(CXXFLAGS) -O -Wa,-mbig-obj" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
 else
+	# ppc64le needs the newsted config.guess to be correctly indentified
+	[ "$(shell uname -p)" == "ppc64le" ] && wget -O openfst-$(OPENFST_VERSION)/config.guess \
+		"http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" || \
+		echo "config.guess unchanged"
 	cd openfst-$(OPENFST_VERSION)/; ./configure --prefix=`pwd` --enable-static --enable-shared --enable-far --enable-ngram-fsts CXX=$(CXX) CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
 endif
 


### PR DESCRIPTION
This commit introduces the PowerPC64le in the Kaldi build system, accepting Atlas, OpenBLAS and CUDA.

A tipical example to build Kaldi in Power8 le is:

 1 - clone Kaldi
 2 - after downloading openfst, download the recent version of
     config.guess
 3 - build tools
 4 - clone the latest openblas:
     https://github.com/xianyi/OpenBLAS/tree/master
     chekout master branch, build with make and make install
 5 - build Kaldi in src/
     run ./configure --shared --mathlib=OPENBLAS \
         --openblas-root=/opt/OpenBLAS/
     make -j 50

Signed-off-by: Jose Ricardo Ziviani <joserz@linux.vnet.ibm.com>
Signed-off-by: Leonardo Augusto Guimaraes Garcia <lagarcia@linux.vnet.ibm.com>