### PR TITLE
Synchronization fix

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
@@ -152,6 +152,13 @@ def train_new_models(dir, iter, srand, num_jobs,
         deriv_time_opts.append("--optimization.max-deriv-time-relative={0}".format(
                                     int(max_deriv_time_relative)))
 
+    # the GPU timing info is only printed if we use the --verbose=1 flag; this
+    # slows down the computation slightly, so don't accumulate it on every
+    # iteration.  Don't do it on iteration 0 either, because we use a smaller
+    # than normal minibatch size, and people may get confused thinking it's
+    # slower for iteration 0 because of the verbose option.
+    verbose_opt = ("--verbose=1" if iter % 20 == 0 and iter > 0 else "")
+
     processes = []
     for job in range(1, num_jobs+1):
         # k is a zero-based index that we will derive the other indexes from.
@@ -169,7 +176,7 @@ def train_new_models(dir, iter, srand, num_jobs,
 
         process_handle = common_lib.run_job(
             """{command} {train_queue_opt} {dir}/log/train.{iter}.{job}.log \
-                    nnet3-chain-train {parallel_train_opts} \
+                    nnet3-chain-train {parallel_train_opts} {verbose_opt} \
                     --apply-deriv-weights={app_deriv_wts} \
                     --l2-regularize={l2} --leaky-hmm-coefficient={leaky} \
                     {cache_io_opts}  --xent-regularize={xent_reg} \
@@ -195,6 +202,7 @@ def train_new_models(dir, iter, srand, num_jobs,
                         fr_shft=frame_shift, l2=l2_regularize,
                         xent_reg=xent_regularize, leaky=leaky_hmm_coefficient,
                         parallel_train_opts=run_opts.parallel_train_opts,
+                        verbose_opt=verbose_opt,
                         momentum=momentum, max_param_change=max_param_change,
                         raw_model=raw_model_string,
                         egs_dir=egs_dir, archive_index=archive_index,

--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
@@ -62,6 +62,13 @@ def train_new_models(dir, iter, srand, num_jobs,
     context_opts = "--left-context={0} --right-context={1}".format(
         left_context, right_context)
 
+    # the GPU timing info is only printed if we use the --verbose=1 flag; this
+    # slows down the computation slightly, so don't accumulate it on every
+    # iteration.  Don't do it on iteration 0 either, because we use a smaller
+    # than normal minibatch size, and people may get confused thinking it's
+    # slower for iteration 0 because of the verbose option.
+    verbose_opt = ("--verbose=1" if iter % 20 == 0 and iter > 0 else "")
+
     processes = []
     for job in range(1, num_jobs+1):
         # k is a zero-based index that we will derive the other indexes from.
@@ -83,7 +90,7 @@ def train_new_models(dir, iter, srand, num_jobs,
         process_handle = common_lib.run_job(
             """{command} {train_queue_opt} {dir}/log/train.{iter}.{job}.log \
                     nnet3-train {parallel_train_opts} {cache_read_opt} \
-                    {cache_write_opt} --print-interval=10 \
+                    {cache_write_opt} {verbose_opt} --print-interval=10 \
                     --momentum={momentum} \
                     --max-param-change={max_param_change} \
                     {deriv_time_opts} "{raw_model}" \
@@ -102,6 +109,7 @@ def train_new_models(dir, iter, srand, num_jobs,
                         job=job,
                         parallel_train_opts=run_opts.parallel_train_opts,
                         cache_read_opt=cache_read_opt,
+                        verbose_opt=verbose_opt,
                         cache_write_opt=cache_write_opt,
                         frame_opts=(""
                                     if chunk_level_training

--- a/src/base/timer.h
+++ b/src/base/timer.h
@@ -64,12 +64,17 @@ class Timer {
  public:
   Timer() { Reset(); }
 
+  // You can initialize with bool to control whether or not you want the time to
+  // be set when the object is created.
+  explicit Timer(bool set_timer) { if (set_timer) Reset(); }
+
   void Reset() { gettimeofday(&this->time_start_, &time_zone_); }
 
   /// Returns time in seconds.
-  double Elapsed() {
+  double Elapsed() const {
     struct timeval time_end;
-    gettimeofday(&time_end, &time_zone_);
+    struct timezone time_zone;
+    gettimeofday(&time_end, &time_zone);
     double t1, t2;
     t1 =  static_cast<double>(time_start_.tv_sec) +
           static_cast<double>(time_start_.tv_usec)/(1000*1000);

--- a/src/base/timer.h
+++ b/src/base/timer.h
@@ -29,10 +29,15 @@ namespace kaldi {
 class Timer {
  public:
   Timer() { Reset(); }
+
+  // You can initialize with bool to control whether or not you want the time to
+  // be set when the object is created.
+  explicit Timer(bool set_timer) { if (set_timer) Reset(); }
+
   void Reset() {
     QueryPerformanceCounter(&time_start_);
   }
-  double Elapsed() {
+  double Elapsed() const {
     LARGE_INTEGER time_end;
     LARGE_INTEGER freq;
     QueryPerformanceCounter(&time_end);

--- a/src/chain/chain-denominator.cc
+++ b/src/chain/chain-denominator.cc
@@ -95,7 +95,7 @@ void DenominatorComputation::AlphaGeneralFrame(int32 t) {
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(std::min<int32>(CU1DBLOCK, num_sequences), 1, 1);
     dim3 dimGrid(n_blocks(num_sequences, dimBlock.x), num_hmm_states, 1);
 
@@ -120,7 +120,7 @@ void DenominatorComputation::AlphaGeneralFrame(int32 t) {
         dimGrid.y = num_hmm_states;
       }
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim)
   } else
 #endif
   {
@@ -325,7 +325,7 @@ void DenominatorComputation::BetaDashGeneralFrame(int32 t) {
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(std::min<int32>(CU1DBLOCK, num_sequences), 1, 1);
     dim3 dimGrid(n_blocks(num_sequences, dimBlock.x), num_hmm_states, 1);
     while (1) {
@@ -351,7 +351,7 @@ void DenominatorComputation::BetaDashGeneralFrame(int32 t) {
         dimGrid.y = num_hmm_states;
       }
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/chain/chain-denominator.cc
+++ b/src/chain/chain-denominator.cc
@@ -120,7 +120,7 @@ void DenominatorComputation::AlphaGeneralFrame(int32 t) {
         dimGrid.y = num_hmm_states;
       }
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim)
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/chain/chain-supervision-test.cc
+++ b/src/chain/chain-supervision-test.cc
@@ -606,6 +606,7 @@ void TestRanges() {
 
 int main() {
   using namespace kaldi;
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (loop = 0; loop < 2; loop++) {

--- a/src/cudamatrix/cu-allocator.cc
+++ b/src/cudamatrix/cu-allocator.cc
@@ -80,11 +80,11 @@ void* CuMemoryAllocator::MallocPitchInternal(size_t row_bytes,
   cudaError_t e;
   for (int32 i = 0; i <= 2; i++) {
     if (num_rows != 1) {
-      Timer tim;
+      CuTimer tim;
       e = cudaMallocPitch(&ans, pitch, row_bytes, num_rows);
       tot_time_taken_in_cuda_malloc_pitch_ += tim.Elapsed();
     } else {
-      Timer tim;
+      CuTimer tim;
       // we might save a little time this way.
       e = cudaMalloc(&ans, row_bytes);
       tot_time_taken_in_cuda_malloc_ += tim.Elapsed();
@@ -155,7 +155,7 @@ CuMemoryAllocator::CuMemoryAllocator(CuAllocatorOptions opts):
 void* CuMemoryAllocator::MallocPitch(size_t row_bytes,
                                      size_t num_rows,
                                      size_t *pitch) {
-  Timer tim;
+  CuTimer tim;
   t_++;
   num_user_allocations_++;
   size_t requested_bytes = row_bytes * num_rows;
@@ -200,7 +200,7 @@ void* CuMemoryAllocator::MallocPitch(size_t row_bytes,
 }
 
 void CuMemoryAllocator::FreeSomeCachedMemory(size_t bytes_to_free_in) {
-  Timer tim;
+  CuTimer tim;
   // the next few lines are responsible for increasing the amount of memory we
   // are going to free, in case the user requested an amount that's very tiny
   // compared with the total amount of memory ever used.  This helps us

--- a/src/cudamatrix/cu-array-inl.h
+++ b/src/cudamatrix/cu-array-inl.h
@@ -204,7 +204,9 @@ void CuArray<int32>::Add(const int32 &value);
 template<class T>
 inline T CuArray<T>::Min() const {
   KALDI_ASSERT(this->Dim() > 0);
+#if HAVE_CUDA == 1
   CuTimer tim;
+#endif
   std::vector<T> tmp(Dim());
   CopyToVec(&tmp);
   T ans = *std::min_element(tmp.begin(), tmp.end());
@@ -220,7 +222,9 @@ inline T CuArray<T>::Min() const {
 template<class T>
 inline T CuArray<T>::Max() const {
   KALDI_ASSERT(this->Dim() > 0);
+#if HAVE_CUDA == 1
   CuTimer tim;
+#endif
   std::vector<T> tmp(Dim());
   CopyToVec(&tmp);
   T ans = *std::max_element(tmp.begin(), tmp.end());

--- a/src/cudamatrix/cu-array-inl.h
+++ b/src/cudamatrix/cu-array-inl.h
@@ -49,14 +49,14 @@ void CuArray<T>::Resize(MatrixIndexT dim, MatrixResizeType resize_type) {
   Destroy();
 
   if (dim == 0) return;
-  
+
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     this->data_ = static_cast<T*>(CuDevice::Instantiate().Malloc(dim * sizeof(T)));
     this->dim_ = dim;
     if (resize_type == kSetZero) this->SetZero();
-    CuDevice::Instantiate().AccuProfile("CuArray::Resize", tim.Elapsed());    
+    CuDevice::Instantiate().AccuProfile("CuArray::Resize", tim);
   } else
 #endif
   {
@@ -79,7 +79,7 @@ void CuArray<T>::Resize(MatrixIndexT dim, MatrixResizeType resize_type) {
 template<typename T>
 void CuArray<T>::Destroy() {
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
+  if (CuDevice::Instantiate().Enabled()) {
     if (data_ != NULL) {
       CuDevice::Instantiate().Free(this->data_);
     }
@@ -100,9 +100,9 @@ void CuArray<T>::CopyFromVec(const std::vector<T> &src) {
   if (src.empty()) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemcpy(data_, &src.front(), src.size()*sizeof(T), cudaMemcpyHostToDevice));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -117,10 +117,10 @@ void CuArray<T>::CopyFromArray(const CuArray<T> &src) {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemcpy(this->data_, src.data_, dim_ * sizeof(T),
                             cudaMemcpyDeviceToDevice));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -136,10 +136,10 @@ void CuArray<T>::CopyToVec(std::vector<T> *dst) const {
   }
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
-    Timer tim;
+  if (CuDevice::Instantiate().Enabled()) {
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemcpy(&dst->front(), Data(), dim_ * sizeof(T), cudaMemcpyDeviceToHost));
-    CuDevice::Instantiate().AccuProfile("CuArray::CopyToVecD2H", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuArray::CopyToVecD2H", tim);
   } else
 #endif
   {
@@ -153,10 +153,10 @@ void CuArray<T>::CopyToHost(T *dst) const {
   if (dim_ == 0) return;
   KALDI_ASSERT(dst != NULL);
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
-    Timer tim;
+  if (CuDevice::Instantiate().Enabled()) {
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemcpy(dst, Data(), dim_ * sizeof(T), cudaMemcpyDeviceToHost));
-    CuDevice::Instantiate().AccuProfile("CuArray::CopyToVecD2H", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuArray::CopyToVecD2H", tim);
   } else
 #endif
   {
@@ -164,15 +164,15 @@ void CuArray<T>::CopyToHost(T *dst) const {
   }
 }
 
- 
+
 template<typename T>
 void CuArray<T>::SetZero() {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
-  if (CuDevice::Instantiate().Enabled()) { 
-    Timer tim;
+  if (CuDevice::Instantiate().Enabled()) {
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemset(data_, 0, dim_ * sizeof(T)));
-    CuDevice::Instantiate().AccuProfile("CuArray::SetZero", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuArray::SetZero", tim);
   } else
 #endif
   {
@@ -181,52 +181,52 @@ void CuArray<T>::SetZero() {
 }
 
 
-template<class T> 
+template<class T>
 void CuArray<T>::Set(const T &value) {
   // This is not implemented yet, we'll do so if it's needed.
   KALDI_ERR << "CuArray<T>::Set not implemented yet for this type.";
 }
 // int32 specialization implemented in 'cudamatrix/cu-array.cc',
-template<> 
+template<>
 void CuArray<int32>::Set(const int32 &value);
 
 
-template<class T> 
+template<class T>
 void CuArray<T>::Add(const T &value) {
   // This is not implemented yet, we'll do so if it's needed.
   KALDI_ERR << "CuArray<T>::Add not implemented yet for this type.";
 }
 // int32 specialization implemented in 'cudamatrix/cu-array.cc',
-template<> 
+template<>
 void CuArray<int32>::Add(const int32 &value);
 
 
-template<class T> 
+template<class T>
 inline T CuArray<T>::Min() const {
   KALDI_ASSERT(this->Dim() > 0);
-  Timer tim;
+  CuTimer tim;
   std::vector<T> tmp(Dim());
   CopyToVec(&tmp);
   T ans = *std::min_element(tmp.begin(), tmp.end());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   }
 #endif
   return ans;
 }
 
 
-template<class T> 
+template<class T>
 inline T CuArray<T>::Max() const {
   KALDI_ASSERT(this->Dim() > 0);
-  Timer tim;
+  CuTimer tim;
   std::vector<T> tmp(Dim());
   CopyToVec(&tmp);
   T ans = *std::max_element(tmp.begin(), tmp.end());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   }
 #endif
   return ans;

--- a/src/cudamatrix/cu-array-test.cc
+++ b/src/cudamatrix/cu-array-test.cc
@@ -59,7 +59,7 @@ static void UnitTestCuArray() {
     std::vector<T> garbage_vec(size2); // We just use garbage_vec to make sure
                                        // we sometimes resize from empty,
                                        // sometimes not.
-    
+
     int32 byte_size = size * sizeof(T);
     std::vector<char> rand_c(byte_size);
     for (size_t i = 0; i < byte_size; i++)
@@ -87,7 +87,7 @@ static void UnitTestCuArray() {
       AssertEqual(vec, vec2);
       KALDI_ASSERT(cu_vec2.Dim() == int32(vec2.size())); // test Dim()
     }
-      
+
     { // test resize with resize_type = kSetZero.
       CuArray<T> cu_vec(vec);
       cu_vec.Resize(size, kSetZero);
@@ -116,6 +116,7 @@ static void UnitTestCuArray() {
 
 
 int main() {
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (; loop < 2; loop++) {

--- a/src/cudamatrix/cu-array.cc
+++ b/src/cudamatrix/cu-array.cc
@@ -38,7 +38,7 @@ void CuArray<int32>::Set(const int32 &value) {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) { 
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK);
     dim3 dimGrid(n_blocks(Dim(), CU2DBLOCK));
@@ -47,7 +47,7 @@ void CuArray<int32>::Set(const int32 &value) {
     cuda_int32_set_const(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -63,7 +63,7 @@ void CuArray<int32>::Add(const int32 &value) {
   if (dim_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) { 
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK);
     dim3 dimGrid(n_blocks(Dim(), CU2DBLOCK));
@@ -72,7 +72,7 @@ void CuArray<int32>::Add(const int32 &value) {
     cuda_int32_add(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-block-matrix-test.cc
+++ b/src/cudamatrix/cu-block-matrix-test.cc
@@ -31,7 +31,7 @@ using namespace kaldi;
 
 namespace kaldi {
 
-template<typename Real> 
+template<typename Real>
 static bool ApproxEqual(const CuBlockMatrix<Real> &A,
                         const CuBlockMatrix<Real> &B,
                         float tol = 0.001) {
@@ -91,7 +91,7 @@ static void UnitTestCuBlockMatrixAddMatBlock() {
     MatrixTransposeType transB = (i % 2 == 1 ? kTrans : kNoTrans),
         transA = (i % 3 == 1 ? kTrans : kNoTrans);
     if (transB == kTrans) std::swap(B_num_rows, B_num_cols);
-    
+
     int32 X_num_rows = 100 + Rand() % 255, X_num_cols = B_num_cols,
         A_num_rows = X_num_rows, A_num_cols = B_num_rows;
     if (data.size() == 0) { X_num_rows = 0; A_num_rows = 0; }
@@ -125,8 +125,8 @@ static void UnitTestCuBlockMatrixAddMatMat() {
       data[b].Resize(dimM, dimN);
       KALDI_LOG << "dimM " << dimM << ", dimN " << dimN << ", stride " << data[b].Stride();
       data[b].SetRandn();
-    }    
-    
+    }
+
     CuBlockMatrix<Real> B(data);
     int32 B_num_rows = B.NumRows(), B_num_cols = B.NumCols();
     // will do B += C D
@@ -143,7 +143,7 @@ static void UnitTestCuBlockMatrixAddMatMat() {
     CuMatrix<Real> C(C_num_rows, C_num_cols), D(D_num_rows, D_num_cols);
     C.SetRandn();
     D.SetRandn();
-    
+
     CuMatrix<Real> Bmat(B);
 
     Real alpha = 2.0, beta = -1.0;
@@ -151,7 +151,7 @@ static void UnitTestCuBlockMatrixAddMatMat() {
     CuBlockMatrix<Real> Bcopy(B);
 
     B.AddMatMat(alpha, C, transC, D, transD, beta);
-    
+
     Bmat.AddMatMat(alpha, C, transC, D, transD, beta);
 
     // Now check that the block-structured part of Bmat is the
@@ -181,6 +181,7 @@ template<typename Real> void CuBlockMatrixUnitTest() {
 
 
 int main() {
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (; loop < 2; loop++) {

--- a/src/cudamatrix/cu-block-matrix.cc
+++ b/src/cudamatrix/cu-block-matrix.cc
@@ -124,7 +124,7 @@ void CuBlockMatrix<Real>::SetCudaData() {
   KALDI_ASSERT(cu_data_ == NULL);
   if (block_data_.size() == 0) return; // Nothing to do.
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     std::vector<CuBlockMatrixData> tmp_cu_data(NumBlocks());
     int32 row_offset = 0, col_offset = 0;
     for (size_t b = 0; b < NumBlocks(); b++) {
@@ -141,7 +141,7 @@ void CuBlockMatrix<Real>::SetCudaData() {
     cu_data_ = static_cast<CuBlockMatrixData*>(
         CuDevice::Instantiate().Malloc(size));
     CU_SAFE_CALL(cudaMemcpy(cu_data_, &(tmp_cu_data[0]), size, cudaMemcpyHostToDevice));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());    
+    CuDevice::Instantiate().AccuProfile(__func__, tim);    
   }
 #endif
 }
@@ -230,7 +230,7 @@ void CuBlockMatrix<Real>::AddMatMat(
   if (NumBlocks() == 0) return; // empty matrix.
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     // (x,y,z) dimensions are (block-id, row-of-block, col-of-block)
     // First some logic to choose block dims...
@@ -252,7 +252,7 @@ void CuBlockMatrix<Real>::AddMatMat(
                            A.Data(), A_num_cols, A_row_stride, A_col_stride,
                            B.Data(), B_row_stride, B_col_stride, alpha, beta);
     CU_SAFE_CALL(cudaGetLastError());    
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());    
+    CuDevice::Instantiate().AccuProfile(__func__, tim);    
   } else
 #endif
   {

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -41,7 +41,6 @@
   if ((ret = (fun)) != 0) { \
     KALDI_ERR << "cudaError_t " << ret << " : \"" << cudaGetErrorString((cudaError_t)ret) << "\" returned from '" << #fun << "'"; \
   } \
-  cudaDeviceSynchronize(); \
 }
 
 #define KALDI_CUDA_ERR(ret, msg) \
@@ -49,8 +48,8 @@
   if (ret != 0) { \
     KALDI_ERR << msg << ", diagnostics: cudaError_t " << ret << " : \"" << cudaGetErrorString((cudaError_t)ret) << "\", in " << __FILE__ << ":" << __LINE__; \
   } \
-  cudaDeviceSynchronize(); \
 }
+
 
 namespace kaldi {
 

--- a/src/cudamatrix/cu-device-test.cc
+++ b/src/cudamatrix/cu-device-test.cc
@@ -99,6 +99,7 @@ void CudaMatrixResizeTest() {
 
 
 int main() {
+  SetVerboseLevel(1);
 #if HAVE_CUDA == 1
   for (int32 loop = 0; loop < 2; loop++) {
     CuDevice::Instantiate().SetDebugStrideMode(true);

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -385,11 +385,17 @@ bool CuDevice::SelectGpuIdAuto() {
 }
 
 
-void CuDevice::AccuProfile(const std::string &key, double time) {
-  if (profile_map_.find(key) == profile_map_.end()) {
-    profile_map_[key] = 0.0;
+void CuDevice::AccuProfile(const char *function_name,
+                           const CuTimer &timer) {
+  if (GetVerboseLevel() >= 1) {
+    cudaDeviceSynchronize();
+    double elapsed = timer.Elapsed();
+
+    if (profile_map_.find(key) == profile_map_.end())
+      profile_map_[key] = elapsed;
+    else
+      profile_map_[key] += elapsed;
   }
-  profile_map_[key] += time;
 }
 
 void CuDevice::PrintMemoryUsage() const {
@@ -403,7 +409,7 @@ void CuDevice::PrintMemoryUsage() const {
 }
 
 void CuDevice::PrintProfile() {
-  if (verbose_ && Enabled()) {
+  if (GetVerboseLevel() >= 1) {
     std::ostringstream os;
     os << "-----\n[cudevice profile]\n";
     unordered_map<std::string, double, StringHasher>::iterator it;
@@ -563,7 +569,7 @@ void CuDevice::CheckGpuHealth() {
 */
 
 CuDevice::CuDevice() :
-    active_gpu_id_(-1), verbose_(true), debug_stride_mode_(false),
+    active_gpu_id_(-1), debug_stride_mode_(false),
     num_debug_stride_allocations_(0), allocator_(CuAllocatorOptions()) {
 }
 

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -388,6 +388,7 @@ bool CuDevice::SelectGpuIdAuto() {
 void CuDevice::AccuProfile(const char *function_name,
                            const CuTimer &timer) {
   if (GetVerboseLevel() >= 1) {
+    std::string key(function_name);
     cudaDeviceSynchronize();
     double elapsed = timer.Elapsed();
 
@@ -520,7 +521,7 @@ void CuDevice::DeviceGetName(char* name, int32 len, int32 dev) {
 
 void CuDevice::CheckGpuHealth() {
   if (!Enabled()) return;
-  Timer t;
+  CuTimer t;
   // prepare small matrices for a quick test
   Matrix<BaseFloat> a(50, 100);
   Matrix<BaseFloat> b(100 ,50);
@@ -535,7 +536,7 @@ void CuDevice::CheckGpuHealth() {
   // check that relative differnence is <1%
   AssertEqual(c, Matrix<BaseFloat>(c1), 0.01);
   // measure time spent in this check
-  AccuProfile(__func__, t.Elapsed());
+  AccuProfile(__func__, t);
 }
 
 

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -36,6 +36,8 @@
 
 namespace kaldi {
 
+class CuTimer;
+
 /**
  * Singleton object which represents the CUDA device
  * responsible for CUBLAS initilalisation, collects profiling info
@@ -90,10 +92,10 @@ class CuDevice {
   /// and it supports double precision.
   bool DoublePrecisionSupported();
 
-  void SetVerbose(bool verbose) {  verbose_ = verbose; }
-
-  /// Sum the IO time
-  void AccuProfile(const std::string &key, double time);
+  /// This function accumulates stats on timing that
+  /// are printed out when you call PrintProfile().  However,
+  /// it only does something if VerboseLevel() >= 2.
+  void AccuProfile(const char *function_name, const CuTimer &timer);
   void PrintProfile();
 
   void PrintMemoryUsage() const;
@@ -172,14 +174,26 @@ class CuDevice {
 
   cudaDeviceProp properties_;
 
-  bool verbose_;
-
+  // there used to be a 'bool verbose_' here.  I'm leaving a placeholder here
+  // instead of removing it because it causes particularly hard-to-debug errors
+  // if compilation is not done right (e.g. make depend was not done), and this
+  // class's members move about.
+  bool unused_;
   bool debug_stride_mode_;
   uint32 num_debug_stride_allocations_;
 
   CuMemoryAllocator allocator_;
 
 }; // class CuDevice
+
+
+// Class CuTimer is a convenience wrapper for class Timer which only
+// sets the time if the verbose level is >= 1.  This helps avoid
+// an unnecessary system call if the verbose level is 0 and you
+// won't be accumulating the timing stats.
+class CuTimer: public Timer {
+  CuTimer(): Timer(GetVerboseLevel() >= 1) { }
+}
 
 // This function is declared as a more convenient way to get the CUDA device handle for use
 // in the CUBLAS v2 API, since we so frequently need to access it.

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -32,6 +32,7 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 #include "base/kaldi-common.h"
+#include "base/timer.h"
 #include "cudamatrix/cu-allocator.h"
 
 namespace kaldi {
@@ -192,8 +193,9 @@ class CuDevice {
 // an unnecessary system call if the verbose level is 0 and you
 // won't be accumulating the timing stats.
 class CuTimer: public Timer {
+ public:
   CuTimer(): Timer(GetVerboseLevel() >= 1) { }
-}
+};
 
 // This function is declared as a more convenient way to get the CUDA device handle for use
 // in the CUBLAS v2 API, since we so frequently need to access it.

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -95,7 +95,7 @@ class CuDevice {
 
   /// This function accumulates stats on timing that
   /// are printed out when you call PrintProfile().  However,
-  /// it only does something if VerboseLevel() >= 2.
+  /// it only does something if VerboseLevel() >= 1.
   void AccuProfile(const char *function_name, const CuTimer &timer);
   void PrintProfile();
 

--- a/src/cudamatrix/cu-math-test.cc
+++ b/src/cudamatrix/cu-math-test.cc
@@ -643,6 +643,7 @@ template<typename Real> void CudaMathUnitTest() {
 
 
 int main() {
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (; loop < 2; loop++) {

--- a/src/cudamatrix/cu-math.cc
+++ b/src/cudamatrix/cu-math.cc
@@ -38,7 +38,7 @@ void RegularizeL1(CuMatrixBase<Real> *weight, CuMatrixBase<Real> *grad, Real l1,
   KALDI_ASSERT(SameDim(*weight, *grad));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(weight->NumCols(), CU2DBLOCK), n_blocks(weight->NumRows(), CU2DBLOCK));
@@ -47,7 +47,7 @@ void RegularizeL1(CuMatrixBase<Real> *weight, CuMatrixBase<Real> *grad, Real l1,
                        weight->Dim(), grad->Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -87,7 +87,7 @@ void Randomize(const CuMatrixBase<Real> &src,
 
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     /*
     Note: default 16x16 block-size limits the --cachesize to matrix size 16*65535 x 16*65535
@@ -112,7 +112,7 @@ void Randomize(const CuMatrixBase<Real> &src,
                    copy_from_idx.Data(), dimtgt, dimsrc);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -137,7 +137,7 @@ void Splice(const CuMatrixBase<Real> &src, const CuArray<int32> &frame_offsets,
 
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(tgt->NumCols(), CU2DBLOCK), n_blocks(tgt->NumRows(), CU2DBLOCK));
@@ -146,7 +146,7 @@ void Splice(const CuMatrixBase<Real> &src, const CuArray<int32> &frame_offsets,
                 frame_offsets.Data(), tgt->Dim(), src.Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -178,7 +178,7 @@ void Copy(const CuMatrixBase<Real> &src, const CuArray<int32> &copy_from_indices
 
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(tgt->NumCols(), CU2DBLOCK), n_blocks(tgt->NumRows(), CU2DBLOCK));
@@ -187,7 +187,7 @@ void Copy(const CuMatrixBase<Real> &src, const CuArray<int32> &copy_from_indices
               copy_from_indices.Data(), tgt->Dim(), src.Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -255,13 +255,13 @@ void NormalizePerRow(const CuMatrixBase<Real>& in, const Real target_rms,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = out->NumRows();
     cuda_normalize_per_row(dimGrid, dimBlock, out->Data(), out->Stride(),
                            in.Data(), in.Dim(), target_rms, add_log_stddev);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -319,7 +319,7 @@ void DiffNormalizePerRow(const CuMatrixBase<Real> &in_value,
   const Real kSquaredNormFloor = 1.3552527156068805425e-20; // 2^-66
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = in_deriv->NumRows();
     cuda_diff_normalize_per_row(dimGrid, dimBlock, in_deriv->Data(),
@@ -327,7 +327,7 @@ void DiffNormalizePerRow(const CuMatrixBase<Real> &in_value,
                                 in_value.Dim(), out_deriv.Data(),
                                 out_deriv.Stride(), target_rms, add_log_stddev);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -466,7 +466,7 @@ void ComputeLstmNonlinearity(const CuMatrixBase<Real> &input,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     int have_dropout_mask = (input_cols == (cell_dim * 5) + 3);
 
@@ -480,7 +480,7 @@ void ComputeLstmNonlinearity(const CuMatrixBase<Real> &input,
                            cell_dim, have_dropout_mask, num_rows, output->Data());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -778,7 +778,7 @@ void BackpropLstmNonlinearity(const CuMatrixBase<Real> &input,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // Each thread block is working on 1 row of the data.
     // It's best that cell dim is a multiple fo CU1DBLOCK
 
@@ -866,7 +866,7 @@ void BackpropLstmNonlinearity(const CuMatrixBase<Real> &input,
 
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -1085,6 +1085,7 @@ template<typename Real> void CudaMatrixSpeedTest() {
 
 
 int main() {
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (loop = 0; loop < 2; loop++) {

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -59,7 +59,7 @@ void CuMatrix<Real>::Resize(MatrixIndexT rows, MatrixIndexT cols,
   if (rows == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     MatrixIndexT row_bytes = cols * sizeof(Real);
     size_t pitch;
     if (stride_type == kDefaultStride) {
@@ -76,7 +76,7 @@ void CuMatrix<Real>::Resize(MatrixIndexT rows, MatrixIndexT cols,
       this->stride_ = cols;
     }
     if (resize_type == kSetZero) this->SetZero();
-    CuDevice::Instantiate().AccuProfile("CuMatrix::Resize", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuMatrix::Resize", tim);
   } else
 #endif
   { // Let the initializer of Matrix<Real> handle the allocation,
@@ -92,9 +92,9 @@ void CuMatrix<Real>::Destroy() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (this->data_ != NULL) {
-      Timer tim;
+      CuTimer tim;
       CuDevice::Instantiate().Free(this->data_);
-      CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+      CuDevice::Instantiate().AccuProfile(__func__, tim);
     }
   } else
 #endif
@@ -222,7 +222,7 @@ void CuMatrixBase<Real>::CopyFromMat(const CuMatrixBase<OtherReal> &M,
       KALDI_ASSERT(M.NumCols() == num_rows_ && M.NumRows() == num_cols_);
     }
     if (M.num_rows_ == 0) return; // Nothing to do.
-    Timer tim;
+    CuTimer tim;
     if (sizeof(Real) == sizeof(OtherReal) && trans == kNoTrans ) {
       MatrixIndexT dst_pitch = stride_ * sizeof(Real);
       MatrixIndexT src_pitch = M.Stride() * sizeof(Real);
@@ -247,7 +247,7 @@ void CuMatrixBase<Real>::CopyFromMat(const CuMatrixBase<OtherReal> &M,
       }
       CU_SAFE_CALL(cudaGetLastError());
     }
-    CuDevice::Instantiate().AccuProfile("CuMatrixBase::CopyFromMat(from other CuMatrixBase)", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuMatrixBase::CopyFromMat(from other CuMatrixBase)", tim);
   } else
 #endif
   {
@@ -279,7 +279,7 @@ void CuMatrixBase<Real>::CopyFromTp(const CuTpMatrix<OtherReal> &M,
     return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_rows_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
@@ -288,7 +288,7 @@ void CuMatrixBase<Real>::CopyFromTp(const CuTpMatrix<OtherReal> &M,
     } else {
       cuda_copy_from_tp_trans(dimGrid, dimBlock, data_, M.Data(), Dim());
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -312,7 +312,7 @@ void CuMatrixBase<Real>::CopyFromMat(const MatrixBase<Real> &src,
   if (CuDevice::Instantiate().Enabled()) {
     if (trans == kNoTrans) {
       KALDI_ASSERT(src.NumRows() == num_rows_ && src.NumCols() == num_cols_);
-      Timer tim;
+      CuTimer tim;
 
       MatrixIndexT dst_pitch = stride_*sizeof(Real);
       MatrixIndexT src_pitch = src.Stride()*sizeof(Real);
@@ -356,7 +356,7 @@ void CuMatrixBase<Real>::CopyFromSp(const CuSpMatrix<Real> &M) {
     return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(NumRows(), CU2DBLOCK),
                  n_blocks(NumRows(), CU2DBLOCK));
@@ -420,7 +420,7 @@ void CuMatrixBase<Real>::CopyToMat(MatrixBase<OtherReal> *dst,
     } else {
       KALDI_ASSERT(dst->NumRows() == NumRows() && dst->NumCols() == NumCols());
       if (num_rows_ == 0) return;
-      Timer tim;
+      CuTimer tim;
 
       MatrixIndexT src_pitch = stride_*sizeof(Real);
       MatrixIndexT dst_pitch = dst->Stride()*sizeof(Real);
@@ -474,10 +474,10 @@ template<typename Real>
 void CuMatrixBase<Real>::SetZero() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemset2D(data_, stride_ * sizeof(Real), 0,
                               num_cols_ * sizeof(Real), num_rows_ ));
-    CuDevice::Instantiate().AccuProfile("CuMatrix::SetZero", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuMatrix::SetZero", tim);
   } else
 #endif
   {
@@ -496,7 +496,7 @@ void CuMatrixBase<Real>::Set(Real value) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -505,7 +505,7 @@ void CuMatrixBase<Real>::Set(Real value) {
     cuda_set_const(dimGrid, dimBlock, data_, value, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -519,7 +519,7 @@ void CuMatrixBase<Real>::SetZeroAboveDiag() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -528,7 +528,7 @@ void CuMatrixBase<Real>::SetZeroAboveDiag() {
     cuda_set_zero_above_diag(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -547,7 +547,7 @@ void CuMatrixBase<Real>::Add(Real value) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -556,7 +556,7 @@ void CuMatrixBase<Real>::Add(Real value) {
     cuda_add(dimGrid, dimBlock, data_, value, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -569,7 +569,7 @@ void CuMatrixBase<Real>::AddToDiag(Real value) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     // We'll create a fake matrix with "num_diag" rows, one
     // columnn, and a stride of "this_stride".  The y-value of
     // the grid/blocks corresponds to the row, in this kernel.
@@ -581,7 +581,7 @@ void CuMatrixBase<Real>::AddToDiag(Real value) {
     cuda_add(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -609,7 +609,7 @@ void CuMatrixBase<Real>::Scale(Real value) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -618,7 +618,7 @@ void CuMatrixBase<Real>::Scale(Real value) {
     cuda_scale(dimGrid, dimBlock, data_, value, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -631,7 +631,7 @@ void CuMatrixBase<Real>::ApplyLog() {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -640,7 +640,7 @@ void CuMatrixBase<Real>::ApplyLog() {
     cuda_apply_log(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -652,7 +652,7 @@ template<typename Real>
 void CuMatrixBase<Real>::MulElements(const CuMatrixBase<Real>& A) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(num_cols_ == A.NumCols());
     KALDI_ASSERT(num_rows_ == A.NumRows());
@@ -664,7 +664,7 @@ void CuMatrixBase<Real>::MulElements(const CuMatrixBase<Real>& A) {
     cuda_mul_elements(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -676,7 +676,7 @@ template<typename Real>
 void CuMatrixBase<Real>::DivElements(const CuMatrixBase<Real>& A) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(num_cols_ == A.NumCols());
     KALDI_ASSERT(num_rows_ == A.NumRows());
@@ -688,7 +688,7 @@ void CuMatrixBase<Real>::DivElements(const CuMatrixBase<Real>& A) {
     cuda_div_elements(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -700,7 +700,7 @@ template<typename Real>
 void CuMatrixBase<Real>::Max(const CuMatrixBase<Real>& A) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(num_cols_ == A.NumCols());
     KALDI_ASSERT(num_rows_ == A.NumRows());
@@ -712,7 +712,7 @@ void CuMatrixBase<Real>::Max(const CuMatrixBase<Real>& A) {
     cuda_max(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -725,7 +725,7 @@ template<typename Real>
 void CuMatrixBase<Real>::Min(const CuMatrixBase<Real>& A) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(num_cols_ == A.NumCols());
     KALDI_ASSERT(num_rows_ == A.NumRows());
@@ -737,7 +737,7 @@ void CuMatrixBase<Real>::Min(const CuMatrixBase<Real>& A) {
     cuda_min(dimGrid, dimBlock, data_, A.data_, Dim(), A.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -750,7 +750,7 @@ template<typename Real>
 void CuMatrixBase<Real>::MulColsVec(const CuVectorBase<Real> &scale) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(scale.Dim() == NumCols());
 
@@ -763,7 +763,7 @@ void CuMatrixBase<Real>::MulColsVec(const CuVectorBase<Real> &scale) {
     CU_SAFE_CALL(cudaGetLastError());
 
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -777,7 +777,7 @@ template<typename Real>
 void CuMatrixBase<Real>::MulRowsVec(const CuVectorBase<Real> &scale) {
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(scale.Dim() == NumRows());
 
@@ -789,7 +789,7 @@ void CuMatrixBase<Real>::MulRowsVec(const CuVectorBase<Real> &scale) {
     CU_SAFE_CALL(cudaGetLastError());
 
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -802,7 +802,7 @@ void CuMatrixBase<Real>::MulRowsGroupMat(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(src.NumCols() > 0);
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     int group_size = this->NumCols() / src.NumCols();
 
     dim3 dimGrid, dimBlock;
@@ -813,7 +813,7 @@ void CuMatrixBase<Real>::MulRowsGroupMat(const CuMatrixBase<Real> &src) {
                             this->Dim(), src.Stride(), group_size);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -833,7 +833,7 @@ void CuMatrixBase<Real>::DiffGroupPnorm(const CuMatrixBase<Real> &in_value,
   KALDI_ASSERT(this->NumCols() == out_value.NumCols() * group_size);
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     const int kWarpSize = 32;
     dim3 dimBlock(kWarpSize, CU1DBLOCK / kWarpSize);
     dim3 dimGrid(n_blocks(NumCols(), dimBlock.x),
@@ -846,7 +846,7 @@ void CuMatrixBase<Real>::DiffGroupPnorm(const CuMatrixBase<Real> &in_value,
                           in_value.Stride(), out_value.Stride(),
                           out_deriv.Stride(), group_size, power);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -863,7 +863,7 @@ void CuMatrixBase<Real>::GroupMaxDeriv(const CuMatrixBase<Real> &src1,
   KALDI_ASSERT(this->NumCols() == src2.NumCols() * group_size);
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(NumCols(), CU2DBLOCK),
                  n_blocks(NumRows(), CU2DBLOCK));
@@ -872,7 +872,7 @@ void CuMatrixBase<Real>::GroupMaxDeriv(const CuMatrixBase<Real> &src1,
                               group_size);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -884,7 +884,7 @@ template<typename Real>
 void CuMatrixBase<Real>::DivRowsVec(const CuVectorBase<Real> &div) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(div.Dim() == NumRows());
 
@@ -902,7 +902,7 @@ void CuMatrixBase<Real>::DivRowsVec(const CuVectorBase<Real> &div) {
     cuda_div_rows_vec(dimGrid, dimBlock, data_, div.data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -916,7 +916,7 @@ template<typename Real>
 void CuMatrixBase<Real>::InvertElements() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
@@ -925,7 +925,7 @@ void CuMatrixBase<Real>::InvertElements() {
     cuda_invert_elements(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -946,7 +946,7 @@ void CuMatrixBase<Real>::AddMat(Real alpha, const CuMatrixBase<Real>& A,
       KALDI_ASSERT(A.NumCols() == num_rows_ && A.NumRows() == num_cols_);
     }
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     // This block dimension seems to work better than the
     // one from GetBlockSizesForSimpleMatrixOperation().
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
@@ -957,7 +957,7 @@ void CuMatrixBase<Real>::AddMat(Real alpha, const CuMatrixBase<Real>& A,
                  (transA == kTrans ? 1 : 0));
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -981,7 +981,7 @@ void CuMatrixBase<Real>::AddMatBlocks(Real alpha, const CuMatrixBase<Real> &A,
   }
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -990,7 +990,7 @@ void CuMatrixBase<Real>::AddMatBlocks(Real alpha, const CuMatrixBase<Real> &A,
                         (transA == kTrans ? 1 : 0));
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1018,7 +1018,7 @@ void CuMatrixBase<Real>::SetMatMatDivMat(const CuMatrixBase<Real> &A,
                     const CuMatrixBase<Real> &B, const CuMatrixBase<Real> &C) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     KALDI_ASSERT(num_rows_ == A.num_rows_ && num_cols_ == A.num_cols_);
     KALDI_ASSERT(num_rows_ == B.num_rows_ && num_cols_ == B.num_cols_);
@@ -1031,7 +1031,7 @@ void CuMatrixBase<Real>::SetMatMatDivMat(const CuMatrixBase<Real> &A,
                              data_, Dim(), A.Stride(), B.Stride(), C.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1049,7 +1049,7 @@ void CuMatrixBase<Real>::AddVecToCols(Real alpha,
 
   #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -1057,7 +1057,7 @@ void CuMatrixBase<Real>::AddVecToCols(Real alpha,
                          data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1077,14 +1077,14 @@ void CuMatrixBase<Real>::AddVecToRows(Real alpha,
   }
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_vec_to_rows(dimGrid, dimBlock, alpha, row.data_, beta, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1120,14 +1120,14 @@ void CuMatrixBase<Real>::AddMatMat(
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_gemm(GetCublasHandle(),
                              (transB==kTrans? CUBLAS_OP_T:CUBLAS_OP_N),
                              (transA==kTrans? CUBLAS_OP_T:CUBLAS_OP_N),
                              m, n, k, alpha, B.data_, B.Stride(),
                              A.data_, A.Stride(), beta, data_, Stride()));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1147,11 +1147,11 @@ void CuMatrixBase<Real>::AddVecVec(
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_ger(GetCublasHandle(), m, n, alpha,
                  y.Data(), 1, x.Data(), 1, data_, Stride()));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1172,14 +1172,14 @@ void CuMatrixBase<Real>::SymAddMat2(
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     cublasOperation_t trans = (transA == kTrans ? CUBLAS_OP_N : CUBLAS_OP_T);
     MatrixIndexT A_other_dim = (transA == kNoTrans ? A.num_cols_ : A.num_rows_);
     CU_SAFE_CALL(cublas_syrk(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER, trans,
                              num_rows_, A_other_dim, alpha, A.Data(), A.Stride(),
                              beta, this->data_, this->stride_));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1202,7 +1202,7 @@ void CuMatrixBase<Real>::AddDiagVecMat(
     }
     KALDI_ASSERT(v.Dim() == this->NumRows());
 
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
@@ -1212,7 +1212,7 @@ void CuMatrixBase<Real>::AddDiagVecMat(
     cuda_add_diag_vec_mat(dimGrid, dimBlock, alpha, data_, Dim(),
                           v.Data(), M.Data(), M_row_stride, M_col_stride, beta);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1236,7 +1236,7 @@ void CuMatrixBase<Real>::AddMatDiagVec(
     }
     KALDI_ASSERT(v.Dim() == this->NumCols());
 
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -1245,7 +1245,7 @@ void CuMatrixBase<Real>::AddMatDiagVec(
     cuda_add_mat_diag_vec(dimGrid, dimBlock, alpha, data_, Dim(),
                           M.Data(), M_row_stride, M_col_stride, v.Data(),  beta);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1259,13 +1259,13 @@ void CuMatrixBase<Real>::AddMatMatElements(Real alpha,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(SameDim(*this, A) && SameDim(A, B));
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_mat_mat_elements(dimGrid, dimBlock, this->data_, A.Data(),
                               B.Data(), Dim(), A.Stride(), B.Stride(), alpha, beta);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1284,7 +1284,7 @@ void CuMatrixBase<Real>::ParametricRelu(
   KALDI_ASSERT(beta.Dim() == this->NumCols());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(src.NumCols(), CU2DBLOCK), n_blocks(src.NumRows(), CU2DBLOCK));
@@ -1293,7 +1293,7 @@ void CuMatrixBase<Real>::ParametricRelu(
                          src.Stride(), alpha.data_, beta.data_);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1315,7 +1315,7 @@ void CuMatrixBase<Real>::DiffParametricRelu(
      const CuVectorBase<Real> &beta) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK), n_blocks(num_rows_, CU2DBLOCK));
@@ -1325,7 +1325,7 @@ void CuMatrixBase<Real>::DiffParametricRelu(
                               alpha.data_, beta.data_);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1345,7 +1345,7 @@ void CuMatrixBase<Real>::Sigmoid(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -1353,7 +1353,7 @@ void CuMatrixBase<Real>::Sigmoid(const CuMatrixBase<Real> &src) {
                  src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1366,7 +1366,7 @@ void CuMatrixBase<Real>::SoftHinge(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -1374,7 +1374,7 @@ void CuMatrixBase<Real>::SoftHinge(const CuMatrixBase<Real> &src) {
                     src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1389,7 +1389,7 @@ void CuMatrixBase<Real>::GroupPnorm(const CuMatrixBase<Real> &src, Real power) {
                this->NumRows() == src.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (power == Real(0) || power == Real(1) || power == Real(2)
         || power == std::numeric_limits<Real>::infinity()) {
       // One thread block per row.
@@ -1415,7 +1415,7 @@ void CuMatrixBase<Real>::GroupPnorm(const CuMatrixBase<Real> &src, Real power) {
                        src.Stride(), group_size, power);
     }
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1430,7 +1430,7 @@ void CuMatrixBase<Real>::GroupMax(const CuMatrixBase<Real> &src) {
                this->NumRows() == src.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // One thread block per row.
     // Use 2D block for small group size to simplify the calculation.
     // Each group is reduced by threads_per_group threads.
@@ -1449,7 +1449,7 @@ void CuMatrixBase<Real>::GroupMax(const CuMatrixBase<Real> &src) {
     cuda_group_max(dimGrid, dimBlock, this->data_, src.data_, this->Dim(),
         src.Stride(), group_size);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1490,7 +1490,7 @@ void CuMatrix<Real>::CompObjfAndDeriv(const std::vector<MatrixElement<Real> >& s
     }
     void *addr = CuDevice::Instantiate().Malloc(sv_labels.size() * sizeof(MatrixElement<Real>));
     CU_SAFE_CALL(cudaMemcpy(addr, sv_labels.data(), sv_labels.size() * sizeof(MatrixElement<Real>), cudaMemcpyHostToDevice));
-    Timer tim;
+    CuTimer tim;
     CuVector<Real> tmp(2, kUndefined);
     int dimBlock(CU1DBLOCK);
     int dimGrid = 1; // only 1 block here. we have loops in each thread.
@@ -1501,7 +1501,7 @@ void CuMatrix<Real>::CompObjfAndDeriv(const std::vector<MatrixElement<Real> >& s
     *tot_objf = tmp_cpu(0);
     *tot_weight = tmp_cpu(1);
     CuDevice::Instantiate().Free(addr);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1525,13 +1525,13 @@ void CuMatrixBase<Real>::ApplySoftMaxPerRow(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = src.num_rows_;
     cuda_softmax_reduce(dimGrid, dimBlock, data_, src.data_, Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1548,14 +1548,14 @@ void CuMatrixBase<Real>::ApplyLogSoftMaxPerRow(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = src.num_rows_;
     cuda_log_softmax_reduce(dimGrid, dimBlock,
                             data_, src.data_, Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1573,14 +1573,14 @@ void CuMatrixBase<Real>::DiffSigmoid(const CuMatrixBase<Real> &value,
   KALDI_ASSERT(SameDim(*this, value) && SameDim(*this, diff));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_diff_sigmoid(dimGrid, dimBlock, data_, diff.data_, value.data_, Dim(), diff.Stride(), value.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1594,7 +1594,7 @@ void CuMatrixBase<Real>::Tanh(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -1602,7 +1602,7 @@ void CuMatrixBase<Real>::Tanh(const CuMatrixBase<Real> &src) {
     cuda_tanh(dimGrid, dimBlock, this->data_, src.data_, this->Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1617,14 +1617,14 @@ void CuMatrixBase<Real>::DiffTanh(const CuMatrixBase<Real> &value,
                                   const CuMatrixBase<Real> &diff) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_diff_tanh(dimGrid, dimBlock, data_, diff.data_, value.data_, Dim(), diff.Stride(), value.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1636,7 +1636,7 @@ template<typename Real>
 void CuMatrixBase<Real>::FindRowMaxId(CuArray<int32> *id) const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     id->Resize(num_rows_);
     MatrixDim d = Dim();
 
@@ -1647,7 +1647,7 @@ void CuMatrixBase<Real>::FindRowMaxId(CuArray<int32> *id) const {
     CU_SAFE_CALL(cudaGetLastError());
 
     // now we have the indices!
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1679,7 +1679,7 @@ void CuMatrixBase<Real>::DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     // CUDA thread layout: one thread block per matrix-row.
     dim3 dimBlock(CU1DBLOCK);
@@ -1688,7 +1688,7 @@ void CuMatrixBase<Real>::DiffSoftmaxPerRow(const CuMatrixBase<Real> &value,
         value.Stride(), diff.Data(), diff.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1713,7 +1713,7 @@ void CuMatrixBase<Real>::DiffLogSoftmaxPerRow(
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     // CUDA thread layout: one thread block per matrix-row.
     dim3 dimBlock(CU1DBLOCK);
@@ -1723,7 +1723,7 @@ void CuMatrixBase<Real>::DiffLogSoftmaxPerRow(
                           out_deriv.Stride(), data_);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1760,13 +1760,13 @@ void CuMatrixBase<Real>::DiffXent(const CuArray<int32> &tgt,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(1, CU2DBLOCK*8);
     dim3 dimGrid(1, n_blocks(tgt.Dim(), CU2DBLOCK*8));
     cuda_diff_xent(dimGrid, dimBlock, tgt.Data(), data_,
                    log_post_tgt->data_, Dim());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1910,13 +1910,13 @@ void CuMatrixBase<Real>::SymInvertPosDef() {
   if (num_rows_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CuMatrix<Real> inv_cholesky(num_rows_, num_rows_);
     this->Cholesky(&inv_cholesky);
     // note: SymAddMat2 only updates lower part of *this.
     this->SymAddMat2(1.0, inv_cholesky, kTrans, 0.0);
     this->CopyLowerToUpper();
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1954,7 +1954,7 @@ Real TraceMatMat(const CuMatrixBase<Real> &A,
     } else {
       KALDI_ASSERT(A.NumRows() == B.NumRows() && A.NumCols() == B.NumCols());
     }
-    Timer tim;
+    CuTimer tim;
     // 2D blocks: each (8x32) block sums up (32x32) elements.
     // 2D grid: try to cover all the matrix A unless it is too big.
     // Kernel will reduce to ~256 elements with good performance,
@@ -1982,7 +1982,7 @@ Real TraceMatMat(const CuMatrixBase<Real> &A,
     CU_SAFE_CALL(cudaGetLastError());
     Vector<Real> result_cpu(result_vec); // copying from CUDA faster than summing in CUDA.
     result = result_cpu.Sum();
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2038,7 +2038,7 @@ void AddMatMatBatched(const Real alpha, std::vector<CuSubMatrix<Real>* > &C,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     Real **device_abc_array =
         static_cast<Real**>(CuDevice::Instantiate().Malloc(3 * size * sizeof(Real*)));
     const Real **device_a_array = const_cast<const Real**>(device_abc_array);
@@ -2068,7 +2068,7 @@ void AddMatMatBatched(const Real alpha, std::vector<CuSubMatrix<Real>* > &C,
     CuDevice::Instantiate().Free(device_abc_array);
     delete[] host_abc_array;
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2096,7 +2096,7 @@ template<typename Real>
 void CuMatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (v.Dim() == num_rows_*num_cols_) {
       if (stride_ == num_cols_) {
         const Real* v_data = v.Data();
@@ -2118,7 +2118,7 @@ void CuMatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {
     } else {
       KALDI_ERR << "Wrong sized arguments";
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2130,7 +2130,7 @@ template<typename Real>
 void CuMatrixBase<Real>::CopyRowsFromVec(const VectorBase<Real> &v) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (v.Dim() == num_rows_*num_cols_) {
       if (stride_ == num_cols_) {
         const Real* v_data = v.Data();
@@ -2152,7 +2152,7 @@ void CuMatrixBase<Real>::CopyRowsFromVec(const VectorBase<Real> &v) {
     } else {
       KALDI_ERR << "Wrong sized arguments";
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2164,7 +2164,7 @@ template<typename Real>
 void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (rv.Dim() == num_rows_ * num_cols_) {
       // treat rv as a matrix of the size (num_cols x num_rows_)
       // and use transposed copy to fill *this
@@ -2189,7 +2189,7 @@ void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
     } else {
       KALDI_ERR<< "Wrong sized arguments";
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2206,12 +2206,12 @@ void CuMatrixBase<Real>::CopyColFromVec(const CuVectorBase<Real> &v,
                static_cast<UnsignedMatrixIndexT>(num_cols_));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     cublas_copy(GetCublasHandle(),
                 v.Dim(), v.Data(), 1,
                 this->data_ + col, this->stride_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2223,13 +2223,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyPow(Real power) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_pow(dimGrid, dimBlock, data_, power, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2241,13 +2241,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyPowAbs(Real power, bool include_sign) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_pow_abs(dimGrid, dimBlock, data_, power, include_sign, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2259,13 +2259,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyHeaviside() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_heaviside(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2278,7 +2278,7 @@ void CuMatrixBase<Real>::Heaviside(const CuMatrixBase<Real> &src) {
   KALDI_ASSERT(SameDim(*this, src));
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -2286,7 +2286,7 @@ void CuMatrixBase<Real>::Heaviside(const CuMatrixBase<Real> &src) {
                    src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -2298,13 +2298,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyExp() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_exp(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2317,13 +2317,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyFloor(Real floor_val) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_floor(dimGrid, dimBlock, data_, floor_val, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2335,13 +2335,13 @@ template<typename Real>
 void CuMatrixBase<Real>::ApplyCeiling(Real ceiling_val) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_apply_ceiling(dimGrid, dimBlock, data_, ceiling_val, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2355,7 +2355,7 @@ void VectorBase<Real>::CopyRowsFromMat(const CuMatrixBase<Real> &mat) {
   KALDI_ASSERT(dim_ == mat.NumCols() * mat.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (mat.Stride() == mat.NumCols()) {
       cudaMemcpy(data_, mat.Data(), sizeof(Real)*dim_, cudaMemcpyDeviceToHost);
     } else {
@@ -2367,7 +2367,7 @@ void VectorBase<Real>::CopyRowsFromMat(const CuMatrixBase<Real> &mat) {
         vec_data += mat.NumCols();
       }
     }
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyRowsFromMat", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyRowsFromMat", tim);
   } else
 #endif
   {
@@ -2389,13 +2389,13 @@ void CuMatrixBase<Real>::CopyCols(const CuMatrixBase<Real> &src,
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(indices.Dim() == NumCols());
     KALDI_ASSERT(NumRows() == src.NumRows());
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_copy_cols(dimGrid, dimBlock, data_, src.Data(), indices.Data(), Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2412,14 +2412,14 @@ void CuMatrixBase<Real>::CopyRows(const CuMatrixBase<Real> &src,
     KALDI_ASSERT(static_cast<MatrixIndexT>(indices.Dim()) == NumRows());
     KALDI_ASSERT(NumCols() == src.NumCols());
 
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_copy_rows(dimGrid, dimBlock, data_, src.Data(), indices.Data(),
                    Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2434,14 +2434,14 @@ void CuMatrixBase<Real>::AddCols(const CuMatrixBase<Real> &src,
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(indices.Dim() == NumCols());
     KALDI_ASSERT(NumRows() == src.NumRows());
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_cols(dimGrid, dimBlock, data_, src.Data(), indices.Data(),
                   Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2455,13 +2455,13 @@ void CuMatrixBase<Real>::CopyRows(const CuArray<const Real*> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(static_cast<MatrixIndexT>(src.Dim()) == NumRows());
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
     cuda_copy_rows(dimGrid, dimBlock, data_, src.Data(), Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2477,13 +2477,13 @@ void CuMatrixBase<Real>::CopyToRows(const CuArray<Real*> &dst) const {
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(static_cast<MatrixIndexT>(dst.Dim()) == NumRows());
 
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_cols_, CU2DBLOCK),
                  n_blocks(num_rows_, CU2DBLOCK));
     cuda_copy_to_rows(dimGrid, dimBlock, dst.Data(), data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2501,14 +2501,14 @@ void CuMatrixBase<Real>::AddRows(Real alpha,
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(static_cast<MatrixIndexT>(indexes.Dim()) == NumRows());
     KALDI_ASSERT(src.NumCols() == NumCols());
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_rows(dimGrid, dimBlock, alpha,
                   data_, src.Data(), indexes.Data(), Dim(), src.Stride());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2523,13 +2523,13 @@ void CuMatrixBase<Real>::AddRows(Real alpha, const CuArray<const Real*> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(static_cast<MatrixIndexT>(src.Dim()) == NumRows());
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_rows(dimGrid, dimBlock, alpha, data_, src.Data(), Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2545,13 +2545,13 @@ void CuMatrixBase<Real>::AddToRows(Real alpha,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(static_cast<MatrixIndexT>(dst.Dim()) == NumRows());
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_to_rows(dimGrid, dimBlock, alpha, dst.Data(), data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2568,14 +2568,14 @@ void CuMatrixBase<Real>::SumColumnRanges(const CuMatrixBase<Real> &src,
   if (NumRows() == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_sum_column_ranges(dimGrid, dimBlock, data_, Dim(), src.Data(),
                            src.Dim(), indices.Data());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2606,14 +2606,14 @@ void CuMatrixBase<Real>::AddRowRanges(const CuMatrixBase<Real> &src,
   if (NumRows() == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
     cuda_add_row_ranges(dimGrid, dimBlock,
                         data_, Dim(), src.Data(), src.Dim(), indexes.Data());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   { // Implement here for the CPU..
@@ -2642,14 +2642,14 @@ void CuMatrixBase<Real>::CopyLowerToUpper() {
   if (num_rows_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     int32 dim = num_rows_;
     dim3 dimGrid(n_blocks(dim, CU2DBLOCK),
                  n_blocks(dim, CU2DBLOCK));
     cuda_copy_low_upp(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2663,14 +2663,14 @@ void CuMatrixBase<Real>::CopyUpperToLower() {
   if (num_rows_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     int32 dim = this->num_rows_;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(dim, CU2DBLOCK),
                  n_blocks(dim, CU2DBLOCK));
     cuda_copy_upp_low(dimGrid, dimBlock, data_, Dim());
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2684,13 +2684,13 @@ Real CuMatrixBase<Real>::Sum() const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
-    Timer tim;
+    CuTimer tim;
 
     CuVector<Real> col_sum(num_rows_, kUndefined);
     cuda_sum_mat_cols(num_rows_, CU1DBLOCK, col_sum.Data(), data_, Dim());
     Real ans = col_sum.Sum();
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
     return ans;
   } else
 #endif
@@ -2705,13 +2705,13 @@ Real CuMatrixBase<Real>::Max() const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
-    Timer tim;
+    CuTimer tim;
 
     CuVector<Real> col_max(num_rows_, kUndefined);
     cuda_max_mat_cols(num_rows_, CU1DBLOCK, col_max.Data(), data_, Dim());
     Real ans = col_max.Max();
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
     return ans;
   } else
 #endif
@@ -2726,13 +2726,13 @@ Real CuMatrixBase<Real>::Min() const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(num_rows_ > 0 && num_cols_ > 0);
-    Timer tim;
+    CuTimer tim;
 
     CuVector<Real> col_min(num_rows_, kUndefined);
     cuda_min_mat_cols(num_rows_, CU1DBLOCK, col_min.Data(), data_, Dim());
     Real ans = col_min.Min();
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
     return ans;
   } else
 #endif
@@ -2746,7 +2746,7 @@ template<typename Real>
 Real CuMatrixBase<Real>::Trace(bool check_square) const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     if (check_square) KALDI_ASSERT(this->num_rows_ == this->num_cols_);
     MatrixIndexT dim = std::min(this->num_rows_, this->num_cols_);
     CuVector<Real> tmp(1, kUndefined); // for result.
@@ -2754,7 +2754,7 @@ Real CuMatrixBase<Real>::Trace(bool check_square) const {
     int dimGrid = 1;// only 1 block here. we have loops in each thread  //(n_blocks(dim_, CU1DBLOCK));
     cuda_vec_sum(dimGrid, dimBlock, data_, tmp.Data(), dim, Stride() + 1);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::Sum", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::Sum", tim);
     return tmp(0);
   } else
 #endif
@@ -2898,7 +2898,7 @@ void CuMatrixBase<Real>::AddMatBlock(
   if (num_rows_ == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     MatrixDim this_dim = Dim();
 
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
@@ -2915,7 +2915,7 @@ void CuMatrixBase<Real>::AddMatBlock(
 
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2960,7 +2960,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha,
                         input.size() * sizeof(MatrixElement<Real>),
                             cudaMemcpyHostToDevice));
 
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(input.size(), CU1DBLOCK));
 
@@ -2968,7 +2968,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha,
                              alpha, (MatrixElement<Real>*)addr, input.size());
     CU_SAFE_CALL(cudaGetLastError());
     CuDevice::Instantiate().Free(addr);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -2986,7 +2986,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha, const CuArray<Int32Pair> &index
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CuVector<Real> tmp_vec(indexes.Dim(), kUndefined);
     CU_SAFE_CALL(cudaMemcpy(tmp_vec.Data(), input, indexes.Dim() * sizeof(Real),
                             cudaMemcpyHostToDevice));
@@ -2996,7 +2996,7 @@ void CuMatrixBase<Real>::AddElements(Real alpha, const CuArray<Int32Pair> &index
     cuda_matrix_add_indexed_values(dimGrid, dimBlock, this->Dim(), alpha,
                                    indexes.Data(), tmp_vec.Data(), indexes.Dim(), this->data_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -3045,7 +3045,7 @@ void CuMatrixBase<Real>::Lookup(const CuArray<Int32Pair> &indices,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     CuArray<Real> cuda_output(num_elements);
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU1DBLOCK, 1);
     dim3 dimGrid(n_blocks(num_elements, CU1DBLOCK), 1);
 
@@ -3054,7 +3054,7 @@ void CuMatrixBase<Real>::Lookup(const CuArray<Int32Pair> &indices,
     CU_SAFE_CALL(cudaGetLastError());
 
     cuda_output.CopyToHost(output);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -3079,7 +3079,7 @@ void CuMatrixBase<Real>::EqualElementMask(const CuMatrixBase<Real> &mat, CuMatri
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimGrid, dimBlock;
     GetBlockSizesForSimpleMatrixOperation(NumRows(), NumCols(),
                                           &dimGrid, &dimBlock);
@@ -3088,7 +3088,7 @@ void CuMatrixBase<Real>::EqualElementMask(const CuMatrixBase<Real> &mat, CuMatri
                             mask->Stride());
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -320,7 +320,7 @@ void CuMatrixBase<Real>::CopyFromMat(const MatrixBase<Real> &src,
       CU_SAFE_CALL(cudaMemcpy2D(data_, dst_pitch, src.Data(), src_pitch,
                                 width, src.NumRows(), cudaMemcpyHostToDevice));
 
-      CuDevice::Instantiate().AccuProfile("CuMatrixBase::CopyFromMat(from CPU)",tim.Elapsed());
+      CuDevice::Instantiate().AccuProfile("CuMatrixBase::CopyFromMat(from CPU)", tim);
     } else {
       CuMatrix<Real> trans_mat(src); // Do the transpose on the GPU board.
       this->CopyFromMat(trans_mat, kTrans);
@@ -361,7 +361,7 @@ void CuMatrixBase<Real>::CopyFromSp(const CuSpMatrix<Real> &M) {
     dim3 dimGrid(n_blocks(NumRows(), CU2DBLOCK),
                  n_blocks(NumRows(), CU2DBLOCK));
     cuda_copy_from_sp(dimGrid, dimBlock, M.Data(), data_, Dim());
-    CuDevice::Instantiate().AccuProfile("CuMatrix::CopyFromSp",tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuMatrix::CopyFromSp", tim);
   } else
 #endif
   {
@@ -428,7 +428,7 @@ void CuMatrixBase<Real>::CopyToMat(MatrixBase<OtherReal> *dst,
       CU_SAFE_CALL(cudaMemcpy2D(dst->Data(), dst_pitch, this->data_, src_pitch,
                                 width, this->num_rows_, cudaMemcpyDeviceToHost));
 
-      CuDevice::Instantiate().AccuProfile("CuMatrix::CopyToMatD2H",tim.Elapsed());
+      CuDevice::Instantiate().AccuProfile("CuMatrix::CopyToMatD2H", tim);
     }
   } else
   #endif

--- a/src/cudamatrix/cu-rand.cc
+++ b/src/cudamatrix/cu-rand.cc
@@ -60,13 +60,13 @@ template<typename Real>
 void CuRand<Real>::RandUniform(CuMatrixBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
     // so we should not use it to generate random numbers over whole stride.
     CuMatrix<Real> tmp(tgt->NumRows(), tgt->NumCols(), kUndefined);
     CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tmp.Data(), tmp.NumRows() * tmp.Stride()));
     tgt->CopyFromMat(tmp);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -78,10 +78,10 @@ template<typename Real>
 void CuRand<Real>::RandUniform(CuMatrix<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // Here we don't need to use 'tmp' matrix,
     CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tgt->Data(), tgt->NumRows() * tgt->Stride()));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -93,9 +93,9 @@ template<typename Real>
 void CuRand<Real>::RandUniform(CuVectorBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(curandGenerateUniformWrap(gen_, tgt->Data(), tgt->Dim()));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -107,7 +107,7 @@ template<typename Real>
 void CuRand<Real>::RandGaussian(CuMatrixBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // Better use 'tmp' matrix, 'tgt' can be a window into a larger matrix,
     // so we should not use it to generate random numbers over whole stride.
     // Also, we ensure to have 'even' number of elements for calling 'curand'
@@ -117,7 +117,7 @@ void CuRand<Real>::RandGaussian(CuMatrixBase<Real> *tgt) {
     CuMatrix<Real> tmp(tgt->NumRows(), num_cols_even, kUndefined);
     CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.NumRows()*tmp.Stride()));
     tgt->CopyFromMat(tmp.ColRange(0,tgt->NumCols()));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -129,7 +129,7 @@ template<typename Real>
 void CuRand<Real>::RandGaussian(CuMatrix<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // Here we don't need to use 'tmp' matrix, if the number of elements is even,
     MatrixIndexT num_elements = tgt->NumRows() * tgt->Stride();
     if (0 == (num_elements % 2)) {
@@ -141,7 +141,7 @@ void CuRand<Real>::RandGaussian(CuMatrix<Real> *tgt) {
       CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.NumRows()*tmp.Stride()));
       tgt->CopyFromMat(tmp.ColRange(0,tgt->NumCols()));
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -153,7 +153,7 @@ template<typename Real>
 void CuRand<Real>::RandGaussian(CuVectorBase<Real> *tgt) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     // To ensure 'even' number of elements, we use 'tmp' vector of even length.
     // Even number of elements is required by 'curand' functions:
     // curandGenerateUniform(), curandGenerateUniformDouble().
@@ -166,7 +166,7 @@ void CuRand<Real>::RandGaussian(CuVectorBase<Real> *tgt) {
       CU_SAFE_CALL(curandGenerateNormalWrap(gen_, tmp.Data(), tmp.Dim()));
       tgt->CopyFromVec(tmp.Range(0,tgt->Dim()));
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-sp-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-sp-matrix-speed-test.cc
@@ -128,12 +128,13 @@ template<typename Real> void CuSpMatrixSpeedTest() {
 
 
 int main() {
-    //Select the GPU
+  SetVerboseLevel(1);
+  //Select the GPU
 #if HAVE_CUDA == 1
-    CuDevice::Instantiate().SelectGpuId("yes"); //-2 .. automatic selection
+  CuDevice::Instantiate().SelectGpuId("yes"); //-2 .. automatic selection
 #endif
 
-    kaldi::CuSpMatrixSpeedTest<float>();
+  kaldi::CuSpMatrixSpeedTest<float>();
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().DoublePrecisionSupported()) {
     kaldi::CuSpMatrixSpeedTest<double>();

--- a/src/cudamatrix/cu-sp-matrix-test.cc
+++ b/src/cudamatrix/cu-sp-matrix-test.cc
@@ -41,7 +41,7 @@ namespace kaldi {
  * Unit Tests
  */
 template<typename Real>
-static void UnitTestCuSpMatrixConstructor() { 
+static void UnitTestCuSpMatrixConstructor() {
   for (MatrixIndexT i = 1; i < 10; i++) {
     MatrixIndexT dim = 10 * i;
 
@@ -56,7 +56,7 @@ static void UnitTestCuSpMatrixConstructor() {
     D.CopyToSp(&E);
 
     SpMatrix<Real> F(D);
-    
+
     AssertEqual(F, B);
      //added by hxu, to test copy from SpMatrix to CuSpMatrix
 
@@ -87,7 +87,7 @@ static void UnitTestCuSpMatrixApproxEqual() {
       KALDI_ASSERT(b1 == b2);
     }
   }
-  
+
 }
 
 
@@ -113,17 +113,17 @@ static void UnitTestCuSpMatrixAddToDiag() {
     SpMatrix<Real> A(dim);
     A.SetRandn();
     CuSpMatrix<Real> B(A);
-    
+
     Matrix<Real> D(A);
     A.AddToDiag(i);
 
     CuMatrix<Real> C(B);
     B.AddToDiag(i);
-    
+
     SpMatrix<Real> E(dim);
     B.CopyToSp(&E);
-    
-    AssertEqual(A, E);    
+
+    AssertEqual(A, E);
   }
 }
 
@@ -137,7 +137,7 @@ static void UnitTestCuSpMatrixCopyFromMat() {
     CuMatrix<Real> A(dim, dim);
     A.SetRandn();
     Matrix<Real> A2(A);
-    
+
     CuSpMatrix<Real> B(A, copy_type);
     SpMatrix<Real> B2(A2, copy_type);
     SpMatrix<Real> B3(B);
@@ -156,7 +156,7 @@ static void UnitTestCuSpMatrixInvert() {
     A.SetRandn();
     KALDI_ASSERT(A.Trace() != 0.0); // true with probability 1...
     SpMatrix<Real> B(A);
-    
+
     CuMatrix<Real> D(A);
     A.AddMat2(1.0, D, kTrans, 1.0);
     A.AddToDiag(i);
@@ -168,7 +168,7 @@ static void UnitTestCuSpMatrixInvert() {
     CuSpMatrix<Real> Acopy(A);
     A.Invert();
     B.Invert();
-    
+
     SpMatrix<Real> A2(A);
     AssertEqual(A2, B);
 
@@ -178,7 +178,7 @@ static void UnitTestCuSpMatrixInvert() {
   }
 }
 
-// TODO (variani) : fails for dim = 0 
+// TODO (variani) : fails for dim = 0
 template<typename Real>
 static void UnitTestCuSpMatrixAddVec2() {
   for (int32 i = 0; i < 50; i++) {
@@ -186,7 +186,7 @@ static void UnitTestCuSpMatrixAddVec2() {
     SpMatrix<Real> A(dim);
     A.SetRandn();
     CuSpMatrix<Real> B(A);
-    
+
     Vector<Real> C(dim);
     C.SetRandn();
     CuVector<Real> D(C);
@@ -232,7 +232,7 @@ template<typename Real>
 static void UnitTestCuSpMatrixAddSp() {
   for (MatrixIndexT i = 1; i < 50; i++) {
     MatrixIndexT dim = 7 * i + Rand() % 10;
-    
+
     SpMatrix<Real> A(dim);
     A.SetRandn();
     CuSpMatrix<Real> B(A);
@@ -242,7 +242,7 @@ static void UnitTestCuSpMatrixAddSp() {
     const CuSpMatrix<Real> D(C);
 
     const Real alpha = 2.0;
-    
+
     A.AddSp(alpha, C);
     B.AddSp(alpha, D);
 
@@ -257,7 +257,7 @@ template<typename Real, typename OtherReal>
 static void UnitTestCuSpMatrixTraceSpSp() {
   for (MatrixIndexT i = 1; i < 2; i++) {
     MatrixIndexT dim = 100 + Rand() % 255;
-    
+
     SpMatrix<Real> A(dim);
     A.SetRandn();
     const CuSpMatrix<Real> B(A);
@@ -297,7 +297,7 @@ void UnitTestCuSpMatrixSetUnit() {
     AssertEqual(S4, cu_S3);
   }
 }
-   
+
 template<class Real>
 static void UnitTestCuSpMatrixIO() {
   for (int32 i = 0; i < 10; i++) {
@@ -323,17 +323,17 @@ template<typename Real, typename OtherReal>
 static void UnitTestCuSpMatrixAddSp() {
   for (MatrixIndexT i = 1; i < 10; i++) {
     MatrixIndexT dim = 100 * i + Rand() % 255;
-    
+
     SpMatrix<Real> A(dim);
     A.SetRandn();
     const CuSpMatrix<Real> B(A);
     SpMatrix<OtherReal> C(dim);
     C.SetRandn();
     const CuSpMatrix<OtherReal> D(C);
-    
+
     A.AddSp(1.0, C);
     B.AddSp(1.0, D);
-    
+
     AssertEqual(A, B);
 
   }
@@ -363,6 +363,7 @@ template<typename Real, typename OtherReal> void CudaSpMatrixUnitTest() {
 
 int main() {
   using namespace kaldi;
+  SetVerboseLevel(1);
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (; loop < 2; loop++) {

--- a/src/cudamatrix/cu-sp-matrix.cc
+++ b/src/cudamatrix/cu-sp-matrix.cc
@@ -44,7 +44,7 @@ void CuSpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
     return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     MatrixIndexT D = this->NumRows();
     if (D == 0)
       return;
@@ -81,7 +81,7 @@ void CuSpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
       default:
         KALDI_ASSERT("Invalid argument to CuSpMatrix::CopyFromMat");
     }
-    CuDevice::Instantiate().AccuProfile("CuSpMatrix::CopyFromMat(from CuMatrixBase)", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuSpMatrix::CopyFromMat(from CuMatrixBase)", tim);
   } else
 #endif
   {
@@ -110,7 +110,7 @@ void CuSpMatrix<Real>::AddVec2(const Real alpha, const CuVectorBase<Real> &v) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (this->num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     size_t nr = this->num_rows_;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(nr, CU2DBLOCK), n_blocks(nr, CU2DBLOCK));
@@ -118,7 +118,7 @@ void CuSpMatrix<Real>::AddVec2(const Real alpha, const CuVectorBase<Real> &v) {
     CU_SAFE_CALL(cublas_spr(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER, this->num_rows_, alpha, v.Data(),
                1, this->Data()));
     
-    CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddVec2", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddVec2", tim);
   } else
 #endif
   {
@@ -135,7 +135,7 @@ void CuSpMatrix<Real>::AddMat2(const Real alpha, const CuMatrixBase<Real> &M,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (this->num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     MatrixIndexT this_dim = this->NumRows(),
         m_other_dim = (transM == kNoTrans ? M.NumCols() : M.NumRows());
 
@@ -152,7 +152,7 @@ void CuSpMatrix<Real>::AddMat2(const Real alpha, const CuMatrixBase<Real> &M,
                 M.Stride(), beta, tmp_mat.Data(), tmp_mat.Stride());
     this->CopyFromMat(tmp_mat, kTakeLower);
     
-    CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddMat2", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddMat2", tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-sparse-matrix.cc
+++ b/src/cudamatrix/cu-sparse-matrix.cc
@@ -211,13 +211,13 @@ void CuSparseMatrix<Real>::CopyElementsToVec(CuVectorBase<Real> *vec) const {
   KALDI_ASSERT(this->NumElements() == vec->Dim());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     cublas_copy(GetCublasHandle(),
                 this->NumElements(),
                 &(this->elements_.Data()->weight),
                 static_cast<size_t>(sizeof(MatrixElement<Real>) / sizeof(Real)),
                 vec->Data(), 1);
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -318,7 +318,7 @@ Real TraceMatSmat(const CuMatrixBase<Real> &A,
     // The Sum() method in CuVector handles a bunch of logic, we use that to
     // comptue the trace.
     CuVector<Real> sum_vec(B.NumElements());
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU1DBLOCK, 1);
     dim3 dimGrid(n_blocks(B.NumElements(), CU1DBLOCK), 1);
     if (trans == kNoTrans) {
@@ -329,7 +329,7 @@ Real TraceMatSmat(const CuMatrixBase<Real> &A,
                                 A.Dim(), B.NumElements(), sum_vec.Data());
     }
     result = sum_vec.Sum();
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -400,7 +400,7 @@ void CuSparseMatrix<Real>::CopyToMat(CuMatrixBase<OtherReal> *M,
   }
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU1DBLOCK, 1);
     dim3 dimGrid(n_blocks(this->NumElements(), CU1DBLOCK), 1);
     if (trans == kNoTrans) {
@@ -410,7 +410,7 @@ void CuSparseMatrix<Real>::CopyToMat(CuMatrixBase<OtherReal> *M,
       cuda_copy_from_smat_trans(dimGrid, dimBlock, M->Data(),
                                 this->Data(), M->Dim(), this->NumElements());
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-test.cc
+++ b/src/cudamatrix/cu-test.cc
@@ -37,7 +37,7 @@ namespace kaldi {
 
 /*
  * INITIALIZERS
- */ 
+ */
 template<typename Real>
 static void InitRand(SpMatrix<Real> *M) {
   do {
@@ -71,7 +71,7 @@ static void UnitTestSetZeroAboveDiag() {
       for (MatrixIndexT j = i + 1; j < dim; j++)
         sum += A(i,j);
     }
-        
+
     KALDI_LOG << "the upper diaganoal sum for A is : " << sum;
     B.CopyToMat(&A);
     sum = 0.0;
@@ -107,7 +107,7 @@ template<typename Real> static void UnitTestCholesky() {
 
     Matrix<Real> D(dim,dim);
     A.CopyToMat(&D);
-    
+
     //KALDI_LOG << "D is: " << D;
     Matrix<Real> E(dim,dim);
     E.AddMatMat(1.0, D, kNoTrans, D, kTrans, 0.0);
@@ -185,7 +185,7 @@ template<typename Real> static void UnitInvert() {
 template<typename Real> static void UnitTestInvert() {
   for (MatrixIndexT iter = 0; iter < 3; iter++) {
     MatrixIndexT dim = 500 + Rand() % 400;
-    
+
     KALDI_LOG << "dim is : ";
     KALDI_LOG << dim;
     CuMatrix<Real> A(dim,dim);
@@ -198,14 +198,14 @@ template<typename Real> static void UnitTestInvert() {
     Matrix<Real> Identity(B);
     B.AddVecVec(1.0, C, C);
     // Now we have a positive-definite B (inversion would
-    // fail if it were not positive definite). 
+    // fail if it were not positive definite).
 
     A.CopyFromMat(B);
-    
+
     A.SymInvertPosDef();
     Matrix<Real> D(dim,dim);
     A.CopyToMat(&D);
-    
+
     Matrix<Real> X(dim,dim);
     X.AddMatMat(1.0, B, kNoTrans, D, kNoTrans, 0.0);
     // KALDI_LOG << "X is (should be identity): " << X;
@@ -236,19 +236,19 @@ template<typename Real> static void UnitTestConstructor() {
     for (MatrixIndexT j = 0; j <= i; j++)
       std::cout << D(i,j) << " ";
     std::cout << '\n';
-  }  
+  }
 }
 
 template<typename Real> static void UnitTestCopySp() {
-  // Checking that the various versions of copying                                 
-  // matrix to SpMatrix work the same in the symmetric case.                         
+  // Checking that the various versions of copying
+  // matrix to SpMatrix work the same in the symmetric case.
   for (MatrixIndexT iter = 0;iter < 5;iter++) {
     int32 dim = 5 + Rand() %  10;
     SpMatrix<Real> A(dim), B(dim);
     A.SetRandn();
     Matrix<Real> C(A);
     //CuMatrix<Real> D(C);
-    
+
     {
       CuMatrix<Real> D2(dim,dim);
       D2.CopyFromMat(C);
@@ -258,11 +258,11 @@ template<typename Real> static void UnitTestCopySp() {
       E.CopyFromMat(D2, kTakeLower);
       KALDI_LOG << "D2 is " << D2;
     }
-    
+
     CuMatrix<Real> D(dim,dim);
     D.CopyFromMat(C);
     KALDI_LOG << "D stride is : " << D.Stride() <<'\n';
-    
+
     CuSpMatrix<Real> E(D,kTakeLower);
     ///CuSpMatrix<Real> E(dim);
     //E.CopyFromMat(D,kTakeLower);
@@ -286,9 +286,9 @@ template<typename Real> static void UnitTestCopySp() {
     CuSpMatrix<Real> G(D, kTakeUpper);
     G.CopyToMat(&B);
     AssertEqual(A, B);
-    */  
+    */
   }
-  
+
 }
 
 template<typename Real> static void UnitTestCopyFromMat() {
@@ -322,7 +322,7 @@ template<typename Real> static void UnitTestCopyFromMat() {
       std::cout << D(i,j) << " ";
     std::cout << '\n';
   }
-  
+
   C.CopyFromMat(A,kTakeMean);
   C.CopyToSp(&D);
   KALDI_LOG << "C is : ";
@@ -331,7 +331,7 @@ template<typename Real> static void UnitTestCopyFromMat() {
       std::cout << D(i,j) << " ";
     std::cout << '\n';
   }
-  
+
   //KALDI_LOG << D;
 }
 
@@ -356,7 +356,7 @@ template<typename Real> static void UnitTestMatrix() {
       As(3, 4) = Bs(3, 4);
     else
       As(3, 4) = (const_cast<const CuSpMatrix<Real>&>(Bs))(3, 4);
-    
+
     KALDI_ASSERT(As(3, 4) == Bs(3, 4));
 
     Vector<Real> v(dim1);
@@ -391,7 +391,7 @@ template<typename Real> static void UnitTestMulTp() {
     M.SetRandn();
     CuVector<Real> cv(v);
     CuTpMatrix<Real> cM(M);
-    
+
     Vector<Real> v2(dim);
     cv.CopyToVec(&v2);
     AssertEqual(v, v2);
@@ -420,7 +420,7 @@ template<typename Real> static void UnitTestVector() {
     //KALDI_LOG << C;
     AssertEqual(A, C);
   }
-  
+
   for (MatrixIndexT iter = 0; iter < 10; iter++) {
     int32 dim = 15 + Rand() % 10;
     CuVector<Real> A(dim);
@@ -460,7 +460,7 @@ template<typename Real> static void UnitTestVector() {
     Vector<Real> A1(dim);
     A.CopyToVec(&A1);
     KALDI_LOG << "cpu min is : " << A1.Min();
-    KALDI_LOG << "gpu min is : " << A.Min();    
+    KALDI_LOG << "gpu min is : " << A.Min();
   }
 
   for (MatrixIndexT iter = 0; iter < 10; iter++) {
@@ -485,7 +485,7 @@ template<typename Real> static void UnitTestVector() {
     A.CopyToVec(&D);
     AssertEqual(D,A1);
   }
-  
+
   for (MatrixIndexT iter = 0; iter < 10; iter++) {
     int32 dim1 = 15 + Rand() % 10;
     int32 dim2 = 10 + Rand() % 10;
@@ -541,7 +541,7 @@ template<typename Real> static void UnitTestVector() {
     Real dot = VecVec(A,B);
     KALDI_LOG << "dot product in gpu: " << dot;
     dot = VecVec(A1,B1);
-    KALDI_LOG << "dot product in cpu: " << dot;    
+    KALDI_LOG << "dot product in cpu: " << dot;
   }
 
   for (MatrixIndexT iter = 0; iter < 10; iter++) {
@@ -575,6 +575,7 @@ static void CuMatrixUnitTest() {
 
 int main() {
   using namespace kaldi;
+  SetVerboseLevel(1);
 #if HAVE_CUDA == 1
   for (int32 loop = 0; loop < 2; loop++) {
     if (loop == 0)
@@ -596,7 +597,7 @@ int main() {
   }
   kaldi::CuDevice::Instantiate().PrintProfile();
 #endif
-  
+
   KALDI_LOG << "Tests succeeded.";
   return 0;
 }

--- a/src/cudamatrix/cu-tp-matrix-test.cc
+++ b/src/cudamatrix/cu-tp-matrix-test.cc
@@ -79,11 +79,11 @@ template<typename Real>
 static void UnitTestCuTpMatrixInvert() {
   for (MatrixIndexT i = 1; i < 10; i++) {
     MatrixIndexT dim = 5 * i + Rand() % 10;
-    
+
     TpMatrix<Real> A(dim);
     A.SetRandn();
     CuTpMatrix<Real> B(A);
-    
+
     AssertEqual<Real>(A, B, 0.005);
     A.Invert();
     B.Invert();
@@ -95,14 +95,14 @@ template<typename Real>
 static void UnitTestCuTpMatrixCopyFromTp() {
   for (MatrixIndexT i = 1; i < 10; i++) {
     MatrixIndexT dim = 5 * i + Rand() % 10;
-    
+
     TpMatrix<Real> A(dim);
     A.SetRandn();
     CuTpMatrix<Real> B(dim);
     B.CopyFromTp(A);
     CuTpMatrix<Real> C(dim);
     C.CopyFromTp(B);
-    
+
     AssertEqual<Real>(A, B);
     AssertEqual<Real>(B, C);
   }
@@ -117,7 +117,7 @@ static void UnitTestCuTpMatrixCopyFromMat() {
     CuMatrix<Real> A(dim, dim);
     A.SetRandn();
     Matrix<Real> A2(A);
-    
+
     CuTpMatrix<Real> B(dim);
     B.CopyFromMat(A, trans);
     TpMatrix<Real> B2(dim);
@@ -186,6 +186,7 @@ template<typename Real> void CudaTpMatrixUnitTest() {
 
 int main() {
   using namespace kaldi;
+  SetVerboseLevel(1);
 
   int32 loop = 0;
 #if HAVE_CUDA == 1
@@ -206,7 +207,7 @@ int main() {
 #else
     kaldi::CudaTpMatrixUnitTest<double>();
 #endif
-  
+
     if (loop == 0)
       KALDI_LOG << "Tests without GPU use succeeded.";
     else

--- a/src/cudamatrix/cu-tp-matrix.cc
+++ b/src/cudamatrix/cu-tp-matrix.cc
@@ -64,7 +64,7 @@ void CuTpMatrix<Real>::Invert() {
 #if HAVE_CUDA==1
   if (CuDevice::Instantiate().Enabled()) {
     if (this->num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU2DBLOCK);
     int dimGrid(n_blocks(this->NumRows(), CU2DBLOCK));
     CuMatrix<Real> tmp(this->NumRows(), this->NumRows());
@@ -92,7 +92,7 @@ void CuTpMatrix<Real>::CopyFromMat(const CuMatrixBase<Real> &M,
     MatrixIndexT num_rows = this->num_rows_;
     KALDI_ASSERT(num_rows == M.NumRows() && this->num_rows_ == M.NumCols());
     if (num_rows == 0) return;
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
     dim3 dimGrid(n_blocks(num_rows, CU2DBLOCK), n_blocks(num_rows, CU2DBLOCK));
     if (Trans == kNoTrans) {

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -304,12 +304,13 @@ template<typename Real> void CudaVectorSpeedTest() {
 
 
 int main() {
-    //Select the GPU
+  kaldi::SetVerboseLevel(1);
+  //Select the GPU
 #if HAVE_CUDA == 1
-    CuDevice::Instantiate().SelectGpuId("yes"); //-2 .. automatic selection
+  CuDevice::Instantiate().SelectGpuId("yes"); //-2 .. automatic selection
 #endif
 
-    kaldi::CudaVectorSpeedTest<float>();
+  kaldi::CudaVectorSpeedTest<float>();
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().DoublePrecisionSupported()) {
     kaldi::CudaVectorSpeedTest<double>();

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -742,8 +742,8 @@ template<typename Real> void CuVectorUnitTest() {
 
 
 int main(int argc, char *argv[]) {
-  //Select the GPU
   using namespace kaldi;
+  SetVerboseLevel(1);
   const char *usage = "Usage: cu-vector-test [options]";
 
   ParseOptions po(usage);
@@ -755,7 +755,7 @@ int main(int argc, char *argv[]) {
     po.PrintUsage();
     exit(1);
   }
-  
+
   int32 loop = 0;
 #if HAVE_CUDA == 1
   for (; loop < 2; loop++) {

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -48,10 +48,10 @@ Real VecVec(const CuVectorBase<Real> &a,
   Real result = 0;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_dot(GetCublasHandle(), a.Dim(), a.Data(), 1, b.Data(),
                             1, &result));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
 } else
 #endif
   {
@@ -81,11 +81,11 @@ void CuVectorBase<Real>::CopyColFromMat(const CuMatrixBase<Real> &mat, MatrixInd
   KALDI_ASSERT(dim_ == mat.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     cublas_copy(GetCublasHandle(),
                 this->dim_, mat.Data() + col, mat.Stride(), this->data_, 1);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim);
   } else
 #endif
   {
@@ -100,13 +100,13 @@ void CuVectorBase<double>::CopyColFromMat(const CuMatrixBase<float> &mat, Matrix
   KALDI_ASSERT(dim_ == mat.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_copy_col_from_mat_df(dimGrid, dimBlock, data_, col, mat.Data(), mat.Dim(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim);
   } else
 #endif
   {
@@ -122,13 +122,13 @@ void CuVectorBase<float>::CopyColFromMat(const CuMatrixBase<double> &mat, Matrix
   KALDI_ASSERT(dim_ == mat.NumRows());
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_copy_col_from_mat_fd(dimGrid, dimBlock, data_, col, mat.Data(), mat.Dim(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyColFromMat", tim);
   } else
 #endif
   {
@@ -142,7 +142,7 @@ void CuVectorBase<Real>::CopyRowsFromMat(const CuMatrixBase<Real> &mat) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     if (mat.Stride() == mat.NumCols() && mat.NumRows() != 0) {
       CU_SAFE_CALL(cudaMemcpy(data_, mat.Data(), sizeof(Real)*dim_,
                               cudaMemcpyDeviceToDevice));
@@ -155,7 +155,7 @@ void CuVectorBase<Real>::CopyRowsFromMat(const CuMatrixBase<Real> &mat) {
         vec_data += mat.NumCols();
       }
     }
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyRowsFromMat", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::CopyRowsFromMat", tim);
   } else
 #endif
   {
@@ -167,7 +167,7 @@ template<typename Real>
 Real CuVectorBase<Real>::Norm(Real p) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     Real ans;
     KALDI_ASSERT(p == 1.0 || p == 2.0);
     if (dim_ == 0) return 0.0;
@@ -176,7 +176,7 @@ Real CuVectorBase<Real>::Norm(Real p) {
     } else {
       cublas_nrm2(GetCublasHandle(), dim_, data_, 1, &ans);
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
     if (ans != ans) {
       KALDI_ERR << "NaN in norm " << *this;
     }
@@ -194,7 +194,7 @@ void CuVectorBase<Real>::CopyRowsFromMat(const MatrixBase<Real> &mat) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     if (mat.Stride() == mat.NumCols()) {
       CU_SAFE_CALL(cudaMemcpy(data_, mat.Data(), sizeof(Real)*dim_,
                               cudaMemcpyHostToDevice));
@@ -208,7 +208,7 @@ void CuVectorBase<Real>::CopyRowsFromMat(const MatrixBase<Real> &mat) {
       }
     }
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -222,7 +222,7 @@ void MatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (num_rows_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     if (Stride() == NumCols()) {
       CU_SAFE_CALL(cudaMemcpy(data_, v.Data(),
                               sizeof(Real)*v.Dim(),
@@ -236,7 +236,7 @@ void MatrixBase<Real>::CopyRowsFromVec(const CuVectorBase<Real> &v) {
         vec_data += NumCols();
       }
     }
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -271,7 +271,7 @@ Real CuVectorBase<Real>::Sum() const {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     Real result;
-    Timer tim;
+    CuTimer tim;
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
@@ -292,7 +292,7 @@ Real CuVectorBase<Real>::Sum() const {
       result = ans_cpu.Sum();
     }
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
     return result;
   } else
 #endif
@@ -306,13 +306,13 @@ void CuVectorBase<Real>::ApplySoftMax() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     size_t dimBlock = CU1DBLOCK;
     size_t dimGrid = 1;       // dimGrid value represent the number of rows
     ::MatrixDim dim = { 1, this->dim_, this->dim_};
     cuda_softmax_reduce(dimGrid, dimBlock, data_, data_, dim, this->dim_);//actually dim is not stride...
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -326,7 +326,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyFloor(Real floor_val) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return 0;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
@@ -335,7 +335,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyFloor(Real floor_val) {
     cuda_vec_apply_floor(dimGrid, dimBlock, data_, floor_val, count_vec.Data(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
     num_floored = count_vec.Sum();
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloor", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloor", tim);
   } else
 #endif
   {
@@ -351,7 +351,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return 0;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
@@ -360,7 +360,7 @@ MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
     cuda_vec_apply_ceiling(dimGrid, dimBlock, data_, ceiling_val, count_vec.Data(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
     num_ceiled = count_vec.Sum();
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyCeiling", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyCeiling", tim);
   } else
 #endif
   {
@@ -374,7 +374,7 @@ void CuVectorBase<Real>::ApplyPow(Real power) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     // for this particular kernel, x is #rows, y is #cols.  so
     // fake matrix with 1 row, Dim() cols.
     dim3 dimBlock(CU1DBLOCK, 1);
@@ -383,7 +383,7 @@ void CuVectorBase<Real>::ApplyPow(Real power) {
     // num_cols is Dim(), num_rows is 1, stride is 1 (it's a don't-care).
     cuda_apply_pow(dimGrid, dimBlock, data_, power, fake_matrix_dim);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyPow", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyPow", tim);
   } else
 #endif
   {
@@ -397,13 +397,13 @@ void CuVectorBase<Real>::ApplyExp() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_vec_apply_exp(dimGrid, dimBlock, data_, dim_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyExp", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyExp", tim);
   } else
 #endif
   {
@@ -417,7 +417,7 @@ void CuVectorBase<Real>::ApplyLog() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
@@ -426,7 +426,7 @@ void CuVectorBase<Real>::ApplyLog() {
     CU_SAFE_CALL(cudaGetLastError());
     if (flag(0) > 0)
       KALDI_ERR << "Trying to take log of a negative number.";
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyLog", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyLog", tim);
   } else
 #endif
   {
@@ -447,7 +447,7 @@ void CuVectorBase<Real>::AddMatVec(const Real alpha,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     // Everything is backwards in CuBlas.  We need to reverse rows, columns,
     // transpose-ness.
@@ -456,7 +456,7 @@ void CuVectorBase<Real>::AddMatVec(const Real alpha,
                              M.NumCols(), M.NumRows(), alpha, M.Data(),
                              M.Stride(), v.Data(), 1, beta, data_, 1));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -474,14 +474,14 @@ void CuVectorBase<Real>::AddSpVec(const Real alpha,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
 
     // Note: in our opinion the CuSpMatrix represents a lower-triangular matrix, but
     // in CUBLAS, for some stupid reason, everything is reversed.
     CU_SAFE_CALL(cublas_spmv(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER, Dim(),
                              alpha, M.Data(), v.Data(), 1, beta, data_, 1));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -497,13 +497,13 @@ void CuVectorBase<Real>::AddVecVec(Real alpha, const CuVectorBase<Real> &v,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_,CU1DBLOCK));
 
     cuda_add_vec_vec(dimGrid, dimBlock, alpha, data_, v.Data(), r.Data(), beta, dim_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::AddVecVec", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::AddVecVec", tim);
   } else
 #endif
   {
@@ -547,7 +547,7 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
                                        MatrixTransposeType transN, Real beta) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     if (transM != transN) {
       KALDI_ASSERT(M.NumCols() == N.NumCols());
@@ -600,7 +600,7 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
     }
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -617,7 +617,7 @@ void CuVectorBase<Real>::AddTpVec(const Real alpha, const CuTpMatrix<Real> &M,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     if (beta == 0.0) {
       if (&v != this) CopyFromVec(v);
       MulTp(M, trans);
@@ -642,10 +642,10 @@ void CuVectorBase<Real>::MulTp(const CuTpMatrix<Real> &M, const MatrixTransposeT
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     cublas_tpmv(GetCublasHandle(), (trans==kTrans? CUBLAS_OP_N:CUBLAS_OP_T),
                 M.NumRows(), M.Data(), data_, 1);
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::MulTp", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::MulTp", tim);
   } else
 #endif
   {
@@ -661,7 +661,7 @@ Real CuVectorBase<Real>::Min() const {
     if (dim_ == 0) {  // min of an empty set is infinity.
       return std::numeric_limits<Real>::infinity();
     }
-    Timer tim;
+    CuTimer tim;
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
@@ -682,7 +682,7 @@ Real CuVectorBase<Real>::Min() const {
       result = ans_cpu.Min();
     }
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -699,7 +699,7 @@ Real CuVectorBase<Real>::Max() const {
     if (dim_ == 0) {  // max of an empty set is -infinity.
       return -std::numeric_limits<Real>::infinity();
     }
-    Timer tim;
+    CuTimer tim;
 
     // Small vectors are copied to RAM and reduced on CPU.
     // The length is chosen by cu-vector-speed-test
@@ -720,7 +720,7 @@ Real CuVectorBase<Real>::Max() const {
       result = ans_cpu.Max();
     }
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -734,12 +734,12 @@ void CuVectorBase<Real>::ReplaceValue(Real orig, Real changed) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_, CU1DBLOCK));
     cuda_replace_value(dimGrid, dimBlock, data_, dim_, orig, changed);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -753,12 +753,12 @@ void CuVectorBase<Real>::MulElements(const CuVectorBase<Real> &v) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(dim_, CU1DBLOCK));
     cuda_vec_mul_elements(dimGrid, dimBlock, data_, v.Data(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile("CuVectorBase::MulElements", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::MulElements", tim);
   } else
 #endif
   {
@@ -773,9 +773,9 @@ void CuVectorBase<double>::CopyFromVec(const CuVectorBase<float> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_copy(GetCublasHandle(), dim_, src.Data(), 1, data_, 1));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -790,9 +790,9 @@ void CuVectorBase<float>::CopyFromVec(const CuVectorBase<double> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_copy(GetCublasHandle(), dim_, src.Data(), 1, data_, 1));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -813,7 +813,7 @@ void CuVectorBase<Real>::CopyFromVec(const VectorBase<OtherReal> &src) {
     } else {
       KALDI_ASSERT(src.Dim() == dim_);
       if (dim_ == 0) return;
-      Timer tim;
+      CuTimer tim;
       CU_SAFE_CALL(cudaMemcpy(data_, src.Data(), src.Dim()*sizeof(Real), cudaMemcpyHostToDevice));
       CuDevice::Instantiate().AccuProfile("CuVector::CopyFromVecH2D",tim.Elapsed());
     }
@@ -844,10 +844,10 @@ void CuVectorBase<Real>::CopyToVec(VectorBase<OtherReal> *dst) const {
       temp.CopyToVec(dst);
     } else {
       if (dim_ == 0) return;
-      Timer tim;
+      CuTimer tim;
       CU_SAFE_CALL(cudaMemcpy(dst->Data(), this->data_,
                               sizeof(Real) * dim_, cudaMemcpyDeviceToHost));
-      CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+      CuDevice::Instantiate().AccuProfile(__func__, tim);
     }
   } else
 #endif
@@ -900,11 +900,11 @@ void CuVector<Real>::Resize(MatrixIndexT dim, MatrixResizeType t) {
   if (dim == 0) return;
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     this->data_ = static_cast<Real*>(CuDevice::Instantiate().Malloc(dim * sizeof(Real)));
     this->dim_ = dim;
     if (t == kSetZero) this->SetZero();
-    CuDevice::Instantiate().AccuProfile("CuVector::Resize", tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVector::Resize", tim);
   } else
 #endif
   {
@@ -971,9 +971,9 @@ void CuVectorBase<Real>::CopyFromVec(const CuVectorBase<Real> &src) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemcpy(data_, src.data_, src.dim_ * sizeof(Real), cudaMemcpyDeviceToDevice));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -990,7 +990,7 @@ void CuVectorBase<Real>::SetZero() {
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(dim_>=0);
     KALDI_ASSERT(data_!=NULL);
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cudaMemset(data_, 0, dim_*sizeof(Real)));
     CuDevice::Instantiate().AccuProfile("CuVector::SetZero",tim.Elapsed());
   } else
@@ -1023,7 +1023,7 @@ template<typename Real>
 void CuVectorBase<Real>::Set(Real value) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU1DBLOCK);
     dim3 dimGrid(n_blocks(Dim(), CU1DBLOCK));
@@ -1031,7 +1031,7 @@ void CuVectorBase<Real>::Set(Real value) {
 
     cuda_set_const(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1045,7 +1045,7 @@ template<typename Real>
 void CuVectorBase<Real>::Add(Real value) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU1DBLOCK);
     dim3 dimGrid(n_blocks(Dim(), CU1DBLOCK));
@@ -1053,7 +1053,7 @@ void CuVectorBase<Real>::Add(Real value) {
 
     cuda_add(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1067,13 +1067,13 @@ void CuVectorBase<Real>::CopyDiagFromPacked(const CuPackedMatrix<Real> &M) {
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(dim_ == M.NumRows());
     if (dim_ == 0) return;
-    Timer tim;
+    CuTimer tim;
     int dimBlock(CU1DBLOCK);
     int dimGrid(n_blocks(Dim(), CU1DBLOCK));
     cuda_vec_copy_diag_from_packed(dimGrid, dimBlock, data_, M.Data(), dim_);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1087,11 +1087,11 @@ void CuVectorBase<Real>::CopyDiagFromMat(const CuMatrix<Real> &M) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     KALDI_ASSERT(dim_ == std::min(M.NumRows(), M.NumCols()));
-    Timer tim;
+    CuTimer tim;
     CU_SAFE_CALL(cublas_copy(GetCublasHandle(), dim_, M.Data(), M.Stride() + 1,
                              data_, 1));
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1106,14 +1106,14 @@ void CuVectorBase<Real>::Scale(Real value) {
   if (CuDevice::Instantiate().Enabled()) {
     if (Dim() == 0 ) return;
 
-    Timer tim;
+    CuTimer tim;
     dim3 dimBlock(CU1DBLOCK);
     dim3 dimGrid(n_blocks(Dim(), CU1DBLOCK));
     ::MatrixDim d = { 1, Dim(), Dim() };
     cuda_scale(dimGrid, dimBlock, data_, value, d);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1128,13 +1128,13 @@ void CuVectorBase<Real>::AddVec(Real alpha, const CuVectorBase<Real> &vec,
 
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     int32 dim = this->dim_;
     Real *data = this->data_;
     const Real *vec_data = vec.data_;
     if (beta != 1.0) CU_SAFE_CALL(cuda_scal(GetCublasHandle(), dim, beta, data, 1));
     if (alpha != 0.0) CU_SAFE_CALL(cuda_axpy(GetCublasHandle(), dim, alpha, vec_data, 1, data, 1));
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
   #endif
   {
@@ -1178,14 +1178,14 @@ void CuVectorBase<Real>::AddColSumMat(Real alpha, const CuMatrixBase<Real> &mat,
                                       Real beta) {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
     KALDI_ASSERT(mat.NumRows() == Dim());
 
     cuda_add_col_sum_mat(mat.NumRows(), CU1DBLOCK, Data(), mat.Data(),
                          mat.Dim(), alpha, beta);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {
@@ -1197,7 +1197,7 @@ template<typename Real>
 void CuVectorBase<Real>::InvertElements() {
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
-    Timer tim;
+    CuTimer tim;
 
     dim3 dimBlock(CU1DBLOCK, 1);
     dim3 dimGrid(n_blocks(dim_, CU1DBLOCK));
@@ -1206,7 +1206,7 @@ void CuVectorBase<Real>::InvertElements() {
     cuda_invert_elements(dimGrid, dimBlock, data_, d);
     CU_SAFE_CALL(cudaGetLastError());
 
-    CuDevice::Instantiate().AccuProfile(__func__, tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile(__func__, tim);
   } else
 #endif
   {

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -815,7 +815,7 @@ void CuVectorBase<Real>::CopyFromVec(const VectorBase<OtherReal> &src) {
       if (dim_ == 0) return;
       CuTimer tim;
       CU_SAFE_CALL(cudaMemcpy(data_, src.Data(), src.Dim()*sizeof(Real), cudaMemcpyHostToDevice));
-      CuDevice::Instantiate().AccuProfile("CuVector::CopyFromVecH2D",tim.Elapsed());
+      CuDevice::Instantiate().AccuProfile("CuVector::CopyFromVecH2D", tim);
     }
   } else
   #endif
@@ -992,7 +992,7 @@ void CuVectorBase<Real>::SetZero() {
     KALDI_ASSERT(data_!=NULL);
     CuTimer tim;
     CU_SAFE_CALL(cudaMemset(data_, 0, dim_*sizeof(Real)));
-    CuDevice::Instantiate().AccuProfile("CuVector::SetZero",tim.Elapsed());
+    CuDevice::Instantiate().AccuProfile("CuVector::SetZero", tim);
   } else
 #endif
   {


### PR DESCRIPTION
This pull request is a different fix to the problem Karel was addressing in PR #1615.
It makes the accumulation of timing stats dependent on verbose level >= 1.
@LvHang, can you please test this PR instead of #1615, since this is the one that's a candidate to merge?
However if it would be easy and you're nearly done testing PR #1615,  testing them both is fine.

Please make run the nnet training scripts in the mini-librispeech setup.  However, you don't have to run that setup from the start, just the neural net training.  When you're done, show me the location; I want to look at the logs.
