### PR TITLE
A couple of fixes in chain model training: fix a bug in compilation (…

### DIFF
--- a/src/chainbin/nnet3-chain-merge-egs.cc
+++ b/src/chainbin/nnet3-chain-merge-egs.cc
@@ -43,12 +43,17 @@ int main(int argc, char *argv[]) {
 
     bool compress = false;
     int32 minibatch_size = 64;
+    bool discard_partial_minibatches = true;
 
     ParseOptions po(usage);
     po.Register("minibatch-size", &minibatch_size, "Target size of minibatches "
                 "when merging (see also --measure-output-frames)");
     po.Register("compress", &compress, "If true, compress the output examples "
                 "(not recommended unless you are writing to disk");
+    po.Register("discard-partial-minibatches", &discard_partial_minibatches,
+                "discard any partial minibatches of 'uneven' size that may be "
+                "encountered at the end; 'true' is recommended, to avoid "
+                "incurring compilation costs.");
 
     po.Read(argc, argv);
 
@@ -79,7 +84,8 @@ int main(int argc, char *argv[]) {
       example_reader.Next();
       num_read++;
 
-      if (minibatch_ready || (example_reader.Done() && !examples.empty())) {
+      if (minibatch_ready || (!discard_partial_minibatches &&
+			      (example_reader.Done() && !examples.empty()))) {
         NnetChainExample merged_eg;
         MergeChainExamples(compress, &examples, &merged_eg);
         std::ostringstream ostr;
@@ -97,5 +103,3 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 }
-
-

--- a/src/nnet3/nnet-compile-utils.cc
+++ b/src/nnet3/nnet-compile-utils.cc
@@ -434,33 +434,62 @@ void EnsureContiguousProperty(
   }
 }
 
-// Function to split a list of pairs into vector of lists of unique pairs
+
+
+/**
+   This function splits a vector of pairs into a list of vectors of pairs.
+   [note: by 'vector' we mean something that has a meaningful index that we care
+   about; by 'list' we mean a collection of elements to be iterated over, without
+   (in this case) meaningful indexes or even order.
+
+   @param [in] list   A vector of pairs; these pairs should be either (-1,-1)
+                      or (a,b) for a >= 0, b >= 0.  At least one element of 'list'
+                      must be different from (-1,-1).
+   @param [out] split_lists   A list, in arbitrary order, of vectors of pairs.
+                     It has the following relationship with 'list':
+                     - Size: for each j, split_lists[j].size() == list.size().
+                     - Contents must match input: For each i:
+                       -  If list[i] == (-1, -1), then
+                          split_lists[j][i] == (-1, -1) for all j.
+                       -  If list[i] != (-1, -1), then
+                         split_lists[j][i] == (-1, -1) for *all but one* j, and
+                         for the remaining j, split_lists[j][i] == list[i].
+                     - Uniqueness: for no j should split_lists[j] contain
+                       any duplicate elements (except the pair (-1,-1), which  is
+                       allowed to exist in duplicate form).
+                     To satisfy the above conditions, this function will create
+                     as many lists in split_lists (i.e. as many j values) as the
+                     number of times that the most frequent pair in 'list'
+                     repeats other than the pair (-1,-1), e.g. if the pair
+                     (10,11) appears 4 times in 'list' and that is the most,
+                     split_lists->size() == 4.
+*/
 void SplitPairList(std::vector<std::pair<int32, int32> >& list,
                    std::vector<std::vector<std::pair<int32, int32> > >* split_lists) {
   split_lists->clear();
+  typedef unordered_map<std::pair<int32, int32>,
+                        int32, PairHasher<int32> > MapType;
+  // this maps a pair not equal to -1,-1, to the number of times we've already seen it.
+  MapType pair_to_count;
+  int32 cur_num_lists = 0;
+
   for (int32 i = 0; i < list.size(); i++)  {
-    // searching for the new pair in the new_split_lists
-    bool added_pair = false;
-    if ( list[i].first == -1)
+    if (list[i].first == -1)
       continue;
-    for (int32 j = 0; j < split_lists->size(); j++)  {
-      std::vector<std::pair<int32, int32> >::const_iterator iter
-          = std::find_if((*split_lists)[j].begin(),
-                         (*split_lists)[j].end(),
-                         PairIsEqualComparator(list[i]));
-      if (iter == (*split_lists)[j].end()) {
-        // this pair is not in this list
-        (*split_lists)[j][i] = list[i];
-        added_pair = true;
-        break;
-      }
+    MapType::iterator iter = pair_to_count.find(list[i]);
+    int32 this_count;
+    if (iter == pair_to_count.end())
+      pair_to_count[list[i]] = this_count = 1;
+    else
+      this_count = (++iter->second);
+    if (this_count > cur_num_lists) {
+      KALDI_ASSERT(this_count == cur_num_lists + 1);
+      split_lists->resize(this_count);
+      split_lists->back().resize(list.size(),
+                                 std::pair<int32, int32>(-1, -1));
+      cur_num_lists++;
     }
-    if (!added_pair)  {
-      std::vector<std::pair<int32, int32> > list_of_pairs(list.size(),
-                                                          std::make_pair(-1, -1));
-      list_of_pairs[i] = list[i];
-      split_lists->push_back(list_of_pairs);
-    }
+    (*split_lists)[this_count-1][i] = list[i];
   }
   if (split_lists->size() == 0)
     KALDI_ERR << "Input list has just dummy pairs";
@@ -477,8 +506,12 @@ void SplitLocationsBackward(
     std::vector<int32> second_values;
     if (ConvertToIndexes(split_lists_intermediate[i],
                          &first_value, &second_values)) {
-      // the .first values are the same
-      if (first_value == -1) continue;  // don't output anything for this.
+      // the .first values in split_lists_intermediate[i] are all the same (or
+      // equal to -1).
+      if (first_value == -1) {
+        // all the .first values were equal to -1.  this is like a NULL marker.
+        continue;
+      }
       std::vector<std::vector<int32> > second_values_split;
       EnsureContiguousProperty(second_values, &second_values_split);
       if (second_values_split.size() == 1) {

--- a/src/nnet3/nnet-compile.cc
+++ b/src/nnet3/nnet-compile.cc
@@ -613,22 +613,16 @@ void Compiler::DoBackwardComputationFromSubmatLocations(
   // trickier to implement efficiently on the GPU, there may be cases
   // which we will refuse to implement backprop for if we get here.
 
-  int32 num_rows = submat_locations.size();
-  std::vector<std::pair<int32, int32> >::const_iterator
-      iter = submat_locations.begin(), end = submat_locations.end();
-  int32 first_submat = iter->first;
-  for (++iter; iter != end; ++iter)
-    if (iter->first != first_submat)
-      break;
-  bool all_same_submatrix = (iter == end);
-  if (all_same_submatrix) {
-    int32 input_deriv_submatrix_index = first_submat;
-    std::vector<int32> indexes(num_rows);
-    for (int32 i = 0; i < num_rows; i++)
-      indexes[i] = submat_locations[i].second;
+
+
+  int32 first_value;
+  std::vector<int32> second_values;
+  if (ConvertToIndexes(submat_locations, &first_value,
+                       &second_values)) {
+    int32 input_deriv_submatrix_index = first_value;
     DoBackwardComputationFromIndexes(deriv_submatrix_index,
                                      input_deriv_submatrix_index,
-                                     indexes,
+                                     second_values,
                                      computation);
     return;
   } else {

--- a/src/nnet3bin/nnet3-merge-egs.cc
+++ b/src/nnet3bin/nnet3-merge-egs.cc
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
         "e.g.\n"
         "nnet3-merge-egs --minibatch-size=512 ark:1.egs ark:- | nnet3-train-simple ... \n"
         "See also nnet3-copy-egs\n";
-        
+
     bool compress = false;
     int32 minibatch_size = 512;
     bool measure_output_frames = true;
@@ -74,9 +74,10 @@ int main(int argc, char *argv[]) {
     po.Register("compress", &compress, "If true, compress the output examples "
                 "(not recommended unless you are writing to disk)");
     po.Register("discard-partial-minibatches", &discard_partial_minibatches,
-		"discard any partial minibatches of 'uneven' size that may be "
-		"encountered at the end.");
-    
+                "discard any partial minibatches of 'uneven' size that may be "
+                "encountered at the end; 'true' is recommended, to avoid "
+                "incurring compilation costs.");
+
     po.Read(argc, argv);
 
     if (po.NumArgs() != 2) {
@@ -89,12 +90,12 @@ int main(int argc, char *argv[]) {
 
     SequentialNnetExampleReader example_reader(examples_rspecifier);
     NnetExampleWriter example_writer(examples_wspecifier);
-    
+
     std::vector<NnetExample> examples;
     examples.reserve(minibatch_size);
 
     int32 cur_num_output_frames = 0;
-    
+
     int64 num_read = 0, num_written = 0;
     while (!example_reader.Done()) {
       const NnetExample &cur_eg = example_reader.Value();
@@ -130,5 +131,3 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 }
-
-


### PR DESCRIPTION
…leads to crash in rare circumstances); discard partial minibatches when merging egs, which was always the intention.

This commit also improves documentation for some internal code.

The only change that really requires testing and could potentially affect results is that we discard partial minibatches; this is done for speed (to avoid unnecessary recompilation).