### PR TITLE
resolve error Ranges not supported for objects of this type

### DIFF
--- a/src/matrix/compressed-matrix.cc
+++ b/src/matrix/compressed-matrix.cc
@@ -782,8 +782,8 @@ void CompressedMatrix::CopyToMat(int32 row_offset,
   KALDI_PARANOID_ASSERT(col_offset < this->NumCols());
   KALDI_PARANOID_ASSERT(row_offset >= 0);
   KALDI_PARANOID_ASSERT(col_offset >= 0);
-  KALDI_ASSERT(row_offset+dest->NumRows() < this->NumRows());
-  KALDI_ASSERT(col_offset+dest->NumCols() < this->NumCols());
+  KALDI_ASSERT(row_offset+dest->NumRows() <= this->NumRows());
+  KALDI_ASSERT(col_offset+dest->NumCols() <= this->NumCols());
   // everything is OK
   GlobalHeader *h = reinterpret_cast<GlobalHeader*>(data_);
   int32 num_rows = h->num_rows, num_cols = h->num_cols,

--- a/src/util/kaldi-holder.cc
+++ b/src/util/kaldi-holder.cc
@@ -23,11 +23,17 @@
 
 namespace kaldi {
 
+// Parse matrix range specifier in form r1:r2,c1:c2
+// where any of those four numbers can be missing. In those
+// cases, the missing number is set either to 0 (for r1 or c1)
+// or the value of parameter rows -1 or columns -1 (which
+// represent the dimensions of the original matrix) for missing
+// r2 or c2, respectively.
+// Examples of valid ranges: 0:39,: or :,:3 or :,5:10
 bool ParseMatrixRangeSpecifier(const std::string &range,
                          const int rows, const int cols,
                           std::vector<int32> *row_range,
                           std::vector<int32> *col_range) {
-
   if (range.empty()) {
     KALDI_ERR << "Empty range specifier.";
     return false;
@@ -81,23 +87,26 @@ bool ParseMatrixRangeSpecifier(const std::string &range,
 
 bool ExtractObjectRange(const GeneralMatrix &input, const std::string &range,
                         GeneralMatrix *output) {
-
-  Matrix<BaseFloat> out;
+  // We just inspect input's type and forward to the correct implementation
+  // if available. For kSparseMatrix, we do just fairly inefficient conversion
+  // to a full matrix.
+  Matrix<BaseFloat> output_mat;
   if (input.Type() == kFullMatrix) {
     const Matrix<BaseFloat> &in = input.GetFullMatrix();
-    ExtractObjectRange(in, range, &out);
+    ExtractObjectRange(in, range, &output_mat);
   } else if (input.Type() == kCompressedMatrix) {
     const CompressedMatrix &in = input.GetCompressedMatrix();
-    ExtractObjectRange(in, range, &out);
-  } else if (input.Type() == kSparseMatrix) {
-    Matrix<BaseFloat> in, out;
-    input.GetMatrix(&in);
-    ExtractObjectRange(in, range, &out);
+    ExtractObjectRange(in, range, &output_mat);
   } else {
-    KALDI_ERR << "Unknown/unsupported matrix type.";
+    KALDI_ASSERT(input.Type() == kSparseMatrix);
+    // NOTE: this is fairly inefficient, so if this happens to be bottleneck
+    // it should be re-implemented more efficiently.
+    Matrix<BaseFloat> input_mat;
+    input.GetMatrix(&input_mat);
+    ExtractObjectRange(input_mat, range, &output_mat);
   }
   output->Clear();
-  output->SwapFullMatrix(&out);
+  output->SwapFullMatrix(&output_mat);
   return true;
 }
 
@@ -106,34 +115,33 @@ bool ExtractObjectRange(const CompressedMatrix &input, const std::string &range,
                         Matrix<Real> *output) {
   std::vector<int32> row_range, col_range;
 
-  if(!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
-                          &row_range, &col_range)) {
+  if (!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
+                                 &row_range, &col_range)) {
     KALDI_ERR << "Could not parse range specifier \"" << range << "\".";
   }
 
   int32 row_size = std::min(row_range[1], input.NumRows() - 1)
                    - row_range[0] + 1,
         col_size = col_range[1] - col_range[0] + 1;
-  /*
-  KALDI_WARN << "size: " << input.NumRows() << "x" << input.NumCols();
-  KALDI_WARN << "range: " << range;
-  KALDI_WARN << "row_range: " << row_range[0] << ":" << row_range[1];
-  KALDI_WARN << "col_range: " << col_range[0] << ":" << col_range[1];
-  KALDI_WARN << "row_size: " << row_size;
-  KALDI_WARN << "col_size: " << col_size;
-  */
+
   output->Resize(row_size, col_size, kUndefined);
   input.CopyToMat(row_range[0], col_range[0], output);
   return true;
 }
+
+// template instantiation
+template bool ExtractObjectRange(const CompressedMatrix &, const std::string &,
+                                 Matrix<float> *);
+template bool ExtractObjectRange(const CompressedMatrix &, const std::string &,
+                                 Matrix<double> *);
 
 template<class Real>
 bool ExtractObjectRange(const Matrix<Real> &input, const std::string &range,
                         Matrix<Real> *output) {
   std::vector<int32> row_range, col_range;
 
-  if(!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
-                          &row_range, &col_range)) {
+  if (!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
+                                 &row_range, &col_range)) {
     KALDI_ERR << "Could not parse range specifier \"" << range << "\".";
   }
 

--- a/src/util/kaldi-holder.cc
+++ b/src/util/kaldi-holder.cc
@@ -23,9 +23,11 @@
 
 namespace kaldi {
 
-template<class Real>
-bool ExtractObjectRange(const Matrix<Real> &input, const std::string &range,
-                        Matrix<Real> *output) {
+bool ParseMatrixRangeSpecifier(const std::string &range,
+                         const int rows, const int cols,
+                          std::vector<int32> *row_range,
+                          std::vector<int32> *col_range) {
+
   if (range.empty()) {
     KALDI_ERR << "Empty range specifier.";
     return false;
@@ -37,41 +39,104 @@ bool ExtractObjectRange(const Matrix<Real> &input, const std::string &range,
     KALDI_ERR << "Invalid range specifier for matrix: " << range;
     return false;
   }
-  std::vector<int32> row_range, col_range;
+
   bool status = true;
+
   if (splits[0] != ":")
-    status = SplitStringToIntegers(splits[0], ":", false, &row_range);
+    status = SplitStringToIntegers(splits[0], ":", false, row_range);
+
   if (splits.size() == 2 && splits[1] != ":") {
-    status = status && SplitStringToIntegers(splits[1], ":", false, &col_range);
+    status = status && SplitStringToIntegers(splits[1], ":", false, col_range);
   }
-  if (row_range.size() == 0) {
-    row_range.push_back(0);
-    row_range.push_back(input.NumRows() - 1);
+  if (row_range->size() == 0) {
+    row_range->push_back(0);
+    row_range->push_back(rows - 1);
   }
-  if (col_range.size() == 0) {
-    col_range.push_back(0);
-    col_range.push_back(input.NumCols() - 1);
+  if (col_range->size() == 0) {
+    col_range->push_back(0);
+    col_range->push_back(cols - 1);
   }
 
   // Length tolerance of 3 -- 2 to account for edge effects when
   // frame-length is 25ms and frame-shift is 10ms, and 1 for rounding effects
   // since segments are usually retained up to 2 decimal places.
   int32 length_tolerance = 3;
-  if (!(status && row_range.size() == 2 && col_range.size() == 2 &&
-        row_range[0] >= 0 && row_range[0] <= row_range[1] &&
-        row_range[1] < input.NumRows() + length_tolerance &&
-        col_range[0] >=0 &&
-        col_range[0] <= col_range[1] && col_range[1] < input.NumCols())) {
+  if (!(status && row_range->size() == 2 && col_range->size() == 2 &&
+        row_range->at(0) >= 0 && row_range->at(0) <= row_range->at(1) &&
+        row_range->at(1) < rows + length_tolerance &&
+        col_range->at(0) >=0 &&
+        col_range->at(0) <= col_range->at(1) && col_range->at(1) < cols)) {
     KALDI_ERR << "Invalid range specifier: " << range
-              << " for matrix of size " << input.NumRows()
-              << "x" << input.NumCols();
+              << " for matrix of size " << rows
+              << "x" << cols;
     return false;
   }
 
-  if (row_range[1] >= input.NumRows())
-    KALDI_WARN << "Row range " << row_range[0] << ":" << row_range[1]
+  if (row_range->at(1) >= rows)
+    KALDI_WARN << "Row range " << row_range->at(0) << ":" << row_range->at(1)
                << " goes beyond the number of rows of the "
-               << "matrix " << input.NumRows();
+               << "matrix " << rows;
+  return status;
+}
+
+bool ExtractObjectRange(const GeneralMatrix &input, const std::string &range,
+                        GeneralMatrix *output) {
+
+  Matrix<BaseFloat> out;
+  if (input.Type() == kFullMatrix) {
+    const Matrix<BaseFloat> &in = input.GetFullMatrix();
+    ExtractObjectRange(in, range, &out);
+  } else if (input.Type() == kCompressedMatrix) {
+    const CompressedMatrix &in = input.GetCompressedMatrix();
+    ExtractObjectRange(in, range, &out);
+  } else if (input.Type() == kSparseMatrix) {
+    Matrix<BaseFloat> in, out;
+    input.GetMatrix(&in);
+    ExtractObjectRange(in, range, &out);
+  } else {
+    KALDI_ERR << "Unknown/unsupported matrix type.";
+  }
+  output->Clear();
+  output->SwapFullMatrix(&out);
+  return true;
+}
+
+template<class Real>
+bool ExtractObjectRange(const CompressedMatrix &input, const std::string &range,
+                        Matrix<Real> *output) {
+  std::vector<int32> row_range, col_range;
+
+  if(!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
+                          &row_range, &col_range)) {
+    KALDI_ERR << "Could not parse range specifier \"" << range << "\".";
+  }
+
+  int32 row_size = std::min(row_range[1], input.NumRows() - 1)
+                   - row_range[0] + 1,
+        col_size = col_range[1] - col_range[0] + 1;
+  /*
+  KALDI_WARN << "size: " << input.NumRows() << "x" << input.NumCols();
+  KALDI_WARN << "range: " << range;
+  KALDI_WARN << "row_range: " << row_range[0] << ":" << row_range[1];
+  KALDI_WARN << "col_range: " << col_range[0] << ":" << col_range[1];
+  KALDI_WARN << "row_size: " << row_size;
+  KALDI_WARN << "col_size: " << col_size;
+  */
+  output->Resize(row_size, col_size, kUndefined);
+  input.CopyToMat(row_range[0], col_range[0], output);
+  return true;
+}
+
+template<class Real>
+bool ExtractObjectRange(const Matrix<Real> &input, const std::string &range,
+                        Matrix<Real> *output) {
+  std::vector<int32> row_range, col_range;
+
+  if(!ParseMatrixRangeSpecifier(range, input.NumRows(), input.NumCols(),
+                          &row_range, &col_range)) {
+    KALDI_ERR << "Could not parse range specifier \"" << range << "\".";
+  }
+
   int32 row_size = std::min(row_range[1], input.NumRows() - 1)
                    - row_range[0] + 1,
         col_size = col_range[1] - col_range[0] + 1;

--- a/src/util/kaldi-holder.h
+++ b/src/util/kaldi-holder.h
@@ -251,9 +251,14 @@ bool ExtractObjectRange(const Vector<Real> &input, const std::string &range,
 /// GeneralMatrix is always of type BaseFloat
 bool ExtractObjectRange(const GeneralMatrix &input, const std::string &range,
                         GeneralMatrix *output);
+
+/// CompressedMatrix is always of the type BaseFloat but it is more
+/// efficient to provide template as it uses CompressedMatrix's own
+/// conversion to Matrix<Real>
 template <class Real>
 bool ExtractObjectRange(const CompressedMatrix &input, const std::string &range,
                         Matrix<Real> *output);
+
 // In SequentialTableReaderScriptImpl and RandomAccessTableReaderScriptImpl, for
 // cases where the scp contained 'range specifiers' (things in square brackets
 // identifying parts of objects like matrices), use this function to separate

--- a/src/util/kaldi-holder.h
+++ b/src/util/kaldi-holder.h
@@ -27,6 +27,7 @@
 #include "util/kaldi-io.h"
 #include "util/text-utils.h"
 #include "matrix/kaldi-vector.h"
+#include "matrix/sparse-matrix.h"
 
 namespace kaldi {
 
@@ -242,12 +243,17 @@ template <class Real>
 bool ExtractObjectRange(const Matrix<Real> &input, const std::string &range,
                         Matrix<Real> *output);
 
-/// The template is specialized types Vector<float> and Vector<double>.  
+/// The template is specialized types Vector<float> and Vector<double>.
 template <class Real>
 bool ExtractObjectRange(const Vector<Real> &input, const std::string &range,
                         Vector<Real> *output);
 
-
+/// GeneralMatrix is always of type BaseFloat
+bool ExtractObjectRange(const GeneralMatrix &input, const std::string &range,
+                        GeneralMatrix *output);
+template <class Real>
+bool ExtractObjectRange(const CompressedMatrix &input, const std::string &range,
+                        Matrix<Real> *output);
 // In SequentialTableReaderScriptImpl and RandomAccessTableReaderScriptImpl, for
 // cases where the scp contained 'range specifiers' (things in square brackets
 // identifying parts of objects like matrices), use this function to separate


### PR DESCRIPTION
This should be resolving the following problem
```
$ /export/a09/jtrmal/kaldi-clean-git/src/featbin/apply-cmvn --norm-means=false --norm-vars=false --utt2spk=ark:data/dev10h.pem_hires_nopitch//split121/99/utt2spk scp:data/dev10h.pem_hires_nopitch//split121/99/cmvn.scp scp:data/dev10h.pem_hires_nopitch//split121/99/feats.scp ark:/dev/null
/export/a09/jtrmal/kaldi-clean-git/src/featbin/apply-cmvn --norm-means=false --norm-vars=false --utt2spk=ark:data/dev10h.pem_hires_nopitch//split121/99/utt2spk scp:data/dev10h.pem_hires_nopitch//split121/99/cmvn.scp scp:data/dev10h.pem_hires_nopitch//split121/99/feats.scp ark:/dev/null
ERROR (apply-cmvn[5.2]:ExtractObjectRange():util/kaldi-holder.h:233) Ranges not supported for objects of this type.

[ Stack-Trace: ]

kaldi::MessageLogger::HandleMessage(kaldi::LogMessageEnvelope const&, char const*)
kaldi::MessageLogger::~MessageLogger()
bool kaldi::ExtractObjectRange<kaldi::GeneralMatrix>(kaldi::GeneralMatrix const&, std::string const&, kaldi::GeneralMatrix*)
kaldi::KaldiObjectHolder<kaldi::GeneralMatrix>::ExtractRange(kaldi::KaldiObjectHolder<kaldi::GeneralMatrix> const&, std::string const&)
kaldi::SequentialTableReaderScriptImpl<kaldi::KaldiObjectHolder<kaldi::GeneralMatrix> >::EnsureObjectLoaded()
kaldi::SequentialTableReaderScriptImpl<kaldi::KaldiObjectHolder<kaldi::GeneralMatrix> >::Value()
kaldi::SequentialTableReader<kaldi::KaldiObjectHolder<kaldi::GeneralMatrix> >::Value()
main
__libc_start_main
/export/a09/jtrmal/kaldi-clean-git/src/featbin/apply-cmvn() [0x44da79]
```