### PR TITLE
minor bugfix to nnet1 alignment script when creating lattices

### DIFF
--- a/egs/wsj/s5/steps/nnet/align.sh
+++ b/egs/wsj/s5/steps/nnet/align.sh
@@ -130,8 +130,8 @@ fi
 if [ "$align_to_lats" == "true" ]; then
   echo "$0: aligning also to lattices '$dir/lat.*.gz'"
   $cmd JOB=1:$nj $dir/log/align_lat.JOB.log \
-    compile-train-graphs --read-disambig-syms=$lang/phones/disambig.int $lat_graph_scale $dir/tree $dir/final.mdl  $lang/L.fst "$tra" ark:- \| \
-    latgen-faster-mapped $lat_decode_opts --word-symbol-table=$lang/words.txt $dir/final.mdl ark:- \
+    compile-train-graphs --read-disambig-syms=$lang/phones/disambig.int $lats_graph_scales $dir/tree $dir/final.mdl  $lang/L.fst "$tra" ark:- \| \
+    latgen-faster-mapped $lats_decode_opts --word-symbol-table=$lang/words.txt $dir/final.mdl ark:- \
       "$feats" "ark:|gzip -c >$dir/lat.JOB.gz" || exit 1;
 fi
 


### PR DESCRIPTION
bug in nnet1's align.sh script which doesn't pass scale options correctly when aligning to generate lattices