### PR TITLE
Fix some issues for compiling kaldi for Android

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -1097,7 +1097,7 @@ if $android ; then
   OPENBLASLIBS="$OPENBLASROOT/lib/libopenblas.a $OPENBLASROOT/lib/libclapack.a $OPENBLASROOT/lib/liblapack.a $OPENBLASROOT/lib/libblas.a $OPENBLASROOT/lib/libf2c.a"
   echo "OPENBLASINC = $OPENBLASROOT/include" >> kaldi.mk
   echo "OPENBLASLIBS = $OPENBLASLIBS" >> kaldi.mk
-  echo "ANDROIDINCDIR = $ANDROIDINCDIR" >> kaldi.mk
+  echo "ANDROIDINC = $ANDROIDINCDIR" >> kaldi.mk
 
   cat makefiles/android_openblas.mk >> kaldi.mk
 

--- a/src/makefiles/android_openblas.mk
+++ b/src/makefiles/android_openblas.mk
@@ -29,7 +29,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self -Wno-mismatched-tags \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
-           -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -DANDROID_BUILD \
+           -DHAVE_CXXABI_H -DHAVE_OPENBLAS -DANDROID_BUILD \
            -I$(OPENBLASINC) -I$(ANDROIDINC) -ftree-vectorize -mfloat-abi=hard \
            -mfpu=neon -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -pthread \
            -g # -O0 -DKALDI_PARANOID


### PR DESCRIPTION
After running ./configure in src folder, kaldi.mk is created with some problems.

1. The variable ANDROIDINCDIR is defined, but ANDROIDINC is used.
2. It seems that execinfo.h, which is included at base/kaldi-error.cc is not supported.

This commit treats these issues.

P.S. If you want to repeat all the steps for cross-compiling to Android, please follow the instructions published at http://jcsilva.github.io/2017/03/18/compile-kaldi-android/