### PR TITLE
Change KALDI_LOG to KALDI_VLOG(1) in ComputeDerivedVars()

### DIFF
--- a/src/ivector/ivector-extractor.cc
+++ b/src/ivector/ivector-extractor.cc
@@ -180,7 +180,7 @@ class IvectorExtractorComputeDerivedVarsClass {
 };
 
 void IvectorExtractor::ComputeDerivedVars() {
-  KALDI_LOG << "Computing derived variables for iVector extractor";
+  KALDI_VLOG(1) << "Computing derived variables for iVector extractor";
   gconsts_.Resize(NumGauss());
   for (int32 i = 0; i < NumGauss(); i++) {
     double var_logdet = -Sigma_inv_[i].LogPosDefDet();
@@ -201,7 +201,7 @@ void IvectorExtractor::ComputeDerivedVars() {
     for (int32 i = 0; i < NumGauss(); i++)
       sequencer.Run(new IvectorExtractorComputeDerivedVarsClass(this, i));
   }
-  KALDI_LOG << "Done.";
+  KALDI_VLOG(1) << "Done.";
 }
 
 


### PR DESCRIPTION
In our production system, this logging is the only verbose part in normal operation, and it appears 
to be a bit spurious, it would be nicer to have this level of verbosity reduced.  