### PR TITLE
Unexpected behaviour of ConvertStringToReal in Android

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -145,13 +145,4 @@ template<> class KaldiCompileTimeAssert<true> {
 #  define KALDI_STRTOLL(cur_cstr, end_cstr) strtoll(cur_cstr, end_cstr, 10);
 #endif
 
-#define KALDI_STRTOD(cur_cstr, end_cstr) strtod(cur_cstr, end_cstr)
-
-#ifdef _MSC_VER
-#  define KALDI_STRTOF(cur_cstr, end_cstr) \
-    static_cast<float>(strtod(cur_cstr, end_cstr));
-#else
-#  define KALDI_STRTOF(cur_cstr, end_cstr) strtof(cur_cstr, end_cstr);
-#endif
-
 #endif  // KALDI_BASE_KALDI_UTILS_H_

--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -145,4 +145,13 @@ template<> class KaldiCompileTimeAssert<true> {
 #  define KALDI_STRTOLL(cur_cstr, end_cstr) strtoll(cur_cstr, end_cstr, 10);
 #endif
 
+#define KALDI_STRTOD(cur_cstr, end_cstr) strtod(cur_cstr, end_cstr)
+
+#ifdef _MSC_VER
+#  define KALDI_STRTOF(cur_cstr, end_cstr) \
+    static_cast<float>(strtod(cur_cstr, end_cstr));
+#else
+#  define KALDI_STRTOF(cur_cstr, end_cstr) strtof(cur_cstr, end_cstr);
+#endif
+
 #endif  // KALDI_BASE_KALDI_UTILS_H_

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -186,10 +186,12 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE inf", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEinf", &d));
   KALDI_ASSERT(!ConvertStringToReal("infGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("inf_GARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("inf GARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE infinity", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEinfinity", &d));
   KALDI_ASSERT(!ConvertStringToReal("infinityGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("infinity_GARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("infinity GARBAGE", &d));
   KALDI_ASSERT(ConvertStringToReal("1.#INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("-1.#INF", &d) && d < 0 && d - d != 0);
@@ -218,6 +220,7 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE nan", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEnan", &d));
   KALDI_ASSERT(!ConvertStringToReal("nanGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("nan_GARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("nan GARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE 1.#QNAN", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE1.#QNAN", &d));

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -243,11 +243,16 @@ void TestNan() {
 template<class Real>
 void TestInf() {
   Real d;
-  std::ostringstream strs;
-  strs << exp(10000);
-  std::string s = strs.str();
+  std::ostringstream pos_strs;
+  pos_strs << exp(10000);
+  std::string pos = pos_strs.str();
 
-  KALDI_ASSERT(ConvertStringToReal(s, &d) && d > 0 && d - d != 0);
+  std::ostringstream neg_strs;
+  neg_strs << -exp(10000);
+  std::string neg = neg_strs.str();
+
+  KALDI_ASSERT(ConvertStringToReal(pos, &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(neg, &d) && d < 0 && d - d != 0);
 }
 
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -178,6 +178,10 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(ConvertStringToReal("Inf", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("InF", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("infinity", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("-infinity", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("1.#INF", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("-1.#INF", &d) && d < 0 && d - d != 0);
 
   KALDI_ASSERT(ConvertStringToReal("nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("+nan", &d) && d != d);
@@ -185,6 +189,8 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(ConvertStringToReal("Nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NAN", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NaN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("1.#QNAN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("-1.#QNAN", &d) && d != d);
 }
 
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -173,47 +173,58 @@ void TestConvertStringToReal() {
 
   // it also works for inf or nan.
   KALDI_ASSERT(ConvertStringToReal("inf", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(" inf", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("inf ", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(" inf ", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("+inf", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("-inf", &d) && d < 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("Inf", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("InF", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("infinity", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("-infinity", &d) && d < 0 && d - d != 0);
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE inf", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEinf", &d));
   KALDI_ASSERT(!ConvertStringToReal("infGARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("inf GARBAGE", &d));
-  KALDI_ASSERT(ConvertStringToReal("infinity", &d) && d > 0 && d - d != 0);
-  KALDI_ASSERT(ConvertStringToReal("-infinity", &d) && d < 0 && d - d != 0);
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE infinity", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEinfinity", &d));
   KALDI_ASSERT(!ConvertStringToReal("infinityGARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("infinity GARBAGE", &d));
   KALDI_ASSERT(ConvertStringToReal("1.#INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("-1.#INF", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("-1.#INF  ", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(" -1.#INF ", &d) && d < 0 && d - d != 0);
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE 1.#INF", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE1.#INF", &d));
   KALDI_ASSERT(!ConvertStringToReal("2.#INF", &d));
   KALDI_ASSERT(!ConvertStringToReal("-2.#INF", &d));
-  KALDI_ASSERT(ConvertStringToReal("1.#INF_GARBAGE", &d) && d > 0 && d - d != 0);  // MSVC
+  KALDI_ASSERT(!ConvertStringToReal("1.#INFGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("1.#INF_GARBAGE", &d));
 
   KALDI_ASSERT(ConvertStringToReal("nan", &d) && d != d);
-  KALDI_ASSERT(!ConvertStringToReal("nan_", &d));
   KALDI_ASSERT(ConvertStringToReal("+nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("-nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("Nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NAN", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NaN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal(" NaN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("NaN ", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal(" NaN ", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("1.#QNAN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("-1.#QNAN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("1.#QNAN  ", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal(" 1.#QNAN ", &d) && d != d);
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE nan", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGEnan", &d));
   KALDI_ASSERT(!ConvertStringToReal("nanGARBAGE", &d));
   KALDI_ASSERT(!ConvertStringToReal("nan GARBAGE", &d));
-  KALDI_ASSERT(ConvertStringToReal("1.#QNAN", &d) && d != d);
-  KALDI_ASSERT(ConvertStringToReal("-1.#QNAN", &d) && d != d);
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE 1.#QNAN", &d));
   KALDI_ASSERT(!ConvertStringToReal("GARBAGE1.#QNAN", &d));
   KALDI_ASSERT(!ConvertStringToReal("2.#QNAN", &d));
   KALDI_ASSERT(!ConvertStringToReal("-2.#QNAN", &d));
-  KALDI_ASSERT(ConvertStringToReal("-1.#QNAN_GARBAGE", &d) && d != d);  // MSVC
+  KALDI_ASSERT(!ConvertStringToReal("-1.#QNAN_GARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("-1.#QNANGARBAGE", &d));
 }
 
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -173,7 +173,18 @@ void TestConvertStringToReal() {
 
   // it also works for inf or nan.
   KALDI_ASSERT(ConvertStringToReal("inf", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("+inf", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("-inf", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("Inf", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("INF", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal("InF", &d) && d > 0 && d - d != 0);
+
   KALDI_ASSERT(ConvertStringToReal("nan", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("+nan", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("-nan", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("Nan", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("NAN", &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal("NaN", &d) && d != d);
 }
 
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -230,6 +230,26 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(!ConvertStringToReal("-1.#QNANGARBAGE", &d));
 }
 
+template<class Real>
+void TestNan() {
+  Real d;
+  std::ostringstream strs;
+  strs << sqrt(-1);
+  std::string s = strs.str();
+
+  KALDI_ASSERT(ConvertStringToReal(s, &d) && d != d);
+}
+
+template<class Real>
+void TestInf() {
+  Real d;
+  std::ostringstream strs;
+  strs << 1.0/0.0;
+  std::string s = strs.str();
+
+  KALDI_ASSERT(ConvertStringToReal(s, &d) && d > 0 && d - d != 0);
+}
+
 
 std::string TrimTmp(std::string s) {
   Trim(&s);
@@ -306,6 +326,10 @@ int main() {
   TestSplitStringOnFirstSpace();
   TestIsToken();
   TestIsLine();
+  TestNan<float>();
+  TestNan<double>();
+  TestInf<float>();
+  TestInf<double>();
   std::cout << "Test OK\n";
 }
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -244,7 +244,7 @@ template<class Real>
 void TestInf() {
   Real d;
   std::ostringstream strs;
-  strs << 1.0/0.0;
+  strs << exp(10000);
   std::string s = strs.str();
 
   KALDI_ASSERT(ConvertStringToReal(s, &d) && d > 0 && d - d != 0);

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -233,26 +233,16 @@ void TestConvertStringToReal() {
 template<class Real>
 void TestNan() {
   Real d;
-  std::ostringstream strs;
-  strs << sqrt(-1);
-  std::string s = strs.str();
-
-  KALDI_ASSERT(ConvertStringToReal(s, &d) && d != d);
+  KALDI_ASSERT(ConvertStringToReal(std::to_string(sqrt(-1)), &d) && d != d);
 }
 
 template<class Real>
 void TestInf() {
   Real d;
-  std::ostringstream pos_strs;
-  pos_strs << exp(10000);
-  std::string pos = pos_strs.str();
-
-  std::ostringstream neg_strs;
-  neg_strs << -exp(10000);
-  std::string neg = neg_strs.str();
-
-  KALDI_ASSERT(ConvertStringToReal(pos, &d) && d > 0 && d - d != 0);
-  KALDI_ASSERT(ConvertStringToReal(neg, &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(std::to_string(exp(10000)), &d) &&
+               d > 0 && d - d != 0);
+  KALDI_ASSERT(ConvertStringToReal(std::to_string(-exp(10000)), &d) &&
+               d < 0 && d - d != 0);
 }
 
 

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -178,19 +178,42 @@ void TestConvertStringToReal() {
   KALDI_ASSERT(ConvertStringToReal("Inf", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("InF", &d) && d > 0 && d - d != 0);
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE inf", &d));
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGEinf", &d));
+  KALDI_ASSERT(!ConvertStringToReal("infGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("inf GARBAGE", &d));
   KALDI_ASSERT(ConvertStringToReal("infinity", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("-infinity", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE infinity", &d));
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGEinfinity", &d));
+  KALDI_ASSERT(!ConvertStringToReal("infinityGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("infinity GARBAGE", &d));
   KALDI_ASSERT(ConvertStringToReal("1.#INF", &d) && d > 0 && d - d != 0);
   KALDI_ASSERT(ConvertStringToReal("-1.#INF", &d) && d < 0 && d - d != 0);
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE 1.#INF", &d));
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE1.#INF", &d));
+  KALDI_ASSERT(!ConvertStringToReal("2.#INF", &d));
+  KALDI_ASSERT(!ConvertStringToReal("-2.#INF", &d));
+  KALDI_ASSERT(ConvertStringToReal("1.#INF_GARBAGE", &d) && d > 0 && d - d != 0);  // MSVC
 
   KALDI_ASSERT(ConvertStringToReal("nan", &d) && d != d);
+  KALDI_ASSERT(!ConvertStringToReal("nan_", &d));
   KALDI_ASSERT(ConvertStringToReal("+nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("-nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("Nan", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NAN", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("NaN", &d) && d != d);
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE nan", &d));
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGEnan", &d));
+  KALDI_ASSERT(!ConvertStringToReal("nanGARBAGE", &d));
+  KALDI_ASSERT(!ConvertStringToReal("nan GARBAGE", &d));
   KALDI_ASSERT(ConvertStringToReal("1.#QNAN", &d) && d != d);
   KALDI_ASSERT(ConvertStringToReal("-1.#QNAN", &d) && d != d);
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE 1.#QNAN", &d));
+  KALDI_ASSERT(!ConvertStringToReal("GARBAGE1.#QNAN", &d));
+  KALDI_ASSERT(!ConvertStringToReal("2.#QNAN", &d));
+  KALDI_ASSERT(!ConvertStringToReal("-2.#QNAN", &d));
+  KALDI_ASSERT(ConvertStringToReal("-1.#QNAN_GARBAGE", &d) && d != d);  // MSVC
 }
 
 

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -162,11 +162,6 @@ bool IsLine(const std::string &line) {
   return true;
 }
 
-
-inline bool starts_with(const std::string &in, const std::string &prefix) {
-  return in.substr(0, prefix.size()) == prefix;
-}
-
 template <class T>
 class NumberIstream{
  public:
@@ -220,19 +215,16 @@ class NumberIstream{
     inf_nan_map["NAN"] = std::numeric_limits<T>::quiet_NaN();
     inf_nan_map["+NAN"] = std::numeric_limits<T>::quiet_NaN();
     inf_nan_map["-NAN"] = - std::numeric_limits<T>::quiet_NaN();
+    // MSVC
+    inf_nan_map["1.#INF"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["-1.#INF"] = - std::numeric_limits<T>::infinity();;
+    inf_nan_map["1.#QNAN"] = std::numeric_limits<T>::quiet_NaN();
+    inf_nan_map["-1.#QNAN"] = - std::numeric_limits<T>::quiet_NaN();
 
     std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 
     if (inf_nan_map.find(str) != inf_nan_map.end()) {
       *x = inf_nan_map[str];
-    } else if (starts_with(str, "1.#INF")) {  // MSVC
-      *x = std::numeric_limits<T>::infinity();
-    } else if (starts_with(str, "-1.#INF")) {  // MSVC
-      *x = - std::numeric_limits<T>::infinity();
-    } else if (starts_with(str, "1.#QNAN")) {  // MSVC
-      *x = std::numeric_limits<T>::quiet_NaN();
-    } else if (starts_with(str, "-1.#QNAN")) {  // MSVC
-      *x = - std::numeric_limits<T>::quiet_NaN();
     } else {
       in_.setstate(std::ios_base::failbit);
     }

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -19,8 +19,6 @@
 
 #include "util/text-utils.h"
 #include <limits>
-#include <map>
-#include <algorithm>
 #include "base/kaldi-common.h"
 
 namespace kaldi {
@@ -190,89 +188,58 @@ inline bool is_nan_text(const std::string &in, const std::string &prefix) {
   return true;
 }
 
-template <class T>
-class number_istream{
- public:
-  explicit number_istream(std::istream &i) : in_(i) {}
-
-  number_istream & operator >> (T &x) {
-    bool neg = false;
-    if (!in_.good()) return *this;
-    in_ >> std::ws;  // eat up any leading white spaces
-    if (in_.peek() == '-') { neg = true; }
-    in_ >> x;
-    if (!in_.fail()) return *this;
-    return parse_on_fail(&x, neg);
+template<typename T>
+bool convert_special_number(const std::string &str, T *out) {
+  if (stricmp(str, "infinity") || stricmp(str, "inf") ||
+      stricmp(str, "+infinity") || stricmp(str, "+inf") ||
+      starts_with(str, "1.#INF")) {
+    *out = std::numeric_limits<T>::infinity();
+    return true;
+  } else if (stricmp(str, "-infinity") || stricmp(str, "-inf") ||
+             starts_with(str, "-1.#INF")) {
+    *out = -std::numeric_limits<T>::infinity();
+    return true;
+  } else if (is_nan_text(str, "nan") || is_nan_text(str, "+nan") ||
+             starts_with(str, "1.#QNAN")) {
+    *out = std::numeric_limits<T>::quiet_NaN();
+    return true;
+  } else if (is_nan_text(str, "-nan") || starts_with(str, "-1.#QNAN")) {
+    *out = -std::numeric_limits<T>::quiet_NaN();
+    return true;
   }
-
- private:
-  std::istream &in_;
-
-  number_istream & parse_on_fail(T *x, bool neg) {
-    std::map<std::string, T> inf_nan_map;
-    // we'll keep just lowercase values.
-    inf_nan_map["inf"] = std::numeric_limits<T>::infinity();
-    inf_nan_map["infinity"] = std::numeric_limits<T>::infinity();
-    inf_nan_map["nan"] = std::numeric_limits<T>::quiet_NaN();
-
-    std::string c;
-    in_.clear();
-    // If the stream is broken even before trying
-    // to read from it, it's pointless to try.
-    if (!(in_ >> c)) return *this;
-
-    // transform c to lowercase.
-    std::transform(c.begin(), c.end(), c.begin(), ::tolower);
-
-    if (inf_nan_map.find(c) != inf_nan_map.end()) {
-      *x = inf_nan_map[c];
-      if (neg) *x = - *x;
-    } else {
-      in_.setstate(std::ios_base::failbit);
-    }
-
-    return *this;
-  }
-};
-
+  return false;
+}
 
 template <typename T>
 bool ConvertStringToReal(const std::string &str,
                          T *out) {
-  if (starts_with(str, "1.#INF")) {
-    *out = std::numeric_limits<T>::infinity();
-    return true;
-  } else if (starts_with(str, "-1.#INF")) {
-    *out = -std::numeric_limits<T>::infinity();
-    return true;
-  } else if (starts_with(str, "1.#QNAN")) {
-    *out = std::numeric_limits<T>::quiet_NaN();
-    return true;
-  } else if (starts_with(str, "-1.#QNAN")) {
-    *out = -std::numeric_limits<T>::quiet_NaN();
+  // remove initial and final spaces
+  std::string trimmed_str = str;
+  Trim(&trimmed_str);
+
+  // if trimmed_str has more than one token,
+  // we will not try to convert it.
+  if (!IsToken(trimmed_str)) {
+    return false;
+  }
+
+  // deals with nan and inf
+  if (convert_special_number(trimmed_str, out)) {
     return true;
   }
 
-  std::stringstream iss(str);
+  std::istringstream iss(trimmed_str);
 
-  number_istream<T> i(iss);
-
-  i >> *out;
-
-  if (iss.fail()) {
+  if (!(iss >> *out)) {
     // Number conversion failed.
     return false;
   }
 
-  // if istringstream was successfully converted to a number, we
-  // need to garantee that there is not any other token in str
+  // if there was a letter appended to the number,
+  // the number was converted, but the letter stayed
+  // in the stream. We should say the conversion failed
   if (iss.tellg() != -1) {
-    std::string rem;
-    iss >> rem;
-    if (rem.find_first_not_of(' ') != std::string::npos) {
-      // there is not only spaces
-      return false;
-    }
+    return false;
   }
 
   return true;

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -195,40 +195,40 @@ class number_istream
 {
  public:
 
-  number_istream (std::istream &i) : in(i) {}
+  number_istream (std::istream &i) : in_(i) {}
 
   number_istream & operator >> (T &x) {
     bool neg = false;
     char c;
-    if (!in.good()) return *this;
-    while (isspace(c = in.peek())) in.get();
+    if (!in_.good()) return *this;
+    while (isspace(c = in_.peek())) in_.get();
     if (c == '-') { neg = true; }
-    in >> x;
-    if (! in.fail()) return *this;
+    in_ >> x;
+    if (! in_.fail()) return *this;
     return parse_on_fail(x, neg);
   }
 
  private:
-  std::istream &in;
+  std::istream &in_;
 
   number_istream & parse_on_fail (T &x, bool neg)
    {
-    std::map<std::string, T> infNanMap;
+    std::map<std::string, T> inf_nam_map;
     // we'll keep just lowercase values.
-    infNanMap["inf"] = std::numeric_limits<T>::infinity();
-    infNanMap["nan"] = std::numeric_limits<T>::quiet_NaN();
+    inf_nam_map["inf"] = std::numeric_limits<T>::infinity();
+    inf_nam_map["nan"] = std::numeric_limits<T>::quiet_NaN();
 
     std::string c;
-    in.clear();
-    if (!(in >> c)) return *this; //If the stream is broken even before trying to read from it, it's pointless to try.
+    in_.clear();
+    if (!(in_ >> c)) return *this; //If the stream is broken even before trying to read from it, it's pointless to try.
 
     std::transform(c.begin(), c.end(), c.begin(), ::tolower); // transform c to lowercase.
 
-    if(infNanMap.find(c) != infNanMap.end()) {
-      x = infNanMap[c];
+    if(inf_nam_map.find(c) != inf_nam_map.end()) {
+      x = inf_nam_map[c];
       if(neg) x = -x;
     }else{
-      in.setstate(std::ios_base::failbit);
+      in_.setstate(std::ios_base::failbit);
     }
 
     return *this;

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -208,11 +208,9 @@ bool convert_special_number(const std::string &str, T *out) {
   return false;
 }
 
+
 bool ConvertStringToReal(const std::string &str,
                          double *out) {
-  const char *this_str = str.c_str();
-  char *end = NULL;
-  errno = 0;
 
 #if defined(_MSC_VER)
   // TODO: check if the new MSVC already supports it
@@ -221,20 +219,20 @@ bool ConvertStringToReal(const std::string &str,
     return true;
 #endif  // defined(_MSC_VER)
 
-  double d = KALDI_STRTOD(this_str, &end);
-  if (end != this_str)
-    while (isspace(*end)) end++;
-  if (end == this_str || *end != '\0' || errno != 0)
+  // http://stackoverflow.com/questions/3825392/string-to-float-conversion
+  std::istringstream i(str);
+
+  if (!(i >> *out)) {
+    // Number conversion failed
+    *out = 0.0;
     return false;
-  *out = d;
+  }
+
   return true;
 }
 
 bool ConvertStringToReal(const std::string &str,
                          float *out) {
-  const char *this_str = str.c_str();
-  char *end = NULL;
-  errno = 0;
 
 #ifdef _MSC_VER
   // TODO: check if the new MSVC already supports it
@@ -242,13 +240,16 @@ bool ConvertStringToReal(const std::string &str,
   if (convert_special_number(str, out))
     return true;
 #endif  // _MSC_VER
+  
+  // http://stackoverflow.com/questions/3825392/string-to-float-conversion
+  std::istringstream i(str);
 
-  float f = KALDI_STRTOF(this_str, &end);
-  if (end != this_str)
-    while (isspace(*end)) end++;
-  if (end == this_str || *end != '\0' || errno != 0)
+  if (!(i >> *out)) {
+    // Number conversion failed
+    *out = 0.0;
     return false;
-  *out = f;
+  }
+
   return true;
 }
 

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -219,16 +219,29 @@ bool ConvertStringToReal(const std::string &str,
     return true;
 #endif  // defined(_MSC_VER)
 
-  // http://stackoverflow.com/questions/3825392/string-to-float-conversion
   std::istringstream i(str);
 
   if (!(i >> *out)) {
-    // Number conversion failed
-    return false;
+    // Number conversion failed.
+    // I know it's not a numeric value.
+    // These lines are here just do check if str is nan or inf
+    const char *this_str = str.c_str();
+    char *end = NULL;
+    errno = 0;
+
+    double d = KALDI_STRTOD(this_str, &end);
+
+    if (end != this_str)
+      while (isspace(*end)) end++;
+    if (end == this_str || *end != '\0' || errno != 0)
+      return false;
+
+    *out = d;
+    return true;
   }
 
-  // if it is not the end of the stream, we
-  // must check if there is only spaces
+  // if istringstream was successfully converted to a number, we
+  // need to garantee that there is not any other token in str
   if (i.tellg() != -1){
     std::string rem;
     i >> rem;
@@ -254,12 +267,26 @@ bool ConvertStringToReal(const std::string &str,
   std::istringstream i(str);
 
   if (!(i >> *out)) {
-    // Number conversion failed
-    return false;
+    // Number conversion failed.
+    // I know it's not a numeric value.
+    // These lines are here just do check if str is nan or inf
+    const char *this_str = str.c_str();
+    char *end = NULL;
+    errno = 0;
+
+    float d = KALDI_STRTOF(this_str, &end);
+
+    if (end != this_str)
+      while (isspace(*end)) end++;
+    if (end == this_str || *end != '\0' || errno != 0)
+      return false;
+
+    *out = d;
+    return true;
   }
 
-  // if it is not the end of the stream, we
-  // must check if there is only spaces
+  // if istringstream was successfully converted to a number, we
+  // need to garantee that there is not any other token in str
   if (i.tellg() != -1){
     std::string rem;
     i >> rem;

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -212,6 +212,7 @@ class number_istream{
     std::map<std::string, T> inf_nan_map;
     // we'll keep just lowercase values.
     inf_nan_map["inf"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["infinity"] = std::numeric_limits<T>::infinity();
     inf_nan_map["nan"] = std::numeric_limits<T>::quiet_NaN();
 
     std::string c;
@@ -238,6 +239,20 @@ class number_istream{
 template <typename T>
 bool ConvertStringToReal(const std::string &str,
                          T *out) {
+  if (starts_with(str, "1.#INF")) {
+    *out = std::numeric_limits<T>::infinity();
+    return true;
+  } else if (starts_with(str, "-1.#INF")) {
+    *out = -std::numeric_limits<T>::infinity();
+    return true;
+  } else if (starts_with(str, "1.#QNAN")) {
+    *out = std::numeric_limits<T>::quiet_NaN();
+    return true;
+  } else if (starts_with(str, "-1.#QNAN")) {
+    *out = -std::numeric_limits<T>::quiet_NaN();
+    return true;
+  }
+
   std::stringstream iss(str);
 
   number_istream<T> i(iss);

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -224,8 +224,18 @@ bool ConvertStringToReal(const std::string &str,
 
   if (!(i >> *out)) {
     // Number conversion failed
-    *out = 0.0;
     return false;
+  }
+
+  // if it is not the end of the stream, we
+  // must check if there is only spaces
+  if (i.tellg() != -1){
+    std::string rem;
+    i >> rem;
+    if(rem.find_first_not_of(' ') != std::string::npos){
+      // there is not only spaces
+      return false;
+    }
   }
 
   return true;
@@ -240,14 +250,23 @@ bool ConvertStringToReal(const std::string &str,
   if (convert_special_number(str, out))
     return true;
 #endif  // _MSC_VER
-  
-  // http://stackoverflow.com/questions/3825392/string-to-float-conversion
+
   std::istringstream i(str);
 
   if (!(i >> *out)) {
     // Number conversion failed
-    *out = 0.0;
     return false;
+  }
+
+  // if it is not the end of the stream, we
+  // must check if there is only spaces
+  if (i.tellg() != -1){
+    std::string rem;
+    i >> rem;
+    if(rem.find_first_not_of(' ') != std::string::npos){
+      // there is not only spaces
+      return false;
+    }
   }
 
   return true;

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -217,7 +217,7 @@ class NumberIstream{
     inf_nan_map["-NAN"] = - std::numeric_limits<T>::quiet_NaN();
     // MSVC
     inf_nan_map["1.#INF"] = std::numeric_limits<T>::infinity();
-    inf_nan_map["-1.#INF"] = - std::numeric_limits<T>::infinity();;
+    inf_nan_map["-1.#INF"] = - std::numeric_limits<T>::infinity();
     inf_nan_map["1.#QNAN"] = std::numeric_limits<T>::quiet_NaN();
     inf_nan_map["-1.#QNAN"] = - std::numeric_limits<T>::quiet_NaN();
 

--- a/src/util/text-utils.h
+++ b/src/util/text-utils.h
@@ -132,15 +132,13 @@ bool ConvertStringToInteger(const std::string &str,
 }
 
 
-/// ConvertStringToReal converts a string into either float or double via
-/// strtod, and returns false if there was any kind of problem (i.e. the string
-/// was not a floating point number or contained extra non-whitespace junk.
+/// ConvertStringToReal converts a string into either float or double
+/// and returns false if there was any kind of problem (i.e. the string
+/// was not a floating point number or contained extra non-whitespace junk).
 /// Be careful- this function will successfully read inf's or nan's.
+template <typename T>
 bool ConvertStringToReal(const std::string &str,
-                         double *out);
-bool ConvertStringToReal(const std::string &str,
-                         float *out);
-
+                         T *out);
 
 /// Removes the beginning and trailing whitespaces from a string
 void Trim(std::string *str);


### PR DESCRIPTION
ConvertStringToReal was implemented using strtod and strtof. These 2 functions
depend on locale. When trying to run Kaldi in Android, you can't
set locales from native code (https://code.google.com/p/android/issues/detail?id=57313), and these functions have an unexpected behaviour.

This PR uses stringstream for dealing with it. You may see that strtod and strtof is still in the source code. It was necessary because there are two tests that verify if NAN and INF were converted to float and stringstream doesn't handle them.