### PR TITLE
WIP: Fixes for Threading Bugs

### DIFF
--- a/src/sgmm2/estimate-am-sgmm2.h
+++ b/src/sgmm2/estimate-am-sgmm2.h
@@ -442,8 +442,9 @@ class UpdateWClass: public MultiThreadable {
       MultiThreadable(other),
       accs_(other.accs_), model_(other.model_), w_(other.w_),
       log_a_(other.log_a_), F_i_ptr_(other.F_i_ptr_), g_i_ptr_(other.g_i_ptr_),
-      F_i_(other.F_i_), g_i_(other.g_i_), tot_like_ptr_(other.tot_like_ptr_),
-      tot_like_(0.0) { }
+      F_i_(other.F_i_.NumRows(), other.F_i_.NumCols()),
+      g_i_(other.g_i_.NumRows(), other.g_i_.NumCols()),
+      tot_like_ptr_(other.tot_like_ptr_), tot_like_(0.0) { }
 
   ~UpdateWClass() {
     F_i_ptr_->AddMat(1.0, F_i_, kNoTrans);


### PR DESCRIPTION
@danpovey I noticed that one of the sgmm2 tests (estimate-am-sgmm2-test) started failing after merging #1350. I found an initialization bug in the new sgmm2 threading code but that did not fix the failing test. I am not sure whether the test failure is caused by a bug in the new threading code or if the new code revealed an already existing problem. I am not familiar with the sgmm2 code, so I can not really tell what the problem is. Could you take a look at it?