### PR TITLE
Very small fix to compare_wer_general.sh

### DIFF
--- a/egs/ami/s5b/local/chain/compare_wer_general.sh
+++ b/egs/ami/s5b/local/chain/compare_wer_general.sh
@@ -4,7 +4,7 @@ mic=$1;
 shift;
 
 echo -n "System               "
-for x in $*; do   printf "% 10s" $x;   done
+for x in $*; do   printf " % 10s" $x;   done
 echo
 
 #for d in exp/sdm1/chain_cleaned/tdnn*/decode_*; do grep Sum $d/*sc*/*ys | utils/best_wer.sh; done|grep eval_hires


### PR DESCRIPTION
fix bugs like (no blank):
```
./local/chain/compare_wer_general.sh sdm1 tdnn_gru1a_sp_bi_ihmali_ld5 tdnn_gru1b_sp_bi_ihmali_ld5 tdnn_gru1c_sp_bi_ihmali_ld5
# System               tdnn_gru1a_sp_bi_ihmali_ld5tdnn_gru1b_sp_bi_ihmali_ld5tdnn_gru1c_sp_bi_ihmali_ld5
```
