### PR TITLE
change --frame argument

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
@@ -71,7 +71,7 @@ def train_new_models(dir, iter, srand, num_jobs,
         archive_index = (k % num_archives) + 1
 
         if not chunk_level_training:
-            frame = (k / num_archives) % frames_per_eg
+            frame = (k / num_archives + archive_index) % frames_per_eg
 
         cache_write_opt = ""
         if job == 1:


### PR DESCRIPTION
@danpovey 
Related to #1370 . Attention, this is in "shortcut" branch, not "master" branch.

Hi Dan,
1. Following you interpretation, I change the code about how to compute the --frame option.
2. I rewrite the tedlium/s5_r2/local/nnet3/run_tdnn.sh so that it will call steps/nnet3/train_dnn.py to train the model. The annotation (line 78-88) is the original shell version. The code (line 90-130) is what I converted.
3. The WER result is followed:
                                 |   after-change  |    ori
decode-dev              |          11.7         |  12.6
decode_dev_rescore |         10.9          |  11.5
decode_test              |         11.8          |  11.9
decode_test_rescore |         11.2          |  10.9
(The result in "ori" column is extracted from "RESULT" file in tedlium/s5_r2)

Hang