### PR TITLE
fix description of --num-threads

### DIFF
--- a/egs/wsj/s5/steps/online/nnet2/train_ivector_extractor.sh
+++ b/egs/wsj/s5/steps/online/nnet2/train_ivector_extractor.sh
@@ -18,7 +18,7 @@
 # subject to various constraints.  The "num_threads" is how many threads a
 # program uses; the "num_processes" is the number of separate processes a single
 # job spawns, and then sums the accumulators in memory.  Our recommendation:
-#  - Set num_threads to the minimum of (4, or how many virtual cores your machine has).
+#  - Set num_threads to the maximum of (4, or how many virtual cores your machine has).
 #    (because of needing to lock various global quantities, the program can't
 #    use many more than 4 threads with good CPU utilization).
 #  - Set num_processes to the number of virtual cores on each machine you have, divided by 


### PR DESCRIPTION
Surely you mean max(4, #hyperthreads-per-machine), and not min(4, #hyperthreads-per-machine), given your explanation "the program can't use many more than 4 threads with good CPU utilization"?

BTW For my poor man's setup with only 6 cores (12 hyperthreads per machine) I had to edit `steps/run_ivector_common.sh`, as these parameters weren't proliferated from the calling script `local/run_tdnn.sh`.  I assume the scripts in `local/` are more eligible for changes for the local set-up than the steps in `steps/` (which hide in `egs/wsj/s5`, but perhaps a sibling of the root `src` would be a better location)?