### PR TITLE
prevent function returning false in case reco2file_and_channel does n…

### DIFF
--- a/egs/wsj/s5/utils/fix_data_dir.sh
+++ b/egs/wsj/s5/utils/fix_data_dir.sh
@@ -92,7 +92,7 @@ function filter_recordings {
 
     filter_file $tmpdir/recordings $data/wav.scp
     [ -f $data/reco2file_and_channel ] && filter_file $tmpdir/recordings $data/reco2file_and_channel
-
+    true
   fi
 }
 


### PR DESCRIPTION
…ot exist

from http://www.linuxjournal.com/content/return-values-bash-functions
```
 If a function does not contain a return statement, its status is set based on the status of the last statement executed in the function. 
```

in case when $data/reco2file_and_channel does not exist, the $? will be false (as it will not be reset by any command afterwards).
that causes one of the signals (EXIT?) we trap to be triggered (as the script sets -e )