### PR TITLE
Implement batch normalization at the code level

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
@@ -556,6 +556,14 @@ def combine_models(dir, num_iters, models_to_combine, num_chunk_per_minibatch_st
             print("{0}: warning: model file {1} does not exist "
                   "(final combination)".format(sys.argv[0], model_file))
 
+    # We reverse the order of the raw model strings so that the freshest one
+    # goes first.  This is important for systems that include batch
+    # normalization-- it means that the freshest batch-norm stats are used.
+    # Since the batch-norm stats are not technically parameters, they are not
+    # combined in the combination code, they are just obtained from the first
+    # model.
+    raw_model_strings = list(reversed(raw_model_strings))
+
     common_lib.run_job(
         """{command} {combine_queue_opt} {dir}/log/combine.log \
                 nnet3-chain-combine --num-iters={opt_iters} \

--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
@@ -489,6 +489,15 @@ def combine_models(dir, num_iters, models_to_combine, egs_dir,
     context_opts = "--left-context={lc} --right-context={rc}".format(
         lc=left_context, rc=right_context)
 
+
+    # We reverse the order of the raw model strings so that the freshest one
+    # goes first.  This is important for systems that include batch
+    # normalization-- it means that the freshest batch-norm stats are used.
+    # Since the batch-norm stats are not technically parameters, they are not
+    # combined in the combination code, they are just obtained from the first
+    # model.
+    raw_model_strings = list(reversed(raw_model_strings))
+
     common_lib.run_job(
         """{command} {combine_queue_opt} {dir}/log/combine.log \
                 nnet3-combine --num-iters=80 \

--- a/egs/wsj/s5/steps/libs/nnet3/xconfig/basic_layers.py
+++ b/egs/wsj/s5/steps/libs/nnet3/xconfig/basic_layers.py
@@ -623,7 +623,7 @@ class XconfigBasicLayer(XconfigLayerBase):
         # Here we just list some likely combinations.. you can just add any
         # combinations you want to use, to this list.
         assert first_token in [ 'relu-layer', 'relu-renorm-layer', 'sigmoid-layer',
-                                'tanh-layer' ]
+                                'tanh-layer', 'relu-batchnorm-layer' ]
         XconfigLayerBase.__init__(self, first_token, key_to_value, prev_names)
 
     def set_default_configs(self):
@@ -743,6 +743,13 @@ class XconfigBasicLayer(XconfigLayerBase):
             elif nonlinearity == 'renorm':
                 line = ('component name={0}.{1}'
                         ' type=NormalizeComponent dim={2}'
+                        ' target-rms={3}'
+                        ''.format(self.name, nonlinearity, output_dim,
+                            target_rms))
+
+            elif nonlinearity == 'batchnorm':
+                line = ('component name={0}.{1}'
+                        ' type=BatchNormComponent dim={2}'
                         ' target-rms={3}'
                         ''.format(self.name, nonlinearity, output_dim,
                             target_rms))

--- a/egs/wsj/s5/steps/libs/nnet3/xconfig/parser.py
+++ b/egs/wsj/s5/steps/libs/nnet3/xconfig/parser.py
@@ -20,6 +20,7 @@ config_to_layer = {
         'output-layer' : xlayers.XconfigOutputLayer,
         'relu-layer' : xlayers.XconfigBasicLayer,
         'relu-renorm-layer' : xlayers.XconfigBasicLayer,
+        'relu-batchnorm-layer' : xlayers.XconfigBasicLayer,
         'sigmoid-layer' : xlayers.XconfigBasicLayer,
         'tanh-layer' : xlayers.XconfigBasicLayer,
         'fixed-affine-layer' : xlayers.XconfigFixedAffineLayer,

--- a/src/chainbin/nnet3-chain-combine.cc
+++ b/src/chainbin/nnet3-chain-combine.cc
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
 
     std::string
         den_fst_rxfilename = po.GetArg(1),
-        raw_nnet_rxfilename = po.GetArg(po.NumArgs() - 2),
+        raw_nnet_rxfilename = po.GetArg(2),
         valid_examples_rspecifier = po.GetArg(po.NumArgs() - 1),
         nnet_wxfilename = po.GetArg(po.NumArgs());
 
@@ -75,15 +75,14 @@ int main(int argc, char *argv[]) {
     ReadFstKaldi(den_fst_rxfilename, &den_fst);
 
     Nnet nnet;
-    // note: nnet_rxfilename is the last arg, which with the way we call it, is
-    // the most recent averaged batch of models.  This is mainly important for
-    // batch-norm-- it ensures that the stats used for batch normalization are
-    // fresh.  (since the batch-norm stats are not technically parameters, they
-    // are obtained from the main model given to the combiner, and are not
-    // subject to combination).
     ReadKaldiObject(raw_nnet_rxfilename, &nnet);
-    SetTestMode(true, &nnet);  // relates to batch-norm.
 
+    // This is needed for batch-norm.  We also ensure in the calling script
+    // that the freshest model comes first on the command line; this
+    // means we use the freshest batch-norm stats.  (Since the batch-norm
+    // stats are not technically parameters, they are not subject to
+    // combination like the rest of the model parameters).
+    SetTestMode(true, &nnet);
 
     std::vector<NnetChainExample> egs;
     egs.reserve(10000);  // reserve a lot of space to minimize the chance of
@@ -103,13 +102,8 @@ int main(int argc, char *argv[]) {
     NnetChainCombiner combiner(combine_config, chain_config,
                                num_nnets, egs, den_fst, nnet);
 
-    // we don't start from the one at position 'num_nnets + 1' because that one
-    // was used to initialize the 'combiner'.  we're reversing the order because
-    // we wanted the 1st model to initialize the combiner (to get fresh
-    // batch-norm stats, if relevant), and reversing the order rather than
-    // mixing it up makes the printed weights easier to view.
-    for (int32 n = num_nnets; n >= 2; n--) {
-      std::string this_nnet_rxfilename = po.GetArg(n);
+    for (int32 n = 1; n < num_nnets; n++) {
+      std::string this_nnet_rxfilename = po.GetArg(n + 2);
       ReadKaldiObject(this_nnet_rxfilename, &nnet);
       combiner.AcceptNnet(nnet);
     }

--- a/src/chainbin/nnet3-chain-compute-prob.cc
+++ b/src/chainbin/nnet3-chain-compute-prob.cc
@@ -20,6 +20,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "nnet3/nnet-chain-diagnostics.h"
+#include "nnet3/nnet-utils.h"
 
 
 int main(int argc, char *argv[]) {
@@ -37,6 +38,7 @@ int main(int argc, char *argv[]) {
         "Usage:  nnet3-chain-compute-prob [options] <raw-nnet3-model-in> <denominator-fst> <training-examples-in>\n"
         "e.g.: nnet3-chain-compute-prob 0.mdl den.fst ark:valid.egs\n";
 
+    bool test_mode = true;
 
     // This program doesn't support using a GPU, because these probabilities are
     // used for diagnostics, and you can just compute them with a small enough
@@ -47,6 +49,9 @@ int main(int argc, char *argv[]) {
     chain::ChainTrainingOptions chain_opts;
 
     ParseOptions po(usage);
+
+    po.Register("test-mode", &test_mode,
+                "If true, set test-mode to true on any BatchNormComponents.");
 
     nnet_opts.Register(&po);
     chain_opts.Register(&po);
@@ -64,6 +69,9 @@ int main(int argc, char *argv[]) {
 
     Nnet nnet;
     ReadKaldiObject(nnet_rxfilename, &nnet);
+
+    if (test_mode)
+      SetTestMode(true, &nnet);
 
     fst::StdVectorFst den_fst;
     ReadFstKaldi(den_fst_rxfilename, &den_fst);

--- a/src/nnet3/nnet-analyze.cc
+++ b/src/nnet3/nnet-analyze.cc
@@ -291,9 +291,6 @@ void ComputeCommandAttributes(
         else
           vars.RecordAccessForSubmatrix(c.arg4, kWriteAccess, &attr);
         break;
-      case kStoreStats:
-        vars.RecordAccessForSubmatrix(c.arg2, kReadAccess, &attr);
-        break;
       case kBackprop:
       case kBackpropNoModelUpdate:
         vars.RecordAccessForSubmatrix(c.arg3, kReadAccess, &attr);
@@ -689,6 +686,11 @@ void ComputationChecker::CheckComputationIndexes() const {
   const std::vector<NnetComputation::SubMatrixInfo> &submatrices =
       computation_.submatrices;
 
+  // This maps from the memo-index > 0 to the Propagate command
+  // which created it.  When the corresponding Backprop command
+  // is encountered, we delete the map element.
+  std::unordered_map<int32, int32> memo_to_command;
+
   for (int32 command_index = 0; command_index < num_commands; command_index++) {
     const NnetComputation::Command &c = computation_.commands[command_index];
     switch (c.command_type) {
@@ -739,19 +741,12 @@ void ComputationChecker::CheckComputationIndexes() const {
         if (!(properties & kPropagateInPlace) &&
             c.arg3 == c.arg4)
           KALDI_ERR << "In-place propagation not supported for this component";
-        break;
-      }
-      case kStoreStats: {
-        if (c.arg1 < 0 || c.arg1 >= nnet_.NumComponents())
-          KALDI_ERR << "Component index out of range";
-        const Component *component = nnet_.GetComponent(c.arg1);
-        int32 properties = component->Properties();
-        if (!(properties & kStoresStats))
-          KALDI_ERR << "StoreStats called on component that does not do it.";
-        if (c.arg2 < 1 || c.arg2 >= num_submatrices)
-          KALDI_ERR << "Invalid sub-matrix index in StoreStats";
-        if (submatrices[c.arg2].num_cols != component->OutputDim())
-          KALDI_ERR << "Dimension mismatch in StoreStats";
+        if (c.arg5 > 0) {
+          KALDI_ASSERT(memo_to_command.count(c.arg5) == 0 &&
+                       "Memo index re-used.");
+          memo_to_command[c.arg5] = command_index;
+        }
+        KALDI_ASSERT(c.arg6 == 0 || c.arg6 == 1);
         break;
       }
       case kBackprop:
@@ -805,6 +800,17 @@ void ComputationChecker::CheckComputationIndexes() const {
         if ((properties & kSimpleComponent) && c.arg6 != 0 &&
             submatrices[c.arg5].num_rows != submatrices[c.arg6].num_rows)
           KALDI_ERR << "Num-rows mismatch in backprop input vs output.";
+        if (c.arg7 != 0) {
+          KALDI_ASSERT(c.arg7 > 0);
+          if (memo_to_command.count(c.arg7) == 0)
+            KALDI_ERR << "Memo-index " << c.arg7 << " not used for propagate.";
+          int32 propagate_command = memo_to_command[c.arg7];
+          memo_to_command.erase(c.arg7);
+          if (c.arg1 != computation_.commands[propagate_command].arg1)
+            KALDI_ERR << "Mismatch in component-node for memo index";
+          if (!(properties & kUsesMemo))
+            KALDI_ERR << "Component not expected to use a memo.";
+        }
         break;
       }
       case kMatrixCopy:
@@ -941,6 +947,11 @@ void ComputationChecker::CheckComputationIndexes() const {
       default:
         KALDI_ERR << "Unknown command type.";
     }
+  }
+  if (!memo_to_command.empty()) {
+    KALDI_ERR << "Memo was used in command "
+              << memo_to_command.begin()->second
+              << " but never consumed.";
   }
 }
 

--- a/src/nnet3/nnet-analyze.h
+++ b/src/nnet3/nnet-analyze.h
@@ -1,6 +1,6 @@
 // nnet3/nnet-analyze.h
 
-// Copyright 2015    Johns Hopkins University (author: Daniel Povey)
+// Copyright 2015-2017    Johns Hopkins University (author: Daniel Povey)
 
 // See ../../COPYING for clarification regarding multiple authors
 //

--- a/src/nnet3/nnet-compile.h
+++ b/src/nnet3/nnet-compile.h
@@ -66,7 +66,8 @@ class Compiler {
   // Some generic information about each step of the computation... a step is an
   // instance of a NetworkNode, but a NetworkNode may in general have multiple
   // steps.  A single step may turn into no commands (for input nodes), or
-  // multiple commands.
+  // multiple commands.  The StepInfo also contains info about the backprop
+  // corresponding to its forward command.
   struct StepInfo {
     int32 node_index;  // network-node index
     int32 value;  // sub-matrix index of value that this step outputs.

--- a/src/nnet3/nnet-component-itf.cc
+++ b/src/nnet3/nnet-component-itf.cc
@@ -151,6 +151,8 @@ Component* Component::NewComponentOfType(const std::string &component_type) {
     ans = new BackpropTruncationComponent();
   } else if (component_type == "LstmNonlinearityComponent") {
     ans = new LstmNonlinearityComponent();
+  } else if (component_type == "BatchNormComponent") {
+    ans = new BatchNormComponent();
   }
   if (ans != NULL) {
     KALDI_ASSERT(component_type == ans->Type());

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -33,39 +33,19 @@ static void ResetSeed(int32 rand_seed, const Component &c) {
     rand_component->ResetGenerator();
   }
 }
-// returns true if two are string are equal except for what looks like it might
-// be a difference last digit of a floating point number, e.g. accept
-// 1.234 to be the same as 1.235.  Not very rigorous.
-static bool StringsApproxEqual(const std::string &a,
-                               const std::string &b) {
-  if (a == b || a.size() != b.size())
+
+// this is the same as calling StringsApproxEqual(), except it prints
+// a warning if it fails.
+bool CheckStringsApproxEqual(const std::string &a,
+                             const std::string &b,
+                             int32 tolerance = 3) {
+  if (!StringsApproxEqual(a, b, tolerance)) {
+    KALDI_WARN << "Strings differ: " << a
+               << "\vs.\n" << b;
+    return false;
+  } else {
     return true;
-  size_t size = a.size();
-  for (size_t pos = 0; pos < size; pos++) {
-    if (a[pos] != b[pos]) {
-      if (!isdigit(a[pos]) || !isdigit(b[pos]))
-        goto fail;
-      // if it's not the last digit in the string, goto fail
-      if (pos + 1 != size && isdigit(a[pos+1]))
-        goto fail;
-      if (pos == 0)
-        goto fail;
-      size_t pos2;
-      for (pos2 = static_cast<ssize_t>(pos) - 1; pos2 > 0; pos2--) {
-        if (a[pos2] == '.') break;  // we accept this difference: we went backwards and found a '.'
-        if (!isdigit(a[pos2]))  // we reject this difference: we went back and
-                                // found non-digit before '.' -> not floating
-                                // point.
-          goto fail;
-      }
-      if (pos2 == 0)
-        goto fail;
-    }
   }
-  return true;
-fail:
-  KALDI_WARN << "Info strings differ: '" << a << "' vs. '" << b << "'.";
-  return false;
 }
 
 
@@ -78,7 +58,8 @@ void TestNnetComponentIo(Component *c) {
   std::ostringstream os2;
   c2->Write(os2, binary);
   if (!binary) {
-    KALDI_ASSERT(os2.str() == os1.str());
+    std::string s1 = os1.str(), s2 = os2.str();
+    KALDI_ASSERT(CheckStringsApproxEqual(s1, s2));
   }
   delete c2;
 }
@@ -97,7 +78,7 @@ void TestNnetComponentAddScale(Component *c) {
   Component *c3 = c2->Copy();
   c3->Add(0.5, *c2);
   c2->Scale(1.5);
-  KALDI_ASSERT(StringsApproxEqual(c2->Info(), c3->Info()));
+  KALDI_ASSERT(CheckStringsApproxEqual(c2->Info(), c3->Info()));
   delete c2;
   delete c3;
 }
@@ -114,7 +95,7 @@ void TestNnetComponentVectorizeUnVectorize(Component *c) {
   KALDI_ASSERT(params.Min()==0.0 && params.Sum()==0.0);
   uc->Vectorize(&params);
   uc2->UnVectorize(params);
-  KALDI_ASSERT(StringsApproxEqual(uc2->Info(), uc->Info()));
+  KALDI_ASSERT(CheckStringsApproxEqual(uc2->Info(), uc->Info()));
   BaseFloat x = uc2->DotProduct(*uc2), y = uc->DotProduct(*uc),
       z = uc2->DotProduct(*uc);
   KALDI_ASSERT(ApproxEqual(x, y) && ApproxEqual(y, z));
@@ -123,15 +104,6 @@ void TestNnetComponentVectorizeUnVectorize(Component *c) {
   for(int i = 0; i < params.Dim(); i++)
     KALDI_ASSERT(params(i) == params2(i));
   delete uc2;
-}
-
-void TestStringsApproxEqual() {
-  // we must test the test.
-  KALDI_ASSERT(!StringsApproxEqual("a", "b"));
-  KALDI_ASSERT(!StringsApproxEqual("1", "2"));
-  KALDI_ASSERT(StringsApproxEqual("1.234", "1.235"));
-  KALDI_ASSERT(StringsApproxEqual("x 1.234 y", "x 1.235 y"));
-  KALDI_ASSERT(StringsApproxEqual("x 1.234 y 6.41", "x 1.235 y 6.49"));
 }
 
 void TestNnetComponentUpdatable(Component *c) {
@@ -152,9 +124,9 @@ void TestNnetComponentUpdatable(Component *c) {
     UpdatableComponent *uc2 = dynamic_cast<UpdatableComponent*>(uc->Copy());
     uc2->Scale(7.0);
     uc2->Add(3.0, *uc);
-    KALDI_ASSERT(StringsApproxEqual(uc2->Info(), uc->Info()));
+    KALDI_ASSERT(CheckStringsApproxEqual(uc2->Info(), uc->Info()));
     uc->Scale(0.0);
-    KALDI_ASSERT(StringsApproxEqual(uc2->Info(), uc->Info()));
+    KALDI_ASSERT(CheckStringsApproxEqual(uc2->Info(), uc->Info()));
     delete uc2;
   } else {
     KALDI_ASSERT(uc->NumParameters() != 0);
@@ -177,7 +149,7 @@ void TestNnetComponentUpdatable(Component *c) {
     vec2.Scale(0.5);
     uc2->UnVectorize(vec2);
     uc3->Scale(0.5);
-    KALDI_ASSERT(uc2->Info() == uc3->Info());
+    KALDI_ASSERT(CheckStringsApproxEqual(uc2->Info(), uc3->Info()));
 
     // testing that Scale(0.0) works the same whether done on the vectorized
     // paramters or via SetZero(), and that unvectorizing something that's been
@@ -238,13 +210,13 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
   }
 
   ResetSeed(rand_seed, c);
-  c.Propagate(NULL, input_data, &output_data1);
+  void *memo = c.Propagate(NULL, input_data, &output_data1);
 
   ResetSeed(rand_seed, c);
-  c.Propagate(NULL, input_data, &output_data2);
+  c.DeleteMemo(c.Propagate(NULL, input_data, &output_data2));
   if (properties & kPropagateInPlace) {
     ResetSeed(rand_seed, c);
-    c.Propagate(NULL, output_data3, &output_data3);
+    c.DeleteMemo(c.Propagate(NULL, output_data3, &output_data3));
     if (!output_data1.ApproxEqual(output_data3)) {
       KALDI_ERR << "Test of kPropagateInPlace flag for component of type "
                 << c.Type() << " failed.";
@@ -263,7 +235,7 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
   }
   if (properties & kLinearInInput) {
     ResetSeed(rand_seed, c);
-    c.Propagate(NULL, input_data_scaled, &output_data5);
+    c.DeleteMemo(c.Propagate(NULL, input_data_scaled, &output_data5));
     output_data5.Scale(0.5);
     AssertEqual(output_data1, output_data5);
   }
@@ -284,6 +256,7 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
              ((properties & kBackpropNeedsInput) ? input_data : empty_mat),
              ((properties & kBackpropNeedsOutput) ? output_data1 : empty_mat),
              output_deriv,
+             memo,
              c_copy,
              &input_deriv1);
   // test with input_deriv2 that's all ones.
@@ -291,6 +264,7 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
              ((properties & kBackpropNeedsInput) ? input_data : empty_mat),
              ((properties & kBackpropNeedsOutput) ? output_data1 : empty_mat),
              output_deriv,
+             memo,
              c_copy,
              &input_deriv2);
   // test backprop in place, if supported.
@@ -299,9 +273,11 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
                ((properties & kBackpropNeedsInput) ? input_data : empty_mat),
                ((properties & kBackpropNeedsOutput) ? output_data1 : empty_mat),
                input_deriv3,
+               memo,
                c_copy,
                &input_deriv3);
   }
+  c.DeleteMemo(memo);
 
   if (properties & kBackpropAdds)
     input_deriv2.Add(-1.0);  // subtract the offset.
@@ -331,14 +307,15 @@ bool TestSimpleComponentDataDerivative(const Component &c,
   output_deriv.SetRandn();
 
   ResetSeed(rand_seed, c);
-  c.Propagate(NULL, input_data, &output_data);
+  void *memo = c.Propagate(NULL, input_data, &output_data);
 
   CuMatrix<BaseFloat> input_deriv(num_rows, input_dim, kSetZero, input_stride_type),
       empty_mat;
   c.Backprop("foobar", NULL,
              ((properties & kBackpropNeedsInput) ? input_data : empty_mat),
              ((properties & kBackpropNeedsOutput) ? output_data : empty_mat),
-             output_deriv, NULL, &input_deriv);
+             output_deriv, memo, NULL, &input_deriv);
+  c.DeleteMemo(memo);
 
   int32 test_dim = 3;
   BaseFloat original_objf = TraceMatMat(output_deriv, output_data, kTrans);
@@ -357,7 +334,7 @@ bool TestSimpleComponentDataDerivative(const Component &c,
     perturbed_input_data.AddMat(1.0, input_data);
 
     ResetSeed(rand_seed, c);
-    c.Propagate(NULL, perturbed_input_data, &perturbed_output_data);
+    c.DeleteMemo(c.Propagate(NULL, perturbed_input_data, &perturbed_output_data));
     measured_objf_change(i) = TraceMatMat(output_deriv, perturbed_output_data,
                                           kTrans) - original_objf;
   }
@@ -412,7 +389,7 @@ bool TestSimpleComponentModelDerivative(const Component &c,
   input_data.SetRandn();
   output_deriv.SetRandn();
 
-  c.Propagate(NULL, input_data, &output_data);
+  void *memo = c.Propagate(NULL, input_data, &output_data);
 
   BaseFloat original_objf = TraceMatMat(output_deriv, output_data, kTrans);
 
@@ -432,13 +409,14 @@ bool TestSimpleComponentModelDerivative(const Component &c,
   c.Backprop("foobar", NULL,
              ((properties & kBackpropNeedsInput) ? input_data : empty_mat),
              ((properties & kBackpropNeedsOutput) ? output_data : empty_mat),
-             output_deriv, c_copy,
+             output_deriv, memo, c_copy,
              (RandInt(0, 1) == 0 ? &input_deriv : NULL));
+  c.DeleteMemo(memo);
 
   if (!test_derivative) { // Just testing that the model update is downhill.
     CuMatrix<BaseFloat> new_output_data(num_rows, output_dim,
                                         kSetZero, output_stride_type);
-    c_copy->Propagate(NULL, input_data, &new_output_data);
+    c.DeleteMemo(c_copy->Propagate(NULL, input_data, &new_output_data));
 
     BaseFloat new_objf = TraceMatMat(output_deriv, new_output_data, kTrans);
     bool ans = (new_objf > original_objf);
@@ -523,7 +501,6 @@ void UnitTestNnetComponent() {
 int main() {
   using namespace kaldi;
   using namespace kaldi::nnet3;
-  TestStringsApproxEqual();
   kaldi::int32 loop = 0;
 #if HAVE_CUDA == 1
   for (loop = 0; loop < 2; loop++) {

--- a/src/nnet3/nnet-computation.h
+++ b/src/nnet3/nnet-computation.h
@@ -186,10 +186,11 @@ struct ComputationRequest {
        for simple Components)
      - arg3 is sub-matrix index of input
      - arg4 is sub-matrix index of output
-   - kStoreStats: Call Component::StoreStats() (used for computing diagnostics
-      such as average activations; called after Propagate).
-     - arg1 is component-index in neural net
-     - arg2 is sub-matrix index of the output of the Propagate function
+     - arg5 is the index of the memo saved from Propagate()'s return value,
+        or 0 if it saves no memo.
+     - arg6 is 1 if we need to call StoreStats() after the Propagate, or 0
+       if we don't.  We used to have a separate command for storing the
+       stats, but that has been removed.
    - kBackprop: Do the back-propagation operation, see Component::Backprop()
      - arg1 is index of component in neural net
      - arg2 is index into ComponentPrecomputedIndexes (0 if NULL; always 0
@@ -198,6 +199,8 @@ struct ComputationRequest {
      - arg4 is submatrix-index of output value (output of Propagate()); 0 if unused
      - arg5 is submatrix-index of output derivative
      - arg6 is submatrix-index of input derivative; 0 if unused.
+     - arg7 is the index of the memo which is generated from the corresponding
+          Propagate() function if the flag kUsesMemo is set; 0 if unused.
    - kBackpropNoModelUpdate: as kBackprop, but does not set the
      'to_update' argument to the Backprop call, even if the model  is updatable,
      so it skips the model-update phase of backprop.
@@ -240,7 +243,7 @@ struct ComputationRequest {
 enum CommandType {
   kAllocMatrixUndefined, kAllocMatrixZeroed,
   kDeallocMatrix, kAllocMatrixFromOther, kAllocMatrixFromOtherZeroed,
-  kPropagate, kStoreStats, kBackprop, kBackpropNoModelUpdate,
+  kPropagate, kBackprop, kBackpropNoModelUpdate,
   kMatrixCopy, kMatrixAdd, kCopyRows, kAddRows,
   kCopyRowsMulti, kCopyToRowsMulti, kAddRowsMulti, kAddToRowsMulti,
   kAddRowRanges, kAcceptInput, kProvideOutput,
@@ -294,11 +297,12 @@ struct NnetComputation {
     int32 arg4;
     int32 arg5;
     int32 arg6;
+    int32 arg7;
     Command(CommandType command_type = kNoOperationMarker,
             int32 arg1 = -1, int32 arg2 = -1, int32 arg3 = -1, int32 arg4 = -1,
-            int32 arg5 = -1, int arg6 = -1):
+            int32 arg5 = -1, int32 arg6 = -1, int32 arg7 = -1):
         command_type(command_type), arg1(arg1), arg2(arg2), arg3(arg3),
-        arg4(arg4), arg5(arg5), arg6(arg6) { }
+        arg4(arg4), arg5(arg5), arg6(arg6), arg7(arg7) { }
     void Read(std::istream &istream, bool binary);
     void Write(std::ostream &ostream, bool binary) const;
   };

--- a/src/nnet3/nnet-compute-test.cc
+++ b/src/nnet3/nnet-compute-test.cc
@@ -82,6 +82,7 @@ void TestNnetDecodable(Nnet *nnet) {
       ivector_dim = std::max<int32>(0, nnet->InputDim("ivector"));
   Matrix<BaseFloat> input(num_frames, input_dim);
 
+  SetTestMode(true, nnet);
 
   input.SetRandn();
   Vector<BaseFloat> ivector(ivector_dim);
@@ -226,6 +227,8 @@ void UnitTestNnetCompute() {
 int main() {
   using namespace kaldi;
   using namespace kaldi::nnet3;
+  // uncommenting the following activates extra checks during optimization, that
+  // can help narrow down the source of problems.
   // SetVerboseLevel(4);
 
 

--- a/src/nnet3/nnet-compute.cc
+++ b/src/nnet3/nnet-compute.cc
@@ -145,6 +145,34 @@ void NnetComputer::DebugAfterExecute(int32 command,
 }
 
 
+void NnetComputer::SaveMemo(int32 memo_index,
+                            const Component &c, void *memo) {
+  if (memo_index <= 0) {
+    if (memo != NULL) {  // memo was returned but is not needed.
+      c.DeleteMemo(memo);
+    }
+  } else {
+    if (memos_.size() <= static_cast<size_t>(memo_index))
+      memos_.resize(memo_index + 1, NULL);
+    memos_[memo_index] = memo;
+  }
+}
+
+void* NnetComputer::GetMemo(int32 memo_index) {
+  if (memo_index == 0) {
+    return NULL;
+  } else {
+    if (static_cast<size_t>(memo_index) >= memos_.size())
+      KALDI_ERR << "Memo requested that was not generated.";
+    void *ans = memos_[memo_index];
+    memos_[memo_index] = NULL;
+    return ans;
+  }
+}
+
+
+
+
 void NnetComputer::ExecuteCommand() {
   const NnetComputation::Command &c = computation_.commands[program_counter_];
   int32 m1, m2;
@@ -185,14 +213,18 @@ void NnetComputer::ExecuteCommand() {
             computation_.component_precomputed_indexes[c.arg2].data;
         const CuSubMatrix<BaseFloat> input(GetSubMatrix(c.arg3));
         CuSubMatrix<BaseFloat> output(GetSubMatrix(c.arg4));
-        component->Propagate(indexes, input, &output);
-        break;
-      }
-      case kStoreStats: {
-        KALDI_ASSERT(nnet_to_update_ != NULL);
-        Component *upd_component = nnet_to_update_->GetComponent(c.arg1);
-        CuSubMatrix<BaseFloat> output(GetSubMatrix(c.arg2));
-        upd_component->StoreStats(output);
+        void *memo = component->Propagate(indexes, input, &output);
+        if (c.arg6) {  // need to store stats.
+          KALDI_ASSERT(nnet_to_update_ != NULL);
+          Component *upd_component = nnet_to_update_->GetComponent(c.arg1);
+          bool was_in_place = (c.arg3 == c.arg4);
+          // if propagate was in-place, provide empty matrix and not 'input', as
+          // input is no longer valid.
+          const CuSubMatrix<BaseFloat> maybe_input(
+              GetSubMatrix(was_in_place ? 0 : c.arg3));
+          upd_component->StoreStats(maybe_input, output, memo);
+        }
+        SaveMemo(c.arg5, *component, memo);
         break;
       }
       case kBackprop:
@@ -213,9 +245,13 @@ void NnetComputer::ExecuteCommand() {
         const CuSubMatrix<BaseFloat> out_value(GetSubMatrix(c.arg4));
         const CuSubMatrix<BaseFloat> out_deriv(GetSubMatrix(c.arg5));
         CuSubMatrix<BaseFloat> in_deriv(GetSubMatrix(c.arg6));
+        void *memo = GetMemo(c.arg7);
         component->Backprop(debug_str.str(), indexes,
-                            in_value, out_value, out_deriv, upd_component,
+                            in_value, out_value, out_deriv,
+                            memo, upd_component,
                             c.arg6 == 0 ? NULL : &in_deriv);
+        if (memo != NULL)
+          component->DeleteMemo(memo);
         break;
       }
       case kMatrixCopy: {

--- a/src/nnet3/nnet-compute.h
+++ b/src/nnet3/nnet-compute.h
@@ -128,8 +128,9 @@ class NnetComputer {
   // The matrices used in the computation.
   std::vector<CuMatrix<BaseFloat> > matrices_;
 
-  // Memos returnedy Propagate() that must be passed to the corresponding
-  // Backprop() routines.
+  // Memos returned by Propagate() that must be passed to the corresponding
+  // Backprop() routines, indexed by memo-index (zeroth element always
+  // NULL).
   std::vector<void*> memos_;
 
 

--- a/src/nnet3/nnet-compute.h
+++ b/src/nnet3/nnet-compute.h
@@ -128,6 +128,10 @@ class NnetComputer {
   // The matrices used in the computation.
   std::vector<CuMatrix<BaseFloat> > matrices_;
 
+  // Memos returnedy Propagate() that must be passed to the corresponding
+  // Backprop() routines.
+  std::vector<void*> memos_;
+
 
   // executes the command in computation_.commands[program_counter_].
   void ExecuteCommand();
@@ -184,6 +188,17 @@ class NnetComputer {
   void DebugAfterExecute(int32 command,
                          const CommandDebugInfo &info,
                          double command_execution_time);
+
+  // simple helper function used in executing Propagate().
+  // saves 'memo' at memo-index 'memo_index'; if memo
+  // is non-NULL and memo_index is 0, it is an error.
+  inline void SaveMemo(int32 memo_index, const Component &c, void *memo);
+
+  // simple helper function used in executing Backprop().
+  // Retrieves memo from 'memo_index' (or returns NULL if
+  // memo_index = 0), and sets that value to NULL as
+  // memos are not reusable.
+  inline void *GetMemo(int32 memo_index);
 
 
 };

--- a/src/nnet3/nnet-general-component.cc
+++ b/src/nnet3/nnet-general-component.cc
@@ -177,7 +177,7 @@ void DistributeComponent::ComputeInputPointers(
 
 
 // virtual
-void DistributeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* DistributeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                     const CuMatrixBase<BaseFloat> &in,
                                     CuMatrixBase<BaseFloat> *out) const {
   KALDI_ASSERT(indexes != NULL &&
@@ -187,6 +187,7 @@ void DistributeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   ComputeInputPointers(indexes, in, num_output_rows, &input_pointers);
   CuArray<const BaseFloat*> input_pointers_cuda(input_pointers);
   out->CopyRows(input_pointers_cuda);
+  return NULL;
 }
 
 // virtual
@@ -195,6 +196,7 @@ void DistributeComponent::Backprop(const std::string &debug_info,
                                    const CuMatrixBase<BaseFloat> &, // in_value,
                                    const CuMatrixBase<BaseFloat> &, // out_value
                                    const CuMatrixBase<BaseFloat> &out_deriv,
+                                   void *memo,
                                    Component *, // to_update,
                                    CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv == NULL) return;
@@ -442,7 +444,7 @@ void StatisticsExtractionComponent::GetInputIndexes(
 }
 
 
-void StatisticsExtractionComponent::Propagate(
+void* StatisticsExtractionComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes_in,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
@@ -468,6 +470,7 @@ void StatisticsExtractionComponent::Propagate(
                   input_dim_).AddRowRanges(in_squared,
                                            indexes->forward_indexes);
   }
+  return NULL;
 }
 
 void StatisticsExtractionComponent::Backprop(
@@ -476,6 +479,7 @@ void StatisticsExtractionComponent::Backprop(
     const CuMatrixBase<BaseFloat> &in_value,
     const CuMatrixBase<BaseFloat> &, // out_value,
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *, // to_update,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   KALDI_ASSERT(indexes_in != NULL);
@@ -764,7 +768,7 @@ StatisticsPoolingComponent::PrecomputeIndexes(
   return ans;
 }
 
-void StatisticsPoolingComponent::Propagate(
+void* StatisticsPoolingComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes_in,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
@@ -810,6 +814,7 @@ void StatisticsPoolingComponent::Propagate(
     // compute the standard deviation via square root.
     variance.ApplyPow(0.5);
   }
+  return NULL;
 }
 
 void StatisticsPoolingComponent::Backprop(
@@ -818,6 +823,7 @@ void StatisticsPoolingComponent::Backprop(
     const CuMatrixBase<BaseFloat> &in_value,
     const CuMatrixBase<BaseFloat> &out_value,
     const CuMatrixBase<BaseFloat> &out_deriv_in,
+    void *memo,
     Component *, // to_update,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   KALDI_ASSERT(indexes_in != NULL);
@@ -1078,13 +1084,14 @@ BackpropTruncationComponent::PrecomputeIndexes(
 }
 
 // virtual
-void BackpropTruncationComponent::Propagate(
+void* BackpropTruncationComponent::Propagate(
                                  const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);
   if (scale_ != 1.0)
     out->Scale(scale_);
+  return NULL;
 }
 
 // virtual
@@ -1093,6 +1100,7 @@ void BackpropTruncationComponent::Backprop(const std::string &debug_info,
                              const CuMatrixBase<BaseFloat> &, //in_value
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &out_deriv,
+                             void *memo,
                              Component *to_update_in, // may be NULL; may be
                              // identical to "this" or different.
                              CuMatrixBase<BaseFloat> *in_deriv) const {
@@ -1213,11 +1221,12 @@ ConstantComponent::ConstantComponent(
     use_natural_gradient_(other.use_natural_gradient_),
     preconditioner_(other.preconditioner_) { }
 
-void ConstantComponent::Propagate(
+void* ConstantComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   out->CopyRowsFromVec(output_);
+  return NULL;
 }
 
 void ConstantComponent::Backprop(
@@ -1226,6 +1235,7 @@ void ConstantComponent::Backprop(
     const CuMatrixBase<BaseFloat> &, // in_value
     const CuMatrixBase<BaseFloat> &, // out_value
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   // we don't update in_deriv, since we set the flag

--- a/src/nnet3/nnet-general-component.h
+++ b/src/nnet3/nnet-general-component.h
@@ -64,7 +64,7 @@ class DistributeComponent: public Component {
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual std::string Type() const { return "DistributeComponent"; }
   virtual int32 Properties() const { return kLinearInInput; }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -72,6 +72,7 @@ class DistributeComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -214,7 +215,7 @@ class StatisticsExtractionComponent: public Component {
     return kPropagateAdds|kReordersIndexes|
         (include_variance_ ? kBackpropNeedsInput : 0);
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -222,6 +223,7 @@ class StatisticsExtractionComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -349,7 +351,7 @@ class StatisticsPoolingComponent: public Component {
          kBackpropNeedsOutput : 0) |
         (num_log_count_features_ == 0 ? kBackpropNeedsInput : 0);
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -357,6 +359,7 @@ class StatisticsPoolingComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -477,7 +480,7 @@ class BackpropTruncationComponent: public Component {
 
   virtual Component* Copy() const;
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -485,6 +488,7 @@ class BackpropTruncationComponent: public Component {
                         const CuMatrixBase<BaseFloat> &, // in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -611,7 +615,7 @@ class ConstantComponent: public UpdatableComponent {
     return
         (is_updatable_ ? kUpdatableComponent|kLinearInParameters : 0);
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -619,6 +623,7 @@ class ConstantComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &, // in_value
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -666,7 +671,6 @@ class ConstantComponent: public UpdatableComponent {
   const ConstantComponent &operator
   = (const ConstantComponent &other); // Disallow.
 };
-
 
 
 

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -5415,7 +5415,7 @@ void BatchNormComponent::ComputeDerived() {
   offset_.Resize(block_dim_);
   scale_.Resize(block_dim_);
   offset_.CopyFromVec(stats_sum_);
-  offset_.Scale(1.0 / count_);
+  offset_.Scale(-1.0 / count_);
   // now offset_ is -mean.
   scale_.CopyFromVec(stats_sumsq_);
   scale_.Scale(1.0 / count_);
@@ -5662,7 +5662,6 @@ void* BatchNormComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
     out->CopyFromMat(in);
     out->AddVecToRows(-1.0, mean, 1.0);
     out->MulColsVec(scale);
-
     return static_cast<void*>(memo);
   } else {
     if (offset_.Dim() != block_dim_) {

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -5424,7 +5424,7 @@ void BatchNormComponent::ComputeDerived() {
   scale_.ApplyFloor(epsilon_);
   scale_.ApplyPow(-0.5);
   // now scale_ = min(variance, epsilon)^{-0.5}.
-  // next, multpiply by the target RMS (normally 1.0).
+  // next, multiply by the target RMS (normally 1.0).
   scale_.Scale(target_rms_);
   offset_.MulElements(scale_);
   // now offset_ is -(scale*mean).
@@ -5842,9 +5842,15 @@ void BatchNormComponent::Write(std::ostream &os, bool binary) const {
 }
 
 void BatchNormComponent::Scale(BaseFloat scale) {
-  count_ *= scale;
-  stats_sum_.Scale(scale);
-  stats_sumsq_.Scale(scale);
+  if (scale == 0) {
+    count_ = 0.0;
+    stats_sum_.SetZero();
+    stats_sumsq_.SetZero();
+  } else {
+    count_ *= scale;
+    stats_sum_.Scale(scale);
+    stats_sumsq_.Scale(scale);
+  }
 }
 
 

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -49,11 +49,12 @@ void PnormComponent::InitFromConfig(ConfigLine *cfl) {
 }
 
 
-void PnormComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* PnormComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                const CuMatrixBase<BaseFloat> &in,
                                CuMatrixBase<BaseFloat> *out) const {
   BaseFloat p = 2.0;
   out->GroupPnorm(in, p);
+  return NULL;
 }
 
 void PnormComponent::Backprop(const std::string &debug_info,
@@ -61,6 +62,7 @@ void PnormComponent::Backprop(const std::string &debug_info,
                               const CuMatrixBase<BaseFloat> &in_value,
                               const CuMatrixBase<BaseFloat> &out_value,
                               const CuMatrixBase<BaseFloat> &out_deriv,
+                              void *memo,
                               Component *to_update,
                               CuMatrixBase<BaseFloat> *in_deriv) const {
   if (!in_deriv)
@@ -118,7 +120,7 @@ std::string DropoutComponent::Info() const {
   return stream.str();
 }
 
-void DropoutComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* DropoutComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
   KALDI_ASSERT(out->NumRows() == in.NumRows() && out->NumCols() == in.NumCols()
@@ -149,6 +151,7 @@ void DropoutComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
     out->CopyColsFromVec(tmp.Row(0));
     out->MulElements(in);
   }
+  return NULL;
 }
 
 
@@ -157,6 +160,7 @@ void DropoutComponent::Backprop(const std::string &debug_info,
                                 const CuMatrixBase<BaseFloat> &in_value,
                                 const CuMatrixBase<BaseFloat> &out_value,
                                 const CuMatrixBase<BaseFloat> &out_deriv,
+                                void *memo,
                                 Component *to_update,
                                 CuMatrixBase<BaseFloat> *in_deriv) const {
   KALDI_ASSERT(in_value.NumRows() == out_value.NumRows() &&
@@ -221,7 +225,7 @@ void SumReduceComponent::InitFromConfig(ConfigLine *cfl) {
 }
 
 
-void SumReduceComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* SumReduceComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                    const CuMatrixBase<BaseFloat> &in,
                                    CuMatrixBase<BaseFloat> *out) const {
   KALDI_ASSERT(out->NumRows() == in.NumRows() && in.NumCols() == input_dim_
@@ -235,6 +239,7 @@ void SumReduceComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
     else
       out->AddMat(1.0, in_block);
   }
+  return NULL;
 }
 
 void SumReduceComponent::Backprop(const std::string &debug_info,
@@ -242,6 +247,7 @@ void SumReduceComponent::Backprop(const std::string &debug_info,
                                   const CuMatrixBase<BaseFloat> &, // in_value
                                   const CuMatrixBase<BaseFloat> &, // out_value
                                   const CuMatrixBase<BaseFloat> &out_deriv,
+                                  void *memo,
                                   Component *, // to_update
                                   CuMatrixBase<BaseFloat> *in_deriv) const {
   if (!in_deriv)  return;
@@ -293,7 +299,7 @@ void ElementwiseProductComponent::InitFromConfig(ConfigLine *cfl) {
   Init(input_dim, output_dim);
 }
 
-void ElementwiseProductComponent::Propagate(
+void* ElementwiseProductComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
@@ -308,6 +314,7 @@ void ElementwiseProductComponent::Propagate(
       out->MulElements(current_in);
     }
   }
+  return NULL;
 }
 
 void ElementwiseProductComponent::Backprop(const std::string &debug_info,
@@ -315,6 +322,7 @@ void ElementwiseProductComponent::Backprop(const std::string &debug_info,
                               const CuMatrixBase<BaseFloat> &in_value,
                               const CuMatrixBase<BaseFloat> &out_value,
                               const CuMatrixBase<BaseFloat> &out_deriv,
+                              void *memo,
                               Component *to_update,
                               CuMatrixBase<BaseFloat> *in_deriv) const {
   if (!in_deriv)  return;
@@ -448,11 +456,12 @@ std::string NormalizeComponent::Info() const {
 // square root is exactly representable as float.
 // If add_log_stddev_ is true, log(max(epsi, sqrt(x^t x / D)))
 // is an extra dimension of the output.
-void NormalizeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* NormalizeComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                    const CuMatrixBase<BaseFloat> &in,
                                    CuMatrixBase<BaseFloat> *out) const {
   KALDI_ASSERT(out->NumCols() == in.NumCols() + (add_log_stddev_ ? 1 : 0));
   cu::NormalizePerRow(in, target_rms_, add_log_stddev_, out);
+  return NULL;
 }
 
 /*
@@ -483,6 +492,7 @@ void NormalizeComponent::Backprop(const std::string &debug_info,
                                   const CuMatrixBase<BaseFloat> &in_value,
                                   const CuMatrixBase<BaseFloat> &, // out_value
                                   const CuMatrixBase<BaseFloat> &out_deriv,
+                                  void *memo,
                                   Component *to_update,
                                   CuMatrixBase<BaseFloat> *in_deriv) const {
   if (!in_deriv)
@@ -491,10 +501,11 @@ void NormalizeComponent::Backprop(const std::string &debug_info,
                           in_deriv);
 }
 
-void SigmoidComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* SigmoidComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
   out->Sigmoid(in);
+  return NULL;
 }
 
 void SigmoidComponent::Backprop(const std::string &debug_info,
@@ -502,6 +513,7 @@ void SigmoidComponent::Backprop(const std::string &debug_info,
                                 const CuMatrixBase<BaseFloat> &,
                                 const CuMatrixBase<BaseFloat> &out_value,
                                 const CuMatrixBase<BaseFloat> &out_deriv,
+                                void *memo,
                                 Component *to_update_in,
                                 CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv != NULL) {
@@ -586,7 +598,9 @@ void SigmoidComponent::RepairGradients(
 
 
 
-void SigmoidComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {
+void SigmoidComponent::StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                                  const CuMatrixBase<BaseFloat> &out_value,
+                                  void *memo) {
   // only store stats about every other minibatch.
   if (RandInt(0, 1) == 0)
     return;
@@ -601,10 +615,11 @@ void SigmoidComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {
 
 
 
-void NoOpComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
-                                 const CuMatrixBase<BaseFloat> &in,
-                                 CuMatrixBase<BaseFloat> *out) const {
+void* NoOpComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+                              const CuMatrixBase<BaseFloat> &in,
+                              CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);
+  return NULL;
 }
 
 void NoOpComponent::Backprop(const std::string &debug_info,
@@ -612,6 +627,7 @@ void NoOpComponent::Backprop(const std::string &debug_info,
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &out_deriv,
+                             void *memo,
                              Component *to_update, // may be NULL; may be identical
                              // to "this" or different.
                              CuMatrixBase<BaseFloat> *in_deriv) const {
@@ -753,11 +769,12 @@ void ClipGradientComponent::InitFromConfig(ConfigLine *cfl) {
        self_repair_scale, 0, 0, 0, 0);
 }
 
-void ClipGradientComponent::Propagate(
+void* ClipGradientComponent::Propagate(
                                  const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);
+  return NULL;
 }
 
 
@@ -766,6 +783,7 @@ void ClipGradientComponent::Backprop(const std::string &debug_info,
                              const CuMatrixBase<BaseFloat> &in_value,
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &out_deriv,
+                             void *memo,
                              Component *to_update_in, // may be NULL; may be identical
                              // to "this" or different.
                              CuMatrixBase<BaseFloat> *in_deriv) const {
@@ -920,13 +938,14 @@ void ClipGradientComponent::Add(BaseFloat alpha, const Component &other_in) {
   num_clipped_ += alpha * other->num_clipped_;
 }
 
-void TanhComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* TanhComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                               const CuMatrixBase<BaseFloat> &in,
                               CuMatrixBase<BaseFloat> *out) const {
   // Apply tanh function to each element of the output...
   // the tanh function may be written as -1 + ( 2 / (1 + e^{-2 x})),
   // which is a scaled and shifted sigmoid.
   out->Tanh(in);
+  return NULL;
 }
 
 
@@ -1001,6 +1020,7 @@ void TanhComponent::Backprop(const std::string &debug_info,
                              const CuMatrixBase<BaseFloat> &,
                              const CuMatrixBase<BaseFloat> &out_value,
                              const CuMatrixBase<BaseFloat> &out_deriv,
+                             void *memo,
                              Component *to_update_in, // may be NULL; may be identical
                              // to "this" or different.
                              CuMatrixBase<BaseFloat> *in_deriv) const {
@@ -1019,7 +1039,9 @@ void TanhComponent::Backprop(const std::string &debug_info,
   The element by element equation of what we're doing would be:
   in_deriv = out_deriv * (1.0 - out_value^2).
   We can accomplish this via calls to the matrix library. */
-void TanhComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {
+void TanhComponent::StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                               const CuMatrixBase<BaseFloat> &out_value,
+                               void *memo) {
   // only store stats about every other minibatch.
   if (RandInt(0, 1) == 0)
     return;
@@ -1031,13 +1053,14 @@ void TanhComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {
   StoreStatsInternal(out_value, &temp_deriv);
 }
 
-void RectifiedLinearComponent::Propagate(
+void* RectifiedLinearComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   // Apply rectified linear function (x >= 0 ? 1.0 : 0.0)
   out->CopyFromMat(in);
   out->ApplyFloor(0.0);
+  return NULL;
 }
 
 void RectifiedLinearComponent::Backprop(
@@ -1046,6 +1069,7 @@ void RectifiedLinearComponent::Backprop(
     const CuMatrixBase<BaseFloat> &, //in_value
     const CuMatrixBase<BaseFloat> &out_value,
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv != NULL) {
@@ -1122,7 +1146,9 @@ void RectifiedLinearComponent::RepairGradients(
 
 
 void RectifiedLinearComponent::StoreStats(
-    const CuMatrixBase<BaseFloat> &out_value) {
+    const CuMatrixBase<BaseFloat> &in_value,
+    const CuMatrixBase<BaseFloat> &out_value,
+    void *memo) {
   // only store stats about every other minibatch.
   if (RandInt(0, 1) == 0)
     return;
@@ -1265,7 +1291,7 @@ void AffineComponent::InitFromConfig(ConfigLine *cfl) {
 
 
 
-void AffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* AffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                 const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
 
@@ -1273,6 +1299,7 @@ void AffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   out->CopyRowsFromVec(bias_params_); // copies bias_params_ to each row
   // of *out.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
+  return NULL;
 }
 
 void AffineComponent::UpdateSimple(const CuMatrixBase<BaseFloat> &in_value,
@@ -1287,6 +1314,7 @@ void AffineComponent::Backprop(const std::string &debug_info,
                                const CuMatrixBase<BaseFloat> &in_value,
                                const CuMatrixBase<BaseFloat> &, // out_value
                                const CuMatrixBase<BaseFloat> &out_deriv,
+                               void *memo,
                                Component *to_update_in,
                                CuMatrixBase<BaseFloat> *in_deriv) const {
   AffineComponent *to_update = dynamic_cast<AffineComponent*>(to_update_in);
@@ -1508,7 +1536,7 @@ void RepeatedAffineComponent::InitFromConfig(ConfigLine *cfl) {
     KALDI_ERR << "Bad initializer " << cfl->WholeLine();
 }
 
-void RepeatedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* RepeatedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                         const CuMatrixBase<BaseFloat> &in,
                                         CuMatrixBase<BaseFloat> *out) const {
   // we gave the kInputContiguous and kOutputContiguous flags-- check that they
@@ -1531,6 +1559,7 @@ void RepeatedAffineComponent::Propagate(const ComponentPrecomputedIndexes *index
 
   out_reshaped.AddMatMat(1.0, in_reshaped, kNoTrans,
                          linear_params_, kTrans, 1.0);
+  return NULL;
 }
 
 void RepeatedAffineComponent::Backprop(const std::string &debug_info,
@@ -1538,6 +1567,7 @@ void RepeatedAffineComponent::Backprop(const std::string &debug_info,
                                        const CuMatrixBase<BaseFloat> &in_value,
                                        const CuMatrixBase<BaseFloat> &, // out_value
                                        const CuMatrixBase<BaseFloat> &out_deriv,
+                                       void *memo,
                                        Component *to_update_in,
                                        CuMatrixBase<BaseFloat> *in_deriv) const {
   KALDI_ASSERT(out_deriv.NumCols() == out_deriv.Stride() &&
@@ -1801,7 +1831,7 @@ void BlockAffineComponent::InitFromConfig(ConfigLine *cfl) {
        param_stddev, bias_mean, bias_stddev);
 }
 
-void BlockAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* BlockAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                      const CuMatrixBase<BaseFloat> &in,
                                      CuMatrixBase<BaseFloat> *out) const {
   out->CopyRowsFromVec(bias_params_);
@@ -1833,6 +1863,7 @@ void BlockAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   DeletePointers(&in_batch);
   DeletePointers(&out_batch);
   DeletePointers(&linear_params_batch);
+  return NULL;
 }
 
 void BlockAffineComponent::Backprop(const std::string &debug_info,
@@ -1840,6 +1871,7 @@ void BlockAffineComponent::Backprop(const std::string &debug_info,
                                     const CuMatrixBase<BaseFloat> &in_value,
                                     const CuMatrixBase<BaseFloat> &, // out_value
                                     const CuMatrixBase<BaseFloat> &out_deriv,
+                                    void *memo,
                                     Component *to_update_in,
                                     CuMatrixBase<BaseFloat> *in_deriv) const {
   BlockAffineComponent *to_update = dynamic_cast<BlockAffineComponent*>(to_update_in);
@@ -2087,12 +2119,13 @@ void PerElementScaleComponent::InitFromConfig(ConfigLine *cfl) {
               << cfl->UnusedValues();
 }
 
-void PerElementScaleComponent::Propagate(
+void* PerElementScaleComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);
   out->MulColsVec(scales_);
+  return NULL;
 }
 
 void PerElementScaleComponent::UpdateSimple(
@@ -2108,6 +2141,7 @@ void PerElementScaleComponent::Backprop(
     const CuMatrixBase<BaseFloat> &in_value,
     const CuMatrixBase<BaseFloat> &, // out_value
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   PerElementScaleComponent *to_update =
@@ -2247,12 +2281,13 @@ void PerElementOffsetComponent::InitFromConfig(ConfigLine *cfl) {
               << cfl->UnusedValues();
 }
 
-void PerElementOffsetComponent::Propagate(
+void* PerElementOffsetComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);
   out->AddVecToRows(1.0, offsets_);
+  return NULL;
 }
 
 void PerElementOffsetComponent::Backprop(
@@ -2261,6 +2296,7 @@ void PerElementOffsetComponent::Backprop(
     const CuMatrixBase<BaseFloat> &, // in_value
     const CuMatrixBase<BaseFloat> &, // out_value
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   PerElementOffsetComponent *to_update =
@@ -2329,11 +2365,12 @@ ConstantFunctionComponent::ConstantFunctionComponent(
     use_natural_gradient_(other.use_natural_gradient_),
     preconditioner_(other.preconditioner_) { }
 
-void ConstantFunctionComponent::Propagate(
+void* ConstantFunctionComponent::Propagate(
     const ComponentPrecomputedIndexes *indexes,
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   out->CopyRowsFromVec(output_);
+  return NULL;
 }
 
 void ConstantFunctionComponent::Backprop(
@@ -2342,6 +2379,7 @@ void ConstantFunctionComponent::Backprop(
     const CuMatrixBase<BaseFloat> &, // in_value
     const CuMatrixBase<BaseFloat> &, // out_value
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
   // we don't update in_deriv, since we set the flag
@@ -2872,11 +2910,12 @@ FixedAffineComponent::FixedAffineComponent(const AffineComponent &c):
     linear_params_(c.LinearParams()),
     bias_params_(c.BiasParams()) { }
 
-void FixedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* FixedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                      const CuMatrixBase<BaseFloat> &in,
                                      CuMatrixBase<BaseFloat> *out) const  {
   out->CopyRowsFromVec(bias_params_); // Adds the bias term first.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
+  return NULL;
 }
 
 void FixedAffineComponent::Backprop(const std::string &debug_info,
@@ -2884,6 +2923,7 @@ void FixedAffineComponent::Backprop(const std::string &debug_info,
                                     const CuMatrixBase<BaseFloat> &, //in_value
                                     const CuMatrixBase<BaseFloat> &, //out_value
                                     const CuMatrixBase<BaseFloat> &out_deriv,
+                                    void *memo,
                                     Component *, //to_update
                                     CuMatrixBase<BaseFloat> *in_deriv) const {
   // kBackpropAdds is true. It's the user's responsibility to zero out
@@ -3021,10 +3061,11 @@ void SumGroupComponent::Write(std::ostream &os, bool binary) const {
   WriteToken(os, binary, "</SumGroupComponent>");
 }
 
-void SumGroupComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* SumGroupComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                   const CuMatrixBase<BaseFloat> &in,
                                   CuMatrixBase<BaseFloat> *out) const {
   out->SumColumnRanges(in, indexes_);
+  return NULL;
 }
 
 void SumGroupComponent::Backprop(const std::string &debug_info,
@@ -3032,12 +3073,13 @@ void SumGroupComponent::Backprop(const std::string &debug_info,
                                  const CuMatrixBase<BaseFloat> &, // in_value,
                                  const CuMatrixBase<BaseFloat> &, // out_value
                                  const CuMatrixBase<BaseFloat> &out_deriv,
+                                 void *memo,
                                  Component *to_update_in,
                                  CuMatrixBase<BaseFloat> *in_deriv) const {
   in_deriv->CopyCols(out_deriv, reverse_indexes_);
 }
 
-void SoftmaxComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* SoftmaxComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const {
   // Apply softmax function to each row of the output...
@@ -3048,6 +3090,8 @@ void SoftmaxComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   // This floor on the output helps us deal with
   // almost-zeros in a way that doesn't lead to overflow.
   out->ApplyFloor(1.0e-20);
+
+  return NULL;
 }
 
 void SoftmaxComponent::Backprop(const std::string &debug_info,
@@ -3055,6 +3099,7 @@ void SoftmaxComponent::Backprop(const std::string &debug_info,
                                 const CuMatrixBase<BaseFloat> &, // in_value,
                                 const CuMatrixBase<BaseFloat> &out_value,
                                 const CuMatrixBase<BaseFloat> &out_deriv,
+                                void *memo,
                                 Component *to_update_in,
                                 CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv == NULL)
@@ -3072,19 +3117,22 @@ void SoftmaxComponent::Backprop(const std::string &debug_info,
   in_deriv->DiffSoftmaxPerRow(out_value, out_deriv);
 }
 
-void SoftmaxComponent::StoreStats(const CuMatrixBase<BaseFloat> &out_value) {
+void SoftmaxComponent::StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                                  const CuMatrixBase<BaseFloat> &out_value,
+                                  void *memo) {
   // We don't store derivative stats for this component type, just activation
   // stats.
   StoreStatsInternal(out_value, NULL);
 }
 
 
-void LogSoftmaxComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* LogSoftmaxComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                     const CuMatrixBase<BaseFloat> &in,
                                     CuMatrixBase<BaseFloat> *out) const {
   // Applies log softmax function to each row of the output. For each row, we do
   // x_i = x_i - log(sum_j exp(x_j))
   out->ApplyLogSoftMaxPerRow(in);
+  return NULL;
 }
 
 void LogSoftmaxComponent::Backprop(const std::string &debug_info,
@@ -3092,6 +3140,7 @@ void LogSoftmaxComponent::Backprop(const std::string &debug_info,
                                    const CuMatrixBase<BaseFloat> &, // in_value
                                    const CuMatrixBase<BaseFloat> &out_value,
                                    const CuMatrixBase<BaseFloat> &out_deriv,
+                                   void *memo,
                                    Component *, // to_update
                                    CuMatrixBase<BaseFloat> *in_deriv) const {
   if (in_deriv == NULL)
@@ -3136,11 +3185,12 @@ std::string FixedScaleComponent::Info() const {
   return stream.str();
 }
 
-void FixedScaleComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
-                                    const CuMatrixBase<BaseFloat> &in,
-                                    CuMatrixBase<BaseFloat> *out) const {
+void* FixedScaleComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+                                     const CuMatrixBase<BaseFloat> &in,
+                                     CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);  // does nothing if same matrix.
   out->MulColsVec(scales_);
+  return NULL;
 }
 
 void FixedScaleComponent::Backprop(const std::string &debug_info,
@@ -3148,6 +3198,7 @@ void FixedScaleComponent::Backprop(const std::string &debug_info,
                                    const CuMatrixBase<BaseFloat> &, // in_value
                                    const CuMatrixBase<BaseFloat> &, // out_value
                                    const CuMatrixBase<BaseFloat> &out_deriv,
+                                   void *memo,
                                    Component *, // to_update
                                    CuMatrixBase<BaseFloat> *in_deriv) const {
   in_deriv->CopyFromMat(out_deriv);  // does nothing if same memory.
@@ -3208,11 +3259,12 @@ std::string FixedBiasComponent::Info() const {
   return stream.str();
 }
 
-void FixedBiasComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* FixedBiasComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                    const CuMatrixBase<BaseFloat> &in,
                                    CuMatrixBase<BaseFloat> *out) const {
   out->CopyFromMat(in);  // will do nothing if in and out have same memory.
   out->AddVecToRows(1.0, bias_, 1.0);
+  return NULL;
 }
 
 void FixedBiasComponent::Backprop(const std::string &debug_info,
@@ -3220,6 +3272,7 @@ void FixedBiasComponent::Backprop(const std::string &debug_info,
                                   const CuMatrixBase<BaseFloat> &, // in_value
                                   const CuMatrixBase<BaseFloat> &, // out_value
                                   const CuMatrixBase<BaseFloat> &out_deriv,
+                                  void *memo,
                                   Component *, // to_update
                                   CuMatrixBase<BaseFloat> *in_deriv) const {
   // the following statement will do nothing if in_deriv and out_deriv have same
@@ -3671,7 +3724,7 @@ void ConvolutionComponent::InputToInputPatches(
 
 // propagation function
 // see function declaration in nnet-simple-component.h for details
-void ConvolutionComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* ConvolutionComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                          const CuMatrixBase<BaseFloat> &in,
                                          CuMatrixBase<BaseFloat> *out) const {
   const int32 num_x_steps = (1 + (input_x_dim_ - filt_x_dim_) / filt_x_step_),
@@ -3712,6 +3765,7 @@ void ConvolutionComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
     delete tgt_batch[p];
     delete patch_batch[p];
   }
+  return NULL;
 }
 
 // scale the parameters
@@ -3826,6 +3880,7 @@ void ConvolutionComponent::Backprop(const std::string &debug_info,
                                     const CuMatrixBase<BaseFloat> &in_value,
                                     const CuMatrixBase<BaseFloat> &, // out_value,
                                     const CuMatrixBase<BaseFloat> &out_deriv,
+                                    void *memo,
                                     Component *to_update_in,
                                     CuMatrixBase<BaseFloat> *in_deriv) const {
   ConvolutionComponent *to_update =
@@ -4186,7 +4241,7 @@ void MaxpoolingComponent::InputToInputPatches(
   The output matrix is also a vectorized 3D-tensor of type zxy.
 */
 
-void MaxpoolingComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* MaxpoolingComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                     const CuMatrixBase<BaseFloat> &in,
                                     CuMatrixBase<BaseFloat> *out) const {
   int32 num_frames = in.NumRows();
@@ -4198,6 +4253,7 @@ void MaxpoolingComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   out->Set(-1e20); // reset a large negative value
   for (int32 q = 0; q < pool_size; q++)
     out->Max(patches.ColRange(q * num_pools, num_pools));
+  return NULL;
 }
 
 // Method to compute the input derivative matrix from the input derivatives
@@ -4255,6 +4311,7 @@ void MaxpoolingComponent::Backprop(const std::string &debug_info,
                                    const CuMatrixBase<BaseFloat> &in_value,
                                    const CuMatrixBase<BaseFloat> &out_value,
                                    const CuMatrixBase<BaseFloat> &out_deriv,
+                                   void *memo,
                                    Component *, // to_update,
                                    CuMatrixBase<BaseFloat> *in_deriv) const {
   if (!in_deriv)
@@ -4364,16 +4421,18 @@ Component* PermuteComponent::Copy() const {
   return ans;
 }
 
-void PermuteComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+void* PermuteComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
                                  const CuMatrixBase<BaseFloat> &in,
                                  CuMatrixBase<BaseFloat> *out) const  {
   out->CopyCols(in, column_map_);
+  return NULL;
 }
 void PermuteComponent::Backprop(const std::string &debug_info,
                                 const ComponentPrecomputedIndexes *indexes,
                                 const CuMatrixBase<BaseFloat> &, //in_value
                                 const CuMatrixBase<BaseFloat> &, // out_value,
                                 const CuMatrixBase<BaseFloat> &out_deriv,
+                                void *memo,
                                 Component *to_update,
                                 CuMatrixBase<BaseFloat> *in_deriv) const  {
   in_deriv->CopyCols(out_deriv, reverse_column_map_);
@@ -4508,7 +4567,7 @@ MatrixStrideType CompositeComponent::GetStrideType(int32 i) const {
 
 
 // virtual
-void CompositeComponent::Propagate(
+void* CompositeComponent::Propagate(
     const ComponentPrecomputedIndexes *, // indexes
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
@@ -4528,7 +4587,7 @@ void CompositeComponent::Propagate(
                                       0, out->NumCols());
       this->Propagate(NULL, in_part, &out_part);
     }
-    return;
+    return NULL;
   }
   std::vector<CuMatrix<BaseFloat> > intermediate_outputs(num_components - 1);
   for (int32 i = 0; i < num_components; i++) {
@@ -4539,11 +4598,19 @@ void CompositeComponent::Propagate(
       intermediate_outputs[i].Resize(num_rows, components_[i]->OutputDim(),
                                      resize_type, GetStrideType(i));
     }
-    components_[i]->Propagate(NULL, (i == 0 ? in : intermediate_outputs[i-1]),
-               (i + 1 == num_components ? out : &(intermediate_outputs[i])));
+    const CuMatrixBase<BaseFloat> &this_in = (i == 0 ? in :
+                                              intermediate_outputs[i-1]);
+    CuMatrixBase<BaseFloat> *this_out = (i + 1 == num_components ?
+                                         out : &(intermediate_outputs[i]));
+    void *memo =  components_[i]->Propagate(NULL, this_in, this_out);
+    // we'll re-do the forward propagation in the backprop, and we can
+    // regenerate any memos there, so no need to keep them.
+    if (memo != NULL)
+      components_[i]->DeleteMemo(memo);
     if (i > 0)
       intermediate_outputs[i-1].Resize(0, 0);
   }
+  return NULL;
 }
 
 
@@ -4645,6 +4712,7 @@ void CompositeComponent::Backprop(const std::string &debug_info,
                                   const CuMatrixBase<BaseFloat> &in_value,
                                   const CuMatrixBase<BaseFloat> &out_value,
                                   const CuMatrixBase<BaseFloat> &out_deriv,
+                                  void *memo,
                                   Component *to_update,
                                   CuMatrixBase<BaseFloat> *in_deriv) const {
   KALDI_ASSERT(in_value.NumRows() == out_deriv.NumRows() &&
@@ -4679,7 +4747,7 @@ void CompositeComponent::Backprop(const std::string &debug_info,
       this->Backprop(debug_info, NULL, in_value_part,
                      (have_output_value ? static_cast<const CuMatrixBase<BaseFloat>&>(out_value_part) :
                       static_cast<const CuMatrixBase<BaseFloat>&>(empty_mat)),
-                     out_deriv_part, to_update,
+                     out_deriv_part, NULL, to_update,
                      in_deriv != NULL ? &in_deriv_part : NULL);
     }
     return;
@@ -4688,45 +4756,60 @@ void CompositeComponent::Backprop(const std::string &debug_info,
   // computed.  in_value and out_deriv will always be supplied.
 
   // intermediate_outputs[i] contains the output of component i.
-  std::vector<CuMatrix<BaseFloat> > intermediate_outputs(num_components - 1);
+  std::vector<CuMatrix<BaseFloat> > intermediate_outputs(num_components);
   // intermediate_derivs[i] contains the deriative at the output of component i.
   std::vector<CuMatrix<BaseFloat> > intermediate_derivs(num_components - 1);
 
-  // Do the propagation again, for all but the last component in the sequence.
-  // later on we can try being more careful about which ones we need to
-  // propagate.
-  for (int32 i = 0; i + 1 < num_components; i++) {
-    // skip the last-but-one component's propagate if the last component's
-    // backprop doesn't need the input and the one previous to that doesn't
-    // need the output.  [lowest hanging fruit for optimization]
-    if (i + 2 == num_components &&
-        !(components_[i+1]->Properties() & kBackpropNeedsInput) &&
-        !(components_[i]->Properties() & kBackpropNeedsOutput))
-      break;
+  KALDI_ASSERT(memo == NULL);
+  // note: only a very few components use memos, but we need to support them.
+  std::vector<void*> memos(num_components, NULL);
+
+  int32 num_components_to_propagate = num_components;
+  if (!(components_[num_components - 1]->Properties() & kUsesMemo)) {
+    // we only need to propagate the very last component if it uses a memo.
+    num_components_to_propagate--;
+    if (num_components > 1) {
+      // skip the last-but-one component's propagate if the last component's
+      // backprop doesn't need the input and the last-but-one component's
+      // backprop doesn't need the output.  This is the lowest hanging fruit for
+      // optimization; other propagates might also be skippable.
+      int32 properties = components_[num_components - 2]->Properties(),
+          next_properties = components_[num_components - 1]->Properties();
+      if (!(properties & (kBackpropNeedsOutput || kUsesMemo)) &&
+          !(next_properties & kBackpropNeedsInput)) {
+        num_components_to_propagate--;
+      }
+    }
+  }
+
+
+  // Do the propagation again.
+  for (int32 i = 0; i < num_components_to_propagate; i++) {
     MatrixResizeType resize_type =
         ((components_[i]->Properties() & kPropagateAdds) ?
          kSetZero : kUndefined);
     intermediate_outputs[i].Resize(num_rows, components_[i]->OutputDim(),
                                    resize_type, GetStrideType(i));
-    components_[i]->Propagate(NULL,
-                              (i == 0 ? in_value : intermediate_outputs[i-1]),
+    memos[i] =
+        components_[i]->Propagate(NULL,
+                             (i == 0 ? in_value : intermediate_outputs[i-1]),
                               &(intermediate_outputs[i]));
   }
+
   for (int32 i = num_components - 1; i >= 0; i--) {
+    const CuMatrixBase<BaseFloat> &this_in_value =
+        (i == 0 ? in_value : intermediate_outputs[i-1]),
+        &this_out_value =
+        (i == num_components - 1 ? out_value : intermediate_outputs[i]);
+
     Component *component_to_update =
         (to_update == NULL ? NULL :
          dynamic_cast<CompositeComponent*>(to_update)->components_[i]);
 
-    if (components_[i]->Properties() & kStoresStats &&
-        component_to_update != NULL)
-      component_to_update->StoreStats(
-          (i + 1 == num_components ? out_value : intermediate_outputs[i]));
+    if (component_to_update != NULL  &&
+        components_[i]->Properties() & kStoresStats)
+      component_to_update->StoreStats(this_in_value, this_out_value, memos[i]);
 
-    // skip the first component's backprop if it's not updatable and in_deriv is
-    // not requested.  Again, this is the lowest-hanging fruit to optimize.
-    if (i == 0 && !(components_[0]->Properties() & kUpdatableComponent) &&
-        in_deriv == NULL)
-      break;
     if (i > 0) {
       MatrixResizeType resize_type =
           ((components_[i]->Properties() & kBackpropAdds) ?
@@ -4734,12 +4817,18 @@ void CompositeComponent::Backprop(const std::string &debug_info,
       intermediate_derivs[i-1].Resize(num_rows, components_[i]->InputDim(),
                                       resize_type, GetStrideType(i - 1));
     }
-    components_[i]->Backprop(debug_info, NULL,
-                             (i == 0 ? in_value : intermediate_outputs[i-1]),
-                             (i + 1 == num_components ? out_value : intermediate_outputs[i]),
-                             (i + 1 == num_components ? out_deriv : intermediate_derivs[i]),
-                             component_to_update,
-                             (i == 0 ? in_deriv : &(intermediate_derivs[i-1])));
+    // skip the first component's backprop if it's not updatable and in_deriv is
+    // not requested.  Again, this is the lowest-hanging fruit to optimize.
+    if (!(i == 0 && !(components_[0]->Properties() & kUpdatableComponent) &&
+          in_deriv == NULL)) {
+      components_[i]->Backprop(debug_info, NULL,
+                this_in_value, this_out_value,
+                (i + 1 == num_components ? out_deriv : intermediate_derivs[i]),
+                memos[i], component_to_update,
+                (i == 0 ? in_deriv : &(intermediate_derivs[i-1])));
+    }
+    if (memos[i] != NULL)
+      components_[i]->DeleteMemo(memos[i]);
   }
 }
 
@@ -5153,11 +5242,12 @@ void LstmNonlinearityComponent::UnVectorize(
 }
 
 
-void LstmNonlinearityComponent::Propagate(
+void* LstmNonlinearityComponent::Propagate(
     const ComponentPrecomputedIndexes *, // indexes
     const CuMatrixBase<BaseFloat> &in,
     CuMatrixBase<BaseFloat> *out) const {
   cu::ComputeLstmNonlinearity(in, params_, out);
+  return NULL;
 }
 
 
@@ -5167,6 +5257,7 @@ void LstmNonlinearityComponent::Backprop(
     const CuMatrixBase<BaseFloat> &in_value,
     const CuMatrixBase<BaseFloat> &, // out_value,
     const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo,
     Component *to_update_in,
     CuMatrixBase<BaseFloat> *in_deriv) const {
 
@@ -5301,6 +5392,485 @@ void LstmNonlinearityComponent::InitFromConfig(ConfigLine *cfl) {
   }
 }
 
+
+
+void BatchNormComponent::ComputeDerived() {
+  if (!test_mode_) {
+    offset_.Resize(0);
+    scale_.Resize(0);
+    return;
+  }
+
+  if (count_ == 0.0) {
+    KALDI_WARN << "Test-mode is set but there is no data count.  "
+        "Creating random counts.  This only makes sense "
+        "in unit-tests.  If you see this in real life, "
+        "something is very wrong.";
+    count_ = 1.0;
+    stats_sum_.SetRandn();
+    stats_sumsq_.SetRandn();
+    stats_sumsq_.AddVecVec(1.0, stats_sum_, stats_sum_, 1.0);
+  }
+
+  offset_.Resize(block_dim_);
+  scale_.Resize(block_dim_);
+  offset_.CopyFromVec(stats_sum_);
+  offset_.Scale(1.0 / count_);
+  // now offset_ is -mean.
+  scale_.CopyFromVec(stats_sumsq_);
+  scale_.Scale(1.0 / count_);
+  scale_.AddVecVec(-1.0, offset_, offset_, 1.0);
+  // now scale_ is variance.
+  scale_.ApplyFloor(epsilon_);
+  scale_.ApplyPow(-0.5);
+  // now scale_ = min(variance, epsilon)^{-0.5}.
+  // next, multpiply by the target RMS (normally 1.0).
+  scale_.Scale(target_rms_);
+  offset_.MulElements(scale_);
+  // now offset_ is -(scale*mean).
+}
+
+void BatchNormComponent::SetTestMode(bool test_mode) {
+  test_mode_ = test_mode;
+  ComputeDerived();
+}
+
+void BatchNormComponent::Check() const {
+  KALDI_ASSERT(dim_ > 0 && block_dim_ > 0 && dim_ % block_dim_ == 0 &&
+               epsilon_ > 0.0 && target_rms_ > 0.0);
+}
+
+BatchNormComponent::BatchNormComponent(const BatchNormComponent &other):
+    dim_(other.dim_), block_dim_(other.block_dim_), epsilon_(other.epsilon_),
+    target_rms_(other.target_rms_), test_mode_(other.test_mode_),
+    count_(other.count_), stats_sum_(other.stats_sum_),
+    stats_sumsq_(other.stats_sumsq_) {
+  ComputeDerived();
+  Check();
+}
+
+
+std::string BatchNormComponent::Info() const {
+  std::ostringstream stream;
+  stream << Type() << ", dim=" << dim_ << ", block-dim=" << block_dim_
+         << ", epsilon=" << epsilon_ << ", target-rms=" << target_rms_
+         << ", count=" << count_;
+  if (count_ > 0) {
+    Vector<BaseFloat> mean(stats_sum_), var(stats_sumsq_);
+    mean.Scale(1.0 / count_);
+    var.Scale(1.0 / count_);
+    // subtract mean^2 from var.
+    var.AddVecVec(-1.0, mean, mean, 1.0);
+    var.ApplyFloor(0.0);
+    var.ApplyPow(0.5);  // make it the stddev.
+    stream << ", data-mean=" << SummarizeVector(mean)
+           << ", data-stddev=" << SummarizeVector(var);
+  }
+  return stream.str();
+}
+
+void BatchNormComponent::InitFromConfig(ConfigLine *cfl) {
+  dim_ = -1;
+  block_dim_ = -1;
+  epsilon_ = 1.0e-03;
+  target_rms_ = 1.0;
+  test_mode_ = false;
+  bool ok = cfl->GetValue("dim", &dim_);
+  cfl->GetValue("block-dim", &block_dim_);
+  cfl->GetValue("epsilon", &epsilon_);
+  cfl->GetValue("target-rms", &target_rms_);
+  cfl->GetValue("test-mode", &test_mode_);
+  if (!ok || dim_ <= 0) {
+    KALDI_ERR << "BatchNormComponent must have 'dim' specified, and > 0";
+  }
+  if (block_dim_ == -1)
+    block_dim_ = dim_;
+  if (!(block_dim_ > 0 && dim_ % block_dim_ == 0 &&
+        epsilon_ > 0 && target_rms_ > 0))
+    KALDI_ERR << "Invalid configuration dim=" << dim_
+              << ", block-dim=" << block_dim_ << ", epsilon=" << epsilon_
+              << ", target-rms=" << target_rms_ << " in BatchNormComponent.";
+  if (cfl->HasUnusedValues())
+    KALDI_ERR << "Could not process these elements in initializer: "
+              << cfl->UnusedValues();
+  count_ = 0;
+  stats_sum_.Resize(block_dim_);
+  stats_sumsq_.Resize(block_dim_);
+  if (test_mode_) {
+    ComputeDerived();
+  }
+}
+
+
+
+/*
+  This comment describes the equations involved in batch normalization, and
+  derives the forward and back-propagation.
+
+
+  This is all dimension-by-dimension, so we just imagine the inputs
+  are scalars x(i), for i=0 .. n-1.
+
+  FORWARD PASS:
+
+  Define xsum  = sum_i x(i)
+         x2sum = sum_i x(i)^2
+          mean = xsum / n
+           var = x2sum / n - (mean*mean)
+         scale = sqrt(var + epsilon)^{-0.5} *
+        offset = -mean * scale
+
+      y(i) = scale * x(i) + offset
+
+    * note: we'll actually implement the epsilon term by flooring the variance to that
+      value instead of adding; this provides certainty that there will be no NaN's
+      appearing even in the presence of roundoff error.  Our backprop formula is
+      such that it's insensitive to this type of difference and doesn't have to be
+      changed, see below.
+
+   Most of the rest of this comment derives how to compute the derivatives.  If
+   you just want the formulas, please skip to the string 'BACKWARD PASS' below.
+
+  We'll use a notation where an apostrophe on something means (the derivative of
+  the objective function w.r.t. that thing), so y'(i) is df/dy(i), and so on.
+  We are given y'(i).  Propagating the derivatives backward:
+     offset' = sum_i y'(i)
+     scale' = (sum_i y'(i) * x(i)) - offset' * mean
+       var' = scale' * -0.5 * sqrt(var + epsilon)^{-1.5}
+            = -0.5 * scale' * scale^3
+      mean' = -offset' * scale - 2 * mean * var'
+      xsum' = mean' / n
+     x2sum' = var' / n
+
+  So the derivatives propagated back to the original data are:
+     x'(i) = y'(i) * scale  +  xsum'  +  x(i) * x2sum'
+
+  The above is quite complicated to compute, but we can use some invariances
+  to work out a simpler way to compute the derivatives.d
+
+  Firstly, note that x'(i) is of the form:
+
+   x'(i) =  y'(i) * scale + [affine function of x(i)].
+
+   [it's a 1-d affine function, i.e. offset and scale].
+ This has the same functional form as:
+
+ x'(i) =  y'(i) * scale + [affine function of y(i)].
+
+  since y(i) is an affine function of x(i) with nonzero scale.
+  Because the output is invariant to shifts in the input, sum_i x'(i)
+  will be zero.  This is sufficient to determine the bias
+  term in the affine function.  [Note: the scale on y(i) doesn't
+  come into it because the y(i) sum to zero].  The offset
+  will just be (sum_i y'(i) * scale / n); this makes the sum of x'(i) zero.
+  So let's write it as
+
+    x'(i) =  (y'(i) - 1/n sum_i y'(i)) * scale + alpha y(i).
+
+  and it will be convenient to define:
+
+  x_deriv_base(i) = (y'(i) - 1/n sum_i y'(i)) * scale
+
+  which is just y'(i) with mean subtraction, scaled according to
+  the scale used in the normalization.  So write
+
+   x'(i) = x_deriv_base(i) + alpha y(i).
+
+ The question is, what is the scale alpha.  We don't actually need to
+ do any differentiation to figure this out.  First, assume there is
+ no "+ epsilon" in the variance; later we'll explain why this doesn't
+ matter.  The key to working out alpha is that the output is invariant
+ to scaling of the input.  Assume we scale around the input's mean,
+ since that makes the math simpler.  We can express this by the
+ constraint that (\sum_i x'(i) * (x(i) - avg-x)) = 0.  This is
+ equivalent to the constraint that (\sum_i x'(i) y (i)) = 0, since
+ y(i) is x(i) - avg-x times a nonzero scale.  We'll use this contraint
+ to determine alpha, Using the above expressionfor x(i), we can write
+ this constraint as:
+   \sum_i ( y(i) x_deriv_base(i)  + alpha y(i) y(i)) = 0.
+ Now, since we said we'd ignore the epsilon, the output has unit variance,
+ so we know that \sum_i y(i) y(i) = n.
+ So alpha = - \sum_i y(i) x_deriv_base(i) / n.  We can actually re-imagine
+ the epsilon term (or variance-flooring) as having been implemented by
+ adding a couple extra rows to the matrix with suitable values, and zero
+ output-deriv for those rows.  If you think about it carefully you'll see that
+ the formula above is valid even if there is flooring of, or an extra term
+ in, the variance.  Anyway the correctness of the derivative will get tested
+ throughly by the component unit-tests.
+
+ So to recap, here is the backprop.
+
+ BACKWARD PASS:
+
+  We are given y'(i), scale, and y(i).
+
+  We compute:
+    x_deriv_base(i) = (y'(i) - 1/n sum_i y'(i)) * scale
+              alpha = - \sum_i y(i) x_deriv_base(i) / n
+              x'(i) = x_deriv_base(i) + alpha y(i)
+  */
+
+
+
+void* BatchNormComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
+                                    const CuMatrixBase<BaseFloat> &in,
+                                    CuMatrixBase<BaseFloat> *out) const {
+  KALDI_ASSERT(SameDim(in, *out) &&
+               (in.NumCols() == dim_ || in.NumCols() == block_dim_));
+  if (in.NumCols() != block_dim_) {
+    // if block_dim_ != dim_, we recurse; this helps keep the main code
+    // simple.
+    KALDI_ASSERT(in.Stride() == in.NumCols() && out->Stride() == out->NumCols());
+    int32 ratio = dim_ / block_dim_, orig_rows = in.NumRows(),
+        orig_cols = in.NumCols(), new_rows = orig_rows * ratio,
+        new_cols = orig_cols / ratio;
+    CuSubMatrix<BaseFloat> in_reshaped(in.Data(), new_rows, new_cols, new_cols),
+        out_reshaped(out->Data(), new_rows, new_cols, new_cols);
+    return Propagate(indexes, in_reshaped, &out_reshaped);
+  }
+
+  // From this point, we can assume that the num-cols of 'in' and 'out'
+  // equals block_dim_.
+
+  if (!test_mode_) {
+    // search in the comment above for FORWARD PASS to see what is being
+    // implemented here.
+    // if this takes too much time due to multiple different CUDA calls,
+    // we'll consider making a single kernel for some of it.
+    Memo *memo = new Memo;
+    int32 num_frames = in.NumRows(), dim = block_dim_;
+    memo->num_frames = num_frames;
+    memo->mean_uvar_scale.Resize(4, dim);
+    CuSubVector<BaseFloat> mean(memo->mean_uvar_scale, 0),
+        uvar(memo->mean_uvar_scale, 1),
+        scale(memo->mean_uvar_scale, 2);
+    mean.AddRowSumMat(1.0 / num_frames, in, 0.0);
+    uvar.AddDiagMat2(1.0 / num_frames, in, kTrans, 0.0);
+    scale.CopyFromVec(uvar);
+    // by applying this scale at this point, we save a multiply later on.
+    BaseFloat var_scale = 1.0 / (target_rms_ * target_rms_);
+    scale.AddVecVec(-var_scale, mean, mean, var_scale);
+    // at this point, 'scale' contains just the variance [divided by target-rms^2].
+    scale.ApplyFloor(var_scale * epsilon_);
+    // Now 'scale' contains the variance floored to epsilon [both divided by
+    // target-rms^2].  We floor instead of adding so that we can be 100% sure
+    // that it's positive even in the presence of roundoff.
+    scale.ApplyPow(-0.5);
+    // now 'scale' is the actual scale we'll use.
+
+    // the next command will do no work if out == in, for in-place propagation.
+    out->CopyFromMat(in);
+    out->AddVecToRows(-1.0, mean, 1.0);
+    out->MulColsVec(scale);
+
+    return static_cast<void*>(memo);
+  } else {
+    if (offset_.Dim() != block_dim_) {
+      if (count_ == 0)
+        KALDI_ERR << "Test mode set in BatchNormComponent, but no stats.";
+      else  // why was ComputeDerived() not called?
+        KALDI_ERR << "Code error in BatchNormComponent";
+    }
+    out->CopyFromMat(in);
+    out->MulColsVec(scale_);
+    out->AddVecToRows(1.0, offset_, 1.0);
+    return NULL;
+  }
+}
+
+void BatchNormComponent::Backprop(
+    const std::string &debug_info,
+    const ComponentPrecomputedIndexes *indexes,
+    const CuMatrixBase<BaseFloat> &in_value,  // unused
+    const CuMatrixBase<BaseFloat> &out_value,
+    const CuMatrixBase<BaseFloat> &out_deriv,
+    void *memo_in,
+    Component *to_update,  // unused
+    CuMatrixBase<BaseFloat> *in_deriv) const {
+
+  KALDI_ASSERT(SameDim(out_value, out_deriv) &&
+               SameDim(out_value, *in_deriv) &&
+               (out_value.NumCols() == dim_ ||
+                out_value.NumCols() == block_dim_));
+  if (out_value.NumCols() != block_dim_) {
+    // if block_dim_ != dim_, we recurse; this helps keep the main code
+    // simple.
+    KALDI_ASSERT(out_value.Stride() == out_value.NumCols() &&
+                 out_deriv.Stride() == out_deriv.NumCols() &&
+                 in_deriv->Stride() == in_deriv->NumCols());
+    int32 ratio = dim_ / block_dim_,
+        orig_rows = out_value.NumRows(),
+        orig_cols = out_value.NumCols(),
+        new_rows = orig_rows * ratio, new_cols = orig_cols / ratio;
+    CuSubMatrix<BaseFloat> out_value_reshaped(out_value.Data(), new_rows,
+                                              new_cols, new_cols),
+        out_deriv_reshaped(out_deriv.Data(), new_rows, new_cols, new_cols),
+        in_deriv_reshaped(in_deriv->Data(), new_rows, new_cols, new_cols);
+    // we'll never use in_value, so pass it in unchanged.
+    Backprop(debug_info, indexes, in_value,
+             out_value_reshaped, out_deriv_reshaped,
+             memo_in, to_update, &in_deriv_reshaped);
+    return;
+  }
+
+  Memo *memo = static_cast<Memo*>(memo_in);
+
+  if (!test_mode_) {
+    // search above for BACKWARD PASS for a comment describing the math.
+    KALDI_ASSERT(memo != NULL && "memo not passed into backprop");
+    int32 num_frames = memo->num_frames;
+    KALDI_ASSERT(out_value.NumRows() == num_frames);
+    CuSubVector<BaseFloat> temp(memo->mean_uvar_scale, 3),
+        scale(memo->mean_uvar_scale, 2);
+    temp.AddRowSumMat(-1.0 / num_frames, out_deriv, 0.0);
+    // the following does no work if in_deriv and out_deriv are the same matrix.
+    in_deriv->CopyFromMat(out_deriv);
+    in_deriv->AddVecToRows(1.0, temp);
+    in_deriv->MulColsVec(scale);
+    // at this point, 'in_deriv' contains:
+    // x_deriv_base(i) = (y'(i) - 1/n sum_i y'(i)) * scale
+    temp.AddDiagMatMat(-1.0 / (num_frames * target_rms_ * target_rms_),
+                       out_value, kTrans, *in_deriv, kNoTrans, 0.0);
+    // now, 'temp' contains the quantity which we described
+    // in the math as:
+    // alpha = - \sum_i y(i) x_deriv_base(i) / n.
+    // The factor 1 / (target_rms_ * target_rms_) comes from following
+    // this additional scaling factor through the math.  In the comment I said
+    // "we know that \sum_i y(i) y(i) = n".  Taking target-rms into account
+    // this becomes "we know that \sum_i y(i) y(i) = n * target-rms^2".
+    in_deriv->AddMatDiagVec(1.0, out_value, kNoTrans, temp, 1.0);
+    // At this point, in_deriv contains  x'(i) = x_deriv_base(i) + alpha y(i).
+
+  } else {
+    KALDI_ASSERT(offset_.Dim() == block_dim_);
+    // the next call does no work if they point to the same memory.
+    in_deriv->CopyFromMat(out_deriv);
+    in_deriv->MulColsVec(scale_);
+  }
+}
+
+void BatchNormComponent::StoreStats(
+    const CuMatrixBase<BaseFloat> &in_value,
+    const CuMatrixBase<BaseFloat> &out_value,
+    void *memo_in) {
+  // in test mode this component does not store stats, it doesn't provide the
+  // kStoresStats flag.
+  KALDI_ASSERT(!test_mode_);
+  KALDI_ASSERT(out_value.NumCols() == dim_ || out_value.NumCols() == block_dim_);
+  if (out_value.NumCols() != block_dim_) {
+    // if block_dim_ != dim_, we recurse; this helps keep the main code
+    // simple.
+    KALDI_ASSERT(out_value.Stride() == out_value.NumCols());
+    int32 ratio = dim_ / block_dim_,
+        orig_rows = out_value.NumRows(),
+        orig_cols = out_value.NumCols(),
+        new_rows = orig_rows * ratio, new_cols = orig_cols / ratio;
+    CuSubMatrix<BaseFloat> out_value_reshaped(out_value.Data(), new_rows,
+                                              new_cols, new_cols);
+    // we'll never use in_value, so just pass it in unchanged.
+    StoreStats(in_value, out_value_reshaped, memo_in);
+    return;
+  }
+
+  Memo *memo = static_cast<Memo*>(memo_in);
+  KALDI_ASSERT(out_value.NumRows() == memo->num_frames);
+
+  CuSubVector<BaseFloat> mean(memo->mean_uvar_scale, 0),
+      uvar(memo->mean_uvar_scale, 1);
+  KALDI_ASSERT(mean.Dim() == block_dim_ && memo->num_frames > 0);
+  BaseFloat num_frames = memo->num_frames;
+  if (stats_sum_.Dim() != block_dim_) {
+    stats_sum_.Resize(block_dim_);
+    stats_sumsq_.Resize(block_dim_);
+    KALDI_ASSERT(count_ == 0);
+  }
+  count_ += num_frames;
+  stats_sum_.AddVec(num_frames, mean, 1.0);
+  stats_sumsq_.AddVec(num_frames, uvar, 1.0);
+}
+
+void BatchNormComponent::Read(std::istream &is, bool binary) {
+  ExpectOneOrTwoTokens(is, binary, "<BatchNormComponent>", "<Dim>");
+  ReadBasicType(is, binary, &dim_);
+  ExpectToken(is, binary, "<BlockDim>");
+  ReadBasicType(is, binary, &block_dim_);
+  ExpectToken(is, binary, "<Epsilon>");
+  ReadBasicType(is, binary, &epsilon_);
+  ExpectToken(is, binary, "<TargetRms>");
+  ReadBasicType(is, binary, &target_rms_);
+  ExpectToken(is, binary, "<TestMode>");
+  ReadBasicType(is, binary, &test_mode_);
+  ExpectToken(is, binary, "<Count>");
+  ReadBasicType(is, binary, &count_);
+  ExpectToken(is, binary, "<StatsMean>");
+  stats_sum_.Read(is, binary);
+  ExpectToken(is, binary, "<StatsVar>");
+  stats_sumsq_.Read(is, binary);
+  stats_sumsq_.AddVecVec(1.0, stats_sum_, stats_sum_, 1.0);
+  stats_sum_.Scale(count_);
+  stats_sumsq_.Scale(count_);
+  ExpectToken(is, binary, "</BatchNormComponent>");
+  ComputeDerived();
+  Check();
+}
+
+void BatchNormComponent::Write(std::ostream &os, bool binary) const {
+  Check();
+  WriteToken(os, binary, "<BatchNormComponent>");
+  WriteToken(os, binary, "<Dim>");
+  WriteBasicType(os, binary, dim_);
+  WriteToken(os, binary, "<BlockDim>");
+  WriteBasicType(os, binary, block_dim_);
+  WriteToken(os, binary, "<Epsilon>");
+  WriteBasicType(os, binary, epsilon_);
+  WriteToken(os, binary, "<TargetRms>");
+  WriteBasicType(os, binary, target_rms_);
+  WriteToken(os, binary, "<TestMode>");
+  WriteBasicType(os, binary, test_mode_);
+  WriteToken(os, binary, "<Count>");
+  WriteBasicType(os, binary,  count_);
+  CuVector<BaseFloat> mean(stats_sum_), var(stats_sumsq_);
+  if (count_ != 0) {
+    mean.Scale(1.0 / count_);
+    var.Scale(1.0 / count_);
+    var.AddVecVec(-1.0, mean, mean, 1.0);
+  }
+  WriteToken(os, binary, "<StatsMean>");
+  mean.Write(os, binary);
+  WriteToken(os, binary, "<StatsVar>");
+  var.Write(os, binary);
+  WriteToken(os, binary, "</BatchNormComponent>");
+}
+
+void BatchNormComponent::Scale(BaseFloat scale) {
+  count_ *= scale;
+  stats_sum_.Scale(scale);
+  stats_sumsq_.Scale(scale);
+}
+
+
+void BatchNormComponent::Add(BaseFloat alpha, const Component &other_in) {
+  const BatchNormComponent *other =
+      dynamic_cast<const BatchNormComponent*>(&other_in);
+  count_ += alpha * other->count_;
+  stats_sum_.AddVec(alpha, other->stats_sum_);
+  stats_sumsq_.AddVec(alpha, other->stats_sumsq_);
+  // this operation might change offset_ and scale_, so we recompute them
+  // in this instance (but not in Scale()).
+  ComputeDerived();
+}
+
+void BatchNormComponent::ZeroStats() {
+  // We only zero the stats if we're not in test mode.  In test mode, this would
+  // be dangerous as the stats are the source for the transform, and zeroing
+  // them and then calling ComputeDerived() again would remove the transform
+  // parameters (offset_ and scale_).
+  if (!test_mode_) {
+    count_ = 0.0;
+    stats_sum_.SetZero();
+    stats_sumsq_.SetZero();
+  }
+}
 
 
 } // namespace nnet3

--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -56,14 +56,15 @@ class PnormComponent: public Component {
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual int32 InputDim() const { return input_dim_; }
   virtual int32 OutputDim() const { return output_dim_; }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
-                         const CuMatrixBase<BaseFloat> &in,
-                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                          const CuMatrixBase<BaseFloat> &in,
+                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
                         const ComponentPrecomputedIndexes *indexes,
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const { return new PnormComponent(input_dim_,
@@ -114,7 +115,7 @@ class DropoutComponent : public RandomComponent {
   // Write component to stream
   virtual void Write(std::ostream &os, bool binary) const;
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -122,6 +123,7 @@ class DropoutComponent : public RandomComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const { return new DropoutComponent(dim_,
@@ -155,14 +157,15 @@ class ElementwiseProductComponent: public Component {
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual int32 InputDim() const { return input_dim_; }
   virtual int32 OutputDim() const { return output_dim_; }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
-                         const CuMatrixBase<BaseFloat> &in,
-                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                          const CuMatrixBase<BaseFloat> &in,
+                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
                         const ComponentPrecomputedIndexes *indexes,
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const { return new ElementwiseProductComponent(input_dim_,
@@ -200,14 +203,15 @@ class NormalizeComponent: public Component {
   virtual std::string Type() const { return "NormalizeComponent"; }
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual Component* Copy() const { return new NormalizeComponent(*this); }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
-                         const CuMatrixBase<BaseFloat> &in,
-                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                          const CuMatrixBase<BaseFloat> &in,
+                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
                         const ComponentPrecomputedIndexes *indexes,
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -242,17 +246,20 @@ class SigmoidComponent: public NonlinearComponent {
     return kSimpleComponent|kBackpropNeedsOutput|kPropagateInPlace|kStoresStats;
   }
   virtual Component* Copy() const { return new SigmoidComponent(*this); }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
-                         const CuMatrixBase<BaseFloat> &in,
-                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                          const CuMatrixBase<BaseFloat> &in,
+                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
                         const ComponentPrecomputedIndexes *indexes,
                         const CuMatrixBase<BaseFloat> &, //in_value
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
-  virtual void StoreStats(const CuMatrixBase<BaseFloat> &out_value);
+  virtual void StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                          const CuMatrixBase<BaseFloat> &out_value,
+                          void *memo);
  private:
   // this function is called from Backprop code and only does something if the
   // self-repair-scale config value is set.
@@ -272,7 +279,7 @@ class TanhComponent: public NonlinearComponent {
   virtual int32 Properties() const {
     return kSimpleComponent|kBackpropNeedsOutput|kPropagateInPlace|kStoresStats;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -280,9 +287,12 @@ class TanhComponent: public NonlinearComponent {
                         const CuMatrixBase<BaseFloat> &, //in_value
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
-  virtual void StoreStats(const CuMatrixBase<BaseFloat> &out_value);
+  virtual void StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                          const CuMatrixBase<BaseFloat> &out_value,
+                          void *memo);
  private:
   // this function is called from Backprop code and only does something if the
   // self-repair-scale config value is set.
@@ -305,7 +315,7 @@ class RectifiedLinearComponent: public NonlinearComponent {
     return kSimpleComponent|kLinearInInput|kBackpropNeedsOutput|kPropagateInPlace|
         kStoresStats;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -313,10 +323,12 @@ class RectifiedLinearComponent: public NonlinearComponent {
                         const CuMatrixBase<BaseFloat> &, //in_value
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
-  virtual void StoreStats(const CuMatrixBase<BaseFloat> &out_value);
-
+  virtual void StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                          const CuMatrixBase<BaseFloat> &out_value,
+                          void *memo);
  private:
   // this function is called from Backprop code and only does something if the
   // self-repair-scale config value is set.
@@ -349,7 +361,7 @@ class SumReduceComponent: public Component {
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual int32 InputDim() const { return input_dim_; }
   virtual int32 OutputDim() const { return output_dim_; }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -357,6 +369,7 @@ class SumReduceComponent: public Component {
                         const CuMatrixBase<BaseFloat> &, // in_value
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const { return new SumReduceComponent(input_dim_,
@@ -401,7 +414,7 @@ class AffineComponent: public UpdatableComponent {
   }
 
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -409,6 +422,7 @@ class AffineComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -501,7 +515,7 @@ class BlockAffineComponent : public UpdatableComponent {
       kBackpropNeedsInput|kBackpropAdds;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
 
@@ -510,6 +524,7 @@ class BlockAffineComponent : public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -564,7 +579,7 @@ class RepeatedAffineComponent: public UpdatableComponent {
     return kSimpleComponent|kUpdatableComponent|kLinearInParameters|
         kBackpropNeedsInput|kBackpropAdds|kInputContiguous|kOutputContiguous;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -572,6 +587,7 @@ class RepeatedAffineComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -660,7 +676,7 @@ class SoftmaxComponent: public NonlinearComponent {
   virtual int32 Properties() const {
     return kSimpleComponent|kBackpropNeedsOutput|kStoresStats;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -668,10 +684,12 @@ class SoftmaxComponent: public NonlinearComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
-  virtual void StoreStats(const CuMatrixBase<BaseFloat> &out_value);
-
+  virtual void StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                          const CuMatrixBase<BaseFloat> &out_value,
+                          void *memo);
   virtual Component* Copy() const { return new SoftmaxComponent(*this); }
  private:
   SoftmaxComponent &operator = (const SoftmaxComponent &other); // Disallow.
@@ -686,7 +704,7 @@ class LogSoftmaxComponent: public NonlinearComponent {
   virtual int32 Properties() const {
     return kSimpleComponent|kBackpropNeedsOutput|kStoresStats;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -694,6 +712,7 @@ class LogSoftmaxComponent: public NonlinearComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -813,7 +832,7 @@ class FixedAffineComponent: public Component {
   virtual int32 InputDim() const { return linear_params_.NumCols(); }
   virtual int32 OutputDim() const { return linear_params_.NumRows(); }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -821,6 +840,7 @@ class FixedAffineComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -865,7 +885,7 @@ public:
   SumGroupComponent() { }
   virtual std::string Type() const { return "SumGroupComponent"; }
   virtual int32 Properties() const { return kSimpleComponent|kLinearInInput; }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -873,6 +893,7 @@ public:
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const;
@@ -912,7 +933,7 @@ class FixedScaleComponent: public Component {
   virtual int32 InputDim() const { return scales_.Dim(); }
   virtual int32 OutputDim() const { return scales_.Dim(); }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -920,6 +941,7 @@ class FixedScaleComponent: public Component {
                         const CuMatrixBase<BaseFloat> &, // in_value
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const;
@@ -954,7 +976,7 @@ class FixedBiasComponent: public Component {
   virtual int32 InputDim() const { return bias_.Dim(); }
   virtual int32 OutputDim() const { return bias_.Dim(); }
   using Component::Propagate; // to avoid name hiding
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -962,6 +984,7 @@ class FixedBiasComponent: public Component {
                         const CuMatrixBase<BaseFloat> &, // in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   virtual Component* Copy() const;
@@ -984,14 +1007,15 @@ class NoOpComponent: public NonlinearComponent {
     return kSimpleComponent|kLinearInInput|kPropagateInPlace;
   }
   virtual Component* Copy() const { return new NoOpComponent(*this); }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
-                         const CuMatrixBase<BaseFloat> &in,
-                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                          const CuMatrixBase<BaseFloat> &in,
+                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
                         const ComponentPrecomputedIndexes *indexes,
                         const CuMatrixBase<BaseFloat> &, //in_value
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
  private:
@@ -1059,7 +1083,7 @@ class ClipGradientComponent: public Component {
                                      num_self_repaired_,
                                      num_backpropped_);}
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1067,6 +1091,7 @@ class ClipGradientComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1162,7 +1187,7 @@ class PermuteComponent: public Component {
 
   virtual Component* Copy() const;
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1170,6 +1195,7 @@ class PermuteComponent: public Component {
                         const CuMatrixBase<BaseFloat> &, //in_value
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1212,7 +1238,7 @@ class PerElementScaleComponent: public UpdatableComponent {
         kLinearInParameters|kBackpropNeedsInput|kPropagateInPlace;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1220,6 +1246,7 @@ class PerElementScaleComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1283,7 +1310,7 @@ class PerElementOffsetComponent: public UpdatableComponent {
            kBackpropInPlace|kPropagateInPlace;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1291,6 +1318,7 @@ class PerElementOffsetComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &, // in_value
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1352,7 +1380,7 @@ class ConstantFunctionComponent: public UpdatableComponent {
         (InputDim() == OutputDim() ? kPropagateInPlace: 0) |
         kBackpropAdds;
   }
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1360,6 +1388,7 @@ class ConstantFunctionComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &, // in_value
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1549,7 +1578,7 @@ class ConvolutionComponent: public UpdatableComponent {
            kBackpropAdds|kPropagateAdds;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1557,6 +1586,7 @@ class ConvolutionComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update_in,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
   void Update(const std::string &debug_info,
@@ -1721,7 +1751,7 @@ class LstmNonlinearityComponent: public UpdatableComponent {
     return kSimpleComponent|kUpdatableComponent|kBackpropNeedsInput;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1729,6 +1759,7 @@ class LstmNonlinearityComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update_in,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1759,13 +1790,11 @@ class LstmNonlinearityComponent: public UpdatableComponent {
   void Init(std::string vector_filename,
             int32 rank, int32 update_period, BaseFloat num_samples_history,
             BaseFloat alpha, BaseFloat max_change_per_minibatch);
-
  private:
 
   // Initializes the natural-gradient object with the configuration we
   // use for this object, which for now is hardcoded at the C++ level.
   void InitNaturalGradient();
-
 
   // Notation: C is the cell dimension; it equals params_.NumCols().
 
@@ -1855,7 +1884,6 @@ class LstmNonlinearityComponent: public UpdatableComponent {
  *
  *
  */
-
 class MaxpoolingComponent: public Component {
  public:
 
@@ -1867,7 +1895,6 @@ class MaxpoolingComponent: public Component {
 
   virtual int32 InputDim() const;
   virtual int32 OutputDim() const;
-  virtual void Check() const;
 
   virtual std::string Info() const;
   virtual void InitFromConfig(ConfigLine *cfl);
@@ -1877,7 +1904,7 @@ class MaxpoolingComponent: public Component {
            kBackpropAdds;
   }
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1885,6 +1912,7 @@ class MaxpoolingComponent: public Component {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &out_value,
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *, // to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 
@@ -1895,12 +1923,15 @@ class MaxpoolingComponent: public Component {
   virtual void Write(std::ostream &os, bool binary) const;
   virtual Component* Copy() const { return new MaxpoolingComponent(*this); }
 
+
+ protected:
   void InputToInputPatches(const CuMatrixBase<BaseFloat>& in,
                            CuMatrix<BaseFloat> *patches) const;
   void InderivPatchesToInderiv(const CuMatrix<BaseFloat>& in_deriv_patches,
                                CuMatrixBase<BaseFloat> *in_deriv) const;
+  virtual void Check() const;
 
- protected:
+
   int32 input_x_dim_;   // size of the input along x-axis
   // (e.g. number of time steps)
   int32 input_y_dim_;   // size of input along y-axis
@@ -1920,6 +1951,172 @@ class MaxpoolingComponent: public Component {
   // before computing the next pool
 
 };
+
+
+/*
+  BatchNormComponent
+
+  This implements batch normalization; for each dimension of the
+  input it normalizes the data to be zero-mean, unit-variance.  You
+  can set the block-dim configuration value to implement spatial
+  batch normalization, see the comment for the variable.
+
+  It's a simple component (uses the kSimpleComponent flag), but it is unusual in
+  that it will give different results if you call it on half the matrix at a
+  time.  Most of the time this would be pretty harmless, so we still return the
+  kSimpleComponent flag.  We may have to modify the test code a little to
+  account for this, or possibly remove the kSimpleComponent flag.  In some sense
+  each output Index depends on every input Index, but putting those dependencies
+  explicitly into the dependency-tracking framework as a GeneralComponent
+  would be very impractical and might lead to a lot of unnecessary things being
+  computed.  You have to be a bit careful where you put this component, and understand
+  what you're doing e.g. putting it in the path of a recurrence is a bit problematic
+  if the minibatch size were small.
+ */
+class BatchNormComponent: public Component {
+ public:
+
+  BatchNormComponent(): dim_(0), block_dim_(0),
+                        epsilon_(1.0e-03), target_rms_(1.0),
+                        test_mode_(false), count_(0) { }
+
+  // call this with 'true' to set 'test mode' where the batch normalization is
+  // done with stored stats.  There won't normally be any need to specially
+  // accumulate these stats; they are stored as a matter of course on each
+  // iteration of training, as for NonlinearComponents, and we'll use the stats
+  // from the most recent [script-level] iteration.
+  void SetTestMode(bool test_mode);
+
+  // constructor using another component
+  BatchNormComponent(const BatchNormComponent &other);
+
+  virtual int32 InputDim() const { return dim_; }
+  virtual int32 OutputDim() const { return dim_; }
+
+  virtual std::string Info() const;
+  // supports the config variables dim, block-dim (which defaults to dim),
+  // epsilon (which defaults to 1.0e-3), and target-rms (which defaults to 1.0,
+  // and is a scaling on the output; it's comparable to the target-rms of
+  // NormalizeComponent).  it also accepts a boolean 'test-mode' config which is
+  // only intended for use in testing code, and not in real situations.  (note:
+  // test-mode is a real thing that's used during 'inference' given a previously
+  // computed model, and we do set test mode in real situations; we just don't
+  // do so from the config, we use the function SetTestMode().
+  virtual void InitFromConfig(ConfigLine *cfl);
+  virtual std::string Type() const { return "BatchNormComponent"; }
+  virtual int32 Properties() const {
+    // If the block-dim is less than the dim, we need the input and output
+    // matrices to be contiguous (stride==num-cols), as we'll be reshaping
+    // internally.  This is not much of a cost, because this will be used
+    // in convnets where we have to do this anyway.
+    return kSimpleComponent|kBackpropNeedsOutput|kPropagateInPlace|
+        kBackpropInPlace|
+        (block_dim_ < dim_ ? kInputContiguous|kOutputContiguous : 0)|
+        (test_mode_ ? 0 : kUsesMemo|kStoresStats);
+  }
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
+                         const CuMatrixBase<BaseFloat> &in,
+                         CuMatrixBase<BaseFloat> *out) const;
+  virtual void Backprop(const std::string &debug_info,
+                        const ComponentPrecomputedIndexes *indexes,
+                        const CuMatrixBase<BaseFloat> &in_value,
+                        const CuMatrixBase<BaseFloat> &out_value,
+                        const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
+                        Component *, // to_update,
+                        CuMatrixBase<BaseFloat> *in_deriv) const;
+
+  virtual void Read(std::istream &is, bool binary); // This Read function
+  // requires that the Component has the correct type.
+
+  /// Write component to stream
+  virtual void Write(std::ostream &os, bool binary) const;
+  virtual Component* Copy() const { return new BatchNormComponent(*this); }
+
+  virtual void Scale(BaseFloat scale);
+  virtual void Add(BaseFloat alpha, const Component &other);
+  virtual void ZeroStats();
+
+
+  virtual void DeleteMemo(void *memo) const { delete static_cast<Memo*>(memo); }
+
+  virtual void StoreStats(const CuMatrixBase<BaseFloat> &in_value,
+                          const CuMatrixBase<BaseFloat> &out_value,
+                          void *memo);
+ private:
+
+  struct Memo {
+    // number of frames (after any reshaping).
+    int32 num_frames;
+    // 'sum_sumsq_scale' is of dimension 4 by block_dim_:
+    // Row 0 = mean = the mean of the rows of the input
+    // Row 1 = uvar = the uncentered variance of the input (= sumsq / num_frames).
+    // Row 2 = scale = the scale of the renormalization, which is
+    // Row 3 is used as a temporary in Backprop.
+    //    the inverse stddev of the input (modified by epsilon_,
+    //    see the Propagate function.
+    CuMatrix<BaseFloat> mean_uvar_scale;
+  };
+
+  void Check() const;
+
+  // this function is used in a couple of places; it turns the raw stats into
+  // the offset/scale term of a normalizing transform.
+  static void ComputeOffsetAndScale(double count,
+                                    BaseFloat epsilon,
+                                    const Vector<double> &stats_sum,
+                                    const Vector<double> &stats_sumsq,
+                                    Vector<BaseFloat> *offset,
+                                    Vector<BaseFloat> *scale);
+  // computes derived parameters offset_ and scale_.
+  void ComputeDerived();
+
+  // Dimension of the input and output.
+  int32 dim_;
+  // This would normally be the same as dim_, but if it's less (and it must be >
+  // 0 and must divide dim_), then each separate block of the input of dimension
+  // 'block_dim_' is treated like a separate frame for the purposes of
+  // normalization.  This can be used to implement spatial batch normalization
+  // for convolutional setups-- assuming the filter-dim has stride 1, which it
+  // always will in the new code in nnet-convolutional-component.h, when it's
+  // finished.
+  int32 block_dim_;
+
+  // Used to avoid exact-zero variances, epsilon has the dimension of a
+  // covariance; in this work it is applied as a floor, not as an additive term
+  // (this is safer in the presence of numerical roundoff).
+  BaseFloat epsilon_;
+
+  // This value will normally be 1.0, which is the default, but you can set it
+  // to other values as a way to control how fast the following layer learns
+  // (smaller -> slower).  The same config exists in NormalizeComponent.
+  BaseFloat target_rms_;
+
+  // This is true if we want the batch normalization to operate in 'test mode'
+  // meaning the data mean and stddev used for the normalziation are fixed
+  // quantities based on previously accumulated stats.  Note: the stats we use
+  // for this are based on the same 'StoreStats' mechanism as we use for
+  // components like SigmoidComponent and ReluComponent; we'll be using
+  // the stats from the most recent [script-level] iteration of training.
+  bool test_mode_;
+
+
+  // total count of stats stored by StoreStats().
+  double count_;
+  // sum-of-data component of stats of input data.
+  CuVector<double> stats_sum_;
+  // sum-of-squared component of stats of input data.
+  CuVector<double> stats_sumsq_;
+
+  // offset_ and scale_ are derived from stats_sum_ and stats_sumsq_; they
+  // dictate the transform that is done in 'test mode'.  They are set only when
+  // reading the model from disk and when calling SetTestMode(true); they are
+  // resized to empty when the stats are updated, to ensure that out-of-date
+  // values are not kept around.
+  CuVector<BaseFloat> offset_;
+  CuVector<BaseFloat> scale_;
+};
+
 
 
 /**
@@ -1971,7 +2168,7 @@ class CompositeComponent: public UpdatableComponent {
   // call would involve propagating the internals.
   virtual int32 Properties() const;
 
-  virtual void Propagate(const ComponentPrecomputedIndexes *indexes,
+  virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
   virtual void Backprop(const std::string &debug_info,
@@ -1979,6 +2176,7 @@ class CompositeComponent: public UpdatableComponent {
                         const CuMatrixBase<BaseFloat> &in_value,
                         const CuMatrixBase<BaseFloat> &, // out_value
                         const CuMatrixBase<BaseFloat> &out_deriv,
+                        void *memo,
                         Component *to_update,
                         CuMatrixBase<BaseFloat> *in_deriv) const;
 

--- a/src/nnet3/nnet-test-utils.cc
+++ b/src/nnet3/nnet-test-utils.cc
@@ -1449,6 +1449,8 @@ static void GenerateRandomComponentConfig(std::string *component_type,
          << " self-repair-scale=0.0";
       break;
     }
+    // I think we'll get in the habit of allocating a larger number of case
+    // labels to the most recently added component, so it gets tested more
     case 31: case 32: case 33: {
       *component_type = "BatchNormComponent";
       int32 block_dim = RandInt(1, 10), dim = block_dim * RandInt(1, 2);

--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -464,6 +464,17 @@ void SetDropoutProportion(BaseFloat dropout_proportion,
   }
 }
 
+
+void SetTestMode(bool test_mode,  Nnet *nnet) {
+  for (int32 c = 0; c < nnet->NumComponents(); c++) {
+    Component *comp = nnet->GetComponent(c);
+    BatchNormComponent *bc = dynamic_cast<BatchNormComponent*>(comp);
+    if (bc != NULL)
+      bc->SetTestMode(test_mode);
+  }
+}
+
+
 void FindOrphanComponents(const Nnet &nnet, std::vector<int32> *components) {
   int32 num_components = nnet.NumComponents(), num_nodes = nnet.NumNodes();
   std::vector<bool> is_used(num_components, false);

--- a/src/nnet3/nnet-utils.h
+++ b/src/nnet3/nnet-utils.h
@@ -164,6 +164,14 @@ std::string NnetInfo(const Nnet &nnet);
 /// the value 'dropout_proportion'
 void SetDropoutProportion(BaseFloat dropout_proportion, Nnet *nnet);
 
+/// This function currently affects only components of type BatchNormComponent.
+/// It sets "test mode" on such components (if you call it with test_mode =
+/// true, otherwise it would set normal mode, but this wouldn't be needed
+/// often).  "test mode" means that instead of using statistics from the batch,
+/// it does a deterministic normalization based on statistics stored at training
+/// time.
+void SetTestMode(bool test_mode, Nnet *nnet);
+
 /// This function finds a list of components that are never used, and outputs
 /// the integer comopnent indexes (you can use these to index
 /// nnet.GetComponentNames() to get their names).

--- a/src/nnet3bin/nnet3-align-compiled.cc
+++ b/src/nnet3bin/nnet3-align-compiled.cc
@@ -29,6 +29,7 @@
 #include "decoder/decoder-wrappers.h"
 #include "decoder/training-graph-compiler.h"
 #include "nnet3/nnet-am-decodable-simple.h"
+#include "nnet3/nnet-utils.h"
 #include "lat/kaldi-lattice.h"
 
 int main(int argc, char *argv[]) {
@@ -111,6 +112,7 @@ int main(int argc, char *argv[]) {
         trans_model.Read(ki.Stream(), binary);
         am_nnet.Read(ki.Stream(), binary);
       }
+      SetTestMode(true, &(am_nnet.GetNnet()));
       // this compiler object allows caching of computations across
       // different utterances.
       CachingOptimizingCompiler compiler(am_nnet.GetNnet(),

--- a/src/nnet3bin/nnet3-combine.cc
+++ b/src/nnet3bin/nnet3-combine.cc
@@ -38,20 +38,20 @@ int main(int argc, char *argv[]) {
         "\n"
         "e.g.:\n"
         " nnet3-combine 1.1.raw 1.2.raw 1.3.raw ark:valid.egs 2.raw\n";
-    
+
     bool binary_write = true;
-    std::string use_gpu = "yes";    
+    std::string use_gpu = "yes";
     NnetCombineConfig combine_config;
-    
+
     ParseOptions po(usage);
     po.Register("binary", &binary_write, "Write output in binary mode");
     po.Register("use-gpu", &use_gpu,
                 "yes|no|optional|wait, only has effect if compiled with CUDA");
-    
+
     combine_config.Register(&po);
-    
+
     po.Read(argc, argv);
-    
+
     if (po.NumArgs() < 3) {
       po.PrintUsage();
       exit(1);
@@ -60,15 +60,22 @@ int main(int argc, char *argv[]) {
 #if HAVE_CUDA==1
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
-    
+
     std::string
-        nnet_rxfilename = po.GetArg(1),
+        nnet_rxfilename = po.GetArg(po.NumArgs() - 2),
         valid_examples_rspecifier = po.GetArg(po.NumArgs() - 1),
         nnet_wxfilename = po.GetArg(po.NumArgs());
 
+    // note: nnet_rxfilename is the last arg, which with the way we call it, is
+    // the most recent averaged batch of models.  This is mainly important for
+    // batch-norm-- it ensures that the stats used for batch normalization are
+    // fresh.  (since the batch-norm stats are not technically parameters, they
+    // are obtained from the main model given to the combiner, and are not
+    // subject to combination).
     Nnet nnet;
     ReadKaldiObject(nnet_rxfilename, &nnet);
-    
+    SetTestMode(true, &nnet);  // relates to batch-norm.
+
 
     std::vector<NnetExample> egs;
     egs.reserve(10000);  // reserve a lot of space to minimize the chance of
@@ -82,14 +89,19 @@ int main(int argc, char *argv[]) {
       KALDI_LOG << "Read " << egs.size() << " examples.";
       KALDI_ASSERT(!egs.empty());
     }
-    
-    
+
+
     int32 num_nnets = po.NumArgs() - 2;
     if (num_nnets > 1 || !combine_config.enforce_sum_to_one) {
       NnetCombiner combiner(combine_config, num_nnets, egs, nnet);
-      
-      for (int32 n = 1; n < num_nnets; n++) {
-        ReadKaldiObject(po.GetArg(1 + n), &nnet);
+
+      // we don't start from the one at 'num_nnets' because that one was used to
+      // initialize the 'combiner'.  we're reversing the order because we wanted
+      // the 1st model to initialize the combiner (to get fresh batch-norm
+      // stats, if relevant), and reversing the order rather than mixing it up
+      // makes the printed weights easier to view.
+      for (int32 n = num_nnets - 1; n >= 1; n--) {
+        ReadKaldiObject(po.GetArg(n), &nnet);
         combiner.AcceptNnet(nnet);
       }
 
@@ -106,7 +118,7 @@ int main(int argc, char *argv[]) {
                 << "without any combination.";
       SetDropoutProportion(0, &nnet);
       WriteKaldiObject(nnet, nnet_wxfilename, binary_write);
-    } 
+    }
     KALDI_LOG << "Finished combining neural nets, wrote model to "
               << nnet_wxfilename;
   } catch(const std::exception &e) {
@@ -114,5 +126,3 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 }
-
-

--- a/src/nnet3bin/nnet3-compute-prob.cc
+++ b/src/nnet3bin/nnet3-compute-prob.cc
@@ -20,6 +20,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "nnet3/nnet-diagnostics.h"
+#include "nnet3/nnet-utils.h"
 
 
 int main(int argc, char *argv[]) {
@@ -37,44 +38,50 @@ int main(int argc, char *argv[]) {
         "Usage:  nnet3-compute-prob [options] <raw-model-in> <training-examples-in>\n"
         "e.g.: nnet3-compute-prob 0.raw ark:valid.egs\n";
 
-    
+
+    bool test_mode = true;
+
     // This program doesn't support using a GPU, because these probabilities are
     // used for diagnostics, and you can just compute them with a small enough
     // amount of data that a CPU can do it within reasonable time.
 
     NnetComputeProbOptions opts;
-    
+
     ParseOptions po(usage);
 
+    po.Register("test-mode", &test_mode,
+                "If true, set test-mode to true on any BatchNormComponents.");
+
     opts.Register(&po);
-    
+
     po.Read(argc, argv);
-    
+
     if (po.NumArgs() != 2) {
       po.PrintUsage();
       exit(1);
     }
-    
+
     std::string raw_nnet_rxfilename = po.GetArg(1),
         examples_rspecifier = po.GetArg(2);
 
     Nnet nnet;
     ReadKaldiObject(raw_nnet_rxfilename, &nnet);
 
+    if (test_mode)
+      SetTestMode(true, &nnet);
+
     NnetComputeProb prob_computer(opts, nnet);
-    
+
     SequentialNnetExampleReader example_reader(examples_rspecifier);
 
     for (; !example_reader.Done(); example_reader.Next())
       prob_computer.Compute(example_reader.Value());
 
     bool ok = prob_computer.PrintTotalStats();
-    
+
     return (ok ? 0 : 1);
   } catch(const std::exception &e) {
     std::cerr << e.what() << '\n';
     return -1;
   }
 }
-
-

--- a/src/nnet3bin/nnet3-compute.cc
+++ b/src/nnet3bin/nnet3-compute.cc
@@ -92,6 +92,7 @@ int main(int argc, char *argv[]) {
 
     Nnet nnet;
     ReadKaldiObject(nnet_rxfilename, &nnet);
+    SetTestMode(true, &nnet);
 
     RandomAccessBaseFloatMatrixReader online_ivector_reader(
         online_ivector_rspecifier);

--- a/src/nnet3bin/nnet3-latgen-faster-looped.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-looped.cc
@@ -26,6 +26,7 @@
 #include "fstext/fstext-lib.h"
 #include "decoder/decoder-wrappers.h"
 #include "nnet3/decodable-simple-looped.h"
+#include "nnet3/nnet-utils.h"
 #include "base/timer.h"
 
 
@@ -96,6 +97,7 @@ int main(int argc, char *argv[]) {
       Input ki(model_in_filename, &binary);
       trans_model.Read(ki.Stream(), binary);
       am_nnet.Read(ki.Stream(), binary);
+      SetTestMode(true, &(am_nnet.GetNnet()));
     }
 
     bool determinize = config.determinize_lattice;

--- a/src/nnet3bin/nnet3-latgen-faster-parallel.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-parallel.cc
@@ -25,6 +25,7 @@
 #include "fstext/fstext-lib.h"
 #include "hmm/transition-model.h"
 #include "nnet3/nnet-am-decodable-simple.h"
+#include "nnet3/nnet-utils.h"
 #include "thread/kaldi-task-sequence.h"
 #include "tree/context-dep.h"
 #include "util/common-utils.h"
@@ -99,6 +100,7 @@ int main(int argc, char *argv[]) {
       Input ki(model_in_filename, &binary);
       trans_model.Read(ki.Stream(), binary);
       am_nnet.Read(ki.Stream(), binary);
+      SetTestMode(true, &(am_nnet.GetNnet()));
     }
 
     bool determinize = config.determinize_lattice;

--- a/src/nnet3bin/nnet3-latgen-faster.cc
+++ b/src/nnet3bin/nnet3-latgen-faster.cc
@@ -26,6 +26,7 @@
 #include "fstext/fstext-lib.h"
 #include "decoder/decoder-wrappers.h"
 #include "nnet3/nnet-am-decodable-simple.h"
+#include "nnet3/nnet-utils.h"
 #include "base/timer.h"
 
 
@@ -93,6 +94,7 @@ int main(int argc, char *argv[]) {
       Input ki(model_in_filename, &binary);
       trans_model.Read(ki.Stream(), binary);
       am_nnet.Read(ki.Stream(), binary);
+      SetTestMode(true, &(am_nnet.GetNnet()));
     }
 
     bool determinize = config.determinize_lattice;

--- a/src/util/text-utils-test.cc
+++ b/src/util/text-utils-test.cc
@@ -1,6 +1,7 @@
 // util/text-utils-test.cc
 
 // Copyright 2009-2011     Microsoft Corporation
+//                2017     Johns Hopkins University (author: Daniel Povey)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -238,6 +239,23 @@ void TestIsLine() {
   KALDI_ASSERT(!IsLine(" a b"));
 }
 
+
+void TestStringsApproxEqual() {
+  // we must test the test.
+  KALDI_ASSERT(!StringsApproxEqual("a", "b"));
+  KALDI_ASSERT(!StringsApproxEqual("1", "2"));
+  KALDI_ASSERT(StringsApproxEqual("1.234", "1.235", 2));
+  KALDI_ASSERT(!StringsApproxEqual("1.234", "1.235", 3));
+  KALDI_ASSERT(StringsApproxEqual("x 1.234 y", "x 1.2345 y", 3));
+  KALDI_ASSERT(!StringsApproxEqual("x 1.234 y", "x 1.2345 y", 4));
+  KALDI_ASSERT(StringsApproxEqual("x 1.234 y 6.41", "x 1.235 y 6.49", 1));
+  KALDI_ASSERT(!StringsApproxEqual("x 1.234 y 6.41", "x 1.235 y 6.49", 2));
+  KALDI_ASSERT(StringsApproxEqual("x 1.234 y 6.41", "x 1.235 y 6.411", 2));
+  KALDI_ASSERT(StringsApproxEqual("x 1.0 y", "x 1.0001 y", 3));
+  KALDI_ASSERT(!StringsApproxEqual("x 1.0 y", "x 1.0001 y", 4));
+}
+
+
 }  // end namespace kaldi
 
 int main() {
@@ -252,8 +270,6 @@ int main() {
   TestSplitStringOnFirstSpace();
   TestIsToken();
   TestIsLine();
+  TestStringsApproxEqual();
   std::cout << "Test OK\n";
 }
-
-
-

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -252,4 +252,85 @@ bool ConvertStringToReal(const std::string &str,
   return true;
 }
 
+
+/*
+  This function is a helper function of StringsApproxEqual.  It should be
+  thought of as a recursive function-- it was designed that way-- but rather
+  than actually recursing (which would cause problems with stack overflow), we
+  just set the args and return to the start.
+
+  The 'decimal_places_tolerance' argument is just passed in from outside,
+  see the documentation for StringsApproxEqual in text-utils.h to see an
+  explanation.  The argument 'places_into_number' provides some information
+  about the strings 'a' and 'b' that precedes the current pointers.
+  For purposes of this comment, let's define the 'decimal' of a number
+  as the part that comes after the decimal point, e.g. in '99.123',
+  '123' would be the decimal.  If 'places_into_number' is -1, it means
+  we're not currently inside some place like that (i.e. it's not the
+  case that we're pointing to the '1' or the '2' or the '3').
+  If it's 0, then we'd be pointing to the first place after the decimal,
+  '1' in this case.  Note if one of the numbers is shorter than the
+  other, like '99.123' versus '99.1234' and 'a' points to the first '3'
+  while 'b' points to the second '4', 'places_into_number' referes to the
+  shorter of the two, i.e. it would be 2 in this example.
+
+
+ */
+bool StringsApproxEqualInternal(const char *a, const char *b,
+                                int32 decimal_places_tolerance,
+                                int32 places_into_number) {
+start:
+  char ca = *a, cb = *b;
+  if (ca == cb) {
+    if (ca == '\0') {
+      return true;
+    } else {
+      if (places_into_number >= 0) {
+        if (isdigit(ca)) {
+          places_into_number++;
+        } else {
+          places_into_number = -1;
+        }
+      } else {
+        if (ca == '.') {
+          places_into_number = 0;
+        }
+      }
+      a++;
+      b++;
+      goto start;
+    }
+  } else {
+    if (places_into_number  >= decimal_places_tolerance &&
+        (isdigit(ca) || isdigit(cb))) {
+      // we're potentially willing to accept this difference between the
+      // strings.
+      if (isdigit(ca)) a++;
+      if (isdigit(cb)) b++;
+      // we'll have advanced at least one of the two strings.
+      goto start;
+    } else if (places_into_number >= 0 &&
+               ((ca == '0' && !isdigit(cb)) || (cb == '0' && !isdigit(ca)))) {
+      // this clause is designed to ensure that, for example,
+      // "0.1" would count the same as "0.100001".
+      if (ca == '0') a++;
+      else b++;
+      places_into_number++;
+      goto start;
+    } else {
+      return false;
+    }
+  }
+
+}
+
+
+bool StringsApproxEqual(const std::string &a,
+                        const std::string &b,
+                        int32 decimal_places_tolerance) {
+  return StringsApproxEqualInternal(a.c_str(), b.c_str(),
+                                    decimal_places_tolerance, -1);
+}
+
+
 }  // end namespace kaldi

--- a/src/util/text-utils.h
+++ b/src/util/text-utils.h
@@ -166,6 +166,22 @@ bool IsToken(const std::string &token);
 bool IsLine(const std::string &line);
 
 
+
+/**
+   This function returns true when two text strings are approximately equal, and
+   false when they are not.  The definition of 'equal' is normal string
+   equality, except that two substrings like "0.31134" and "0.311341" would be
+   considered equal.  'decimal_places_tolerance' controls how many digits after
+   the '.' have to match up.
+   E.g. StringsApproxEqual("hello 0.23 there", "hello 0.24 there", 2) would
+   return false because there is a difference in the 2nd decimal, but with
+   an argument of 1 it would return true.
+ */
+bool StringsApproxEqual(const std::string &a,
+                        const std::string &b,
+                        int32 decimal_places_check = 2);
+
+
 }  // namespace kaldi
 
 #endif  // KALDI_UTIL_TEXT_UTILS_H_


### PR DESCRIPTION
Includes some deeper modifications to the nnet3 framework-- the concept of 'memos' that can be passed between the Propagate and the corresponding Backprop. 

@tomkocse will work on testing this out with some script level changes, and seeing how it compares in terms of performance with using NormalizeLayer.
