### PR TITLE
generic read fst, the version supports constfst and vectorfst

### DIFF
--- a/egs/wsj/s5/utils/mkgraph.sh
+++ b/egs/wsj/s5/utils/mkgraph.sh
@@ -135,7 +135,7 @@ fi
 trap "rm -f $dir/HCLG.fst.$$" EXIT HUP INT PIPE TERM
 if [[ ! -s $dir/HCLG.fst || $dir/HCLG.fst -ot $dir/HCLGa.fst ]]; then
   add-self-loops --self-loop-scale=$loopscale --reorder=true \
-    $model < $dir/HCLGa.fst > $dir/HCLG.fst.$$ || exit 1;
+    $model < $dir/HCLGa.fst | fstconvert --fst_type=const > $dir/HCLG.fst.$$ || exit 1;
   mv $dir/HCLG.fst.$$ $dir/HCLG.fst
   if [ $tscale == 1.0 -a $loopscale == 1.0 ]; then
     # No point doing this test if transition-scale not 1, as it is bound to fail.
@@ -168,6 +168,4 @@ cp $lang/phones/disambig.{txt,int} $dir/phones/ 2> /dev/null
 cp $lang/phones/silence.csl $dir/phones/ || exit 1;
 cp $lang/phones.txt $dir/ 2> /dev/null # ignore the error if it's not there.
 
-# to make const fst:
-# fstconvert --fst_type=const $dir/HCLG.fst $dir/HCLG_c.fst
 am-info --print-args=false $model | grep pdfs | awk '{print $NF}' > $dir/num_pdfs

