### PR TITLE
Add CuVectorBase::CopyElements() and VecMatVec() + tests

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -502,6 +502,14 @@ void cudaD_matrix_lookup(dim3 Gr, dim3 Bl, const double *data, MatrixDim dim,
 void cudaF_matrix_lookup(dim3 Gr, dim3 Bl, const float *data, MatrixDim dim,
                          const Int32Pair *indices, int indices_size,
                          float *output);
+void cudaD_vector_copy_elements(dim3 Gr, dim3 Bl, double *data, int dim,
+                                const double *src_mat, int mat_stride,
+                                bool transpose,
+                                const MatrixIndexT_cuda* elements);
+void cudaF_vector_copy_elements(dim3 Gr, dim3 Bl, float *data, int dim,
+                                const float *src_mat, int mat_stride,
+                                bool transpose,
+                                const MatrixIndexT_cuda* elements);
 void cudaD_max(dim3 Gr, dim3 Bl, double *mat, const double *A, MatrixDim dst_d,
                int src_stride);
 void cudaF_max(dim3 Gr, dim3 Bl, float *mat, const float *A, MatrixDim dst_d,

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -936,6 +936,20 @@ inline void cuda_matrix_lookup(dim3 Gr, dim3 Bl, const float *data,
                                int indices_size, float *output) {
   cudaF_matrix_lookup(Gr, Bl, data, dim, indices, indices_size, output);
 }
+inline void cuda_vector_copy_elements(dim3 Gr, dim3 Bl, double *data, int dim,
+                                      const double *src_mat, int mat_stride,
+                                      bool transpose,
+                                      const MatrixIndexT_cuda* elements) {
+  cudaD_vector_copy_elements(Gr, Bl, data, dim, src_mat, mat_stride,
+                             transpose, elements);
+}
+inline void cuda_vector_copy_elements(dim3 Gr, dim3 Bl, float *data, int dim,
+                                      const float *src_mat, int mat_stride,
+                                      bool transpose,
+                                      const MatrixIndexT_cuda* elements) {
+  cudaF_vector_copy_elements(Gr, Bl, data, dim, src_mat, mat_stride,
+                             transpose, elements);
+}
 inline void cuda_max(dim3 Gr, dim3 Bl, double *mat, const double *A,
                      MatrixDim dst_d, int src_stride) {
   cudaD_max(Gr, Bl, mat, A, dst_d, src_stride);

--- a/src/cudamatrix/cu-matrix.h
+++ b/src/cudamatrix/cu-matrix.h
@@ -485,7 +485,6 @@ class CuMatrixBase {
   /// 0 <= element[i] < NumCols().
   /// It adds alpha to each element (*this)(i, elements[i])
   /// for 0 <= i < NumRows().
-  /// TODO: implement this.
   void AddToElements(Real alpha, const CuArrayBase<int32> &elements);
 
 

--- a/src/cudamatrix/cu-vector.h
+++ b/src/cudamatrix/cu-vector.h
@@ -126,9 +126,9 @@ class CuVectorBase {
   /// If trans == kTrans,
   /// expects mat.NumCols() to equal this.Dim(), and for each i,
   /// copies mat(elements[i], i) to (*this)(i).
-  /// TODO: implement this.
-  void CopyElements(const CuMatrix<BaseFloat> &mat, const MatrixTransposeType trans,
-                    CuArrayBase<int32> &elements);
+  void CopyElements(const CuMatrixBase<Real> &mat,
+                    const MatrixTransposeType trans,
+                    const CuArrayBase<int32> &elements);
 
   void ApplySoftMax();
   void ApplyExp();
@@ -379,7 +379,6 @@ Vector<Real>::Vector(const CuVectorBase<OtherReal> &cu) {
 }
 
 /// Returns \f$ v_1^T M v_2  \f$ .
-/// TODO:  implement this.
 template<typename Real>
 Real VecMatVec(const CuVectorBase<Real> &v1, const CuMatrixBase<Real> &M,
                const CuVectorBase<Real> &v2);


### PR DESCRIPTION
Two notes:
1. After adding a new unit test to cu-vector-test.cc, [ApplyExp](https://github.com/hhadian/kaldi/blob/625518d2b06481d0fa663242dad2cf9ce7da4df7/src/cudamatrix/cu-vector-test.cc#L522) unit test fails [which is completely unrelated anyway]. I guess it is simply because the random state has changed and a random number is generated on which ApplyExp has an error > 0.000001
2. There are some lines in cu-vector-test.cc where a random int is generated using `int32 M = 10 % Rand() % 100;`. I guess the first `%` should be `+`. Should I fix them?