### PR TITLE
[scripts] Quote '{' in perl regexp

### DIFF
--- a/egs/wsj/s5/steps/nnet3/get_saturation.pl
+++ b/egs/wsj/s5/steps/nnet3/get_saturation.pl
@@ -54,7 +54,7 @@ while (<STDIN>) {
     # An example of a line like this is right at the bottom of this program, it's extremely long.
     my $ok = 1;
     foreach my $sigmoid_name ( ("i_t", "f_t", "o_t") ) {
-      if (m/${sigmoid_name}_sigmoid={[^}]+deriv-avg=[^}]+mean=([^,]+),/) {
+      if (m/${sigmoid_name}_sigmoid=[{][^}]+deriv-avg=[^}]+mean=([^,]+),/) {
         $num_nonlinearities += 1;
         my $this_saturation = 1.0 - ($1 / 0.25);
         $total_saturation += $this_saturation;
@@ -63,7 +63,7 @@ while (<STDIN>) {
       }
     }
     foreach my $tanh_name ( ("c_t", "m_t") ) {
-      if (m/${tanh_name}_tanh={[^}]+deriv-avg=[^}]+mean=([^,]+),/) {
+      if (m/${tanh_name}_tanh=[{][^}]+deriv-avg=[^}]+mean=([^,]+),/) {
         $num_nonlinearities += 1;
         my $this_saturation = 1.0 - ($1 / 1.0);
         $total_saturation += $this_saturation;


### PR DESCRIPTION
Fix Perl warninig "Unescaped left brace in regex is deprecated." This use has been deprecated in Perl 5.22, and would become an erorr in 5.26.
http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22{%22_should_now_be_escaped_in_a_pattern
https://unix.stackexchange.com/a/238708/103076

The use of `[{]` vs. `\{` is probably the most backward-compatible.