### PR TITLE
Speed up AddColSumMat with transfrom reduce kernel template

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -30,6 +30,12 @@
 #if HAVE_CUDA == 1
 extern "C" {
 
+void cudaD_add_col_sum_mat(int Gr, int Bl, double* result, const double* mat,
+                           const MatrixDim d, const double alpha,
+                           const double beta);
+void cudaF_add_col_sum_mat(int Gr, int Bl, float* result, const float* mat,
+                           const MatrixDim d, const float alpha,
+                           const float beta);
 void cudaD_add_cols(dim3 Gr, dim3 Bl, double* dst, const double* src,
                     const MatrixIndexT_cuda* reorder, MatrixDim dst_dim,
                     int src_stride);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -38,6 +38,16 @@
 
 namespace kaldi {
 
+inline void cuda_add_col_sum_mat(int Gr, int Bl, double* result,
+                                 const double* mat, const MatrixDim d,
+                                 const double alpha, const double beta) {
+  cudaD_add_col_sum_mat(Gr, Bl, result, mat, d, alpha, beta);
+}
+inline void cuda_add_col_sum_mat(int Gr, int Bl, float* result,
+                                 const float* mat, const MatrixDim d,
+                                 const float alpha, const float beta) {
+  cudaF_add_col_sum_mat(Gr, Bl, result, mat, d, alpha, beta);
+}
 inline void cuda_add_cols(dim3 Gr, dim3 Bl, double* dst, const double* src,
                           const MatrixIndexT_cuda* reorder, MatrixDim dst_dim,
                           int src_stride) {


### PR DESCRIPTION
Speed up AddColSumMat with transfrom reduce kernel template

```
speed(gflops)                                  dim  old     new    speedup
    CuVector::AddColSumMat<float>[no-trans],    16  0.0057  0.0172 3.01x
    CuVector::AddColSumMat<float>[no-trans],    32  0.0242  0.0668 2.76x
    CuVector::AddColSumMat<float>[no-trans],    64  0.0992  0.2577 2.60x
    CuVector::AddColSumMat<float>[no-trans],   128  0.3747  0.9280 2.48x
    CuVector::AddColSumMat<float>[no-trans],   256  1.4711  3.0541 2.08x
    CuVector::AddColSumMat<float>[no-trans],   512  5.1709  9.4713 1.83x
    CuVector::AddColSumMat<float>[no-trans],  1024 12.4352 20.4517 1.64x
    CuVector::AddColSumMat<double>[no-trans],   16  0.0060  0.0175 2.91x
    CuVector::AddColSumMat<double>[no-trans],   32  0.0240  0.0672 2.80x
    CuVector::AddColSumMat<double>[no-trans],   64  0.1006  0.2712 2.70x
    CuVector::AddColSumMat<double>[no-trans],  128  0.3691  0.9097 2.46x
    CuVector::AddColSumMat<double>[no-trans],  256  1.4530  3.1044 2.14x
    CuVector::AddColSumMat<double>[no-trans],  512  4.4524  7.5872 1.70x
    CuVector::AddColSumMat<double>[no-trans], 1024 11.1212 16.1423 1.45x
```