### PR TITLE
changed --nj value to  instead of hard coded to 100

### DIFF
--- a/egs/wsj/s5/local/chain/tuning/run_tdnn_1b.sh
+++ b/egs/wsj/s5/local/chain/tuning/run_tdnn_1b.sh
@@ -131,7 +131,7 @@ fi
 if [ $stage -le 13 ]; then
   # Get the alignments as lattices (gives the chain training more freedom).
   # use the same num-jobs as the alignments
-  steps/align_fmllr_lats.sh --nj 100 --cmd "$train_cmd" ${lores_train_data_dir} \
+  steps/align_fmllr_lats.sh --nj $nj --cmd "$train_cmd" ${lores_train_data_dir} \
     data/lang $gmm_dir $lat_dir
   rm $lat_dir/fsts.*.gz # save space
 fi


### PR DESCRIPTION
Also, shouldn't the ali_dir be used instead of the gmm_dir?The alignment with lats is hard coded to use 100 jobs, but it is supposed to use the same number of jobs that were used to build i-vectors.