### PR TITLE
[scripts]: Fix syntax error in validate_lang.pl

### DIFF
--- a/egs/wsj/s5/utils/validate_lang.pl
+++ b/egs/wsj/s5/utils/validate_lang.pl
@@ -760,6 +760,8 @@ if (-s "$lang/phones/word_boundary.int") {
       if (! defined $is_disambig{$phone}) {
         if ($phone == "<<eos>>") {
           $state = "eos";
+        } elsif ($phone == 0) {
+          $exit = 1; print "--> ERROR: unexpected phone sequence=$phoneseq, wordseq=$wordseq\n"; last;
         } else {
           $state = $wbtype{$phone};
         }


### PR DESCRIPTION
Fixes de8d03dd6450a0b93ad3e907f007b022cc905766