### PR TITLE
Add xent_regularize parameter to Aspire chain recipes

### DIFF
--- a/egs/aspire/s5/local/chain/tuning/run_blstm_7b.sh
+++ b/egs/aspire/s5/local/chain/tuning/run_blstm_7b.sh
@@ -20,6 +20,7 @@ num_data_reps=3
 
 
 min_seg_len=
+xent_regularize=0.1
 chunk_width=150
 chunk_left_context=40
 chunk_right_context=40
@@ -197,7 +198,7 @@ if [ $stage -le 12 ]; then
     --cmd "$decode_cmd" \
     --feat.online-ivector-dir exp/nnet3/ivectors_train_min${min_seg_len} \
     --feat.cmvn-opts "--norm-means=false --norm-vars=false" \
-    --chain.xent-regularize 0.1 \
+    --chain.xent-regularize $xent_regularize \
     --chain.leaky-hmm-coefficient 0.1 \
     --chain.l2-regularize 0.00005 \
     --chain.apply-deriv-weights false \

--- a/egs/aspire/s5/local/chain/tuning/run_tdnn_7b.sh
+++ b/egs/aspire/s5/local/chain/tuning/run_tdnn_7b.sh
@@ -20,6 +20,7 @@ num_data_reps=3
 
 
 min_seg_len=
+xent_regularize=0.1
 frames_per_eg=150
 # End configuration section.
 echo "$0 $@"  # Print the command line for logging
@@ -191,7 +192,7 @@ if [ $stage -le 12 ]; then
     --cmd "$decode_cmd" \
     --feat.online-ivector-dir exp/nnet3/ivectors_train_min${min_seg_len} \
     --feat.cmvn-opts "--norm-means=false --norm-vars=false" \
-    --chain.xent-regularize 0.1 \
+    --chain.xent-regularize $xent_regularize \
     --chain.leaky-hmm-coefficient 0.1 \
     --chain.l2-regularize 0.00005 \
     --chain.apply-deriv-weights false \


### PR DESCRIPTION
Fixes a bug in `learning_rate_factor=$(echo "print 0.5/$xent_regularize" | python)`