### PR TITLE
cudamatrix: accelerating the BLSTM training

### DIFF
--- a/src/cudamatrix/cu-array.cc
+++ b/src/cudamatrix/cu-array.cc
@@ -33,11 +33,11 @@
 
 namespace kaldi {
 
-template<> 
+template<>
 void CuArray<int32>::Set(const int32 &value) {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
+  if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
 
     dim3 dimBlock(CU2DBLOCK);
@@ -45,7 +45,7 @@ void CuArray<int32>::Set(const int32 &value) {
     ::MatrixDim d = { 1, Dim(), Dim() };
 
     cuda_int32_set_const(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -58,11 +58,11 @@ void CuArray<int32>::Set(const int32 &value) {
 }
 
 
-template<> 
+template<>
 void CuArray<int32>::Add(const int32 &value) {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
+  if (CuDevice::Instantiate().Enabled()) {
     Timer tim;
 
     dim3 dimBlock(CU2DBLOCK);
@@ -70,7 +70,7 @@ void CuArray<int32>::Add(const int32 &value) {
     ::MatrixDim d = { 1, Dim(), Dim() };
 
     cuda_int32_add(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -80,7 +80,7 @@ void CuArray<int32>::Add(const int32 &value) {
       data_[i] += value;
     }
   }
-} 
+}
 
 
 }  // namespace kaldi

--- a/src/cudamatrix/cu-array.h
+++ b/src/cudamatrix/cu-array.h
@@ -65,15 +65,15 @@ class CuArray {
   const T* Data() const { return data_; }
 
   T* Data() { return data_; }
- 
+
   /// Allocate the memory.  resize_type may be kSetZero or kUndefined.
   /// kCopyData not yet supported (can be implemented if needed).
   void Resize(MatrixIndexT dim, MatrixResizeType resize_type = kSetZero);
-  
+
   /// Deallocate the memory and set dim_ and data_ to zero.  Does not call any
   /// destructors of the objects stored.
   void Destroy();
-  
+
   /// This function resizes if needed.  Note: copying to GPU is done via memcpy,
   /// and any constructors or assignment operators are not called.
   void CopyFromVec(const std::vector<T> &src);
@@ -96,13 +96,13 @@ class CuArray {
   /// Sets the memory for the object to zero, via memset.  You should verify
   /// that this makes sense for type T.
   void SetZero();
-  
+
   /// Set to a constant value.  Note: any copying is done as if using memcpy, and
   /// assignment operators or destructors are not called.  This is NOT IMPLEMENTED
   /// YET except for T == int32 (the current implementation will just crash).
   void Set(const T &value);
-  
-  /// Add a constant value. This is NOT IMPLEMENTED YET except for T == int32 
+
+  /// Add a constant value. This is NOT IMPLEMENTED YET except for T == int32
   /// (the current implementation will just crash).
   void Add(const T &value);
 
@@ -125,7 +125,7 @@ class CuArray {
   /// I/O
   void Read(std::istream &is, bool binary);
   void Write(std::ostream &is, bool binary) const;
-  
+
  private:
   MatrixIndexT dim_;     ///< dimension of the vector
   T *data_;  ///< GPU data pointer (if GPU not available,

--- a/src/cudamatrix/cu-block-matrix.cc
+++ b/src/cudamatrix/cu-block-matrix.cc
@@ -251,7 +251,7 @@ void CuBlockMatrix<Real>::AddMatMat(
     cuda_block_add_mat_mat(dimGrid, dimBlock, cu_data_, NumBlocks(),
                            A.Data(), A_num_cols, A_row_stride, A_col_stride,
                            B.Data(), B_row_stride, B_col_stride, alpha, beta);
-    CU_SAFE_CALL(cudaGetLastError());    
+    CUDA_GET_LAST_ERROR;    
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());    
   } else
 #endif

--- a/src/cudamatrix/cu-math.cc
+++ b/src/cudamatrix/cu-math.cc
@@ -45,7 +45,7 @@ void RegularizeL1(CuMatrixBase<Real> *weight, CuMatrixBase<Real> *grad, Real l1,
 
     cuda_regularize_l1(dimGrid, dimBlock, weight->Data(), grad->Data(), l1, lr,
                        weight->Dim(), grad->Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -110,7 +110,7 @@ void Randomize(const CuMatrixBase<Real> &src,
 
     cuda_randomize(dimGrid, dimBlock, tgt->Data(), src.Data(),
                    copy_from_idx.Data(), dimtgt, dimsrc);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -144,7 +144,7 @@ void Splice(const CuMatrixBase<Real> &src, const CuArray<int32> &frame_offsets,
 
     cuda_splice(dimGrid, dimBlock, tgt->Data(), src.Data(),
                 frame_offsets.Data(), tgt->Dim(), src.Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -185,7 +185,7 @@ void Copy(const CuMatrixBase<Real> &src, const CuArray<int32> &copy_from_indices
 
     cuda_copy(dimGrid, dimBlock, tgt->Data(), src.Data(),
               copy_from_indices.Data(), tgt->Dim(), src.Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -260,7 +260,7 @@ void NormalizePerRow(const CuMatrixBase<Real>& in, const Real target_rms,
     size_t dimGrid = out->NumRows();
     cuda_normalize_per_row(dimGrid, dimBlock, out->Data(), out->Stride(),
                            in.Data(), in.Dim(), target_rms, add_log_stddev);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -326,7 +326,7 @@ void DiffNormalizePerRow(const CuMatrixBase<Real> &in_value,
                                 in_deriv->Stride(), in_value.Data(),
                                 in_value.Dim(), out_deriv.Data(),
                                 out_deriv.Stride(), target_rms, add_log_stddev);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -478,7 +478,7 @@ void ComputeLstmNonlinearity(const CuMatrixBase<Real> &input,
     cuda_lstm_nonlinearity(dimGrid, dimBlock, input.Data(), input.Stride(),
                            params.Data(), params.Stride(), output->Stride(),
                            cell_dim, have_dropout_mask, num_rows, output->Data());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -864,7 +864,7 @@ void BackpropLstmNonlinearity(const CuMatrixBase<Real> &input,
       }
     }
 
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -245,7 +245,7 @@ void CuMatrixBase<Real>::CopyFromMat(const CuMatrixBase<OtherReal> &M,
         cuda_copy_from_mat_trans(dimGrid, dimBlock, data_, M.data_, Dim(),
             M.Dim());
       }
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
     }
     CuDevice::Instantiate().AccuProfile("CuMatrixBase::CopyFromMat(from other CuMatrixBase)", tim.Elapsed());
   } else
@@ -503,7 +503,7 @@ void CuMatrixBase<Real>::Set(Real value) {
                                           &dimGrid, &dimBlock);
 
     cuda_set_const(dimGrid, dimBlock, data_, value, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -526,7 +526,7 @@ void CuMatrixBase<Real>::SetZeroAboveDiag() {
                                           &dimGrid, &dimBlock);
 
     cuda_set_zero_above_diag(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -554,7 +554,7 @@ void CuMatrixBase<Real>::Add(Real value) {
                                           &dimGrid, &dimBlock);
 
     cuda_add(dimGrid, dimBlock, data_, value, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -579,7 +579,7 @@ void CuMatrixBase<Real>::AddToDiag(Real value) {
     dim3 dimGrid(1, n_blocks(num_diag, CU1DBLOCK));
     ::MatrixDim d = { num_diag, 1, this_stride };
     cuda_add(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -616,7 +616,7 @@ void CuMatrixBase<Real>::Scale(Real value) {
                                           &dimGrid, &dimBlock);
 
     cuda_scale(dimGrid, dimBlock, data_, value, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -638,7 +638,7 @@ void CuMatrixBase<Real>::ApplyLog() {
                                           &dimGrid, &dimBlock);
 
     cuda_apply_log(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -662,7 +662,7 @@ void CuMatrixBase<Real>::MulElements(const CuMatrixBase<Real>& A) {
                                           &dimGrid, &dimBlock);
 
     cuda_mul_elements(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -686,7 +686,7 @@ void CuMatrixBase<Real>::DivElements(const CuMatrixBase<Real>& A) {
                                           &dimGrid, &dimBlock);
 
     cuda_div_elements(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -710,7 +710,7 @@ void CuMatrixBase<Real>::Max(const CuMatrixBase<Real>& A) {
                                           &dimGrid, &dimBlock);
 
     cuda_max(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -735,7 +735,7 @@ void CuMatrixBase<Real>::Min(const CuMatrixBase<Real>& A) {
                                           &dimGrid, &dimBlock);
 
     cuda_min(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -760,7 +760,7 @@ void CuMatrixBase<Real>::MulColsVec(const CuVectorBase<Real> &scale) {
                                           &dimGrid, &dimBlock);
 
     cuda_mul_cols_vec(dimGrid, dimBlock, data_, scale.data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -786,7 +786,7 @@ void CuMatrixBase<Real>::MulRowsVec(const CuVectorBase<Real> &scale) {
                                           &dimGrid, &dimBlock);
 
     cuda_mul_rows_vec(dimGrid, dimBlock, data_, scale.data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -811,7 +811,7 @@ void CuMatrixBase<Real>::MulRowsGroupMat(const CuMatrixBase<Real> &src) {
 
     cuda_mul_rows_group_mat(dimGrid, dimBlock, this->data_, src.data_,
                             this->Dim(), src.Stride(), group_size);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -845,7 +845,7 @@ void CuMatrixBase<Real>::DiffGroupPnorm(const CuMatrixBase<Real> &in_value,
                           out_value.Data(), out_deriv.Data(), Dim(),
                           in_value.Stride(), out_value.Stride(),
                           out_deriv.Stride(), group_size, power);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -870,7 +870,7 @@ void CuMatrixBase<Real>::GroupMaxDeriv(const CuMatrixBase<Real> &src1,
     cuda_calc_group_max_deriv(dimGrid, dimBlock, this->data_, src1.Data(),
                               src2.Data(), Dim(), src1.Stride(), src2.Stride(),
                               group_size);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -900,7 +900,7 @@ void CuMatrixBase<Real>::DivRowsVec(const CuVectorBase<Real> &div) {
       }
     }
     cuda_div_rows_vec(dimGrid, dimBlock, data_, div.data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -923,7 +923,7 @@ void CuMatrixBase<Real>::InvertElements() {
                                           &dimGrid, &dimBlock);
 
     cuda_invert_elements(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -955,7 +955,7 @@ void CuMatrixBase<Real>::AddMat(Real alpha, const CuMatrixBase<Real>& A,
     cuda_add_mat(dimGrid, dimBlock, alpha, A.data_,
                  data_, Dim(), A.Stride(),
                  (transA == kTrans ? 1 : 0));
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -988,7 +988,7 @@ void CuMatrixBase<Real>::AddMatBlocks(Real alpha, const CuMatrixBase<Real> &A,
     cuda_add_mat_blocks(dimGrid, dimBlock, alpha, A.data_, num_row_blocks,
                         num_col_blocks, data_, Dim(), A.Stride(),
                         (transA == kTrans ? 1 : 0));
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1029,7 +1029,7 @@ void CuMatrixBase<Real>::SetMatMatDivMat(const CuMatrixBase<Real> &A,
                                           &dimGrid, &dimBlock);
     cuda_set_mat_mat_div_mat(dimGrid, dimBlock, A.data_, B.data_, C.data_,
                              data_, Dim(), A.Stride(), B.Stride(), C.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1055,7 +1055,7 @@ void CuMatrixBase<Real>::AddVecToCols(Real alpha,
                                           &dimGrid, &dimBlock);
     cuda_add_vec_to_cols(dimGrid, dimBlock, alpha, col.data_, beta,
                          data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1082,7 +1082,7 @@ void CuMatrixBase<Real>::AddVecToRows(Real alpha,
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_vec_to_rows(dimGrid, dimBlock, alpha, row.data_, beta, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1211,7 +1211,7 @@ void CuMatrixBase<Real>::AddDiagVecMat(
       std::swap(M_row_stride, M_col_stride);
     cuda_add_diag_vec_mat(dimGrid, dimBlock, alpha, data_, Dim(),
                           v.Data(), M.Data(), M_row_stride, M_col_stride, beta);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1244,7 +1244,7 @@ void CuMatrixBase<Real>::AddMatDiagVec(
     if (transM == kTrans) std::swap(M_row_stride, M_col_stride);
     cuda_add_mat_diag_vec(dimGrid, dimBlock, alpha, data_, Dim(),
                           M.Data(), M_row_stride, M_col_stride, v.Data(),  beta);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1291,7 +1291,7 @@ void CuMatrixBase<Real>::ParametricRelu(
 
     cuda_parametric_relu(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
                          src.Stride(), alpha.data_, beta.data_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1323,7 +1323,7 @@ void CuMatrixBase<Real>::DiffParametricRelu(
     cuda_diff_parametric_relu(dimGrid, dimBlock, data_, diff.data_, value.data_,
                               Dim(), diff.Stride(), value.Stride(),
                               alpha.data_, beta.data_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1351,7 +1351,7 @@ void CuMatrixBase<Real>::Sigmoid(const CuMatrixBase<Real> &src) {
                                           &dimGrid, &dimBlock);
     cuda_sigmoid(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
                  src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1372,7 +1372,7 @@ void CuMatrixBase<Real>::SoftHinge(const CuMatrixBase<Real> &src) {
                                           &dimGrid, &dimBlock);
     cuda_soft_hinge(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
                     src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1414,7 +1414,7 @@ void CuMatrixBase<Real>::GroupPnorm(const CuMatrixBase<Real> &src, Real power) {
       cuda_group_pnorm(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
                        src.Stride(), group_size, power);
     }
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1448,7 +1448,7 @@ void CuMatrixBase<Real>::GroupMax(const CuMatrixBase<Real> &src) {
     dim3 dimGrid(NumRows());
     cuda_group_max(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
         src.Stride(), group_size);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1529,7 +1529,7 @@ void CuMatrixBase<Real>::ApplySoftMaxPerRow(const CuMatrixBase<Real> &src) {
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = src.num_rows_;
     cuda_softmax_reduce(dimGrid, dimBlock, data_, src.data_, Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1553,7 +1553,7 @@ void CuMatrixBase<Real>::ApplyLogSoftMaxPerRow(const CuMatrixBase<Real> &src) {
     size_t dimGrid = src.num_rows_;
     cuda_log_softmax_reduce(dimGrid, dimBlock,
                             data_, src.data_, Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1578,7 +1578,7 @@ void CuMatrixBase<Real>::DiffSigmoid(const CuMatrixBase<Real> &value,
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_diff_sigmoid(dimGrid, dimBlock, data_, diff.data_, value.data_, Dim(), diff.Stride(), value.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1600,7 +1600,7 @@ void CuMatrixBase<Real>::Tanh(const CuMatrixBase<Real> &src) {
                                           &dimGrid, &dimBlock);
 
     cuda_tanh(dimGrid, dimBlock, this->data_, src.data_, this->Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1622,7 +1622,7 @@ void CuMatrixBase<Real>::DiffTanh(const CuMatrixBase<Real> &value,
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_diff_tanh(dimGrid, dimBlock, data_, diff.data_, value.data_, Dim(), diff.Stride(), value.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1644,7 +1644,7 @@ void CuMatrixBase<Real>::FindRowMaxId(CuArray<int32> *id) const {
     dim3 dimBlock(CU1DBLOCK);
     dim3 dimGrid(num_rows_);
     cuda_find_row_max_id(dimGrid, dimBlock, data_, NULL, id->Data(), d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     // now we have the indices!
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -1686,7 +1686,7 @@ void CuMatrixBase<Real>::DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
     dim3 dimGrid(num_rows_);
     cuda_diff_softmax(dimGrid, dimBlock, data_, this->Dim(), value.Data(),
         value.Stride(), diff.Data(), diff.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1721,7 +1721,7 @@ void CuMatrixBase<Real>::DiffLogSoftmaxPerRow(
     cuda_diff_log_softmax(dimGrid, dimBlock, this->Dim(), out_value.Data(),
                           out_value.Stride(), out_deriv.Data(),
                           out_deriv.Stride(), data_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1979,7 +1979,7 @@ Real TraceMatMat(const CuMatrixBase<Real> &A,
       cuda_trace_mat_mat_trans(dimGrid, dimBlock, A.Data(), B.Data(), A.Dim(),
           B.Stride(), result_vec.Data());
     }
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     Vector<Real> result_cpu(result_vec); // copying from CUDA faster than summing in CUDA.
     result = result_cpu.Sum();
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -2114,7 +2114,7 @@ void CuMatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {
       GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                             &dimGrid, &dimBlock);
       cuda_copy_rows_from_vec(dimGrid, dimBlock, data_, this->Dim(), v.Data());
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
     } else {
       KALDI_ERR << "Wrong sized arguments";
     }
@@ -2148,7 +2148,7 @@ void CuMatrixBase<Real>::CopyRowsFromVec(const VectorBase<Real> &v) {
       GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                             &dimGrid, &dimBlock);
       cuda_copy_rows_from_vec(dimGrid, dimBlock, this->data_, this->Dim(), v.Data());
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
     } else {
       KALDI_ERR << "Wrong sized arguments";
     }
@@ -2176,7 +2176,7 @@ void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
                    n_blocks(rv_dim.rows, warpSize));
       cuda_copy_from_mat_trans(dimGrid, dimBlock, data_, rv.Data(), Dim(),
                                rv_dim);
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
     } else if (rv.Dim() == num_rows_) {
       // use 2D block (8x32) and large enough grid to cover matrix *this
       // dimBlock.x need to be at least warpSize for coalesced memory access.
@@ -2185,7 +2185,7 @@ void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
       dim3 dimGrid(n_blocks(num_cols_, dimBlock.x),
                    n_blocks(num_rows_, dimBlock.y));
       cuda_copy_cols_from_vec(dimGrid, dimBlock, Data(), Dim(), rv.Data());
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
     } else {
       KALDI_ERR<< "Wrong sized arguments";
     }
@@ -2210,7 +2210,7 @@ void CuMatrixBase<Real>::CopyColFromVec(const CuVectorBase<Real> &v,
     cublas_copy(GetCublasHandle(),
                 v.Dim(), v.Data(), 1,
                 this->data_ + col, this->stride_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2228,7 +2228,7 @@ void CuMatrixBase<Real>::ApplyPow(Real power) {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_pow(dimGrid, dimBlock, data_, power, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2246,7 +2246,7 @@ void CuMatrixBase<Real>::ApplyPowAbs(Real power, bool include_sign) {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_pow_abs(dimGrid, dimBlock, data_, power, include_sign, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2264,7 +2264,7 @@ void CuMatrixBase<Real>::ApplyHeaviside() {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_heaviside(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2284,7 +2284,7 @@ void CuMatrixBase<Real>::Heaviside(const CuMatrixBase<Real> &src) {
                                           &dimGrid, &dimBlock);
     cuda_heaviside(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
                    src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -2303,7 +2303,7 @@ void CuMatrixBase<Real>::ApplyExp() {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_exp(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2322,7 +2322,7 @@ void CuMatrixBase<Real>::ApplyFloor(Real floor_val) {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_floor(dimGrid, dimBlock, data_, floor_val, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2340,7 +2340,7 @@ void CuMatrixBase<Real>::ApplyCeiling(Real ceiling_val) {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_ceiling(dimGrid, dimBlock, data_, ceiling_val, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2394,7 +2394,7 @@ void CuMatrixBase<Real>::CopyCols(const CuMatrixBase<Real> &src,
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_copy_cols(dimGrid, dimBlock, data_, src.Data(), indices.Data(), Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2418,7 +2418,7 @@ void CuMatrixBase<Real>::CopyRows(const CuMatrixBase<Real> &src,
                                           &dimGrid, &dimBlock);
     cuda_copy_rows(dimGrid, dimBlock, data_, src.Data(), indices.Data(),
                    Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2440,7 +2440,7 @@ void CuMatrixBase<Real>::AddCols(const CuMatrixBase<Real> &src,
                                           &dimGrid, &dimBlock);
     cuda_add_cols(dimGrid, dimBlock, data_, src.Data(), indices.Data(),
                   Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2460,7 +2460,7 @@ void CuMatrixBase<Real>::CopyRows(const CuArray<const Real*> &src) {
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
     cuda_copy_rows(dimGrid, dimBlock, data_, src.Data(), Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2482,7 +2482,7 @@ void CuMatrixBase<Real>::CopyToRows(const CuArray<Real*> &dst) const {
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
     cuda_copy_to_rows(dimGrid, dimBlock, dst.Data(), data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2507,7 +2507,7 @@ void CuMatrixBase<Real>::AddRows(Real alpha,
                                           &dimGrid, &dimBlock);
     cuda_add_rows(dimGrid, dimBlock, alpha,
                   data_, src.Data(), indexes.Data(), Dim(), src.Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2528,7 +2528,7 @@ void CuMatrixBase<Real>::AddRows(Real alpha, const CuArray<const Real*> &src) {
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_rows(dimGrid, dimBlock, alpha, data_, src.Data(), Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2550,7 +2550,7 @@ void CuMatrixBase<Real>::AddToRows(Real alpha,
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_to_rows(dimGrid, dimBlock, alpha, dst.Data(), data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2574,7 +2574,7 @@ void CuMatrixBase<Real>::SumColumnRanges(const CuMatrixBase<Real> &src,
                                           &dimGrid, &dimBlock);
     cuda_sum_column_ranges(dimGrid, dimBlock, data_, Dim(), src.Data(),
                            src.Dim(), indices.Data());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2612,7 +2612,7 @@ void CuMatrixBase<Real>::AddRowRanges(const CuMatrixBase<Real> &src,
                                           &dimGrid, &dimBlock);
     cuda_add_row_ranges(dimGrid, dimBlock,
                         data_, Dim(), src.Data(), src.Dim(), indexes.Data());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2648,7 +2648,7 @@ void CuMatrixBase<Real>::CopyLowerToUpper() {
     dim3 dimGrid(n_blocks(dim, CU2DBLOCK),
                  n_blocks(dim, CU2DBLOCK));
     cuda_copy_low_upp(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2669,7 +2669,7 @@ void CuMatrixBase<Real>::CopyUpperToLower() {
     dim3 dimGrid(n_blocks(dim, CU2DBLOCK),
                  n_blocks(dim, CU2DBLOCK));
     cuda_copy_upp_low(dimGrid, dimBlock, data_, Dim());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -2753,7 +2753,7 @@ Real CuMatrixBase<Real>::Trace(bool check_square) const {
     int dimBlock(CU1DBLOCK);
     int dimGrid = 1;// only 1 block here. we have loops in each thread  //(n_blocks(dim_, CU1DBLOCK));
     cuda_vec_sum(dimGrid, dimBlock, data_, tmp.Data(), dim, Stride() + 1);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::Sum", tim.Elapsed());
     return tmp(0);
   } else
@@ -2913,7 +2913,7 @@ void CuMatrixBase<Real>::AddMatBlock(
                           B.CuData(), B_num_blocks, alpha, beta,
                           (transB == kTrans ? 1 : 0));
 
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -2966,7 +2966,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha,
 
     cuda_matrix_add_elements(dimGrid, dimBlock, this->data_, this->Dim(),
                              alpha, (MatrixElement<Real>*)addr, input.size());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().Free(addr);
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -2995,7 +2995,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha, const CuArray<Int32Pair> &index
     int dimGrid = n_blocks(indexes.Dim(), CU1DBLOCK);
     cuda_matrix_add_indexed_values(dimGrid, dimBlock, this->Dim(), alpha,
                                    indexes.Data(), tmp_vec.Data(), indexes.Dim(), this->data_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -3051,7 +3051,7 @@ void CuMatrixBase<Real>::Lookup(const CuArray<Int32Pair> &indices,
 
     cuda_matrix_lookup(dimGrid, dimBlock, this->data_, this->Dim(),
                        indices.Data(), num_elements, cuda_output.Data());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     cuda_output.CopyToHost(output);
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
@@ -3086,7 +3086,7 @@ void CuMatrixBase<Real>::EqualElementMask(const CuMatrixBase<Real> &mat, CuMatri
     cuda_equal_element_mask(dimGrid, dimBlock, this->data_, mat.Data(),
                             mask->Data(), this->Dim(), mat.Stride(),
                             mask->Stride());
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else

--- a/src/cudamatrix/cu-packed-matrix.cc
+++ b/src/cudamatrix/cu-packed-matrix.cc
@@ -281,7 +281,7 @@ void CuPackedMatrix<Real>::SetDiag(Real alpha) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(NumRows(),CU1DBLOCK));
     cuda_set_diag_packed(dimGrid,dimBlock,data_,alpha,num_rows_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuPackedMatrix::SetDiag", tim.Elapsed());
   } else
 #endif
@@ -315,7 +315,7 @@ void CuPackedMatrix<Real>::ScaleDiag(Real alpha) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(NumRows(),CU1DBLOCK));
     cuda_scale_diag_packed(dimGrid,dimBlock,data_,alpha,num_rows_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuPackedMatrix::ScaleDiag", tim.Elapsed());
   } else
 #endif
@@ -351,7 +351,7 @@ void CuPackedMatrix<Real>::AddToDiag(Real r) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(NumRows(),CU1DBLOCK));
     cuda_add_diag_packed(dimGrid,dimBlock,data_,r,num_rows_);
-    CU_SAFE_CALL(cudaGetLastError());    
+    CUDA_GET_LAST_ERROR;    
     CuDevice::Instantiate().AccuProfile("CuPackedMatrix::AddToDiag", tim.Elapsed());
   } else
 #endif

--- a/src/cudamatrix/cu-sp-matrix.cc
+++ b/src/cudamatrix/cu-sp-matrix.cc
@@ -58,7 +58,7 @@ void CuSpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
           dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
           dim3 dimGrid(n_blocks(D, CU2DBLOCK), n_blocks(D, CU2DBLOCK));
           cuda_take_mean(dimGrid, dimBlock, M.Data(), this->data_, M.Dim());
-          CU_SAFE_CALL(cudaGetLastError());
+          CUDA_GET_LAST_ERROR;
         }
         break;
       case kTakeLower:
@@ -67,7 +67,7 @@ void CuSpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
           dim3 dimBlock(1, block_size);
           dim3 dimGrid(D, n_blocks(D, block_size));
           cuda_take_lower(dimGrid, dimBlock, M.Data(), this->data_, M.Dim());
-          CU_SAFE_CALL(cudaGetLastError());
+          CUDA_GET_LAST_ERROR;
         }
         break;
       case kTakeUpper:
@@ -75,7 +75,7 @@ void CuSpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
           dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
           dim3 dimGrid(n_blocks(D, CU2DBLOCK), n_blocks(D, CU2DBLOCK));
           cuda_take_upper(dimGrid, dimBlock, M.Data(), this->data_, M.Dim());
-          CU_SAFE_CALL(cudaGetLastError());
+          CUDA_GET_LAST_ERROR;
         }
         break;
       default:

--- a/src/cudamatrix/cu-tp-matrix.cc
+++ b/src/cudamatrix/cu-tp-matrix.cc
@@ -71,7 +71,7 @@ void CuTpMatrix<Real>::Invert() {
     int dim = this->NumRows();
     Real alpha = 1.0;
     cuda_set_diag(dimGrid, dimBlock, tmp.Data(), alpha, tmp.Dim());
-    CU_SAFE_CALL(cudaGetLastError());        
+    CUDA_GET_LAST_ERROR;        
     CuMatrix<Real> tmp2(dim, dim);
     tmp2.CopyFromTp(*this);
     CU_SAFE_CALL(cublas_trsm(GetCublasHandle(), dim, dim, alpha, tmp2.Data(), tmp2.Dim().stride, 
@@ -100,7 +100,7 @@ void CuTpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
     } else {
       cuda_take_upper(dimGrid, dimBlock, M.Data(), this->data_, M.Dim());
     }
-    CU_SAFE_CALL(cudaGetLastError());        
+    CUDA_GET_LAST_ERROR;        
   } else
 #endif
   {

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -115,7 +115,7 @@ template<typename Real> void TestCuVectorSumChooseMinLength() {
         }
         CuVector<Real> ans(dimGrid, kUndefined);
         cuda_vec_sum(dimGrid, dimBlock, M.Data(), ans.Data(), M.Dim(), 1);
-        CU_SAFE_CALL(cudaGetLastError());
+        CUDA_GET_LAST_ERROR;
         Vector<Real> ans_cpu(ans);
         result = ans_cpu.Sum();
       }

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -84,7 +84,7 @@ void CuVectorBase<Real>::CopyColFromMat(const CuMatrixBase<Real> &mat, MatrixInd
     Timer tim;
     cublas_copy(GetCublasHandle(),
                 this->dim_, mat.Data() + col, mat.Stride(), this->data_, 1);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
   } else
 #endif
@@ -105,7 +105,7 @@ void CuVectorBase<double>::CopyColFromMat(const CuMatrixBase<float> &mat, Matrix
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_copy_col_from_mat_df(dimGrid, dimBlock, data_, col, mat.Data(), mat.Dim(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
   } else
 #endif
@@ -127,7 +127,7 @@ void CuVectorBase<float>::CopyColFromMat(const CuMatrixBase<double> &mat, Matrix
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_copy_col_from_mat_fd(dimGrid, dimBlock, data_, col, mat.Data(), mat.Dim(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
   } else
 #endif
@@ -207,7 +207,7 @@ void CuVectorBase<Real>::CopyRowsFromMat(const MatrixBase<Real> &mat) {
         vec_data += mat.NumCols();
       }
     }
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -287,7 +287,7 @@ Real CuVectorBase<Real>::Sum() const {
       }
       CuVector<Real> ans(dimGrid, kUndefined);
       cuda_vec_sum(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
       Vector<Real> ans_cpu(ans);
       result = ans_cpu.Sum();
     }
@@ -311,7 +311,7 @@ void CuVectorBase<Real>::ApplySoftMax() {
     size_t dimGrid = 1;       // dimGrid value represent the number of rows
     ::MatrixDim dim = { 1, this->dim_, this->dim_};
     cuda_softmax_reduce(dimGrid, dimBlock, data_, data_, dim, this->dim_);//actually dim is not stride...
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -333,7 +333,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyFloor(Real floor_val) {
     CuVector<float> count_vec(dim_, kUndefined);
 
     cuda_vec_apply_floor(dimGrid, dimBlock, data_, floor_val, count_vec.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     num_floored = count_vec.Sum();
     CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloor", tim.Elapsed());
   } else
@@ -358,7 +358,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
     CuVector<float> count_vec(dim_, kUndefined);
 
     cuda_vec_apply_ceiling(dimGrid, dimBlock, data_, ceiling_val, count_vec.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     num_ceiled = count_vec.Sum();
     CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyCeiling", tim.Elapsed());
   } else
@@ -382,7 +382,7 @@ void CuVectorBase<Real>::ApplyPow(Real power) {
     ::MatrixDim fake_matrix_dim = { 1, Dim(), 1 };
     // num_cols is Dim(), num_rows is 1, stride is 1 (it's a don't-care).
     cuda_apply_pow(dimGrid, dimBlock, data_, power, fake_matrix_dim);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyPow", tim.Elapsed());
   } else
 #endif
@@ -402,7 +402,7 @@ void CuVectorBase<Real>::ApplyExp() {
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_vec_apply_exp(dimGrid, dimBlock, data_, dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyExp", tim.Elapsed());
   } else
 #endif
@@ -423,7 +423,7 @@ void CuVectorBase<Real>::ApplyLog() {
 
     CuVector<Real> flag(1);
     cuda_vec_apply_log(dimGrid, dimBlock, data_, flag.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     if (flag(0) > 0)
       KALDI_ERR << "Trying to take log of a negative number.";
     CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyLog", tim.Elapsed());
@@ -502,7 +502,7 @@ void CuVectorBase<Real>::AddVecVec(Real alpha, const CuVectorBase<Real> &v,
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_add_vec_vec(dimGrid, dimBlock, alpha, data_, v.Data(), r.Data(), beta, dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::AddVecVec", tim.Elapsed());
   } else
 #endif
@@ -598,7 +598,7 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
                                  M.Data(), M.Dim(), beta, data_);
       }
     }
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -677,7 +677,7 @@ Real CuVectorBase<Real>::Min() const {
       }
       CuVector<Real> ans(dimGrid, kUndefined);
       cuda_vec_min(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
       Vector<Real> ans_cpu(ans);
       result = ans_cpu.Min();
     }
@@ -715,7 +715,7 @@ Real CuVectorBase<Real>::Max() const {
       }
       CuVector<Real> ans(dimGrid, kUndefined);
       cuda_vec_max(dimGrid, dimBlock, data_, ans.Data(), dim_, 1);
-      CU_SAFE_CALL(cudaGetLastError());
+      CUDA_GET_LAST_ERROR;
       Vector<Real> ans_cpu(ans);
       result = ans_cpu.Max();
     }
@@ -738,7 +738,7 @@ void CuVectorBase<Real>::ReplaceValue(Real orig, Real changed) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_, CU1DBLOCK));
     cuda_replace_value(dimGrid, dimBlock, data_, dim_, orig, changed);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -757,7 +757,7 @@ void CuVectorBase<Real>::MulElements(const CuVectorBase<Real> &v) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_, CU1DBLOCK));
     cuda_vec_mul_elements(dimGrid, dimBlock, data_, v.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile("CuVectorBase::MulElements", tim.Elapsed());
   } else
 #endif
@@ -1030,7 +1030,7 @@ void CuVectorBase<Real>::Set(Real value) {
     ::MatrixDim d = { 1, Dim(), Dim() };
 
     cuda_set_const(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1052,7 +1052,7 @@ void CuVectorBase<Real>::Add(Real value) {
     ::MatrixDim d = { 1, Dim(), Dim() };
 
     cuda_add(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
 #endif
@@ -1071,7 +1071,7 @@ void CuVectorBase<Real>::CopyDiagFromPacked(const CuPackedMatrix<Real> &M) {
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(Dim(), CU1DBLOCK));
     cuda_vec_copy_diag_from_packed(dimGrid, dimBlock, data_, M.Data(), dim_);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1111,7 +1111,7 @@ void CuVectorBase<Real>::Scale(Real value) {
     dim3 dimGrid(n_blocks(Dim(), CU1DBLOCK));
     ::MatrixDim d = { 1, Dim(), Dim() };
     cuda_scale(dimGrid, dimBlock, data_, value, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1183,7 +1183,7 @@ void CuVectorBase<Real>::AddColSumMat(Real alpha, const CuMatrixBase<Real> &mat,
 
     cuda_add_col_sum_mat(mat.NumRows(), CU1DBLOCK, Data(), mat.Data(),
                          mat.Dim(), alpha, beta);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else
@@ -1204,7 +1204,7 @@ void CuVectorBase<Real>::InvertElements() {
     MatrixDim d = {1, dim_, dim_};
 
     cuda_invert_elements(dimGrid, dimBlock, data_, d);
-    CU_SAFE_CALL(cudaGetLastError());
+    CUDA_GET_LAST_ERROR;
 
     CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
   } else


### PR DESCRIPTION
- by removing some of the 'cudaDeviceSynchronize()' calls, the training
  time of a BLSTM epoch drops to 55.5% of original time (nnet1)
- consequently, the 'time-stats' in the 'profile' are a little inaccurate for some functions,