### PR TITLE
do not segfault if hyp does not match ref

### DIFF
--- a/egs/wsj/s5/run.sh
+++ b/egs/wsj/s5/run.sh
@@ -130,7 +130,7 @@ if [ $stage -le 2 ]; then
       # This is just confirming they're equivalent.
       for mode in 1 2 3 4; do
         steps/lmrescore.sh --mode $mode --cmd "$decode_cmd" \
-          data/lang_nosp_test_{tgpr,tg} data/test_dev93 \
+          data/lang_nosp_test_{tgpr,tg} data/test_${data} \
           exp/tri1/decode_nosp_tgpr_${data} \
           exp/tri1/decode_nosp_tgpr_${data}_tg$mode  || exit 1;
       done

--- a/src/bin/compute-wer-bootci.cc
+++ b/src/bin/compute-wer-bootci.cc
@@ -116,9 +116,9 @@ void GetBootstrapWERInterval(
       BaseFloat *mean, BaseFloat *interval) {
     BaseFloat wer_accum = 0.0, wer_mult_accum = 0.0;
 
-    for (int32 i = 0; i <= replications; ++i) {
+    for (int32 i = 0; i < replications; ++i) {
       int32 num_words = 0, word_errs = 0;
-      for (int32 j = 0; j <= edit_word_per_hyp.size(); ++j) {
+      for (int32 j = 0; j < edit_word_per_hyp.size(); ++j) {
         int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size());
         word_errs += edit_word_per_hyp[random_pos].first;
         num_words += edit_word_per_hyp[random_pos].second;
@@ -140,9 +140,9 @@ void GetBootstrapWERTwoSystemComparison(
       int32 replications, BaseFloat *p_improv) {
     int32 improv_accum = 0.0;
 
-    for (int32 i = 0; i <= replications; ++i) {
+    for (int32 i = 0; i < replications; ++i) {
       int32 word_errs = 0;
-      for (int32 j = 0; j <= edit_word_per_hyp.size(); ++j) {
+      for (int32 j = 0; j < edit_word_per_hyp.size(); ++j) {
         int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size());
         word_errs += edit_word_per_hyp[random_pos].first -
                         edit_word_per_hyp2[random_pos].first;

--- a/src/bin/compute-wer-bootci.cc
+++ b/src/bin/compute-wer-bootci.cc
@@ -119,7 +119,7 @@ void GetBootstrapWERInterval(
     for (int32 i = 0; i < replications; ++i) {
       int32 num_words = 0, word_errs = 0;
       for (int32 j = 0; j < edit_word_per_hyp.size(); ++j) {
-        int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size());
+        int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size() - 1);
         word_errs += edit_word_per_hyp[random_pos].first;
         num_words += edit_word_per_hyp[random_pos].second;
         }
@@ -143,7 +143,7 @@ void GetBootstrapWERTwoSystemComparison(
     for (int32 i = 0; i < replications; ++i) {
       int32 word_errs = 0;
       for (int32 j = 0; j < edit_word_per_hyp.size(); ++j) {
-        int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size());
+        int32 random_pos = kaldi::RandInt(0, edit_word_per_hyp.size() - 1);
         word_errs += edit_word_per_hyp[random_pos].first -
                         edit_word_per_hyp2[random_pos].first;
         }


### PR DESCRIPTION
should be addressing #1572 
the output after the modification looks like:
```
$ ./compute-wer-bootci --mode=all ark:hyp ark:ref
./compute-wer-bootci --mode=all ark:hyp ark:ref
Set1: %WER -nan 95% Conf Interval [ -nan, -nan ]
```
instead of segfaulting

y.