### PR TITLE
do not fail if the ivector extractor belongs to other user

### DIFF
--- a/egs/wsj/s5/steps/nnet2/check_ivectors_compatible.sh
+++ b/egs/wsj/s5/steps/nnet2/check_ivectors_compatible.sh
@@ -23,7 +23,7 @@ if [ ! -z "$id_a" ] && [ ! -z "${id_b}" ] ; then
   if [ "${id_a}" == "${id_b}" ]; then
     exit 0
   else
-    echo >&2 "$0: ERROR: iVector id in ${id_a} and the iVector id in ${id_a} do not match"
+    echo >&2 "$0: ERROR: iVector id ${id_a} in $dir_a and the iVector id ${id_b} in $dir_b do not match"
     echo >&2 "$0: ERROR: that means that the systems are not compatible."
     exit 1
   fi

--- a/egs/wsj/s5/steps/nnet2/get_ivector_id.sh
+++ b/egs/wsj/s5/steps/nnet2/get_ivector_id.sh
@@ -30,8 +30,8 @@ elif [ -f $ivecdir/final.ie ] ; then
   # is not read-only media or the user des not have access rights
   # in that case we will just behave as if the id is not available
   id=$(md5sum $ivecdir/final.ie | awk '{print $1}')
-  echo "$id" > $ivecdir/final.ie.id || exit 1
-  cat $ivecdir/final.ie.id
+  echo "$id" > $ivecdir/final.ie.id || true
+  echo "$id"
 else
   exit 0
 fi


### PR DESCRIPTION
@danpovey this addresses issues when the ivectors are getting generated from, for example, a symlinked directory that does not allow +w to the current user.
