### PR TITLE
[egs] change type of max_lda_jobs to int

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -771,7 +771,7 @@ class CommonParser(object):
                                  dest='rand_prune', default=4.0,
                                  help="Value used in preconditioning "
                                  "matrix estimation")
-        self.parser.add_argument("--trainer.lda.max-lda-jobs", type=float,
+        self.parser.add_argument("--trainer.lda.max-lda-jobs", type=int,
                                  dest='max_lda_jobs', default=10,
                                  help="Max number of jobs used for "
                                  "LDA stats accumulation")


### PR DESCRIPTION
When it is a float and the user supplies a non-default argument,
then compute_preconditioning_matrix fails because bash can't handle:
run.pl JOB=1:10.0 ...

Signed-off-by: Amit Beka <amit.beka>