--- a/src/bin/latgen-faster-mapped-parallel.cc
+++ b/src/bin/latgen-faster-mapped-parallel.cc
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -98,14 +98,14 @@ int main(int argc, char *argv[]) {
     double tot_like = 0.0;
     kaldi::int64 frame_count = 0;
     int num_success = 0, num_fail = 0;
-    VectorFst<StdArc> *decode_fst = NULL; // only used if there is a single
-                                          // decoding graph.
+    Fst<StdArc> *decode_fst = NULL; // only used if there is a single
+                                    // decoding graph.
 
     TaskSequencer<DecodeUtteranceLatticeFasterClass> sequencer(sequencer_config);
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader loglike_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
-      decode_fst = fst::ReadFstKaldi(fst_in_str);
+      decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
 
       {
         for (; !loglike_reader.Done(); loglike_reader.Next()) {

--- a/src/bin/latgen-faster-mapped.cc
+++ b/src/bin/latgen-faster-mapped.cc
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader loglike_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/fstbin/fstisstochastic.cc
+++ b/src/fstbin/fstisstochastic.cc
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 
     std::string fst_in_filename = po.GetOptArg(1);
 
-    VectorFst<StdArc> *fst = ReadFstKaldi(fst_in_filename);
+    Fst<StdArc> *fst = ReadFstKaldiGeneric(fst_in_filename);
 
     bool ans;
     StdArc::Weight min, max;

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -215,6 +215,76 @@ bool GetLinearSymbolSequence(const Fst<Arc> &fst,
   }
 }
 
+// see fstext-utils.h for comment.
+template<class Arc, class I>
+bool GetLinearSymbolSequences(const Fst<Arc> &fst,
+                              vector<vector<I> > *isymbols_out,
+                              vector<vector<I> > *osymbols_out,
+                              vector<typename Arc::Weight> *weights_out) {
+  typedef typename Arc::StateId StateId;
+  typedef typename Arc::Weight Weight;
+
+  if (isymbols_out) isymbols_out->clear();
+  if (osymbols_out) osymbols_out->clear();
+  if (weights_out) weights_out->clear();
+
+  StateId start_state = fst.Start();
+  if (start_state == kNoStateId) {  // no paths.
+    return true; // empty FST counts as having this structure.
+  }
+
+  if (fst.Final(start_state) != Weight::Zero())
+    return false; // We don't allow final-prob on the start state.
+
+  size_t N = fst.NumArcs(start_state), n = 0;
+  if (isymbols_out) isymbols_out->resize(N);
+  if (osymbols_out) osymbols_out->resize(N);
+  if (weights_out) weights_out->resize(N);
+
+  bool error = false;
+
+  for (ArcIterator<Fst<Arc> > aiter(fst, start_state);
+       !aiter.Done();
+       aiter.Next(), n++) {
+    StateId cur_state = start_state;
+    if (isymbols_out) (*isymbols_out)[n].clear();
+    if (osymbols_out) (*osymbols_out)[n].clear();
+    if (weights_out) (*weights_out)[n] = Weight::One();
+
+    while (1) {
+      if (fst.Final(cur_state) != Weight::Zero()) {
+        (*weights_out)[n] = Times((*weights_out)[n],
+                                  fst.Final(cur_state));
+        if (fst.NumArcs(cur_state) != 0)
+          error = true;
+        break;
+      } else {
+        if (fst.NumArcs(cur_state) != 1) {
+          error = true;
+          break;
+        }
+        ArcIterator<Fst<Arc> > aiter(fst, cur_state);
+        const Arc &arc = aiter.Value();
+        if (isymbols_out && arc.ilabel != 0)
+          (*isymbols_out)[n].push_back(arc.ilabel);
+        if (osymbols_out && arc.ilabel != 0)
+          (*osymbols_out)[n].push_back(arc.olabel);
+        if (weights_out)
+          (*weights_out)[n] = Times((*weights_out)[n], arc.weight);
+        cur_state = arc.nextstate;
+      }
+    }
+    if (error) break;
+  }
+  if (error) {
+    if (isymbols_out) isymbols_out->clear();
+    if (osymbols_out) osymbols_out->clear();
+    if (weights_out) weights_out->clear();
+    return false;
+  } else {
+    return true;
+  }
+}
 
 // see fstext-utils.sh for comment.
 template<class Arc>
@@ -1203,16 +1273,29 @@ bool IsStochasticFst(const Fst<LogArc> &fst,
   return ans;
 }
 
-/// Tests whether a tropical FST is stochastic in the log
-/// semiring (casts it and does the check.)
-bool IsStochasticFstInLog(const VectorFst<StdArc> &fst,
+// Tests whether a tropical FST is stochastic in the log
+// semiring. (casts it and does the check.)
+// This function deals with the generic fst.
+// This version currently supports ConstFst<StdArc> or VectorFst<StdArc>.
+// Otherwise, it will be died with an error.
+bool IsStochasticFstInLog(const Fst<StdArc> &fst,
                           float delta,
                           StdArc::Weight *min_sum,
                           StdArc::Weight *max_sum) {
-  VectorFst<LogArc> logfst;
-  Cast(fst, &logfst);
+  bool ans = false;
   LogArc::Weight log_min, log_max;
-  bool ans = IsStochasticFst(logfst, delta, &log_min, &log_max);
+  if (fst.Type() == "const") {
+    ConstFst<LogArc> logfst;
+    Cast(dynamic_cast<const ConstFst<StdArc>&>(fst), &logfst);
+    ans = IsStochasticFst(logfst, delta, &log_min, &log_max);
+  } else if (fst.Type() == "vector") {
+    VectorFst<LogArc> logfst;
+    Cast(dynamic_cast<const VectorFst<StdArc>&>(fst), &logfst);
+    ans = IsStochasticFst(logfst, delta, &log_min, &log_max);
+  } else {
+    KALDI_ERR << "This version currently supports ConstFst<StdArc> "
+              << "or VectorFst<StdArc>";
+  }
   if (min_sum) *min_sum = StdArc::Weight(log_min.Value());
   if (max_sum) *max_sum = StdArc::Weight(log_max.Value());
   return ans;

--- a/src/fstext/fstext-utils.h
+++ b/src/fstext/fstext-utils.h
@@ -135,6 +135,27 @@ bool GetLinearSymbolSequence(const Fst<Arc> &fst,
                              vector<I> *osymbols_out,
                              typename Arc::Weight *tot_weight_out);
 
+/// GetLinearSymbolSequence gets the symbol sequences and weights
+/// from an FST as output by the ShortestPath algorithm (called with
+/// some parameter n), which has up to n arcs out from the start state,
+/// and if you follow one of the arcs you enter a linear sequence of
+/// states.  This function outputs the info in a more N-best-list-like
+/// format.  It returns true if the FST had the expected structure,
+/// and false otherwise (note: an empty FST counts as having this
+/// structure).  We don't accept an FST that has a final-prob on the start
+/// state, as it wouldn't be clear whether to put it as the first or
+/// last path (this function is used in an N-best context where the
+/// paths' ordering is somewhat meaningful.)
+/// This function will set the output vectors to the appropriate
+/// size, and for each path will output the input and output symbols as
+/// vectors (not including epsilons).  It outputs the total weight
+/// for each path.
+template<class Arc, class I>
+bool GetLinearSymbolSequences(const Fst<Arc> &fst,
+                              vector<vector<I> > *isymbols_out,
+                              vector<vector<I> > *osymbols_out,
+                              vector<typename Arc::Weight> *tot_weight_out);
+
 
 /// This function converts an FST with a special structure, which is
 /// output by the OpenFst functions ShortestPath and RandGen, and converts
@@ -415,7 +436,7 @@ bool IsStochasticFst(const Fst<Arc> &fst,
 
 
 // IsStochasticFstInLog makes sure it's stochastic after casting to log.
-inline bool IsStochasticFstInLog(const VectorFst<StdArc> &fst,
+inline bool IsStochasticFstInLog(const Fst<StdArc> &fst,
                                  float delta = kDelta,  // kDelta = 1.0/1024.0 by default.
                                  StdArc::Weight *min_sum = NULL,
                                  StdArc::Weight *max_sum = NULL);

--- a/src/fstext/kaldi-fst-io.cc
+++ b/src/fstext/kaldi-fst-io.cc
@@ -42,6 +42,71 @@ VectorFst<StdArc> *ReadFstKaldi(std::string rxfilename) {
   return fst;
 }
 
+Fst<StdArc> *ReadFstKaldiGeneric(std::string rxfilename, bool throw_on_err) {
+  if (rxfilename == "") rxfilename = "-"; // interpret "" as stdin,
+  // for compatibility with OpenFst conventions.
+  kaldi::Input ki(rxfilename);
+  fst::FstHeader hdr;
+  // Read FstHeader which contains the type of FST
+  if (!hdr.Read(ki.Stream(), rxfilename)) {
+    if(throw_on_err) {
+      KALDI_ERR << "Reading FST: error reading FST header from "
+                << kaldi::PrintableRxfilename(rxfilename);
+    } else {
+      KALDI_WARN << "We fail to read FST header from "
+                 << kaldi::PrintableRxfilename(rxfilename) 
+                 << ". A NULL pointer is returned.";
+      return NULL;
+    }
+  }
+  // Check the type of Arc
+  if (hdr.ArcType() != fst::StdArc::Type()) {
+    if(throw_on_err) {
+      KALDI_ERR << "FST with arc type " << hdr.ArcType() << " is not supported.";
+    } else {
+      KALDI_WARN << "Fst with arc type" << hdr.ArcType()
+                 << " is not supported. A NULL pointer is returned.";
+      return NULL;
+    }
+  }
+  // Read the FST
+  FstReadOptions ropts("<unspecified>", &hdr);
+  Fst<StdArc> *fst = NULL;
+  if (hdr.FstType() == "const") {
+    fst = ConstFst<StdArc>::Read(ki.Stream(), ropts);
+  } else if (hdr.FstType() == "vector") {
+    fst = VectorFst<StdArc>::Read(ki.Stream(), ropts);
+  }
+  if (!fst) {
+    if(throw_on_err) {
+     KALDI_ERR << "Could not read fst from "
+               << kaldi::PrintableRxfilename(rxfilename);
+    } else {
+      KALDI_WARN << "Could not read fst from "
+                 << kaldi::PrintableRxfilename(rxfilename)
+                 << ". A NULL pointer is returned.";
+      return NULL;
+    }
+  }
+  return fst;
+}
+
+VectorFst<StdArc> *CastToVectorFst(Fst<StdArc> *fst) {
+  // This version currently supports ConstFst<StdArc> or VectorFst<StdArc>         
+  std::string real_type = fst->Type();
+  KALDI_ASSERT(real_type == "vector" || real_type == "const");
+  if (real_type == "vector") {
+    return dynamic_cast<VectorFst<StdArc> *>(fst);
+  } else {
+    // As the 'fst' can't cast to VectorFst, I'm creating a new 
+    // VectorFst<StdArc> initialized by 'fst', and deletes 'fst'.
+    VectorFst<StdArc> *new_fst = new VectorFst<StdArc>(*fst);
+    KALDI_WARN << "The 'fst' is deleted.";
+    delete fst;
+    return new_fst;
+  }
+}
+
 void ReadFstKaldi(std::string rxfilename, fst::StdVectorFst *ofst) {
   fst::StdVectorFst *fst = ReadFstKaldi(rxfilename);
   *ofst = *fst;

--- a/src/fstext/kaldi-fst-io.h
+++ b/src/fstext/kaldi-fst-io.h
@@ -41,6 +41,22 @@ namespace fst {
 // doesn't support the text-mode option that we generally like to support.
 VectorFst<StdArc> *ReadFstKaldi(std::string rxfilename);
 
+// Read a binary FST using Kaldi I/O mechanisms (pipes, etc.)
+// If it can't read the FST, if throw_on_err == true it throws using KALDI_ERR;
+// otherwise it prints a warning and returns. Note:this
+// doesn't support the text-mode option that we generally like to support.
+// This version currently supports ConstFst<StdArc> or VectorFst<StdArc>
+// (const-fst can give better performance for decoding).
+Fst<StdArc> *ReadFstKaldiGeneric(std::string rxfilename,
+                                 bool throw_on_err = true);
+
+// This function attempts to dynamic_cast the pointer 'fst' (which will likely
+// have been returned by ReadFstGeneric()), to the more derived 
+// type VectorFst<StdArc>. If this succeeds, it returns the same pointer;
+// if it fails, it converts the FST type (by creating a new VectorFst<stdArc>
+// initialized by 'fst'), prints a warning, and deletes 'fst'.
+VectorFst<StdArc> *CastToVectorFst(Fst<StdArc> *fst);
+
 // Version of ReadFstKaldi() that writes to a pointer.  Assumes
 // the FST is binary with no binary marker.  Crashes on error.
 void ReadFstKaldi(std::string rxfilename, VectorFst<StdArc> *ofst);
@@ -54,17 +70,16 @@ void WriteFstKaldi(const VectorFst<StdArc> &fst,
 // This is a more general Kaldi-type-IO mechanism of writing FSTs to
 // streams, supporting binary or text-mode writing.  (note: we just
 // write the integers, symbol tables are not supported).
-// On error, throws using KALDI_ERRR.
+// On error, throws using KALDI_ERR.
 template <class Arc>
 void WriteFstKaldi(std::ostream &os, bool binary,
                    const VectorFst<Arc> &fst);
 
 // A generic Kaldi-type-IO mechanism of reading FSTs from streams,
-// supporting binary or text-mode reading/writing
+// supporting binary or text-mode reading/writing.
 template <class Arc>
 void ReadFstKaldi(std::istream &is, bool binary,
                   VectorFst<Arc> *fst);
-
 
 // This is a Holder class with T = VectorFst<Arc>, that meets the requirements
 // of a Holder class as described in ../util/kaldi-holder.h. This enables us to

--- a/src/gmmbin/gmm-latgen-biglm-faster.cc
+++ b/src/gmmbin/gmm-latgen-biglm-faster.cc
@@ -146,6 +146,7 @@ int main(int argc, char *argv[]) {
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
     using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
     using fst::ReadFstKaldi;
 
@@ -193,11 +194,13 @@ int main(int argc, char *argv[]) {
       trans_model.Read(ki.Stream(), binary);
       am_gmm.Read(ki.Stream(), binary);
     }
-
-    VectorFst<StdArc> *old_lm_fst = ReadFstKaldi(old_lm_fst_rxfilename);
+    
+    VectorFst<StdArc> *old_lm_fst = fst::CastToVectorFst(
+        fst::ReadFstKaldiGeneric(old_lm_fst_rxfilename));
     ApplyProbabilityScale(-1.0, old_lm_fst); // Negate old LM probs...
     
-    VectorFst<StdArc> *new_lm_fst = ReadFstKaldi(new_lm_fst_rxfilename);
+    VectorFst<StdArc> *new_lm_fst = fst::CastToVectorFst(
+        fst::ReadFstKaldiGeneric(new_lm_fst_rxfilename));
 
     fst::BackoffDeterministicOnDemandFst<StdArc> old_lm_dfst(*old_lm_fst);
     fst::BackoffDeterministicOnDemandFst<StdArc> new_lm_dfst(*new_lm_fst);
@@ -231,7 +234,7 @@ int main(int argc, char *argv[]) {
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
 
       {
         LatticeBiglmFasterDecoder decoder(*decode_fst, config, &cache_dfst);

--- a/src/gmmbin/gmm-latgen-faster-parallel.cc
+++ b/src/gmmbin/gmm-latgen-faster-parallel.cc
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
     using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -111,8 +112,8 @@ int main(int argc, char *argv[]) {
     double tot_like = 0.0;
     kaldi::int64 frame_count = 0;
     int num_done = 0, num_err = 0;
-    VectorFst<StdArc> *decode_fst = NULL; // only used if there is a single
-                                          // decoding graph.
+    Fst<StdArc> *decode_fst = NULL; // only used if there is a single
+                                    // decoding graph.
 
     TaskSequencer<DecodeUtteranceLatticeFasterClass> sequencer(sequencer_config);
 
@@ -120,7 +121,7 @@ int main(int argc, char *argv[]) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
 
-      decode_fst = fst::ReadFstKaldi(fst_in_str);
+      decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/gmmbin/gmm-latgen-faster-regtree-fmllr.cc
+++ b/src/gmmbin/gmm-latgen-faster-regtree-fmllr.cc
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -123,7 +123,7 @@ int main(int argc, char *argv[]) {
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       
       {
         LatticeFasterDecoder decoder(*decode_fst, config);

--- a/src/gmmbin/gmm-latgen-faster.cc
+++ b/src/gmmbin/gmm-latgen-faster.cc
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/gmmbin/gmm-latgen-map.cc
+++ b/src/gmmbin/gmm-latgen-map.cc
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage = "Decode features using GMM-based model.  Note: the input\n"
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
 
     if (ClassifyRspecifier(fst_in_filename, NULL, NULL) == kNoRspecifier) {
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_filename);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_filename);
 
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
       for (; !feature_reader.Done(); feature_reader.Next()) {

--- a/src/gmmbin/gmm-latgen-simple.cc
+++ b/src/gmmbin/gmm-latgen-simple.cc
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
       am_gmm.Read(ki.Stream(), binary);
     }
 
-    VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_filename);
+    Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_filename);
 
     bool determinize = config.determinize_lattice;
     CompactLatticeWriter compact_lattice_writer;

--- a/src/nnet2bin/nnet-latgen-faster-parallel.cc
+++ b/src/nnet2bin/nnet-latgen-faster-parallel.cc
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi::nnet2;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -106,11 +106,11 @@ int main(int argc, char *argv[]) {
     double tot_like = 0.0;
     kaldi::int64 frame_count = 0;
     int num_done = 0, num_err = 0;
-    VectorFst<StdArc> *decode_fst = NULL;
+    Fst<StdArc> *decode_fst = NULL;
     if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
 
-      decode_fst = fst::ReadFstKaldi(fst_in_str);
+      decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/nnet2bin/nnet-latgen-faster.cc
+++ b/src/nnet2bin/nnet-latgen-faster.cc
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi::nnet2;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
       SequentialBaseFloatCuMatrixReader feature_reader(feature_rspecifier);
 
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/nnet3bin/nnet3-latgen-faster-looped.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-looped.cc
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi::nnet3;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
 
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/nnet3bin/nnet3-latgen-faster-parallel.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-parallel.cc
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi::nnet3;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
 
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/nnet3bin/nnet3-latgen-faster.cc
+++ b/src/nnet3bin/nnet3-latgen-faster.cc
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi::nnet3;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
       SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
 
       // Input FST is just one FST, not a table of FSTs.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset();
 
       {

--- a/src/online2bin/online2-wav-gmm-latgen-faster.cc
+++ b/src/online2bin/online2-wav-gmm-latgen-faster.cc
@@ -129,7 +129,7 @@ int main(int argc, char *argv[]) {
     OnlineGmmDecodingModels gmm_models(decode_config);
     
     
-    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldi(fst_rxfilename);
+    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldiGeneric(fst_rxfilename);
     
     fst::SymbolTable *word_syms = NULL;
     if (word_syms_rxfilename != "")

--- a/src/online2bin/online2-wav-nnet2-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet2-latgen-faster.cc
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
       nnet.Read(ki.Stream(), binary);
     }
 
-    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldi(fst_rxfilename);
+    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldiGeneric(fst_rxfilename);
 
     fst::SymbolTable *word_syms = NULL;
     if (word_syms_rxfilename != "")

--- a/src/online2bin/online2-wav-nnet2-latgen-threaded.cc
+++ b/src/online2bin/online2-wav-nnet2-latgen-threaded.cc
@@ -164,7 +164,7 @@ int main(int argc, char *argv[]) {
       am_nnet.Read(ki.Stream(), binary);
     }
     
-    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldi(fst_rxfilename);
+    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldiGeneric(fst_rxfilename);
     
     fst::SymbolTable *word_syms = NULL;
     if (word_syms_rxfilename != "")

--- a/src/online2bin/online2-wav-nnet3-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet3-latgen-faster.cc
@@ -169,7 +169,7 @@ int main(int argc, char *argv[]) {
                                                         &am_nnet);
 
 
-    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldi(fst_rxfilename);
+    fst::Fst<fst::StdArc> *decode_fst = ReadFstKaldiGeneric(fst_rxfilename);
 
     fst::SymbolTable *word_syms = NULL;
     if (word_syms_rxfilename != "")

--- a/src/sgmm2bin/sgmm2-latgen-faster-parallel.cc
+++ b/src/sgmm2bin/sgmm2-latgen-faster-parallel.cc
@@ -57,7 +57,7 @@ void ProcessUtterance(const AmSgmm2 &am_sgmm,
                       int32 *num_done,
                       int32 *num_err,
                       TaskSequencer<DecodeUtteranceLatticeFasterClass> *sequencer) {
-  using fst::VectorFst;
+  using fst::Fst;
   using std::vector;
 
   Sgmm2PerSpkDerivedVars *spk_vars = new Sgmm2PerSpkDerivedVars; // decodable
@@ -109,6 +109,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
+    using fst::Fst;
     using fst::VectorFst;
     using fst::StdArc;
 
@@ -164,7 +165,7 @@ int main(int argc, char *argv[]) {
     kaldi::int64 frame_count = 0;    
     int num_done = 0, num_err = 0;
     Timer timer;
-    VectorFst<StdArc> *decode_fst = NULL;
+    Fst<StdArc> *decode_fst = NULL;
     fst::SymbolTable *word_syms = NULL;
     
     TaskSequencer<DecodeUtteranceLatticeFasterClass> sequencer(
@@ -206,7 +207,7 @@ int main(int argc, char *argv[]) {
       // It has to do with what happens on UNIX systems if you call fork() on a
       // large process: the page-table entries are duplicated, which requires a
       // lot of virtual memory.
-      decode_fst = fst::ReadFstKaldi(fst_in_str);
+      decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset(); // exclude graph loading time.
       
       {

--- a/src/sgmm2bin/sgmm2-latgen-faster.cc
+++ b/src/sgmm2bin/sgmm2-latgen-faster.cc
@@ -52,7 +52,7 @@ bool ProcessUtterance(LatticeFasterDecoder &decoder,
                       CompactLatticeWriter *compact_lattice_writer,
                       LatticeWriter *lattice_writer,
                       double *like_ptr) { // puts utterance's like in like_ptr on success.
-  using fst::VectorFst;
+  using fst::Fst;
 
   Sgmm2PerSpkDerivedVars spk_vars;
   if (spkvecs_reader.IsOpen()) {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
     using namespace kaldi;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
-    using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -182,7 +182,7 @@ int main(int argc, char *argv[]) {
       // It has to do with what happens on UNIX systems if you call fork() on a
       // large process: the page-table entries are duplicated, which requires a
       // lot of virtual memory.
-      VectorFst<StdArc> *decode_fst = fst::ReadFstKaldi(fst_in_str);
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
       timer.Reset(); // exclude graph loading time.
       
       {


### PR DESCRIPTION
Hi Dan,
I open the PR to track the solution about generic read FST.
Now, I modify the fstext/kaldi-fst-io.h/cc so that it can read constfst or vectorfst and return a Fst<StdArc> pointer. I change the utils/mkgraph.sh and gmmbin/gmm-latgen-faster.cc and test it. I confirm it can get the same result as original code.
Then, I will modify other *-lattgen-faster and test them.
Hang