### PR TITLE
[src] Fix compiler warnings and work around bug on Windows

### DIFF
--- a/src/feat/wave-reader.cc
+++ b/src/feat/wave-reader.cc
@@ -19,6 +19,7 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cstdio>
 #include <limits>
 #include <sstream>

--- a/src/fstext/context-fst.h
+++ b/src/fstext/context-fst.h
@@ -309,9 +309,9 @@ class ArcIterator< ContextFst<A> >
   }
 };
 
-template <class A, class I> inline
-void ContextFst<A, I>::InitStateIterator(StateIteratorData<A> *data) const {
-  data->base = new StateIterator< ContextFst<A> >(*this);
+template <class Arc, class I> inline
+void ContextFst<Arc, I>::InitStateIterator(StateIteratorData<Arc> *data) const {
+  data->base = new StateIterator< ContextFst<Arc> >(*this);
 }
 
 

--- a/src/util/text-utils.cc
+++ b/src/util/text-utils.cc
@@ -178,7 +178,7 @@ class NumberIstream{
   std::istream &in_;
 
   bool RemainderIsOnlySpaces() {
-    if (in_.tellg() != -1) {
+    if (in_.tellg() != std::istream::pos_type(-1)) {
       std::string rem;
       in_ >> rem;
 


### PR DESCRIPTION
 * Add missing header in wave-reader.cc
 * Construct ios::pos_type out of constant -1 in text-utils.cc
 * Work around template name capture bug in MS compiler
