### PR TITLE
Delete Idct in init.config

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/xconfig/basic_layers.py
+++ b/egs/wsj/s5/steps/libs/nnet3/xconfig/basic_layers.py
@@ -999,7 +999,7 @@ class XconfigIdctLayer(XconfigLayerBase):
                        'dim': -1,
                        'cepstral-lifter': 22.0,
                        'affine-transform-file': '',
-                       'write-init-config': True}
+                       'write-init-config': False}
 
     def check_configs(self):
         if self.config['affine-transform-file'] is None:


### PR DESCRIPTION
I found in my experiments and wsj/s5/local/chain/tuning/run_cnn_tdnn_1{a,b}.sh that the lda.mat was not used during training. But the output from idct in init.config will conflict with output from fixed-affine-layer if we want to reuse the same input, like:

```
  input dim=100 name=ivector
  input dim=40 name=input
  # please note that it is important to have input layer with the name=input
  # as the layer immediately preceding the fixed-affine-layer to enable
  # the use of short notation for the descriptor
  fixed-affine-layer name=lda input=Append(-1,0,1,ReplaceIndex(ivector, t, 0)) affine-transform-file=exp/ihm/chain_cleaned/tdnn_lstm1i_batchnorm_combinetest_with_cnn1_feature-fusion_sp_bi_ld5/configs/lda.mat
  idct-layer name=idct input=input dim=40 cepstral-lifter=22 affine-transform-file=exp/ihm/chain_cleaned/tdnn_lstm1i_batchnorm_combinetest_with_cnn1_feature-fusion_sp_bi_ld5/configs/idct.mat
      
  conv-relu-batchnorm-layer name=cnn1 input=idct height-in=40 height-out=40 time-offsets=-1,0,1 height-offsets=-1,0,1 num-filters-out=32 learning-rate-factor=0.333 max-change=0.25
  conv-relu-batchnorm-layer name=cnn2 input=cnn1 height-in=40 height-out=40 time-offsets=-1,0,1 height-offsets=-1,0,1 num-filters-out=32
  relu-batchnorm-layer name=tdnn0 input=cnn2 dim=512 
  # the first splicing is moved before the lda layer, so no splicing here
  relu-batchnorm-layer name=tdnn1 input=Append(tdnn0,lda) dim=1024
```