### PR TITLE
fix fisher_swbd chain dir naming

### DIFF
--- a/egs/fisher_swbd/s5/local/chain/run_blstm_6h.sh
+++ b/egs/fisher_swbd/s5/local/chain/run_blstm_6h.sh
@@ -38,8 +38,8 @@ fi
 
 dir=$dir${affix:+_$affix}
 train_set=train_nodup_sp
-ali_dir=exp/tri5a_ali_nodup
-treedir=exp/chain/tri6_tree_11000
+ali_dir=exp/tri5a_ali_nodup_sp
+treedir=exp/chain/tri6_tree
 lang=data/lang_chain
 
 # The iVector-extraction and feature-dumping parts are the same as the standard
@@ -54,7 +54,7 @@ if [ $stage -le 9 ]; then
   # use the same num-jobs as the alignments
   nj=$(cat $ali_dir/num_jobs) || exit 1;
   steps/align_fmllr_lats.sh --nj $nj --cmd "$train_cmd" data/$train_set \
-    data/lang exp/tri5a exp/tri5a_lats_nodup_sp
+    data/lang exp/tri5a exp/tri5a_lats_nodup_sp || exit 1;
   rm exp/tri5a_lats_nodup_sp/fsts.*.gz # save space
 fi
 
@@ -75,7 +75,7 @@ if [ $stage -le 11 ]; then
   # Build a tree using our new topology.
   steps/nnet3/chain/build_tree.sh --frame-subsampling-factor 3 \
       --leftmost-questions-truncate -1 \
-      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir
+      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir || exit 1;
 fi
 
 if [ $stage -le 12 ]; then

--- a/egs/fisher_swbd/s5/local/chain/run_tdnn_7b.sh
+++ b/egs/fisher_swbd/s5/local/chain/run_tdnn_7b.sh
@@ -34,8 +34,8 @@ fi
 
 dir=${dir}${affix:+_$affix}
 train_set=train_nodup_sp
-ali_dir=exp/tri5a_ali_nodup
-treedir=exp/chain/tri6_tree_11000
+ali_dir=exp/tri5a_ali_nodup_sp
+treedir=exp/chain/tri6_tree
 lang=data/lang_chain
 
 
@@ -51,7 +51,7 @@ if [ $stage -le 9 ]; then
   # use the same num-jobs as the alignments
   nj=$(cat $ali_dir/num_jobs) || exit 1;
   steps/align_fmllr_lats.sh --nj $nj --cmd "$train_cmd" data/$train_set \
-    data/lang exp/tri5a exp/tri5a_lats_nodup_sp
+    data/lang exp/tri5a exp/tri5a_lats_nodup_sp || exit 1;
   rm exp/tri5a_lats_nodup_sp/fsts.*.gz # save space
 fi
 
@@ -72,7 +72,7 @@ if [ $stage -le 11 ]; then
   # Build a tree using our new topology.
   steps/nnet3/chain/build_tree.sh --frame-subsampling-factor 3 \
       --leftmost-questions-truncate -1 \
-      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir
+      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir || exit 1;
 fi
 
 if [ $stage -le 12 ]; then


### PR DESCRIPTION
Fixing #1299 
The tree dir is a bad tuning name and is renamed. train.py willl throw error that tree dir not exist if the user start after tree building with tree generated using the old script.