### PR TITLE
RNNLM data-preparation (#1707)

### DIFF
--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -49,8 +49,16 @@ rnnlm/get_unigram_probs.py --vocab-file=$data_dir/vocab/words.txt \
                            $data_dir/data > $dir/unigram_probs.txt
 
 # choose features
-rnnlm/choose_features.py $data_dir/vocab/words.txt \
-      --unigram-probs=$dir/unigram_probs.txt > $dir/features.txt
-
+rnnlm/choose_features.py --unigram-probs=$dir/unigram_probs.txt \
+                         $data_dir/vocab/words.txt > $dir/features.txt
 # validate features
 rnnlm/validate_features.py $dir/features.txt
+
+# make features for word
+rnnlm/make_word_features.py --unigram-probs=$dir/unigram_probs.txt \
+                         $data_dir/vocab/words.txt $dir/features.txt \
+                         > $dir/word_feats.txt
+
+# validate word features
+rnnlm/validate_word_features.py --features-file $dir/features.txt \
+                                $dir/word_feats.txt

--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -47,3 +47,7 @@ EOF
 rnnlm/get_unigram_probs.py --vocab-file=$data_dir/vocab/words.txt \
                            --data-weights-file=$dir/data_weights.txt \
                            $data_dir/data > $dir/unigram_probs.txt
+
+# choose features
+rnnlm/choose_features.py $data_dir/vocab/words.txt \
+      --unigram-probs=$dir/unigram_probs.txt > $dir/features.txt

--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# To be run from the egs/ directory.
+
+. path.sh
+
+set -e -o pipefail -u
+
+export LC_ALL=C
+export PYTHONIOENCODING='utf-8'
+
+# it should contain things like
+# foo.txt, bar.txt, and dev.txt (dev.txt is a special filename that's
+# obligatory).
+dir=data/rnnlm/
+
+# validata data dir
+rnnlm/validate_data_dir.py $dir/data/
+
+# get unigram counts
+rnnlm/get_unigram_counts.sh $dir/data/
+
+# get vocab
+rnnlm/get_vocab.py $dir/data > $dir/vocab/words.txt
+
+# Choose weighting and multiplicity of data.
+# The following choices would mean that data-source 'foo'
+# is repeated once per epoch and has a weight of 0.5 in the
+# objective function when training, and data-source 'bar' is repeated twice
+# per epoch and has a data -weight of 1.5.
+# There is no contraint that the average of the data weights equal one.
+# Note: if a data-source has zero multiplicity, it just means you are ignoring
+# it; but you must include all data-sources.
+#cat > exp/foo/data_weights.txt <<EOF
+#foo 1   0.5
+#bar 2   1.5
+#baz 0   0.0
+#EOF
+mkdir -p exp/rnnlm/
+cat > exp/rnnlm/data_weights.txt <<EOF
+ted 1   1.0
+EOF

--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -12,16 +12,19 @@ export PYTHONIOENCODING='utf-8'
 # it should contain things like
 # foo.txt, bar.txt, and dev.txt (dev.txt is a special filename that's
 # obligatory).
-dir=data/rnnlm/
+data_dir=data/rnnlm
+dir=exp/rnnlm/
+mkdir -p $dir
 
 # validata data dir
-rnnlm/validate_data_dir.py $dir/data/
+rnnlm/validate_data_dir.py $data_dir/data/
 
 # get unigram counts
-rnnlm/get_unigram_counts.sh $dir/data/
+rnnlm/get_unigram_counts.sh $data_dir/data/
 
 # get vocab
-rnnlm/get_vocab.py $dir/data > $dir/vocab/words.txt
+mkdir -p $data_dir/vocab
+rnnlm/get_vocab.py $data_dir/data > $data_dir/vocab/words.txt
 
 # Choose weighting and multiplicity of data.
 # The following choices would mean that data-source 'foo'
@@ -36,7 +39,11 @@ rnnlm/get_vocab.py $dir/data > $dir/vocab/words.txt
 #bar 2   1.5
 #baz 0   0.0
 #EOF
-mkdir -p exp/rnnlm/
-cat > exp/rnnlm/data_weights.txt <<EOF
+cat > $dir/data_weights.txt <<EOF
 ted 1   1.0
 EOF
+
+# get unigram probs
+rnnlm/get_unigram_probs.py --vocab-file=$data_dir/vocab/words.txt \
+                           --data-weights-file=$dir/data_weights.txt \
+                           $data_dir/data > $dir/unigram_probs.txt

--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -51,3 +51,6 @@ rnnlm/get_unigram_probs.py --vocab-file=$data_dir/vocab/words.txt \
 # choose features
 rnnlm/choose_features.py $data_dir/vocab/words.txt \
       --unigram-probs=$dir/unigram_probs.txt > $dir/features.txt
+
+# validate features
+rnnlm/validate_features.py $dir/features.txt

--- a/egs/tedlium/s5_r2/rnnlm
+++ b/egs/tedlium/s5_r2/rnnlm
@@ -1,0 +1,1 @@
+../../../scripts/rnnlm/

--- a/scripts/rnnlm/choose_features.py
+++ b/scripts/rnnlm/choose_features.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+import math
+
+
+parser = argparse.ArgumentParser(description="This script chooses the sparse feature representation of words. "
+                                             "To be more specific, it chooses the set of features-- you compute "
+                                             "them for the specific words by calling rnnlm/make_word_features.py.",
+                                 epilog="E.g. " + sys.argv[0] + " --unigram-probs=exp/rnnlm/unigram_probs.txt "
+                                        "data/rnnlm/vocab/words.txt > exp/rnnlm/features.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--unigram-probs", type=str, default='', required=True,
+                    help="Specify the file containing unigram probs.")
+parser.add_argument("--min-ngram-order", type=int, default=1,
+                    help="minimum length of n-grams of characters to"
+                         "make potential features.")
+parser.add_argument("--max-ngram-order", type=int, default=3,
+                    help="maximum length of n-grams of characters to"
+                         "make potential features.")
+parser.add_argument("--min-frequency", type=float, default=1.0e-06,
+                    help="minimum frequency with which an n-gram character "
+                         "feature is encountered (counted as binary presence in a word times unigram "
+                         "probs of words), for it to be used as a feature. e.g. "
+                         "if less than 1.0e-06 of tokens contain the n-gram 'xyz', "
+                         "then it wouldn't be used as a feature.")
+parser.add_argument("--include-unigram-feature", type=str, default='true',
+                    choices=['true', 'false'],
+                    help="If true, the unigram frequency of a word is "
+                         "one of the features.  [note: one reason we "
+                         "want to include this, is to make it easier to "
+                         "port models to new vocabularies and domains].")
+parser.add_argument("--include-length-feature", type=str, default='true',
+                    choices=['true', 'false'],
+                    help="If true, the length in characters of a word is one of the features.")
+parser.add_argument("--top-word-features", type=int, default=2000,
+                    help="The most frequent n words each get their own "
+                         "special feature, in addition to any other features "
+                         "that the word may naturally get.")
+parser.add_argument("--special-words", type=str, default='<s>,</s>,<brk>',
+                    help="List of special words that get their own special "
+                        "features and do not get any other features.")
+
+parser.add_argument("vocab_file",
+                    help="Path for vocab file")
+
+args = parser.parse_args()
+
+if args.min_ngram_order < 1:
+    sys.exit(sys.argv[0] + ": --min-ngram-order must be at least 1.")
+if args.max_ngram_order < args.min_ngram_order:
+    sys.exit(sys.argv[0] + ": --max-ngram-order must be larger than or equal to --min-ngram-order.")
+
+SPECIAL_SYMBOLS = ["<eps>", "<s>", "<brk>"]
+
+# read the voab
+def ReadVocab(vocab_file):
+    vocab = {}
+    with open(vocab_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2
+            if fields[0] in vocab:
+                sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
+                                       .format(fields[0], vocab_file))
+            vocab[fields[0]] = int(fields[1])
+
+    # check there is no duplication and no gap among word ids
+    sorted_ids = sorted(vocab.values())
+    assert len(sorted_ids) == len(vocab)
+    for idx, id in enumerate(sorted_ids):
+        assert idx == id
+
+    return vocab
+
+# read the unigram probs
+def ReadUnigramProbs(unigram_probs_file):
+    unigram_probs = []
+    with open(unigram_probs_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2
+            idx = int(fields[0])
+            if idx >= len(unigram_probs):
+                unigram_probs.extend([None] * (idx - len(unigram_probs) + 1))
+            unigram_probs[idx] = float(fields[1])
+
+    for prob in unigram_probs:
+        assert not prob is None
+
+    return unigram_probs
+
+vocab = ReadVocab(args.vocab_file)
+wordlist = [ x[0] for x in sorted(vocab.items(), key=lambda x:x[1]) ]
+unigram_probs = ReadUnigramProbs(args.unigram_probs)
+assert len(unigram_probs) == len(wordlist)
+
+vocab_size = len(vocab) - len(SPECIAL_SYMBOLS)
+
+num_features = 0
+
+# special words features
+if args.special_words != '':
+    for word in args.special_words.split(','):
+        print("{0}\tspecial\t{1}".format(num_features, word))
+        num_features += 1
+
+# unigram features
+if args.include_unigram_feature == 'true':
+    entropy = 0.0
+    for idx, p in enumerate(unigram_probs):
+        if wordlist[idx] in SPECIAL_SYMBOLS:
+            continue
+        entropy += math.log(p)
+    entropy /= -vocab_size
+
+    print("{0}\tunigram\t{1}".format(num_features, entropy))
+    num_features += 1
+
+# length features
+if args.include_length_feature == 'true':
+    print("{0}\tlength".format(num_features))
+    num_features += 1
+
+# top words features
+top_words = {}
+if args.top_word_features > 0:
+    sorted_words = sorted(zip(wordlist, unigram_probs), key=lambda x:x[1], reverse=True)
+    num_words = 0
+    for word, _ in sorted_words:
+        if word in SPECIAL_SYMBOLS + ["</s>"]:
+            continue
+
+        print("{0}\tword\t{1}".format(num_features, word))
+        num_features += 1
+
+        top_words[word] = 1
+        num_words += 1
+        if num_words > args.top_word_features:
+            break
+
+# n-gram features
+initial_feats = {}
+final_feats = {}
+match_feats = {}
+word_feats = {}
+for word in wordlist:
+    if word in SPECIAL_SYMBOLS + ["</s>"]:
+        continue
+
+    word_freq = unigram_probs[vocab[word]]
+    for pos in range(len(word) + 1): # +1 for EOW
+        for order in range(args.min_ngram_order, args.max_ngram_order + 1):
+            start = pos - order + 1
+            end = pos + 1
+
+            if start < -1:
+                continue
+
+            if start < 0 and end > len(word):
+                feats = word_feats
+                start = 0
+                end = len(word)
+            elif start < 0:
+                feats = initial_feats
+                start = 0
+            elif end > len(word):
+                feats = final_feats
+                end = len(word)
+            else:
+                feats = match_feats
+            if start >= end:
+                continue
+
+            feat = word[start:end]
+            if feat in feats:
+                feats[feat] += word_freq
+            else:
+                feats[feat] = word_freq
+
+for feat, freq in initial_feats.items():
+    if freq < args.min_frequency:
+        continue
+    print("{0}\tinitial\t{1}".format(num_features, feat))
+    num_features += 1
+
+for feat, freq in final_feats.items():
+    if freq < args.min_frequency:
+        continue
+    print("{0}\tfinal\t{1}".format(num_features, feat))
+    num_features += 1
+
+for feat, freq in match_feats.items():
+    if freq < args.min_frequency:
+        continue
+    print("{0}\tmatch\t{1}".format(num_features, feat))
+    num_features += 1
+
+for feat, freq in word_feats.items():
+    if freq < args.min_frequency or feat in top_words:
+        continue
+    print("{0}\tword\t{1}".format(num_features, feat))
+    num_features += 1
+
+print(sys.argv[0] + ": chosen {0} features.".format(num_features), file=sys.stderr)

--- a/scripts/rnnlm/choose_features.py
+++ b/scripts/rnnlm/choose_features.py
@@ -42,7 +42,7 @@ parser.add_argument("--top-word-features", type=int, default=2000,
                          "that the word may naturally get.")
 parser.add_argument("--special-words", type=str, default='<s>,</s>,<brk>',
                     help="List of special words that get their own special "
-                        "features and do not get any other features.")
+                         "features and do not get any other features.")
 
 parser.add_argument("vocab_file",
                     help="Path for vocab file")
@@ -56,8 +56,9 @@ if args.max_ngram_order < args.min_ngram_order:
 
 SPECIAL_SYMBOLS = ["<eps>", "<s>", "<brk>"]
 
+
 # read the voab
-def ReadVocab(vocab_file):
+def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -76,8 +77,9 @@ def ReadVocab(vocab_file):
 
     return vocab
 
+
 # read the unigram probs
-def ReadUnigramProbs(unigram_probs_file):
+def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
     with open(unigram_probs_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -89,13 +91,13 @@ def ReadUnigramProbs(unigram_probs_file):
             unigram_probs[idx] = float(fields[1])
 
     for prob in unigram_probs:
-        assert not prob is None
+        assert prob is not None
 
     return unigram_probs
 
-vocab = ReadVocab(args.vocab_file)
-wordlist = [ x[0] for x in sorted(vocab.items(), key=lambda x:x[1]) ]
-unigram_probs = ReadUnigramProbs(args.unigram_probs)
+vocab = read_vocab(args.vocab_file)
+wordlist = [x[0] for x in sorted(vocab.items(), key=lambda x:x[1])]
+unigram_probs = read_unigram_probs(args.unigram_probs)
 assert len(unigram_probs) == len(wordlist)
 
 vocab_size = len(vocab) - len(SPECIAL_SYMBOLS)
@@ -128,7 +130,7 @@ if args.include_length_feature == 'true':
 # top words features
 top_words = {}
 if args.top_word_features > 0:
-    sorted_words = sorted(zip(wordlist, unigram_probs), key=lambda x:x[1], reverse=True)
+    sorted_words = sorted(zip(wordlist, unigram_probs), key=lambda x: x[1], reverse=True)
     num_words = 0
     for word, _ in sorted_words:
         if word in SPECIAL_SYMBOLS + ["</s>"]:
@@ -152,7 +154,7 @@ for word in wordlist:
         continue
 
     word_freq = unigram_probs[vocab[word]]
-    for pos in range(len(word) + 1): # +1 for EOW
+    for pos in range(len(word) + 1):  # +1 for EOW
         for order in range(args.min_ngram_order, args.max_ngram_order + 1):
             start = pos - order + 1
             end = pos + 1

--- a/scripts/rnnlm/get_unigram_counts.sh
+++ b/scripts/rnnlm/get_unigram_counts.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# The script creates text files containing the unigram counts of words.
+# things like dev.counts, foo.counts, bar.counts,
+# with lines like:
+# hello  12341
+
+if [ $# != 1 ]; then
+  echo "Usage: rnnlm/get_unigram_counts.sh <data-dir>"
+  echo "e.g.: rnnlm/get_unigram_counts.sh data/rnnlm/data"
+  echo "This script gets unigram counts of words from data sources, "
+  echo "and writes them out in xx.counts files"
+  exit 1
+fi
+
+data=$1
+[ ! -d $data ] && echo "$0: no such directory $data" && exit 1;
+
+set -e -o pipefail -u
+
+export LC_ALL=C
+
+for f in `ls $data/*.txt`; do
+  cat $f | sed 's!</S>!</s>!g' | \
+      awk '{for(i = 1; i <= NF; i++) {print $i;} print "</s>"}' | sort | uniq -c | \
+      awk '{print $2,$1}' > ${f%.*}.counts
+done
+
+echo "get_unigram_counts.sh: get counts in $data/*.counts"

--- a/scripts/rnnlm/get_unigram_probs.py
+++ b/scripts/rnnlm/get_unigram_probs.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="This script gets the unigram probabilities of words.",
+                                 epilog="E.g. " + sys.argv[0] + " --vocab-file=data/rnnlm/vocab/words.txt "
+                                         "--data-weights-file=exp/rnnlm/data_weights.txt data/rnnlm/data "
+                                         "> exp/rnnlm/unigram_probs.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--vocab-file", type=str, default='', required=True,
+                    help="Specify the vocab file.")
+parser.add_argument("--data-weights-file", type=str, default='', required=True,
+                    help="Specify the data-weights file.")
+parser.add_argument("--smooth-unigram-counts", type=float, default=1.0,
+                    help="Specify the constant for smoothing. We will add "
+                         "(smooth_unigram_counts * num_words_with_non_zero_counts / vocab_size) "
+                         "to every unigram counts.")
+parser.add_argument("data_dir",
+                    help="Directory in which to look for data")
+
+args = parser.parse_args()
+
+SPECIAL_SYMBOLS = ["<eps>", "<s>", "<brk>"]
+
+# get the name with txt and counts file path for all data sorces
+def GetAllDataSources(data_dir):
+    data_sources = {}
+    for f in os.listdir(data_dir):
+        full_path = data_dir + "/" + f
+        if f == 'dev.txt' or f == 'dev.counts' or os.path.isdir(full_path):
+            continue
+        if f.endswith(".txt"):
+            name = f[0:-4]
+            if name in data_sources:
+                data_sources[name] = (full_path, data_sources[name][1])
+            else:
+                data_sources[name] = (full_path, None)
+        elif f.endswith(".counts"):
+            name = f[0:-7]
+            if name in data_sources:
+                data_sources[name] = (data_sources[name][0], full_path)
+            else:
+                data_sources[name] = (None, full_path)
+        else:
+            sys.exit(sys.argv[0] + ": Text directory should not contain files with suffixes "
+                     "other than .txt or .counts: " + f)
+
+    for name, (txt_file, counts_file) in data_sources.items():
+        if txt_file is None or counts_file is None:
+            sys.exit(sys.argv[0] + ": Missing .txt or .counts file for data source: " + name)
+
+    return data_sources
+
+# read the data-weights for data sorces
+def ReadDataWeights(weights_file, data_sources):
+    data_weights = {}
+    with open(weights_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 3
+            if fields[0] in data_weights:
+                sys.exit(sys.argv[0] + ": duplicated data source({0}) specified in "
+                                       "data-weights: {1}".format(fields[0], weights_file))
+            data_weights[fields[0]] = (int(fields[1]), float(fields[2]))
+
+    for name in data_sources.keys():
+        if not name in data_weights:
+            sys.exit(sys.argv[0] + ": Weight for data source '{0}' not set".format(name))
+
+    return data_weights
+
+# read the voab
+def ReadVocab(vocab_file):
+    vocab = {}
+    with open(vocab_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2
+            if fields[0] in vocab:
+                sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
+                                       .format(fields[0], vocab_file))
+            vocab[fields[0]] = int(fields[1])
+
+    # check there is no duplication and no gap among word ids
+    sorted_ids = sorted(vocab.values())
+    assert len(sorted_ids) == len(vocab)
+    for idx, id in enumerate(sorted_ids):
+        assert idx == id
+
+    return vocab
+
+# Get total (weighted) count for words from all data_sources
+def GetCounts(data_sources, data_weights, vocab):
+    counts = [0.0] * len(vocab)
+
+    for name, (_, counts_file) in data_sources.items():
+        weight = data_weights[name][0] * data_weights[name][1]
+        if weight == 0.0:
+            continue
+
+        with open(counts_file, 'r', encoding="utf-8") as f:
+            for line in f:
+                fields = line.split()
+                assert len(fields) == 2
+
+                counts[vocab[fields[0]]] += weight * int(fields[1])
+
+    return counts
+
+# Smooth counts and get unigram probs for words
+def GetUnigramProb(vocab, counts, smooth_constant):
+    special_symbol_ids = [vocab[x] for x in SPECIAL_SYMBOLS]
+    vocab_size = len(vocab) - len(SPECIAL_SYMBOLS)
+    num_words_with_non_zero_counts = 0
+    for word_id, count in enumerate(counts):
+        if word_id in special_symbol_ids :
+            continue
+        if counts[word_id] > 0:
+            num_words_with_non_zero_counts += 1
+
+    if num_words_with_non_zero_counts < vocab_size and smooth_constant == 0.0:
+        sys.exit(sys.argv[0] + ": --smooth-unigram-counts should not be zero, "
+                               "since there are words with zero-counts")
+
+    smooth_count = smooth_constant * num_words_with_non_zero_counts / vocab_size
+
+    total_counts = 0.0
+    for word_id, count in enumerate(counts):
+        if word_id in special_symbol_ids:
+            continue
+        counts[word_id] += smooth_count
+        total_counts += counts[word_id]
+
+    probs = []
+    for count in counts:
+        probs.append(count / total_counts)
+
+    return probs
+
+
+data_sources = GetAllDataSources(args.data_dir)
+data_weights = ReadDataWeights(args.data_weights_file, data_sources)
+vocab = ReadVocab(args.vocab_file)
+
+counts = GetCounts(data_sources, data_weights, vocab)
+probs = GetUnigramProb(vocab, counts, args.smooth_unigram_counts)
+
+for idx, p in enumerate(probs):
+    print(idx, p)
+
+print(sys.argv[0] + ": generated unigram probs.", file=sys.stderr)

--- a/scripts/rnnlm/get_unigram_probs.py
+++ b/scripts/rnnlm/get_unigram_probs.py
@@ -6,8 +6,8 @@ import sys
 
 parser = argparse.ArgumentParser(description="This script gets the unigram probabilities of words.",
                                  epilog="E.g. " + sys.argv[0] + " --vocab-file=data/rnnlm/vocab/words.txt "
-                                         "--data-weights-file=exp/rnnlm/data_weights.txt data/rnnlm/data "
-                                         "> exp/rnnlm/unigram_probs.txt",
+                                        "--data-weights-file=exp/rnnlm/data_weights.txt data/rnnlm/data "
+                                        "> exp/rnnlm/unigram_probs.txt",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 parser.add_argument("--vocab-file", type=str, default='', required=True,
@@ -25,8 +25,9 @@ args = parser.parse_args()
 
 SPECIAL_SYMBOLS = ["<eps>", "<s>", "<brk>"]
 
+
 # get the name with txt and counts file path for all data sorces
-def GetAllDataSources(data_dir):
+def get_all_data_sources(data_dir):
     data_sources = {}
     for f in os.listdir(data_dir):
         full_path = data_dir + "/" + f
@@ -54,8 +55,9 @@ def GetAllDataSources(data_dir):
 
     return data_sources
 
+
 # read the data-weights for data sorces
-def ReadDataWeights(weights_file, data_sources):
+def read_data_weights(weights_file, data_sources):
     data_weights = {}
     with open(weights_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -67,13 +69,14 @@ def ReadDataWeights(weights_file, data_sources):
             data_weights[fields[0]] = (int(fields[1]), float(fields[2]))
 
     for name in data_sources.keys():
-        if not name in data_weights:
+        if name not in data_weights:
             sys.exit(sys.argv[0] + ": Weight for data source '{0}' not set".format(name))
 
     return data_weights
 
+
 # read the voab
-def ReadVocab(vocab_file):
+def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -92,8 +95,9 @@ def ReadVocab(vocab_file):
 
     return vocab
 
+
 # Get total (weighted) count for words from all data_sources
-def GetCounts(data_sources, data_weights, vocab):
+def get_counts(data_sources, data_weights, vocab):
     counts = [0.0] * len(vocab)
 
     for name, (_, counts_file) in data_sources.items():
@@ -110,13 +114,14 @@ def GetCounts(data_sources, data_weights, vocab):
 
     return counts
 
+
 # Smooth counts and get unigram probs for words
-def GetUnigramProb(vocab, counts, smooth_constant):
+def get_unigram_probs(vocab, counts, smooth_constant):
     special_symbol_ids = [vocab[x] for x in SPECIAL_SYMBOLS]
     vocab_size = len(vocab) - len(SPECIAL_SYMBOLS)
     num_words_with_non_zero_counts = 0
     for word_id, count in enumerate(counts):
-        if word_id in special_symbol_ids :
+        if word_id in special_symbol_ids:
             continue
         if counts[word_id] > 0:
             num_words_with_non_zero_counts += 1
@@ -141,12 +146,12 @@ def GetUnigramProb(vocab, counts, smooth_constant):
     return probs
 
 
-data_sources = GetAllDataSources(args.data_dir)
-data_weights = ReadDataWeights(args.data_weights_file, data_sources)
-vocab = ReadVocab(args.vocab_file)
+data_sources = get_all_data_sources(args.data_dir)
+data_weights = read_data_weights(args.data_weights_file, data_sources)
+vocab = read_vocab(args.vocab_file)
 
-counts = GetCounts(data_sources, data_weights, vocab)
-probs = GetUnigramProb(vocab, counts, args.smooth_unigram_counts)
+counts = get_counts(data_sources, data_weights, vocab)
+probs = get_unigram_probs(vocab, counts, args.smooth_unigram_counts)
 
 for idx, p in enumerate(probs):
     print(idx, p)

--- a/scripts/rnnlm/get_vocab.py
+++ b/scripts/rnnlm/get_vocab.py
@@ -17,7 +17,8 @@ args = parser.parse_args()
 eos_symbol = '</s>'
 special_symbols = ['<s>', '<brk>', '<eps>']
 
-def AddCounts(word_counts, text_file):
+
+def add_counts(word_counts, text_file):
     with open(text_file, 'r', encoding="utf-8") as f:
         for line in f:
             line = line.strip()
@@ -35,7 +36,7 @@ for f in os.listdir(args.data_dir):
     if os.path.isdir(full_path):
         continue
     if f.endswith(".counts"):
-        AddCounts(word_counts, full_path)
+        add_counts(word_counts, full_path)
 
 if len(word_counts) == 0:
     sys.exit(sys.argv[0] + ": Directory {0} should contain at least one .counts file "

--- a/scripts/rnnlm/get_vocab.py
+++ b/scripts/rnnlm/get_vocab.py
@@ -37,6 +37,10 @@ for f in os.listdir(args.data_dir):
     if f.endswith(".counts"):
         AddCounts(word_counts, full_path)
 
+if len(word_counts) == 0:
+    sys.exit(sys.argv[0] + ": Directory {0} should contain at least one .counts file "
+             .format(args.data_dir))
+
 print("<eps> 0")
 print("<s> 1")
 print("</s> 2")
@@ -48,3 +52,5 @@ for word, _ in sorted(word_counts.items(), key=lambda x: x[1], reverse=True):
         continue
     print("{0} {1}".format(word, idx))
     idx += 1
+
+print(sys.argv[0] + ": vocab is generated with {0} words.".format(idx), file=sys.stderr)

--- a/scripts/rnnlm/get_vocab.py
+++ b/scripts/rnnlm/get_vocab.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="This script get a vocab from unigram counts "
+                                 "of words produced by get_unigram_counts.sh",
+                                 epilog="E.g. " + sys.argv[0] + " data/rnnlm/data > data/rnnlm/vocab/words.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("data_dir",
+                    help="Directory in which to look for unigram counts.")
+
+args = parser.parse_args()
+
+eos_symbol = '</s>'
+special_symbols = ['<s>', '<brk>', '<eps>']
+
+def AddCounts(word_counts, text_file):
+    with open(text_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            word_and_count = line.split()
+            assert len(word_and_count) == 2
+            if word_and_count[0] in word_counts:
+                word_counts[word_and_count[0]] += int(word_and_count[1])
+            else:
+                word_counts[word_and_count[0]] = int(word_and_count[1])
+
+word_counts = {}
+
+for f in os.listdir(args.data_dir):
+    full_path = args.data_dir + "/" + f
+    if os.path.isdir(full_path):
+        continue
+    if f.endswith(".counts"):
+        AddCounts(word_counts, full_path)
+
+print("<eps> 0")
+print("<s> 1")
+print("</s> 2")
+print("<brk> 3")
+
+idx = 4
+for word, _ in sorted(word_counts.items(), key=lambda x: x[1], reverse=True):
+    if word == "</s>":
+        continue
+    print("{0} {1}".format(word, idx))
+    idx += 1

--- a/scripts/rnnlm/make_word_features.py
+++ b/scripts/rnnlm/make_word_features.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+import math
+
+
+parser = argparse.ArgumentParser(description="This script turns the words into the sparse feature representation, "
+                                             "using features from rnnlm/make_word_features.py.",
+                                 epilog="E.g. " + sys.argv[0] + " --unigram-probs=exp/rnnlm/unigram_probs.txt "
+                                        "data/rnnlm/vocab/words.txt exp/rnnlm/features.txt "
+                                        "> exp/rnnlm/word_feats.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--unigram-probs", type=str, default='', required=True,
+                    help="Specify the file containing unigram probs.")
+
+parser.add_argument("vocab_file", help="Path for vocab file")
+parser.add_argument("features_file", help="Path for features file")
+
+args = parser.parse_args()
+
+# read the voab
+def ReadVocab(vocab_file):
+    vocab = {}
+    with open(vocab_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2
+            if fields[0] in vocab:
+                sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
+                                       .format(fields[0], vocab_file))
+            vocab[fields[0]] = int(fields[1])
+
+    # check there is no duplication and no gap among word ids
+    sorted_ids = sorted(vocab.values())
+    assert len(sorted_ids) == len(vocab)
+    for idx, id in enumerate(sorted_ids):
+        assert idx == id
+
+    return vocab
+
+# read the unigram probs
+def ReadUnigramProbs(unigram_probs_file):
+    unigram_probs = []
+    with open(unigram_probs_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2
+            idx = int(fields[0])
+            if idx >= len(unigram_probs):
+                unigram_probs.extend([None] * (idx - len(unigram_probs) + 1))
+            unigram_probs[idx] = float(fields[1])
+
+    for prob in unigram_probs:
+        assert not prob is None
+
+    return unigram_probs
+
+# read the features
+# output is a dict with key can be 'special', 'unigram', 'length' and 'ngram',
+#   feats['special'] is a dict whose key is special words and value is the feat_id
+#   feats['unigram'] is a tuple with (feat_id, log_ppl)
+#   feats['length']  is a int represents feat_id
+#   feats['ngram']   is a list of tuple with (feat_id, feat_type, ngram),
+#                    where feat_type can be 'match', 'initial', 'final' or 'word',
+#                    ngram is the substr used to compare
+def ReadFeatures(features_file):
+    feats = {}
+    feats['special'] = {}
+    feats['ngram'] = []
+
+    with open(features_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            fields = line.split()
+            assert len(fields) == 2 or len(fields) == 3
+
+            feat_id = int(fields[0])
+            feat_type = fields[1]
+            if feat_type == 'special':
+                feats['special'][fields[2]] = feat_id
+            elif feat_type == 'unigram':
+                feats['unigram'] = (feat_id, float(fields[2]))
+            elif feat_type == 'length':
+                feats['length'] = feat_id
+            elif feat_type in ['word', 'match', 'initial', 'final']:
+                feats['ngram'].append((feat_id, feat_type, fields[2]))
+            else:
+                sys.exit(sys.argv[0] + ": error feature type: {0}".format(feat_type))
+
+    return feats
+
+vocab = ReadVocab(args.vocab_file)
+unigram_probs = ReadUnigramProbs(args.unigram_probs)
+feats = ReadFeatures(args.features_file)
+
+for word, idx in sorted(vocab.items(), key=lambda x:x[1]):
+    print("{0}".format(idx), end="")
+
+    if idx == 0:
+        print("")
+        continue
+
+    prefix = "\t"
+    if word in feats['special']:
+        feat_id = feats['special'][word]
+        print(prefix + "{0} 1".format(feat_id), end="")
+        print("")
+        continue
+
+    if 'unigram' in feats:
+        feat_id = feats['unigram'][0]
+        log_ppl = feats['unigram'][1]
+        logp = math.log(unigram_probs[idx])
+        print(prefix + "{0} {1}".format(feat_id, logp / log_ppl + 1), end="")
+        prefix = " "
+
+    if 'length' in feats:
+        feat_id = feats['length']
+        print(prefix + "{0} {1}".format(feat_id, len(word)), end="")
+        prefix = " "
+
+    for ngram_feat in feats['ngram']:
+        feat_id = ngram_feat[0]
+        feat_type = ngram_feat[1]
+        ngram = ngram_feat[2]
+
+        active = False
+        if feat_type == "match":
+            if ngram in word:
+                active = True
+        elif feat_type == "initial":
+            if len(word) >= len(ngram) and word[:len(ngram)] == ngram:
+                active = True
+        elif feat_type == "final":
+            if len(word) >= len(ngram) and word[len(word)-len(ngram):] == ngram:
+                active = True
+        elif feat_type == "word":
+            if word == ngram:
+                active = True
+        else:
+            sys.exit(sys.argv[0] + ": error feature type: {0}".format(feat_type))
+
+        if active:
+            print(prefix + "{0} 1".format(feat_id), end="")
+            prefix = " "
+
+    print("")
+
+print(sys.argv[0] + ": make features for {0} words.".format(len(vocab)), file=sys.stderr)

--- a/scripts/rnnlm/make_word_features.py
+++ b/scripts/rnnlm/make_word_features.py
@@ -21,8 +21,9 @@ parser.add_argument("features_file", help="Path for features file")
 
 args = parser.parse_args()
 
+
 # read the voab
-def ReadVocab(vocab_file):
+def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -41,8 +42,9 @@ def ReadVocab(vocab_file):
 
     return vocab
 
+
 # read the unigram probs
-def ReadUnigramProbs(unigram_probs_file):
+def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
     with open(unigram_probs_file, 'r', encoding="utf-8") as f:
         for line in f:
@@ -54,9 +56,10 @@ def ReadUnigramProbs(unigram_probs_file):
             unigram_probs[idx] = float(fields[1])
 
     for prob in unigram_probs:
-        assert not prob is None
+        assert prob is not None
 
     return unigram_probs
+
 
 # read the features
 # output is a dict with key can be 'special', 'unigram', 'length' and 'ngram',
@@ -71,7 +74,7 @@ def ReadUnigramProbs(unigram_probs_file):
 #                    of ngram feature respectively.
 #   feats['min_ngram_order'] is a int represents min-ngram-order
 #   feats['max_ngram_order'] is a int represents max-ngram-order
-def ReadFeatures(features_file):
+def read_features(features_file):
     feats = {}
     feats['special'] = {}
     feats['match'] = {}
@@ -112,11 +115,11 @@ def ReadFeatures(features_file):
 
     return feats
 
-vocab = ReadVocab(args.vocab_file)
-unigram_probs = ReadUnigramProbs(args.unigram_probs)
-feats = ReadFeatures(args.features_file)
+vocab = read_vocab(args.vocab_file)
+unigram_probs = read_unigram_probs(args.unigram_probs)
+feats = read_features(args.features_file)
 
-for word, idx in sorted(vocab.items(), key=lambda x:x[1]):
+for word, idx in sorted(vocab.items(), key=lambda x: x[1]):
     print("{0}".format(idx), end="")
 
     if idx == 0:
@@ -147,7 +150,7 @@ for word, idx in sorted(vocab.items(), key=lambda x:x[1]):
         print(prefix + "{0} 1".format(feat_id), end="")
         prefix = " "
 
-    for pos in range(len(word) + 1): # +1 for EOW
+    for pos in range(len(word) + 1):  # +1 for EOW
         for order in range(feats['min_ngram_order'], feats['max_ngram_order'] + 1):
             start = pos - order + 1
             end = pos + 1

--- a/scripts/rnnlm/make_word_features.py
+++ b/scripts/rnnlm/make_word_features.py
@@ -98,7 +98,7 @@ def ReadFeatures(features_file):
                 ngram = fields[2]
                 feats[feat_type][ngram] = feat_id
                 if feat_type == 'word':
-                    order = len(ngram) + 2
+                    continue
                 elif feat_type in ['initial', 'final']:
                     order = len(ngram) + 1
                 else:
@@ -107,7 +107,6 @@ def ReadFeatures(features_file):
                     feats['max_ngram_order'] = order
                 if order < feats['min_ngram_order']:
                     feats['min_ngram_order'] = order
-                    feats['max_ngram_order'] = order
             else:
                 sys.exit(sys.argv[0] + ": error feature type: {0}".format(feat_type))
 

--- a/scripts/rnnlm/validate_data_dir.py
+++ b/scripts/rnnlm/validate_data_dir.py
@@ -33,7 +33,7 @@ if not os.path.exists("{0}/dev.txt".format(args.data_dir)):
 num_text_files = 0
 
 
-def CheckTextFile(text_file):
+def check_text_file(text_file):
     with open(text_file, 'r', encoding="utf-8") as f:
         found_nonempty_line = False
         lineno = 0
@@ -60,7 +60,7 @@ def CheckTextFile(text_file):
                              "at the end of a line is disallowed!)".format(line, text_file, lineno))
                 if len(words) >= 1000:
                     print(sys.argv[0] + ": Too long line with {0} words in file "
-                             "{1} at {2}".format(len(words), text_file, lineno), file=sys.stderr)
+                          "{1} at {2}".format(len(words), text_file, lineno), file=sys.stderr)
     if not found_nonempty_line:
         sys.exit(sys.argv[0] + ": Input file {0} doesn't look right.".format(text_file))
 
@@ -102,7 +102,7 @@ for f in os.listdir(args.data_dir):
                  "other than .txt: " + f)
     if not os.path.isfile(full_path):
         sys.exit(sys.argv[0] + ": Expected {0} to be a file.".format(full_path))
-    CheckTextFile(full_path)
+    check_text_file(full_path)
     num_text_files += 1
 
 if num_text_files < 2:

--- a/scripts/rnnlm/validate_data_dir.py
+++ b/scripts/rnnlm/validate_data_dir.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Validates data directory containing text "
+                                 "files from one or more data sources, including dev.txt.",
+                                 epilog="E.g. " + sys.argv[0] + " data/rnnlm/data",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--spot-check", type=str, default='true',
+                    choices=['true', 'false'],
+                    help="If true, only do spot check on text files.")
+parser.add_argument("--allow-internal-eos", type=str, default='true',
+                    choices=['true', 'false'],
+                    help="If true, allow internal </s> in lines of the text.")
+parser.add_argument("data_dir",
+                    help="Directory in which to look for text data")
+
+args = parser.parse_args()
+
+eos_symbol = '</s>'
+special_symbols = ['<s>', '<brk>', '<eps>']
+
+if not os.path.exists(args.data_dir):
+    sys.exit(sys.argv[0] + ": Expected directory {0} to exist".format(args.data_dir))
+
+if not os.path.exists("{0}/dev.txt".format(args.data_dir)):
+    sys.exit(sys.argv[0] + ": Expected file {0}/dev.txt to exist".format(args.data_dir))
+
+
+num_text_files = 0
+
+
+def CheckTextFile(text_file):
+    with open(text_file, 'r', encoding="utf-8") as f:
+        found_nonempty_line = False
+        lineno = 0
+        if args.allow_internal_eos == 'true':
+            disallowed_symbols = special_symbols
+        else:
+            disallowed_symbols = special_symbols + [eos_symbol]
+        for line in f:
+            line = line.strip("\n")
+            if line is None:
+                break
+            lineno += 1
+            if args.spot_check == 'true' and lineno > 10:
+                break
+            words = line.split()
+            if len(words) != 0:
+                found_nonempty_line = True
+                for word in words:
+                    if word.lower() in disallowed_symbols:
+                        sys.exit(sys.argv[0] + ": Found suspicious line '{0}' in file {1} at {2} ({3} "
+                                 " symbol is disallowed!)".format(line, text_file, lineno, word))
+                if words[-1].lower() == eos_symbol:
+                    sys.exit(sys.argv[0] + ": Found suspicious line '{0}' in file {1} at {2} (EOS symbol "
+                             "at the end of a line is disallowed!)".format(line, text_file, lineno))
+                if len(words) >= 1000:
+                    print(sys.argv[0] + ": Too long line with {0} words in file "
+                             "{1} at {2}".format(len(words), text_file, lineno), file=sys.stderr)
+    if not found_nonempty_line:
+        sys.exit(sys.argv[0] + ": Input file {0} doesn't look right.".format(text_file))
+
+    # Next we're going to check that it's not the case
+    # that the first and second fields have disjoint words on them, and the
+    # first field is always unique, which would be the case if the lines started
+    # with some kind of utterance-id
+    first_field_set = set()
+    other_fields_set = set()
+    with open(text_file, 'r', encoding="utf-8") as f:
+        for line in f:
+            array = line.split()
+            if len(array) > 0:
+                first_word = array[0]
+                if first_word in first_field_set or first_word in other_fields_set:
+                    # the first field isn't always unique, or is shared with other
+                    # fields.
+                    return
+                first_field_set.add(first_word)
+            for i in range(1, len(array)):
+                other_word = array[i]
+                if other_word in first_field_set:
+                    # the first field has a value shared by some word not in the
+                    # first position.
+                    return
+                other_fields_set.add(other_word)
+    print(sys.argv[0] + ": input file {0} looks suspicious; check that you "
+          "don't have utterance-ids in the first field (i.e. you shouldn't provide "
+          "lines that look like 'utterance-id1 hello there').  Ignore this warning "
+          "if you don't have that problem.".format(text_file), file=sys.stderr)
+
+
+for f in os.listdir(args.data_dir):
+    full_path = args.data_dir + "/" + f
+    if os.path.isdir(full_path):
+        continue
+    if not f.endswith(".txt"):
+        sys.exit(sys.argv[0] + ": Text directory should not contain files with suffixes "
+                 "other than .txt: " + f)
+    if not os.path.isfile(full_path):
+        sys.exit(sys.argv[0] + ": Expected {0} to be a file.".format(full_path))
+    CheckTextFile(full_path)
+    num_text_files += 1
+
+if num_text_files < 2:
+    sys.exit(sys.argv[0] + ": Directory {0} should contain at least one .txt file "
+             "other than dev.txt.".format(args.data_dir))

--- a/scripts/rnnlm/validate_data_dir.py
+++ b/scripts/rnnlm/validate_data_dir.py
@@ -20,8 +20,8 @@ parser.add_argument("data_dir",
 
 args = parser.parse_args()
 
-eos_symbol = '</s>'
-special_symbols = ['<s>', '<brk>', '<eps>']
+EOS_SYMBOL = '</s>'
+SPECIAL_SYMBOLS = ['<s>', '<brk>', '<eps>']
 
 if not os.path.exists(args.data_dir):
     sys.exit(sys.argv[0] + ": Expected directory {0} to exist".format(args.data_dir))
@@ -38,9 +38,9 @@ def CheckTextFile(text_file):
         found_nonempty_line = False
         lineno = 0
         if args.allow_internal_eos == 'true':
-            disallowed_symbols = special_symbols
+            disallowed_symbols = SPECIAL_SYMBOLS
         else:
-            disallowed_symbols = special_symbols + [eos_symbol]
+            disallowed_symbols = SPECIAL_SYMBOLS + [EOS_SYMBOL]
         for line in f:
             line = line.strip("\n")
             if line is None:
@@ -55,7 +55,7 @@ def CheckTextFile(text_file):
                     if word.lower() in disallowed_symbols:
                         sys.exit(sys.argv[0] + ": Found suspicious line '{0}' in file {1} at {2} ({3} "
                                  " symbol is disallowed!)".format(line, text_file, lineno, word))
-                if words[-1].lower() == eos_symbol:
+                if words[-1].lower() == EOS_SYMBOL:
                     sys.exit(sys.argv[0] + ": Found suspicious line '{0}' in file {1} at {2} (EOS symbol "
                              "at the end of a line is disallowed!)".format(line, text_file, lineno))
                 if len(words) >= 1000:

--- a/scripts/rnnlm/validate_features.py
+++ b/scripts/rnnlm/validate_features.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Validates features file, produced by rnnlm/choose_features.py.",
+                                 epilog="E.g. " + sys.argv[0] + " exp/rnnlm/features.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--special-words", type=str, default='<s>,</s>,<brk>',
+                    help="List of special words that get their own special "
+                        "features and do not get any other features.")
+parser.add_argument("features_file",
+                    help="File containing features")
+
+args = parser.parse_args()
+
+EOS_SYMBOL = '</s>'
+SPECIAL_SYMBOLS = ['<s>', '<brk>', '<eps>']
+
+if not os.path.isfile(args.features_file):
+    sys.exit(sys.argv[0] + ": Expected file {0} to exist".format(args.features_file))
+
+if args.special_words != '':
+    special_words = {}
+    for word in args.special_words.split(','):
+        special_words[word] = 1
+
+with open(args.features_file, 'r', encoding="utf-8") as f:
+    idx = 0
+    match_feats = {}
+    inital_feats = {}
+    final_feats = {}
+    word_feats = {}
+    for line in f:
+        fields = line.split()
+        assert len(fields) == 2 or len(fields) == 3
+
+        assert idx == int(fields[0])
+        idx += 1
+
+        if len(fields) == 2:
+            assert fields[1] == "length"
+        else:
+            if fields[1]  == "special":
+                if not fields[2] in special_words:
+                    sys.exit(sys.argv[0] + ": Not a special word: {0}".format(fields[2]))
+            elif fields[1] ==  "unigram":
+                if float(fields[2]) <= 0.0:
+                    sys.exit(sys.argv[0] + ": log-unigram-ppl should be a positive value: {0}".format(fields[2]))
+            elif fields[1] ==  "word":
+                if fields[2] in word_feats:
+                    sys.exit(sys.argv[0] + ": duplicated word feature: {0}".format(fields[2]))
+                word_feats[fields[2]] = 1
+            elif fields[1] ==  "initial":
+                if fields[2] in inital_feats:
+                    sys.exit(sys.argv[0] + ": duplicated initial feature: {0}".format(fields[2]))
+                inital_feats[fields[2]] = 1
+            elif fields[1] ==  "final":
+                if fields[2] in final_feats:
+                    sys.exit(sys.argv[0] + ": duplicated final feature: {0}".format(fields[2]))
+                final_feats[fields[2]] = 1
+            elif fields[1] ==  "match":
+                if fields[2] in match_feats:
+                    sys.exit(sys.argv[0] + ": duplicated match feature: {0}".format(fields[2]))
+                match_feats[fields[2]] = 1
+            else:
+                sys.exit(sys.argv[0] + ": Error line format: {0}".format(line))

--- a/scripts/rnnlm/validate_features.py
+++ b/scripts/rnnlm/validate_features.py
@@ -28,6 +28,8 @@ if args.special_words != '':
         special_words[word] = 1
 
 with open(args.features_file, 'r', encoding="utf-8") as f:
+    has_unigram = False
+    has_length = False
     idx = 0
     match_feats = {}
     inital_feats = {}
@@ -42,26 +44,32 @@ with open(args.features_file, 'r', encoding="utf-8") as f:
 
         if len(fields) == 2:
             assert fields[1] == "length"
+            if has_length:
+                sys.exit(sys.argv[0] + ": Too many 'length' features")
+            has_length = True
         else:
             if fields[1]  == "special":
                 if not fields[2] in special_words:
                     sys.exit(sys.argv[0] + ": Not a special word: {0}".format(fields[2]))
-            elif fields[1] ==  "unigram":
+            elif fields[1] == "unigram":
                 if float(fields[2]) <= 0.0:
                     sys.exit(sys.argv[0] + ": log-unigram-ppl should be a positive value: {0}".format(fields[2]))
-            elif fields[1] ==  "word":
+                if has_unigram:
+                    sys.exit(sys.argv[0] + ": Too many 'unigram' features")
+                has_unigram = True
+            elif fields[1] == "word":
                 if fields[2] in word_feats:
                     sys.exit(sys.argv[0] + ": duplicated word feature: {0}".format(fields[2]))
                 word_feats[fields[2]] = 1
-            elif fields[1] ==  "initial":
+            elif fields[1] == "initial":
                 if fields[2] in inital_feats:
                     sys.exit(sys.argv[0] + ": duplicated initial feature: {0}".format(fields[2]))
                 inital_feats[fields[2]] = 1
-            elif fields[1] ==  "final":
+            elif fields[1] == "final":
                 if fields[2] in final_feats:
                     sys.exit(sys.argv[0] + ": duplicated final feature: {0}".format(fields[2]))
                 final_feats[fields[2]] = 1
-            elif fields[1] ==  "match":
+            elif fields[1] == "match":
                 if fields[2] in match_feats:
                     sys.exit(sys.argv[0] + ": duplicated match feature: {0}".format(fields[2]))
                 match_feats[fields[2]] = 1

--- a/scripts/rnnlm/validate_features.py
+++ b/scripts/rnnlm/validate_features.py
@@ -10,7 +10,7 @@ parser = argparse.ArgumentParser(description="Validates features file, produced 
 
 parser.add_argument("--special-words", type=str, default='<s>,</s>,<brk>',
                     help="List of special words that get their own special "
-                        "features and do not get any other features.")
+                         "features and do not get any other features.")
 parser.add_argument("features_file",
                     help="File containing features")
 
@@ -48,7 +48,7 @@ with open(args.features_file, 'r', encoding="utf-8") as f:
                 sys.exit(sys.argv[0] + ": Too many 'length' features")
             has_length = True
         else:
-            if fields[1]  == "special":
+            if fields[1] == "special":
                 if not fields[2] in special_words:
                     sys.exit(sys.argv[0] + ": Not a special word: {0}".format(fields[2]))
             elif fields[1] == "unigram":

--- a/scripts/rnnlm/validate_word_features.py
+++ b/scripts/rnnlm/validate_word_features.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Validates word features file, produced by rnnlm/make_word_features.py.",
+                                 epilog="E.g. " + sys.argv[0] + " --features-file=exp/rnnlm/features.txt "
+                                        "exp/rnnlm/word_feats.txt",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--features-file", type=str, default='', required=True,
+                    help="File containing features")
+parser.add_argument("word_features_file", help="File containing word features")
+
+args = parser.parse_args()
+
+# we only need to know the feat_id for 'special', 'unigram' and 'length'
+special_feat_ids = []
+unigram_feat_id = -1
+length_feat_id = -1
+max_feat_id = -1
+with open(args.features_file, 'r', encoding="utf-8") as f:
+    for line in f:
+        fields = line.split()
+        assert len(fields) == 2 or len(fields) == 3
+
+        feat_id = int(fields[0])
+        if fields[1] == "special":
+            special_feat_ids.append(feat_id)
+        elif fields[1] == "unigram":
+            unigram_feat_id = feat_id
+        elif fields[1] == "length":
+            length_feat_id = feat_id
+
+        if feat_id > max_feat_id:
+            max_feat_id = feat_id
+
+with open(args.word_features_file, 'r', encoding="utf-8") as f:
+    for line in f:
+        fields = line.split()
+        assert len(fields) > 0 and len(fields) % 2 == 1
+        word_id = int(fields[0])
+
+        if len(fields) == 1:
+            if word_id != 0:
+                sys.exit(sys.argv[0] + ": Only <eps> can have no feature: {0}.".format(line))
+        i = 1
+        while i < len(fields):
+            feat_id = int(fields[i])
+            feat_value = fields[i + 1]
+            if feat_id in special_feat_ids:
+                if len(fields) != 3:
+                    sys.exit(sys.argv[0] + ": Special word can only have one feature: {0}.".format(line))
+                if int(feat_value) != 1:
+                    sys.exit(sys.argv[0] + ": Value of special word feature must be 1: {0}.".format(line))
+            elif feat_id == unigram_feat_id:
+                try:
+                    float(feat_value)
+                except ValueError:
+                    sys.exit(sys.argv[0] + ": Value of unigram feature should be a float number: {0}.".format(line))
+            elif feat_id == length_feat_id:
+                try:
+                    int(feat_value)
+                except ValueError:
+                    sys.exit(sys.argv[0] + ": Value of length feature should be a integer number: {0}.".format(line))
+            else:
+                if feat_id > max_feat_id:
+                    sys.exit(sys.argv[0] + ": Wrong feat_id: {0}.".format(line))
+                if int(feat_value) != 1:
+                    sys.exit(sys.argv[0] + ": Value of ngram feature must be 1: {0}.".format(line))
+            i += 2


### PR DESCRIPTION
This PR is for Issue #1707.

Testings are done with tedlium s5_r2 setup. Main script is ./local/rnnlm/prepare_rnnlm_data.sh.

Testing data is generated by following commands:
```
dir=data/rnnlm/data/
mkdir -p $dir
for s in dev train test; do
  cut -d ' ' -f 2- data/$s/text | tr 'a-z' 'A-Z' > $dir/$s.txt
done
cat $dir/train.txt $dir/test.txt > $dir/ted.txt
rm $dir/train.txt $dir/test.txt
```
And add some '\</s\>' and Chinese words are added to the first lines of dev.txt manually to test encoding.

There are two questions I still need to confirm:
1) Does the BOW and EOW need to be considered as a word when we computing the ngram-order? More specifically, when user set --max-ngram-order=3, do we produce 'final ing' or only 'final ng', current implementation is the latter one.

2) I use a naive way to loop over all the features with every words in make_word_features.py, this turns out to be slow. Do we need to do some advance trick to speedup it?
