### PR TITLE
fix: chain do not need sp align

### DIFF
--- a/egs/fisher_swbd/s5/local/chain/run_blstm_6h.sh
+++ b/egs/fisher_swbd/s5/local/chain/run_blstm_6h.sh
@@ -37,8 +37,9 @@ EOF
 fi
 
 dir=$dir${affix:+_$affix}
+build_tree_train_set=train_nodup
 train_set=train_nodup_sp
-ali_dir=exp/tri5a_ali_nodup_sp
+build_tree_ali_dir=exp/tri5a_ali
 treedir=exp/chain/tri6_tree
 lang=data/lang_chain
 
@@ -52,7 +53,7 @@ local/nnet3/run_ivector_common.sh --stage $stage \
 if [ $stage -le 9 ]; then
   # Get the alignments as lattices (gives the CTC training more freedom).
   # use the same num-jobs as the alignments
-  nj=$(cat $ali_dir/num_jobs) || exit 1;
+  nj=$(cat $build_tree_ali_dir/num_jobs) || exit 1;
   steps/align_fmllr_lats.sh --nj $nj --cmd "$train_cmd" data/$train_set \
     data/lang exp/tri5a exp/tri5a_lats_nodup_sp || exit 1;
   rm exp/tri5a_lats_nodup_sp/fsts.*.gz # save space
@@ -75,7 +76,7 @@ if [ $stage -le 11 ]; then
   # Build a tree using our new topology.
   steps/nnet3/chain/build_tree.sh --frame-subsampling-factor 3 \
       --leftmost-questions-truncate -1 \
-      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir || exit 1;
+      --cmd "$train_cmd" 11000 data/$build_tree_train_set $lang $build_tree_ali_dir $treedir || exit 1;
 fi
 
 if [ $stage -le 12 ]; then

--- a/egs/fisher_swbd/s5/local/chain/run_tdnn_7b.sh
+++ b/egs/fisher_swbd/s5/local/chain/run_tdnn_7b.sh
@@ -33,8 +33,10 @@ EOF
 fi
 
 dir=${dir}${affix:+_$affix}
+
 train_set=train_nodup_sp
-ali_dir=exp/tri5a_ali_nodup_sp
+build_tree_train_set=train_nodup
+build_tree_ali_dir=exp/tri5a_ali
 treedir=exp/chain/tri6_tree
 lang=data/lang_chain
 
@@ -49,7 +51,7 @@ local/nnet3/run_ivector_common.sh --stage $stage \
 if [ $stage -le 9 ]; then
   # Get the alignments as lattices (gives the chain training more freedom).
   # use the same num-jobs as the alignments
-  nj=$(cat $ali_dir/num_jobs) || exit 1;
+  nj=$(cat $build_tree_ali_dir/num_jobs) || exit 1;
   steps/align_fmllr_lats.sh --nj $nj --cmd "$train_cmd" data/$train_set \
     data/lang exp/tri5a exp/tri5a_lats_nodup_sp || exit 1;
   rm exp/tri5a_lats_nodup_sp/fsts.*.gz # save space
@@ -72,7 +74,7 @@ if [ $stage -le 11 ]; then
   # Build a tree using our new topology.
   steps/nnet3/chain/build_tree.sh --frame-subsampling-factor 3 \
       --leftmost-questions-truncate -1 \
-      --cmd "$train_cmd" 11000 data/$train_set $lang $ali_dir $treedir || exit 1;
+      --cmd "$train_cmd" 11000 data/$build_tree_train_set $lang $build_tree_ali_dir $treedir || exit 1;
 fi
 
 if [ $stage -le 12 ]; then


### PR DESCRIPTION
This reverts part of the change in #1303 
I made a mistake to use alignments of sp data in chain training, which is not true. Now #1299 should be fixed.