### PR TITLE
learn_lexicon.sh: few more minor fixes

### DIFF
--- a/egs/wsj/s5/steps/dict/learn_lexicon.sh
+++ b/egs/wsj/s5/steps/dict/learn_lexicon.sh
@@ -43,7 +43,7 @@ prior_counts_tot=15
 prior_mean="0.7,0.2,0.1"
 num_gauss=
 num_leaves=
-retrain_src_mdl=true
+retrain_src_mdl=false
 
 cleanup=true
 # End configuration section.  
@@ -251,7 +251,7 @@ if [ $stage -le 2 ]; then
     cat - $dir/non_scored_entries | \
     sort | uniq > $dir/dict_expanded_train/lexicon.txt || exit 1;
   
-  utils/prepare_lang.sh $dir/dict_expanded_train "$oov_symbol" \
+  utils/prepare_lang.sh --phone-symbol-table $ref_lang/phones.txt $dir/dict_expanded_train "$oov_symbol" \
     $dir/lang_expanded_train_tmp $dir/lang_expanded_train || exit 1;
 fi
 


### PR DESCRIPTION
Sorry, a few more bugs

The help message states retrain_src_mdl=false by default, but it is not. It could be the other way around (modify help message), but seems like "false" was planned as the default behavior according to the parameter passed explicitly in kaldi/egs/tedlium/s5_r2/local/run_learn_lex.sh

Second fix is just to make sure the script does not crash due to a different phone map