### PR TITLE
fixed latgen-faster-mapped-parallel multiple-fst case

### DIFF
--- a/src/bin/latgen-faster-mapped-parallel.cc
+++ b/src/bin/latgen-faster-mapped-parallel.cc
@@ -154,8 +154,10 @@ int main(int argc, char *argv[]) {
           delete loglikes;
           continue;
         }
+        fst::VectorFst<StdArc> *fst = 
+          new fst::VectorFst<StdArc>(fst_reader.Value());
         LatticeFasterDecoder *decoder =
-          new LatticeFasterDecoder(fst_reader.Value(), config);
+          new LatticeFasterDecoder(config, fst);
         DecodableMatrixScaledMapped *decodable = new
             DecodableMatrixScaledMapped(trans_model, acoustic_scale, loglikes);
         DecodeUtteranceLatticeFasterClass *task =


### PR DESCRIPTION
LatticeFasterDecoder was created with wrong constructor that took ref of temp object.