### PR TITLE
add `mkdir -p $dir` which might not exist yet

### DIFF
--- a/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding.sh
+++ b/egs/wsj/s5/steps/online/nnet2/prepare_online_decoding.sh
@@ -77,6 +77,7 @@ if [ ! -z "$iedir" ]; then
 fi
 
 utils/lang/check_phones_compatible.sh $lang/phones.txt $srcdir/phones.txt || exit 1;
+mkdir -p $dir
 cp $lang/phones.txt $dir || exit 1;
 
 dir=$(readlink -f $dir) # Convert $dir to an absolute pathname, so that the


### PR DESCRIPTION
The next line in the diff 
```sh
cp $lang/phones.txt $dir || exit 1;
```
will turn `$dir` into a file rather than a directory, which causes problems.