### PR TITLE
Enhancing confidences,

### DIFF
--- a/src/latbin/lattice-mbr-decode.cc
+++ b/src/latbin/lattice-mbr-decode.cc
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
         "[ sausage-stats-wspecifier [ times-wspecifier] ] ] \n"
         " e.g.: lattice-mbr-decode --acoustic-scale=0.1 ark:1.lats "
         "'ark,t:|int2sym.pl -f 2- words.txt > text' ark:/dev/null ark:1.sau\n";
-    
+
     ParseOptions po(usage);
     BaseFloat acoustic_scale = 1.0;
     BaseFloat lm_scale = 1.0;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
                 "words [for debug output]");
     po.Register("one-best-times", &one_best_times, "If true, output times "
                 "corresponding to one-best, not whole sausage.");
-    
+
     po.Read(argc, argv);
 
     if (po.NumArgs() < 2 || po.NumArgs() > 5) {
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
         bayes_risk_wspecifier = po.GetOptArg(3),
         sausage_stats_wspecifier = po.GetOptArg(4),
         times_wspecifier = po.GetOptArg(5);
-    
+
     // Read as compact lattice.
     SequentialCompactLatticeReader clat_reader(lats_rspecifier);
 
@@ -84,16 +84,16 @@ int main(int argc, char *argv[]) {
     PosteriorWriter sausage_stats_writer(sausage_stats_wspecifier);
 
     BaseFloatPairVectorWriter times_writer(times_wspecifier);
-    
+
     fst::SymbolTable *word_syms = NULL;
-    if (word_syms_filename != "") 
+    if (word_syms_filename != "")
       if (!(word_syms = fst::SymbolTable::ReadText(word_syms_filename)))
         KALDI_ERR << "Could not read symbol table from file "
                    << word_syms_filename;
 
     int32 n_done = 0, n_words = 0;
     BaseFloat tot_bayes_risk = 0.0;
-    
+
     for (; !clat_reader.Done(); clat_reader.Next()) {
       std::string key = clat_reader.Key();
       CompactLattice clat = clat_reader.Value();
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
       if (times_wspecifier != "")
         times_writer.Write(key, one_best_times ? mbr.GetOneBestTimes() :
                            mbr.GetSausageTimes());
-      
+
       n_done++;
       n_words += mbr.GetOneBest().size();
       tot_bayes_risk += mbr.GetBayesRisk();
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
     KALDI_LOG << "Average Bayes Risk per sentence is "
               << (tot_bayes_risk / n_done) << " and per word, "
               << (tot_bayes_risk / n_words);
-    
+
     delete word_syms;
     return (n_done != 0 ? 0 : 1);
   } catch(const std::exception &e) {

--- a/src/latbin/lattice-to-ctm-conf.cc
+++ b/src/latbin/lattice-to-ctm-conf.cc
@@ -57,6 +57,7 @@ int main(int argc, char *argv[]) {
     ParseOptions po(usage);
     BaseFloat acoustic_scale = 1.0, inv_acoustic_scale = 1.0, lm_scale = 1.0;
     BaseFloat frame_shift = 0.01;
+    int32 confidence_digits = 2;
 
     std::string word_syms_filename;
     po.Register("acoustic-scale", &acoustic_scale, "Scaling factor for "
@@ -66,6 +67,8 @@ int main(int argc, char *argv[]) {
     po.Register("lm-scale", &lm_scale, "Scaling factor for language model "
                 "probabilities");
     po.Register("frame-shift", &frame_shift, "Time in seconds between frames.");
+    po.Register("confidence-digits", &confidence_digits, "Number of decimal digits for confidences in 'ctm'.");
+
 
     MinimumBayesRiskOptions mbr_opts;
     mbr_opts.Register(&po);
@@ -118,7 +121,7 @@ int main(int argc, char *argv[]) {
     Output ko(ctm_wxfilename, false); // false == non-binary writing mode.
     ko.Stream() << std::fixed;  // Set to "fixed" floating point model, where precision() specifies
     // the #digits after the decimal point.
-    ko.Stream().precision(2);
+    ko.Stream().precision(confidence_digits);
 
     int32 n_done = 0, n_words = 0;
     BaseFloat tot_bayes_risk = 0.0;

--- a/src/latbin/lattice-to-ctm-conf.cc
+++ b/src/latbin/lattice-to-ctm-conf.cc
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
         "Usage: lattice-to-ctm-conf [options]  <lattice-rspecifier> \\\n"
         "                                          <ctm-wxfilename>\n"
         "Usage: lattice-to-ctm-conf [options]  <lattice-rspecifier> \\\n"
-        "                     [<1best-rspecifier>] <ctm-wxfilename>\n"
+        "                     [<1best-rspecifier> [<times-rspecifier]] <ctm-wxfilename>\n"
         " e.g.: lattice-to-ctm-conf --acoustic-scale=0.1 ark:1.lats 1.ctm\n"
         "   or: lattice-to-ctm-conf --acoustic-scale=0.1 --decode-mbr=false\\\n"
         "                                      ark:1.lats ark:1.1best 1.ctm\n"
@@ -56,7 +56,6 @@ int main(int argc, char *argv[]) {
 
     ParseOptions po(usage);
     BaseFloat acoustic_scale = 1.0, inv_acoustic_scale = 1.0, lm_scale = 1.0;
-    bool decode_mbr = true;
     BaseFloat frame_shift = 0.01;
 
     std::string word_syms_filename;
@@ -66,13 +65,14 @@ int main(int argc, char *argv[]) {
                 "of setting the acoustic scale: you can set its inverse.");
     po.Register("lm-scale", &lm_scale, "Scaling factor for language model "
                 "probabilities");
-    po.Register("decode-mbr", &decode_mbr, "If true, do Minimum Bayes Risk "
-                "decoding (else, Maximum a Posteriori)");
     po.Register("frame-shift", &frame_shift, "Time in seconds between frames.");
+
+    MinimumBayesRiskOptions mbr_opts;
+    mbr_opts.Register(&po);
 
     po.Read(argc, argv);
 
-    if (po.NumArgs() != 2 && po.NumArgs() != 3) {
+    if (po.NumArgs() != 2 && po.NumArgs() != 3 && po.NumArgs() != 4) {
       po.PrintUsage();
       exit(1);
     }
@@ -81,7 +81,8 @@ int main(int argc, char *argv[]) {
     if (inv_acoustic_scale != 1.0)
       acoustic_scale = 1.0 / inv_acoustic_scale;
 
-    std::string lats_rspecifier, one_best_rspecifier, ctm_wxfilename;
+    std::string lats_rspecifier, one_best_rspecifier,
+                times_rspecifier, ctm_wxfilename;
 
     if (po.NumArgs() == 2) {
       lats_rspecifier = po.GetArg(1);
@@ -91,7 +92,13 @@ int main(int argc, char *argv[]) {
       lats_rspecifier = po.GetArg(1);
       one_best_rspecifier = po.GetArg(2);
       ctm_wxfilename = po.GetArg(3);
+    } else if (po.NumArgs() == 4) {
+      lats_rspecifier = po.GetArg(1);
+      one_best_rspecifier = po.GetArg(2);
+      times_rspecifier = po.GetArg(3);
+      ctm_wxfilename = po.GetArg(4);
     }
+
 
     // Ensure the output ctm file is not a wspecifier
     WspecifierType ctm_wx_type;
@@ -106,6 +113,7 @@ int main(int argc, char *argv[]) {
     SequentialCompactLatticeReader clat_reader(lats_rspecifier);
 
     RandomAccessInt32VectorReader one_best_reader(one_best_rspecifier);
+    RandomAccessBaseFloatPairVectorReader times_reader(times_rspecifier);
 
     Output ko(ctm_wxfilename, false); // false == non-binary writing mode.
     ko.Stream() << std::fixed;  // Set to "fixed" floating point model, where precision() specifies
@@ -124,14 +132,27 @@ int main(int argc, char *argv[]) {
       MinimumBayesRisk *mbr = NULL;
 
       if (one_best_rspecifier == "") {
-        mbr = new MinimumBayesRisk(clat, decode_mbr);
+        mbr = new MinimumBayesRisk(clat, mbr_opts);
       } else {
+        // check,
         if (!one_best_reader.HasKey(key)) {
           KALDI_WARN << "No 1-best present for utterance " << key;
           continue;
         }
-        const std::vector<int32> &one_best = one_best_reader.Value(key);
-        mbr = new MinimumBayesRisk(clat, one_best, decode_mbr);
+        if (times_rspecifier != "" && !times_reader.HasKey(key)) {
+          KALDI_WARN << "No 'times' present for utterance " << key;
+          continue;
+        }
+        // get the 'mbr' decoding object,
+        if (times_rspecifier == "") {
+          const std::vector<int32> &one_best = one_best_reader.Value(key);
+          mbr = new MinimumBayesRisk(clat, one_best, mbr_opts); // no 'times',
+        } else {
+          // with initial 'times' of the bins,
+          const std::vector<int32> &one_best = one_best_reader.Value(key);
+          const std::vector<std::pair<BaseFloat,BaseFloat> > &times = times_reader.Value(key);
+          mbr = new MinimumBayesRisk(clat, one_best, times, mbr_opts);
+        }
       }
 
       const std::vector<BaseFloat> &conf = mbr->GetOneBestConfidences();
@@ -140,7 +161,7 @@ int main(int argc, char *argv[]) {
           mbr->GetOneBestTimes();
       KALDI_ASSERT(conf.size() == words.size() && words.size() == times.size());
       for (size_t i = 0; i < words.size(); i++) {
-        KALDI_ASSERT(words[i] != 0); // Should not have epsilons.
+        KALDI_ASSERT(words[i] != 0 || mbr_opts.print_silence); // Should not have epsilons.
         ko.Stream() << key << " 1 " << (frame_shift * times[i].first) << ' '
                     << (frame_shift * (times[i].second-times[i].first)) << ' '
                     << words[i] << ' ' << conf[i] << '\n';


### PR DESCRIPTION
Hi, during the MGB evals I have updated the way how confidecnes are computed inside 'lattice-to-ctm-conf'. The idea is to be able to score the 'reference transcripts', to calculate its confidence by using a lattice 'unioned' with the aligned transcripts. To make it work, we need to properly initialize the 'sausage bins' both with the word-sequence as well as begin/end times of bins...

Could you please look at the code? I also added a class `MinimumBayesRiskOptions` and added the support to print the CTM even with the epsiolon bins, some of them have zero duration... But other <eps> bins will have non-zero duration and a low confidence here will indicate that there's a word missing from 'reference transcript' ...

Best, Karel.