### PR TITLE
Add configuration check for CUDA incompatible g++ compilers

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -380,18 +380,39 @@ function configure_cuda {
       failure "Cannot cross compile with CUDA support"
     fi
 
-    echo "Using CUDA toolkit $CUDATKDIR (nvcc compiler and runtime libraries)"
-    echo >> kaldi.mk
-    echo "# CUDA configuration" >> kaldi.mk
-    echo >> kaldi.mk
-    echo CUDA = true >> kaldi.mk
-    echo CUDATKDIR = $CUDATKDIR >> kaldi.mk
-
     # Determine 'CUDA_ARCH',
     CUDA_VERSION=$($CUDATKDIR/bin/nvcc -V | tr '.,' '_ ' | awk '/release/{sub(/.*release/,""); print $1;}') # MAJOR_MINOR,
     if [ -z "$CUDA_VERSION" ] ; then
       echo "Cannot figure out CUDA_VERSION from the nvcc output. Either your CUDA is too new or too old."
       exit 1
+    fi
+
+    COMPILER_VER_INFO=$($CXX --version 2>/dev/null)
+    if [[ $COMPILER_VER_INFO == *"g++"* ]]; then
+      GCC_VER=$($COMPILER -dumpversion)
+      GCC_VER_NUM=$(echo $GCC_VER | sed 's/\./ /g' | xargs printf "%d%02d%02d")
+      case $CUDA_VERSION in
+        5_5)
+          MIN_UNSUPPORTED_GCC_VER="5.0"
+          MIN_UNSUPPORTED_GCC_VER_NUM=50000;
+        ;;
+        6_*)
+          MIN_UNSUPPORTED_GCC_VER="5.0"
+          MIN_UNSUPPORTED_GCC_VER_NUM=50000;
+        ;;
+        7_*)
+          MIN_UNSUPPORTED_GCC_VER="5.0"
+          MIN_UNSUPPORTED_GCC_VER_NUM=50000;
+        ;;
+        8_*)
+          MIN_UNSUPPORTED_GCC_VER="6.0"
+          MIN_UNSUPPORTED_GCC_VER_NUM=60000;
+        ;;
+      esac
+      if [ $GCC_VER_NUM -ge $MIN_UNSUPPORTED_GCC_VER_NUM ]; then
+        failure "CUDA $CUDA_VERSION does not support $CXX (g++-$GCC_VER).
+                 You need g++ < $MIN_UNSUPPORTED_GCC_VER."
+      fi
     fi
 
     case $CUDA_VERSION in
@@ -401,6 +422,13 @@ function configure_cuda {
       8_*) CUDA_ARCH="-gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62" ;;
       *) echo "Unsupported CUDA_VERSION (CUDA_VERSION=$CUDA_VERSION), please report it to Kaldi mailing list, together with 'nvcc -h' or 'ptxas -h' which lists allowed -gencode values..."; exit 1 ;;
     esac
+
+    echo "Using CUDA toolkit $CUDATKDIR (nvcc compiler and runtime libraries)"
+    echo >> kaldi.mk
+    echo "# CUDA configuration" >> kaldi.mk
+    echo >> kaldi.mk
+    echo CUDA = true >> kaldi.mk
+    echo CUDATKDIR = $CUDATKDIR >> kaldi.mk
     echo "CUDA_ARCH = $CUDA_ARCH" >> kaldi.mk
     echo >> kaldi.mk
 


### PR DESCRIPTION
These checks are fairly loose since we do not want to be too restrictive with g++ version unless we know for a fact that a particular g++ version is incompatible with the particular CUDA toolkit installed on the system.

I added the check inside configure_cuda function since this check is relevant only when compiling with CUDA.

Relates to #1744.