### PR TITLE
[src]: Add function to freeze natural gradient [to be used in adversa…

### DIFF
--- a/src/nnet2/nnet-precondition-online.cc
+++ b/src/nnet2/nnet-precondition-online.cc
@@ -607,6 +607,7 @@ OnlinePreconditioner& OnlinePreconditioner::operator = (
   update_period_ = other.update_period_;
   num_samples_history_ = other.num_samples_history_;
   alpha_ = other.alpha_;
+  delta_ = other.delta_;
   epsilon_ = other.epsilon_;
   t_ = other.t_;
   self_debug_ = other.self_debug_;

--- a/src/nnet3/natural-gradient-online.cc
+++ b/src/nnet3/natural-gradient-online.cc
@@ -142,6 +142,8 @@ void OnlineNaturalGradient::Init(const CuMatrixBase<BaseFloat> &R0) {
   else
     num_init_iters = 3;
 
+  this_copy.frozen_ = false;   // un-freeze if it was frozen, so we can
+                               // initialize.
   for (int32 i = 0; i < num_init_iters; i++) {
     BaseFloat scale;
     R0_copy.CopyFromMat(R0);

--- a/src/nnet3/natural-gradient-online.cc
+++ b/src/nnet3/natural-gradient-online.cc
@@ -25,7 +25,7 @@ namespace nnet3 {
 
 OnlineNaturalGradient::OnlineNaturalGradient():
     rank_(40), update_period_(1), num_samples_history_(2000.0), alpha_(4.0),
-    epsilon_(1.0e-10), delta_(5.0e-04), t_(-1),
+    epsilon_(1.0e-10), delta_(5.0e-04), frozen_(false), t_(-1),
     num_updates_skipped_(0), self_debug_(false) { }
 
 
@@ -344,10 +344,23 @@ void OnlineNaturalGradient::PreconditionDirectionsInternal(
 
   bool locked = update_mutex_.TryLock();
   if (locked) {
-    // Just hard-code it here that we do 10 updates before skipping any.
+    // We'll release the lock if we don't plan to update the parameters.
+
+    // Explanation of the conditions below:
+    // if (frozen_) because we don't do the update is the user called Freeze().
+    // I forget why the (t_ > t) is here; probably some race condition encountered
+    //   a long time ago.  Not important; nnet3 doesn't use multiple threads anyway.
+    // The condition:
+    // (num_updates_skipped_ < update_period_ - 1 && t_ >= num_initial_updates)
+    // means we can update if either we're in the first 10 updates (e.g. first
+    // 10 minibatches), or if we've skipped 'update_period_ - 1' batches of data
+    // without updating the parameters (this allows us to update only, say,
+    // every 4 times, for speed, after updating the first 10 times).
+
+    // Just hard-code it here that we do 10 initial updates before skipping any.
     const int num_initial_updates = 10;
-    if (t_ > t || (num_updates_skipped_ < update_period_ - 1 &&
-                   t_ >= num_initial_updates)) {
+    if (frozen_ || t_ > t || (num_updates_skipped_ < update_period_ - 1 &&
+                              t_ >= num_initial_updates)) {
       update_mutex_.Unlock();
       // We got the lock but we were already beaten to it by another thread, or
       // we don't want to update yet due to update_period_ > 1 (this saves
@@ -362,11 +375,12 @@ void OnlineNaturalGradient::PreconditionDirectionsInternal(
     // the same or later starting point (making our update stale), or because
     // update_period_ > 1.  We just apply the preconditioning and return.
 
-    // note: we don't bother with any locks before incrementing
+    // note: we don't bother with any locks before checking frozen_ or incrementing
     // num_updates_skipped_ below, because the worst that could happen is that,
     // on very rare occasions, we could skip one or two more updates than we
     // intended.
-    num_updates_skipped_++;
+    if (!frozen_)
+      num_updates_skipped_++;
 
     BaseFloat tr_Xt_XtT = TraceMatMat(*X_t, *X_t, kTrans);
     // X_hat_t = X_t - H_t W_t
@@ -614,6 +628,7 @@ OnlineNaturalGradient::OnlineNaturalGradient(const OnlineNaturalGradient &other)
     rank_(other.rank_), update_period_(other.update_period_),
     num_samples_history_(other.num_samples_history_),
     alpha_(other.alpha_), epsilon_(other.epsilon_), delta_(other.delta_),
+    frozen_(other.frozen_),
     t_(other.t_), num_updates_skipped_(other.num_updates_skipped_),
     self_debug_(other.self_debug_), W_t_(other.W_t_),
     rho_t_(other.rho_t_), d_t_(other.d_t_) {
@@ -627,6 +642,7 @@ OnlineNaturalGradient& OnlineNaturalGradient::operator = (
   num_samples_history_ = other.num_samples_history_;
   alpha_ = other.alpha_;
   epsilon_ = other.epsilon_;
+  delta_ = other.delta_;
   t_ = other.t_;
   self_debug_ = other.self_debug_;
   W_t_ = other.W_t_;

--- a/src/nnet3/natural-gradient-online.h
+++ b/src/nnet3/natural-gradient-online.h
@@ -425,6 +425,9 @@ class OnlineNaturalGradient {
   int32 GetRank() const { return rank_; }
   int32 GetUpdatePeriod() const { return update_period_; }
 
+  // see comment where 'frozen_' is declared.
+  inline void Freeze(bool frozen) { frozen_ = frozen; }
+
   // The "R" pointer is both the input (R in the comment) and the output (P in
   // the comment; equal to the preconditioned directions before scaling by
   // gamma).  If the pointer "row_prod" is supplied, it's set to the inner product
@@ -541,6 +544,14 @@ class OnlineNaturalGradient {
   // value of D_t.  It's needed to control roundoff error.  We apply the same
   // floor to the eigenvalues in D_t.
   BaseFloat delta_;
+
+  // this is set to true if the user has called the function Freeze(true), until
+  // they call  Freeze(false).  It's used to disable the natural gradient
+  // update (and stop incrementing t_).  However, if the object is uninitialized
+  // (t_ == 0) it doesn't prevent it from being initialized.  This is used
+  // in adversarial training to ensure that the Fisher matrix is updated only
+  // the *second* time we see the same data (to avoid biasing the update).
+  bool frozen_;
 
   // t is a counter that measures how many updates we've done.
   int32 t_;


### PR DESCRIPTION
…rial training]; minor bugfix.

@freewym, this is for you to merge with your adversarial training setup.
You can declare a function
`virtual void UpdatableComponent::FreezeNaturalGradient(bool freeze) { }`
and then override it to call `Freeze(freeze)` on all the objects of type OnlineNaturalGradient,
where applicable.  Don't forget CompositeComponent.  And you'd declare in nnet-utils.h:

`void FreezeNaturalGradient(bool freeze, Nnet *nnet);`

This will enable us to have control (in a non-hacky way) over when the NG is updated in the adversarial training.  E.g. you'd do:
```
FreezeNaturalGradient(true, delta_nnet_);
[do the adversarial step here.]
FreezeNaturalGradient(false, delta_nnet_);
```
