### PR TITLE
nnet1: minor updates of scripts,

### DIFF
--- a/egs/wsj/s5/steps/conf/append_eval_to_ctm.py
+++ b/egs/wsj/s5/steps/conf/append_eval_to_ctm.py
@@ -38,11 +38,11 @@ with open(eval_in, 'r') as f:
     assert(tag == 'op')
     hyp_vec = hyp_vec.split()
     op_vec = op_vec.split()
-    # Fill create eval vector with symbols 'C', 'S', 'I',
+    # Fill create eval vector with symbols 'C', 'S', 'I'
     assert(utt not in eval_vec)
     eval_vec[utt] = []
     for op,hyp in zip(op_vec, hyp_vec):
-      if hyp != '<eps>': eval_vec[utt].append(op)
+      if op != 'D': eval_vec[utt].append((op,hyp))
 
 # Load the 'ctm' into dictionary,
 ctm = dict()
@@ -56,9 +56,20 @@ with open(ctm_in) as f:
 ctm_eval = []
 for utt,ctm_part in ctm.iteritems():
   ctm_part.sort(key = operator.itemgetter(2)) # Sort by 'beg' time,
-  # extending the 'tuple' by '+':
-  merged = [ tup + (evl,) for tup,evl in zip(ctm_part,eval_vec[utt]) ]
-  ctm_eval.extend(merged)
+  try:
+    # merging 'tuples' by '+', the record has format:
+    # (utt, ch, beg, dur, ctm_wrd, conf, op, hyp_wrd)
+    merged = [ ctm_tup + evl_tup for ctm_tup,evl_tup in zip(ctm_part,eval_vec[utt]) ]
+    # check,
+    for j in range(len(merged)):
+      hyp_wrd = merged[j][-1]
+      ctm_wrd = merged[j][-4]
+      assert hyp_wrd == ctm_wrd, "We failed with words: hyp_wrd %s, ctm_wrd %s" % (hyp_wrd,ctm_wrd) # Check that words in 'ctm' and 'utt_stats' match!
+      merged[j] = merged[j][:-1] # dropping the 'hyp_wrd' (the last element of tuple),
+    # append,
+    ctm_eval.extend(merged)
+  except KeyError:
+    print 'Missing key', utt, 'in the word-evaluation stats from scoring'
 
 # Sort again,
 ctm_eval.sort(key = operator.itemgetter(0,1,2))

--- a/egs/wsj/s5/steps/nnet/align.sh
+++ b/egs/wsj/s5/steps/nnet/align.sh
@@ -15,6 +15,7 @@ beam=10
 retry_beam=40
 nnet_forward_opts="--no-softmax=true --prior-scale=1.0"
 ivector=            # rx-specifier with i-vectors (ark-with-vectors),
+text= # (optional) transcipts we align to,
 
 align_to_lats=false # optionally produce alignment in lattice format
  lats_decode_opts="--acoustic-scale=0.1 --beam=20 --lattice_beam=10"
@@ -62,9 +63,10 @@ feature_transform=$srcdir/final.feature_transform
 model=$dir/final.mdl
 
 # Check that files exist
-for f in $sdata/1/feats.scp $sdata/1/text $lang/L.fst $nnet $model $feature_transform $class_frame_counts; do
+for f in $sdata/1/feats.scp $lang/L.fst $nnet $model $feature_transform $class_frame_counts; do
   [ ! -f $f ] && echo "$0: missing file $f" && exit 1;
 done
+[ -z "$text" -a ! -f $sdata/1/text ] && echo "$0: missing file $f" && exit 1
 
 
 # PREPARE FEATURE EXTRACTION PIPELINE
@@ -113,11 +115,11 @@ echo "$0: aligning data '$data' using nnet/model '$srcdir', putting alignments i
 
 # Map oovs in reference transcription, 
 oov=`cat $lang/oov.int` || exit 1;
-tra="ark:utils/sym2int.pl --map-oov $oov -f 2- $lang/words.txt $sdata/JOB/text|";
+[ -z "$text" ] && text=$sdata/JOB/text
+tra="ark:utils/sym2int.pl --map-oov $oov -f 2- $lang/words.txt $text |";
 # We could just use align-mapped in the next line, but it's less efficient as it compiles the
 # training graphs one by one.
 if [ $stage -le 0 ]; then
-  train_graphs="ark:compile-train-graphs --read-disambig-syms=$lang/phones/disambig.int $dir/tree $dir/final.mdl $lang/L.fst '$tra' ark:- |"
   $cmd JOB=1:$nj $dir/log/align.JOB.log \
     compile-train-graphs --read-disambig-syms=$lang/phones/disambig.int $dir/tree $dir/final.mdl $lang/L.fst "$tra" ark:- \| \
     align-compiled-mapped $scale_opts --beam=$beam --retry-beam=$retry_beam $dir/final.mdl ark:- \

--- a/egs/wsj/s5/steps/nnet/make_bn_feats.sh
+++ b/egs/wsj/s5/steps/nnet/make_bn_feats.sh
@@ -44,7 +44,7 @@ bnfeadir=$5
 
 # copy the dataset metadata from srcdata.
 mkdir -p $data $logdir $bnfeadir || exit 1;
-utils/copy_data_dir.sh $srcdata $data; rm $data/{feats,cmvn}.scp 2>/dev/null
+utils/copy_data_dir.sh $srcdata $data; rm -f $data/{feats,cmvn}.scp 2>/dev/null
 
 # make $bnfeadir an absolute pathname.
 [ '/' != ${bnfeadir:0:1} ] && bnfeadir=$PWD/$bnfeadir


### PR DESCRIPTION
steps/conf/append_eval_to_ctm.py
- now safer, added check that the word-sequences from 'ctm' and 'utt_stats' are the same,

steps/nnet/align.sh 
- now supports aligning to optional external 'text' file,

steps/nnet/make_bn_feats.sh 
- now doesn't crash if the files to remove don't exist,