### PR TITLE
fixing openfstwin patch for compat.h (Windows build)

### DIFF
--- a/tools/extras/openfstwin-1.3.4.patch
+++ b/tools/extras/openfstwin-1.3.4.patch
@@ -2,16 +2,6 @@ diff --git a/src/include/fst/compat.h b/src/include/fst/compat.h
 index 00e2dba..ff8bacc 100644
 --- a/src/include/fst/compat.h
 +++ b/src/include/fst/compat.h
-@@ -23,7 +23,9 @@
- #ifdef _MSC_VER //AddedPD
- #include <BaseTsd.h>
- typedef SSIZE_T ssize_t;
-+#if _MSC_VER < 1900 //AddedYT -- Visual Studio 2016 already has snprintf
- #define snprintf _snprintf
-+#endif  // _MSC_VER < 1900
- #define strtoll _strtoi64
- #ifndef OPENFSTEXPORT
- 	#ifdef _DEBUG
 @@ -37,7 +39,7 @@ typedef SSIZE_T ssize_t;
  		  #pragma comment (lib, "openfst64.lib")
      #else


### PR DESCRIPTION
Source `compat.h` already contains checking of `_MSC_VER < 1900` and consequently it is not possible to apply the patch.