### PR TITLE
Fix a typo in csj_run_rnnlm.sh

### DIFF
--- a/egs/csj/s5/local/csj_run_rnnlm.sh
+++ b/egs/csj/s5/local/csj_run_rnnlm.sh
@@ -44,7 +44,7 @@ local/csj_train_rnnlms.sh --dict-suffix "_nosp" \
 echo h500 Begin
 local/csj_train_rnnlms.sh --dict-suffix "_nosp" \
     --hidden 500 --nwords 10000 --class 200 \
-    --direct 0 data/local/rnnlm.h400
+    --direct 0 data/local/rnnlm.h500
 
 #SKIP
 


### PR DESCRIPTION
Typo fixing in kaldi/egs/csj/s5/local/csj_run_rnnlm.sh @ 47

`45 local/csj_train_rnnlms.sh --dict-suffix "_nosp" \`
`46    --hidden 500 --nwords 10000 --class 200 \`
`47 --direct 0 data/local/rnnlm.h400`
to
`45 local/csj_train_rnnlms.sh --dict-suffix "_nosp" \`
`46    --hidden 500 --nwords 10000 --class 200 \`
`47 --direct 0 data/local/rnnlm.h500`
