### PR TITLE
make the combine stage optional

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -818,6 +818,14 @@ class CommonParser(object):
                                  the final model combination stage.  These
                                  models will themselves be averages of
                                  iteration-number ranges""")
+        self.parser.add_argument("--trainer.optimization.do-final-combination",
+                                 dest='do_final_combination', type=str,
+                                 action=common_lib.StrToBoolAction,
+                                 choices=["true", "false"], default=True,
+                                 help="""Use this to specify conducting final
+                                 model combination or not. If the option is set
+                                 to false, for now just copy the last-numbered
+                                 model to final model.""")
         self.parser.add_argument("--trainer.optimization.combine-sum-to-one-penalty",
                                  type=float, dest='combine_sum_to_one_penalty', default=0.0,
                                  help="""If > 0, activates 'soft' enforcement of the

--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -822,10 +822,9 @@ class CommonParser(object):
                                  dest='do_final_combination', type=str,
                                  action=common_lib.StrToBoolAction,
                                  choices=["true", "false"], default=True,
-                                 help="""Use this to specify conducting final
-                                 model combination or not. If the option is set
-                                 to false, for now just copy the last-numbered
-                                 model to final model.""")
+                                 help="""Set this to false to disable the final
+                                 'combine' stage (in this case we just use the
+                                 last-numbered model as the final.mdl).""")
         self.parser.add_argument("--trainer.optimization.combine-sum-to-one-penalty",
                                  type=float, dest='combine_sum_to_one_penalty', default=0.0,
                                  help="""If > 0, activates 'soft' enforcement of the

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -401,10 +401,15 @@ def train(args, run_opts):
     num_iters = ((num_archives_to_process * 2)
                  / (args.num_jobs_initial + args.num_jobs_final))
 
-    models_to_combine = common_train_lib.get_model_combine_iters(
-        num_iters, args.num_epochs,
-        num_archives_expanded, args.max_models_combine,
-        args.num_jobs_final)
+    # If do_final_combination is True, compute the set of models_to_combine.
+    # Otherwise, models_to_combine will be none.
+    if args.do_final_combination:
+        models_to_combine = common_train_lib.get_model_combine_iters(
+            num_iters, args.num_epochs,
+            num_archives_expanded, args.max_models_combine,
+            args.num_jobs_final)
+    else:
+        models_to_combine = None
 
     min_deriv_time = None
     max_deriv_time_relative = None
@@ -496,17 +501,28 @@ def train(args, run_opts):
         num_archives_processed = num_archives_processed + current_num_jobs
 
     if args.stage <= num_iters:
-        logger.info("Doing final combination to produce final.mdl")
-        chain_lib.combine_models(
-            dir=args.dir, num_iters=num_iters,
-            models_to_combine=models_to_combine,
-            num_chunk_per_minibatch_str=args.num_chunk_per_minibatch,
-            egs_dir=egs_dir,
-            leaky_hmm_coefficient=args.leaky_hmm_coefficient,
-            l2_regularize=args.l2_regularize,
-            xent_regularize=args.xent_regularize,
-            run_opts=run_opts,
-            sum_to_one_penalty=args.combine_sum_to_one_penalty)
+        if args.do_final_combination:
+            logger.info("Doing final combination to produce final.mdl")
+            chain_lib.combine_models(
+                dir=args.dir, num_iters=num_iters,
+                models_to_combine=models_to_combine,
+                num_chunk_per_minibatch_str=args.num_chunk_per_minibatch,
+                egs_dir=egs_dir,
+                leaky_hmm_coefficient=args.leaky_hmm_coefficient,
+                l2_regularize=args.l2_regularize,
+                xent_regularize=args.xent_regularize,
+                run_opts=run_opts,
+                sum_to_one_penalty=args.combine_sum_to_one_penalty)
+        else:
+            logger.info("Copying the last-numbered model to final.mdl")
+            common_lib.force_symlink("{0}.mdl".format(num_iters),
+                                     "{0}/final.mdl".format(args.dir))
+            chain_lib.compute_train_cv_probabilities(
+                dir=dir, iter='final', egs_dir=egs_dir,
+                l2_regularize=args.l2_regularize,
+                xent_regularize=args.xent_regularize,
+                leaky_hmm_coefficient=args.leaky_hmm_coefficient,
+                run_opts=run_opts)
 
 
     if args.cleanup:

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -517,13 +517,10 @@ def train(args, run_opts):
             logger.info("Copying the last-numbered model to final.mdl")
             common_lib.force_symlink("{0}.mdl".format(num_iters),
                                      "{0}/final.mdl".format(args.dir))
-            chain_lib.compute_train_cv_probabilities(
-                dir=args.dir, iter='final', egs_dir=egs_dir,
-                l2_regularize=args.l2_regularize,
-                xent_regularize=args.xent_regularize,
-                leaky_hmm_coefficient=args.leaky_hmm_coefficient,
-                run_opts=run_opts)
-
+            common_lib.force_symlink("compute_prob_valid.{iter}.log".format(
+                                         iter=num_iters-1),
+                                     "{dir}/log/compute_prob_valid.final.log".format(
+                                         dir=args.dir))
 
     if args.cleanup:
         logger.info("Cleaning up the experiment directory "

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -518,7 +518,7 @@ def train(args, run_opts):
             common_lib.force_symlink("{0}.mdl".format(num_iters),
                                      "{0}/final.mdl".format(args.dir))
             chain_lib.compute_train_cv_probabilities(
-                dir=dir, iter='final', egs_dir=egs_dir,
+                dir=args.dir, iter='final', egs_dir=egs_dir,
                 l2_regularize=args.l2_regularize,
                 xent_regularize=args.xent_regularize,
                 leaky_hmm_coefficient=args.leaky_hmm_coefficient,

--- a/egs/wsj/s5/steps/nnet3/train_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_dnn.py
@@ -369,31 +369,21 @@ def train(args, run_opts):
     if args.stage <= num_iters + 1:
         logger.info("Getting average posterior for purposes of "
                     "adjusting the priors.")
-        if args.do_final_combination:
-            avg_post_vec_file = train_lib.common.compute_average_posterior(
-                dir=args.dir, iter='combined', egs_dir=egs_dir,
-                num_archives=num_archives,
-                prior_subset_size=args.prior_subset_size, run_opts=run_opts)
+        
+        # If args.do_fianl_combination is true, we will use the combined model.
+        # Otherwise, we will use the last_numbered model.
+        real_iter = 'combined' if args.do_final_combination else num_iters
+        avg_post_vec_file = train_lib.common.compute_average_posterior(
+            dir=args.dir, iter=real_iter, 
+            egs_dir=egs_dir, num_archives=num_archives,
+            prior_subset_size=args.prior_subset_size, run_opts=run_opts)
 
-            logger.info("Re-adjusting priors based on computed posteriors")
-            combined_model = "{dir}/combined.mdl".format(dir=args.dir)
-            final_model = "{dir}/final.mdl".format(dir=args.dir)
-            train_lib.common.adjust_am_priors(args.dir, combined_model,
-                                            avg_post_vec_file, final_model,
-                                            run_opts)
-        else:
-            avg_post_vec_file = train_lib.common.compute_average_posterior(
-                dir=args.dir, iter=num_iters, egs_dir=egs_dir,
-                num_archives=num_archives,
-                prior_subset_size=args.prior_subset_size, run_opts=run_opts)
-
-            logger.info("Re-adjusting priors based on computed posteriors")
-            last_numbered_model = "{dir}/{iter}.mdl".format(dir=args.dir,
-                                                            iter=num_iters)
-            final_model = "{dir}/final.mdl".format(dir=args.dir)
-            train_lib.common.adjust_am_priors(args.dir, last_numbered_model,
-                                            avg_post_vec_file, final_model,
-                                            run_opts)
+        logger.info("Re-adjusting priors based on computed posteriors")
+        combined_or_last_numbered_model = "{dir}/{iter}.mdl".format(dir=args.dir,
+                iter=real_iter)
+        final_model = "{dir}/final.mdl".format(dir=args.dir)
+        train_lib.common.adjust_am_priors(args.dir, combined_or_last_numbered_model,
+                avg_post_vec_file, final_model, run_opts)
 
 
     if args.cleanup:

--- a/egs/wsj/s5/steps/nnet3/train_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_dnn.py
@@ -370,7 +370,7 @@ def train(args, run_opts):
         logger.info("Getting average posterior for purposes of "
                     "adjusting the priors.")
         
-        # If args.do_fianl_combination is true, we will use the combined model.
+        # If args.do_final_combination is true, we will use the combined model.
         # Otherwise, we will use the last_numbered model.
         real_iter = 'combined' if args.do_final_combination else num_iters
         avg_post_vec_file = train_lib.common.compute_average_posterior(

--- a/egs/wsj/s5/steps/nnet3/train_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_dnn.py
@@ -357,8 +357,8 @@ def train(args, run_opts):
         num_archives_processed = num_archives_processed + current_num_jobs
 
     if args.stage <= num_iters:
-        logger.info("Doing final combination to produce final.mdl")
         if args.do_final_combination:
+            logger.info("Doing final combination to produce final.mdl")
             train_lib.common.combine_models(
                 dir=args.dir, num_iters=num_iters,
                 models_to_combine=models_to_combine,

--- a/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
@@ -60,11 +60,6 @@ def get_args():
                         help="Image augmentation options")
 
     # trainer options
-    parser.add_argument("--trainer.final-combination", type=str,
-                        action=common_lib.StrToBoolAction,
-                        default=True, choices=["true", "false"],
-                        dest='final_combination',
-                        help="If false, skip final combination step")
     parser.add_argument("--trainer.prior-subset-size", type=int,
                         dest='prior_subset_size', default=20000,
                         help="Number of samples for computing priors")
@@ -298,10 +293,15 @@ def train(args, run_opts):
     num_iters = ((num_archives_to_process * 2)
                  / (args.num_jobs_initial + args.num_jobs_final))
 
-    models_to_combine = common_train_lib.get_model_combine_iters(
-        num_iters, args.num_epochs,
-        num_archives_expanded, args.max_models_combine,
-        args.num_jobs_final)
+    # If do_final_combination is True, compute the set of models_to_combine.
+    # Otherwise, models_to_combine will be none.
+    if args.do_final_combination:
+        models_to_combine = common_train_lib.get_model_combine_iters(
+            num_iters, args.num_epochs,
+            num_archives_expanded, args.max_models_combine,
+            args.num_jobs_final)
+    else:
+        models_to_combine = None
 
     if os.path.exists('{0}/valid_diagnostic.scp'.format(args.egs_dir)):
         if os.path.exists('{0}/valid_diagnostic.egs'.format(args.egs_dir)):
@@ -390,7 +390,7 @@ def train(args, run_opts):
         num_archives_processed = num_archives_processed + current_num_jobs
 
     if args.stage <= num_iters:
-        if args.final_combination:
+        if args.do_final_combination:
             logger.info("Doing final combination to produce final.raw")
             train_lib.common.combine_models(
                 dir=args.dir, num_iters=num_iters,

--- a/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
@@ -349,10 +349,15 @@ def train(args, run_opts):
     num_iters = ((num_archives_to_process * 2)
                  / (args.num_jobs_initial + args.num_jobs_final))
 
-    models_to_combine = common_train_lib.get_model_combine_iters(
-        num_iters, args.num_epochs,
-        num_archives, args.max_models_combine,
-        args.num_jobs_final)
+    # If do_final_combination is True, compute the set of models_to_combine.
+    # Otherwise, models_to_combine will be none.
+    if args.do_final_combination:
+        models_to_combine = common_train_lib.get_model_combine_iters(
+            num_iters, args.num_epochs,
+            num_archives, args.max_models_combine,
+            args.num_jobs_final)
+    else:
+        models_to_combine = None
 
 
     min_deriv_time = None
@@ -442,14 +447,18 @@ def train(args, run_opts):
         num_archives_processed = num_archives_processed + current_num_jobs
 
     if args.stage <= num_iters:
-        logger.info("Doing final combination to produce final.raw")
-        train_lib.common.combine_models(
-            dir=args.dir, num_iters=num_iters,
-            models_to_combine=models_to_combine, egs_dir=egs_dir,
-            minibatch_size_str=args.num_chunk_per_minibatch,
-            run_opts=run_opts, chunk_width=args.chunk_width,
-            get_raw_nnet_from_am=False,
-            sum_to_one_penalty=args.combine_sum_to_one_penalty)
+        if args.do_final_combination:
+            logger.info("Doing final combination to produce final.raw")
+            train_lib.common.combine_models(
+                dir=args.dir, num_iters=num_iters,
+                models_to_combine=models_to_combine, egs_dir=egs_dir,
+                minibatch_size_str=args.num_chunk_per_minibatch,
+                run_opts=run_opts, chunk_width=args.chunk_width,
+                get_raw_nnet_from_am=False,
+                sum_to_one_penalty=args.combine_sum_to_one_penalty)
+        else:
+            common_lib.force_symlink("{0}.raw".format(num_iters),
+                                     "{0}/final.raw".format(args.dir))
 
     if args.compute_average_posteriors and args.stage <= num_iters + 1:
         logger.info("Getting average posterior for purposes of "

--- a/egs/wsj/s5/steps/nnet3/train_rnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_rnn.py
@@ -456,7 +456,7 @@ def train(args, run_opts):
         logger.info("Getting average posterior for purposes of "
                     "adjusting the priors.")
 
-        # If args.do_fianl_combination is true, we will use the combined model.
+        # If args.do_final_combination is true, we will use the combined model.
         # Otherwise, we will use the last_numbered model.
         real_iter = 'combined' if args.do_final_combination else num_iters
         avg_post_vec_file = train_lib.common.compute_average_posterior(


### PR DESCRIPTION
Hi Dan,
I take steps/nnet3/train_dnn.py as an example to show how I modify the codes.

There is one question in line 367 of steps/nnet3/train_dnn.py. For convenience, I copy the last-numbered model to combine model so that the code conduct adjusting the priors uniformly. It's a little bit opportunistic. In another way, I can adjust the priors directly but it will make the codes looks a bit redundancy. How do you think about it?

Hang