### PR TITLE
Fixing 'curand' issues #1339

### DIFF
--- a/src/cudamatrix/cu-rand-speed-test.cc
+++ b/src/cudamatrix/cu-rand-speed-test.cc
@@ -56,63 +56,166 @@ std::string MeanVariance(const CuMatrixBase<Real>& m) {
   return std::string("mean ") + ToString(mean) + ", std-dev " + ToString(std::sqrt(var));
 }
 
+template<typename Real>
+std::string MeanVariance(const CuVectorBase<Real>& v) {
+  std::ostringstream os;
+  Real mean = v.Sum() / v.Dim();
+  CuVector<Real> tmp(v);
+  tmp.Add(-mean);
+  tmp.ApplyPow(2.0);
+  Real var = tmp.Sum() / tmp.Dim();
+  return std::string("mean ") + ToString(mean) + ", std-dev " + ToString(std::sqrt(var));
+}
+
+
 template <typename Real>
-void CuRandUniformMatrixSpeedTest() {
+void CuRandUniformMatrixSpeedTest(const int32 iter) {
   Timer t;
   CuRand<Real> rand;
-  CuMatrix<Real> m(249,2011);
-  for (int32 i = 0; i < 200; i++) {
+  CuMatrix<Real> m(249,1001, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
     rand.RandUniform(&m);
   }
-  KALDI_LOG << __func__ << NameOf<Real>() << " t = " << t.Elapsed() << "s, " << MeanVariance(m);
+  CuMatrix<Real> m2(256,1024, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandUniform(&m2);
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (m.NumRows() * m.NumCols() + m2.NumRows() * m2.NumCols()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(m) << ")";
 }
 
 template <typename Real>
-void CuRandGaussianMatrixSpeedTest() {
+void CuRandUniformMatrixBaseSpeedTest(const int32 iter) {
   Timer t;
   CuRand<Real> rand;
-  CuMatrix<Real> m(249,2011);
-  for (int32 i = 0; i < 200; i++) {
+  CuMatrix<Real> m(249,1001, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandUniform(dynamic_cast<CuMatrixBase<Real>*>(&m));
+  }
+  CuMatrix<Real> m2(256,1024, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandUniform(dynamic_cast<CuMatrixBase<Real>*>(&m2));
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (m.NumRows() * m.NumCols() + m2.NumRows() * m2.NumCols()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(m) << ")";
+}
+
+template <typename Real>
+void CuRandGaussianMatrixSpeedTest(const int32 iter) {
+  Timer t;
+  CuRand<Real> rand;
+  CuMatrix<Real> m(249,1001, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
     rand.RandGaussian(&m);
   }
-  KALDI_LOG << __func__ << NameOf<Real>() << " t = " << t.Elapsed() << "s, " << MeanVariance(m);
+  CuMatrix<Real> m2(256,1024, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandGaussian(&m2);
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (m.NumRows() * m.NumCols() + m2.NumRows() * m2.NumCols()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(m) << ")";
 }
 
 template <typename Real>
-void CuRandGaussianVectorSpeedTest() {
+void CuRandGaussianMatrixBaseSpeedTest(const int32 iter) {
   Timer t;
   CuRand<Real> rand;
-  CuVector<Real> v(2011);
-  for (int32 i = 0; i < 200; i++) {
+  CuMatrix<Real> m(249,1001, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandGaussian(dynamic_cast<CuMatrixBase<Real>*>(&m));
+  }
+  CuMatrix<Real> m2(256,1024, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandGaussian(dynamic_cast<CuMatrixBase<Real>*>(&m2));
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (m.NumRows() * m.NumCols() + m2.NumRows() * m2.NumCols()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(m) << ")";
+}
+
+template <typename Real>
+void CuRandUniformVectorSpeedTest(const int32 iter) {
+  Timer t;
+  CuRand<Real> rand;
+  CuVector<Real> v(2011, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandUniform(&v);
+  }
+  CuVector<Real> v2(2048, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandUniform(&v2);
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (v.Dim() + v2.Dim()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(v) << ")";
+}
+
+template <typename Real>
+void CuRandGaussianVectorSpeedTest(const int32 iter) {
+  Timer t;
+  CuRand<Real> rand;
+  CuVector<Real> v(2011, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
     rand.RandGaussian(&v);
   }
-  KALDI_LOG << __func__ << NameOf<Real>() << " t = " << t.Elapsed() << "s";
+  CuVector<Real> v2(2048, kUndefined);
+  for (int32 i = 0; i < iter; i++) {
+    rand.RandGaussian(&v2);
+  }
+  // flops = number of generated random numbers per second,
+  Real flops = iter * (v.Dim() + v2.Dim()) / t.Elapsed();
+  KALDI_LOG << __func__ << NameOf<Real>()
+            << " Speed was " << flops << " rand_elems/s. "
+            << "(debug " << MeanVariance(v) << ")";
 }
 
 } // namespace kaldi
 
 
 int main() {
-  for (int32 loop = 0; loop < 2; loop++) {
+  int32 iter = 10; // Be quick on CPU,
 #if HAVE_CUDA == 1
+  for (int32 loop = 0; loop < 2; loop++) { // NO for loop if 'HAVE_CUDA != 1',
     CuDevice::Instantiate().SetDebugStrideMode(true);
-    if (loop == 0)
+    if ( loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");
-    else
+    else {
       CuDevice::Instantiate().SelectGpuId("yes");
+      iter = 400; // GPUs are faster,
+    }
 #endif
-    kaldi::CuRandUniformMatrixSpeedTest<float>();
-    kaldi::CuRandGaussianMatrixSpeedTest<float>();
-    kaldi::CuRandGaussianVectorSpeedTest<float>();
+    Timer t;
+    kaldi::CuRandUniformMatrixSpeedTest<float>(iter);
+    kaldi::CuRandUniformMatrixBaseSpeedTest<float>(iter);
+    kaldi::CuRandUniformVectorSpeedTest<float>(iter);
+    kaldi::CuRandGaussianMatrixSpeedTest<float>(iter);
+    kaldi::CuRandGaussianMatrixBaseSpeedTest<float>(iter);
+    kaldi::CuRandGaussianVectorSpeedTest<float>(iter);
     fprintf(stderr, "---\n");
 
-    kaldi::CuRandUniformMatrixSpeedTest<double>();
-    kaldi::CuRandGaussianMatrixSpeedTest<double>();
-    kaldi::CuRandGaussianVectorSpeedTest<double>();
-    fprintf(stderr, "\n");
-  }
-
+    kaldi::CuRandUniformMatrixSpeedTest<double>(iter);
+    kaldi::CuRandUniformMatrixBaseSpeedTest<double>(iter);
+    kaldi::CuRandUniformVectorSpeedTest<double>(iter);
+    kaldi::CuRandGaussianMatrixSpeedTest<double>(iter);
+    kaldi::CuRandGaussianMatrixBaseSpeedTest<double>(iter);
+    kaldi::CuRandGaussianVectorSpeedTest<double>(iter);
+    fprintf(stderr, "--- ELAPSED %fs.\n\n", t.Elapsed());
 #if HAVE_CUDA == 1
+  } // NO for loop if 'HAVE_CUDA != 1',
+
   CuDevice::Instantiate().PrintProfile();
 #endif
   std::cout << "Tests succeeded.\n";

--- a/src/cudamatrix/cu-rand.cc
+++ b/src/cudamatrix/cu-rand.cc
@@ -1,6 +1,6 @@
 // cudamatrix/cu-rand.cc
 
-// Copyright 2016  Brno University of Technology (author Karel Vesely)
+// Copyright 2016-2017  Brno University of Technology (author Karel Vesely)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -21,18 +21,50 @@
 
 namespace kaldi {
 
+#if HAVE_CUDA == 1
+/// Wrappers of curand functions to interface both float and double as 1 function,
+
+/// Wrapper of curandGenerateUniform(), curandGenerateUniformDouble(),
+template<typename Real>
+curandStatus_t curandGenerateUniformWrap(curandGenerator_t gen, Real *ptr, size_t num);
+//
 template<>
-void CuRand<float>::RandUniform(CuMatrixBase<float> *tgt) {
+curandStatus_t curandGenerateUniformWrap(curandGenerator_t gen, float *ptr, size_t num) {
+  return curandGenerateUniform(gen, ptr, num);
+}
+template<>
+curandStatus_t curandGenerateUniformWrap(curandGenerator_t gen, double *ptr, size_t num) {
+  return curandGenerateUniformDouble(gen, ptr, num);
+}
+
+/// Wrapper of curandGenerateNormal(), curandGenerateNormalDouble(),
+template<typename Real>
+curandStatus_t curandGenerateNormalWrap(
+    curandGenerator_t gen, Real *ptr, size_t num);
+//
+template<>
+curandStatus_t curandGenerateNormalWrap<float>(
+    curandGenerator_t gen, float *ptr, size_t num) {
+  return curandGenerateNormal(gen, ptr, num, 0.0 /*mean*/, 1.0 /*stddev*/);
+}
+template<>
+curandStatus_t curandGenerateNormalWrap<double>(
+    curandGenerator_t gen, double *ptr, size_t num) {
+  return curandGenerateNormalDouble(gen, ptr, num, 0.0 /*mean*/, 1.0 /*stddev*/);
+}
+/// End of wrappers.
+#endif
+
+
+template<typename Real>
+void CuRand<Real>::RandUniform(CuMatrixBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
     // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
     // so we should not use it to generate random numbers over whole stride.
-    CuMatrix<float> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
-    // We need even number of `elements', or it crahes!
-    // (possibly touching 1 element after array, into the padding of memory alignment),
-    size_t tmp_elems_even = (1 + (tmp.NumRows()*tmp.Stride() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateUniform(gen_, tmp.Data(), tmp_elems_even));
+    CuMatrix<Real> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
+    CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tmp.Data(), tmp.NumRows() * tmp.Stride()));
     tgt->CopyFromMat(tmp);
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -42,19 +74,13 @@ void CuRand<float>::RandUniform(CuMatrixBase<float> *tgt) {
   }
 }
 
-template<>
-void CuRand<double>::RandUniform(CuMatrixBase<double> *tgt) {
+template<typename Real>
+void CuRand<Real>::RandUniform(CuMatrix<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
-    // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
-    // so we should not use it to generate random numbers over whole stride.
-    CuMatrix<double> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
-    // We need even number of `elements', or it crahes!
-    // (possibly touching 1 element after array, into the padding of memory alignment),
-    size_t tmp_elems_even = (1 + (tmp.NumRows()*tmp.Stride() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateUniformDouble(gen_, tmp.Data(), tmp_elems_even));
-    tgt->CopyFromMat(tmp);
+    // Here we don't need to use 'tmp' matrix,
+    CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tgt->Data(), tgt->NumRows() * tgt->Stride()));
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -63,19 +89,34 @@ void CuRand<double>::RandUniform(CuMatrixBase<double> *tgt) {
   }
 }
 
-template<>
-void CuRand<float>::RandGaussian(CuMatrixBase<float> *tgt) {
+template<typename Real>
+void CuRand<Real>::RandUniform(CuVectorBase<Real> *tgt) {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    Timer tim;
+    CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tgt->Data(), tgt->Dim()));
+    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+  } else
+#endif
+  {
+    tgt->Vec().SetRandUniform();
+  }
+}
+
+template<typename Real>
+void CuRand<Real>::RandGaussian(CuMatrixBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
     // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
     // so we should not use it to generate random numbers over whole stride.
-    CuMatrix<float> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
-    // We need even number of `elements', or it crahes!
-    // (possibly touching 1 element after array, into the padding of memory alignment),
-    size_t tmp_elems_even = (1 + (tmp.NumRows()*tmp.Stride() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateNormal(gen_, tmp.Data(), tmp_elems_even, 0.0, 1.0));
-    tgt->CopyFromMat(tmp);
+    // Also, we ensure to have 'even' number of elements for calling 'curand'
+    // by possibly adding one column. Even number of elements is required by
+    // curandGenerateUniform(), curandGenerateUniformDouble().
+    MatrixIndexT num_cols_even = tgt->NumCols() + (tgt->NumCols() % 2); // + 0 or 1,
+    CuMatrix<Real> tmp(tgt->NumRows(), num_cols_even, kUndefined);
+    CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.NumRows()*tmp.Stride()));
+    tgt->CopyFromMat(tmp.ColRange(0,tgt->NumCols()));
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -84,19 +125,22 @@ void CuRand<float>::RandGaussian(CuMatrixBase<float> *tgt) {
   }
 }
 
-template<>
-void CuRand<double>::RandGaussian(CuMatrixBase<double> *tgt) {
+template<typename Real>
+void CuRand<Real>::RandGaussian(CuMatrix<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
-    // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
-    // so we should not use it to generate random numbers over whole stride.
-    CuMatrix<double> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
-    // We need even number of `elements', or it crahes!
-    // (possibly touching 1 element after array, into the padding of memory alignment),
-    size_t tmp_elems_even = (1 + (tmp.NumRows()*tmp.Stride() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateNormalDouble(gen_, tmp.Data(), tmp_elems_even, 0.0, 1.0));
-    tgt->CopyFromMat(tmp);
+    // Here we don't need to use 'tmp' matrix, if the number of elements is even,
+    MatrixIndexT num_elements = tgt->NumRows() * tgt->Stride();
+    if (0 == (num_elements % 2)) {
+      CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tgt->Data(), num_elements));
+    } else {
+      // We use 'tmp' matrix with one column added, this guarantees 'even' number of elements.
+      MatrixIndexT num_cols_even = tgt->NumCols() + (tgt->NumCols() % 2); // + 0 or 1,
+      CuMatrix<Real> tmp(tgt->NumRows(), num_cols_even, kUndefined);
+      CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.NumRows()*tmp.Stride()));
+      tgt->CopyFromMat(tmp.ColRange(0,tgt->NumCols()));
+    }
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -105,28 +149,23 @@ void CuRand<double>::RandGaussian(CuMatrixBase<double> *tgt) {
   }
 }
 
-template<>
-void CuRand<float>::RandGaussian(CuVectorBase<float> *tgt) {
+template<typename Real>
+void CuRand<Real>::RandGaussian(CuVectorBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
-    MatrixIndexT dim_even = (1 + (tgt->Dim() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateNormal(gen_, tgt->Data(), dim_even, 0.0, 1.0));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
-  } else
-#endif
-  {
-    tgt->Vec().SetRandn();
-  }
-}
-
-template<>
-void CuRand<double>::RandGaussian(CuVectorBase<double> *tgt) {
-#if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
-    MatrixIndexT dim_even = (1 + (tgt->Dim() - 1) / 2) * 2;
-    CU_SAFE_CALL(curandGenerateNormalDouble(gen_, tgt->Data(), dim_even, 0.0, 1.0));
+    // To ensure 'even' number of elements, we use 'tmp' vector of even length.
+    // Even number of elements is required by 'curand' functions:
+    // curandGenerateUniform(), curandGenerateUniformDouble().
+    MatrixIndexT num_elements = tgt->Dim();
+    if (0 == (num_elements % 2)) {
+      CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tgt->Data(), tgt->Dim()));
+    } else {
+      MatrixIndexT dim_even = tgt->Dim() + (tgt->Dim() % 2); // + 0 or 1,
+      CuVector<Real> tmp(dim_even, kUndefined);
+      CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.Dim()));
+      tgt->CopyFromVec(tmp.Range(0,tgt->Dim()));
+    }
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif

--- a/src/cudamatrix/cu-rand.h
+++ b/src/cudamatrix/cu-rand.h
@@ -68,8 +68,11 @@ class CuRand {
 
   /// Fill with uniform [0..1] floats,
   void RandUniform(CuMatrixBase<Real> *tgt);
+  void RandUniform(CuMatrix<Real> *tgt);
+  void RandUniform(CuVectorBase<Real> *tgt);
   /// Fill with Normal random numbers,
   void RandGaussian(CuMatrixBase<Real> *tgt);
+  void RandGaussian(CuMatrix<Real> *tgt);
   void RandGaussian(CuVectorBase<Real> *tgt);
 
   /// align probabilities to discrete 0/1 states (use uniform sampling),

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -255,6 +255,14 @@ void CuVectorBase<Real>::SetRandn() {
   tmp.RandGaussian(this);
 }
 
+template<typename Real>
+void CuVectorBase<Real>::SetRandUniform() {
+  if (dim_ == 0) return;
+  CuRand<Real> tmp;
+  tmp.RandUniform(this);
+}
+
+
 
 template<typename Real>
 Real CuVectorBase<Real>::Sum() const {

--- a/src/cudamatrix/cu-vector.h
+++ b/src/cudamatrix/cu-vector.h
@@ -125,7 +125,9 @@ class CuVectorBase {
   MatrixIndexT ApplyCeiling(Real ceiling_val);
   void ApplyPow(Real power);
   Real Sum() const;
+
   void SetRandn();
+  void SetRandUniform();
 
   CuSubVector<Real> Range(const MatrixIndexT o, const MatrixIndexT l) {
     return CuSubVector<Real>(*this, o, l);

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -307,6 +307,14 @@ void VectorBase<Real>::SetRandn() {
 }
 
 template<typename Real>
+void VectorBase<Real>::SetRandUniform() {
+  kaldi::RandomState rstate;
+  for (MatrixIndexT i = 0; i < Dim(); i++) {
+    *(data_+i) = RandUniform(&rstate);
+  }
+}
+
+template<typename Real>
 MatrixIndexT VectorBase<Real>::RandCategorical() const {
   kaldi::RandomState rstate;
   Real sum = this->Sum();

--- a/src/matrix/kaldi-vector.h
+++ b/src/matrix/kaldi-vector.h
@@ -50,6 +50,9 @@ class VectorBase {
   /// Set vector to random normally-distributed noise.
   void SetRandn();
 
+  /// Sets to numbers uniformly distributed on (0,1)
+  void SetRandUniform();
+
   /// This function returns a random index into this vector,
   /// chosen with probability proportional to the corresponding
   /// element.  Requires that this->Min() >= 0 and this->Sum() > 0.


### PR DESCRIPTION
added VectorBase::SetRandUniform(), CuVectorBase::SetRandUniform(), 

cudamatrix,curand: added wrapper template functions for 'curand' calls
to support both float and double by 1 function

cudamatrix,curand: refactored the code
- in 'SetRandn' the 'even' number of elements is done by appending a column to a matrix,
- optimized the code for cases solvable without 'tmp' matrix,
- updated the unit test, testing both with CuMatrix and CuMatrixBase,
  testing with various column number.

The unit tests in src/{cudamatrix,chain} and src/nnet{ ,2,3} passed OK...

Also the RBMs are training normally, but it would be wise to test it on some other task, before the merge is done (with dropout or similar).