### PR TITLE
fix_constant_function2: Fix to learning rate in ConstantFunctionComponent

### DIFF
--- a/src/nnet3/nnet-general-component.h
+++ b/src/nnet3/nnet-general-component.h
@@ -156,9 +156,9 @@ class DistributeComponentPrecomputedIndexes:
   StatisticsPoolingComponent to extract moving-average mean and
   standard-deviation statistics.
 
-  StatisticsExtractionExomponent designed to extract statistics-- 0th-order,
+  StatisticsExtractionComponent is designed to extract statistics-- 0th-order,
   1st-order and optionally diagonal 2nd-order stats-- from small groups of
-  frames, such as 10 frame.  The statistics will then be further processed by
+  frames, such as 10 frames.  The statistics will then be further processed by
   StatisticsPoolingComponent to compute moving-average means and (if configured)
   standard deviations.  The reason for the two-component way of doing this is
   efficiency, particularly in the graph-compilation phase.  (Otherwise there
@@ -185,7 +185,7 @@ class DistributeComponentPrecomputedIndexes:
   An output of this component will be 'computable' any time at least one of
   the corresponding inputs is computable.
 
-   In all cases the first dimension of the output will be a count (between 1 and
+  In all cases the first dimension of the output will be a count (between 1 and
   10 inclusive in this example).  If include-variance=false, then the output
   dimension will be input-dim + 1.  and the output dimensions >0 will be
   1st-order statistics (sums of the input).  If include-variance=true, then the
@@ -441,7 +441,7 @@ class StatisticsPoolingComponentPrecomputedIndexes:
 };
 
 // BackpropTruncationComponent zeroes out the gradients every certain number
-// of frames, as well as having gradient-clipping functionality as 
+// of frames, as well as having gradient-clipping functionality as
 // ClipGradientComponent.
 // This component will be used to prevent gradient explosion problem in
 // recurrent neural networks
@@ -505,7 +505,7 @@ class BackpropTruncationComponent: public Component {
  private:
   // input/output dimension
   int32 dim_;
-  
+
   // threshold (e.g., 30) to be used for clipping corresponds to max-row-norm
   BaseFloat clipping_threshold_;
 

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -2342,12 +2342,13 @@ std::string ConstantFunctionComponent::Info() const {
 }
 
 ConstantFunctionComponent::ConstantFunctionComponent():
-    input_dim_(-1), is_updatable_(true), use_natural_gradient_(true) { }
+    UpdatableComponent(), input_dim_(-1), is_updatable_(true),
+    use_natural_gradient_(true) { }
 
 ConstantFunctionComponent::ConstantFunctionComponent(
     const ConstantFunctionComponent &other):
-    input_dim_(other.input_dim_), output_(other.output_),
-    is_updatable_(other.is_updatable_),
+    UpdatableComponent(other), input_dim_(other.input_dim_),
+    output_(other.output_), is_updatable_(other.is_updatable_),
     use_natural_gradient_(other.use_natural_gradient_),
     preconditioner_(other.preconditioner_) { }
 

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -1105,7 +1105,7 @@ static void GenerateRandomComponentConfig(std::string *component_type,
                                           std::string *config) {
 
   int32 n = RandInt(0, 30);
-  BaseFloat learning_rate = 0.001 * RandInt(1, 3);
+  BaseFloat learning_rate = 0.001 * RandInt(1, 100);
 
   std::ostringstream os;
   switch(n) {


### PR DESCRIPTION
* In src/nnet3/nnet-simple-component.cc added calls to UpdatableComponent constructors in ConstantFunctionComponent. This solves the bug where the learning rate isn't copied when Copy() is called.
* Minor change to src/nnet3/nnet-test-utils.cc so that GenerateRandomComponentConfig initializes components with a wider range of learning rates. This is to prevent certain bugs from being missed in test code.
* In src/nnet3/nnet-general-component.h fixed typos in documentation for StatisticsExtractionComponent.