### PR TITLE
Change the regular expression match syntax used for version checking

### DIFF
--- a/src/base/get_version.sh
+++ b/src/base/get_version.sh
@@ -39,15 +39,10 @@ cd "$(dirname ${BASH_SOURCE[0]})"
 # Read the partial version number specified in the first line of src/.version.
 version=$(head -1 ../.version)
 
-# Empty version number is not allowed.
-if [ -z "$version" ]; then
-  version="?"
-fi
-
 if [ -e ../.short_version ]; then
   echo "$0: File src/.short_version exists."
   echo "$0: Stopping the construction of full version number from git history."
-elif [[ $version != +([0-9]).+([0-9]) ]]; then
+elif ! [[ $version =~ ^[0-9][0-9]*.[0-9][0-9]*$ ]]; then
   echo "$0: The version number \"$version\" specified in src/.version is not" \
        "in MAJOR.MINOR format."
   echo "$0: Stopping the construction of full version number from git history."
@@ -74,6 +69,11 @@ else
   head_commit=$(git log -1 --pretty=oneline | cut -f 1 -d ' ')
   head_commit_short=$(git log -1 --oneline --abbrev=4 | cut -f 1 -d ' ')
   version="$version-${head_commit_short}"
+fi
+
+# Empty version number is not allowed.
+if [ -z "$version" ]; then
+  version="?"
 fi
 
 # Write version info to a temporary file.


### PR DESCRIPTION
This is to support older bash versions.