### PR TITLE
Bump Travis clang to v3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.8
+      - llvm-toolchain-precise-3.9
     packages:
       - gdb
       - gcc-4.9
       - g++-4.9
       - gfortran-4.9
       - liblapack-dev
-      - clang-3.8
+      - clang-3.9
 
 branches:
   only:
@@ -30,7 +30,7 @@ before_install:
   - tools/extras/travis_install_bindeps.sh $XROOT
 
 script:
-  - CXX=clang++-3.8
+  - CXX=clang++-3.9
     CFLAGS="-march=native"
     LDFLAGS="-llapack"
     INCDIRS="$XROOT/usr/include"

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -4,7 +4,7 @@
 # Typical usage shown below; any one can be safely left unset.
 #   INCDIRS="~/xroot/usr/include"
 #   LIBDIRS="~/xroot/usr/lib /usr/lib/openblas-base"
-#   CXX=clang++-3.8
+#   CXX=clang++-3.9
 #   CFLAGS="-march=native -O2"
 #   LDFLAGS="-llapack"
 

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -46,6 +46,7 @@ then
   exit 0;
 fi
 
+
 # Prepare environment variables
 CF="\"$CFLAGS -g $(addsw -I $INCDIRS)\""
 LDF="\"$LDFLAGS $(addsw -L $LIBDIRS)\""

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -46,7 +46,6 @@ then
   exit 0;
 fi
 
-
 # Prepare environment variables
 CF="\"$CFLAGS -g $(addsw -I $INCDIRS)\""
 LDF="\"$LDFLAGS $(addsw -L $LIBDIRS)\""


### PR DESCRIPTION
@danpovey I noticed I didn't try clang-3.9 after figuring out how to build with clang-3.8. I initially had trouble with clang-3.9 on Travis Ubuntu 12.04 VE but that was before I made the changes to get clang-3.8 working. Let's see if we can build with clang-3.9. 