### PR TITLE
Change default return value of install_sacc.sh

### DIFF
--- a/tools/extras/install_sacc.sh
+++ b/tools/extras/install_sacc.sh
@@ -71,4 +71,4 @@ cd SAcC_GLNXA64
   && echo "**Error testing SAcC-- something went wrong." && exit 1;
 
 echo "Test succeeded."
-exit 1;
+exit 0;


### PR DESCRIPTION
The install script for SAcC was returning an error code of 1 on a
successfull install.

Change it to the more "standard" return value of 0.

Fixes #1336.