### PR TITLE
Fix for threaded nnet2 decoding

### DIFF
--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -374,8 +374,10 @@ void SingleUtteranceNnet2DecoderThreaded::RunDecoderSearch(
 
 
 void SingleUtteranceNnet2DecoderThreaded::WaitForAllThreads() {
-  for (int32 i = 0; i < 2; i++)  // there are 2 spawned threads.
-    threads_[i].join();
+  for (int32 i = 0; i < 2; i++) {  // there are 2 spawned threads.
+    if (threads_[i].joinable())
+      threads_[i].join();
+  }
   if (error_)
     KALDI_ERR << "Error encountered during decoding.  See above.";
 }


### PR DESCRIPTION
With STL threads, a thread can only be called `join()` once. However, `SingleUtteranceNnet2DecoderThreaded::WaitForAllThreads()` is called many times: once via `Wait()` from online2-wav-nnet2-latgen-threaded.cc, and the second time in the destructor, which causes a system error when running `online2-wav-nnet2-latgen-threaded` (right before the exit).

With this patch we check whether a thread is joinable before calling `join()`. This fixes the problem mentioned above.