### PR TITLE
Enable Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ notifications:
 
 language: cpp
 
+cache:
+  directories:
+  - $HOME/.ccache
+
 os:
   - linux
 
@@ -13,7 +17,6 @@ addons:
       - llvm-toolchain-precise-3.8
     packages:
       - gdb
-      - gcc-4.9
       - g++-4.9
       - gfortran-4.9
       - liblapack-dev
@@ -22,20 +25,38 @@ addons:
 branches:
   only:
     - master
-    - kaldi_52
 
 before_install:
   - cat /proc/sys/kernel/core_pattern
   - export XROOT=~/xroot
   - tools/extras/travis_install_bindeps.sh $XROOT
+  - export PATH=$XROOT/usr/bin:$PATH
+
+before_script:
+  - which ccache
+  - ccache --version
+  - ccache --show-stats
+  - ccache --zero-stats --max-size=3G
+
+env:
+  - CI_TARGETS="all ext"        # Job1: Build everything.
+  - CI_TARGETS="test"           # Job2: Test libraries. #### ext_test? adds 5min compile, runs 1 test.
 
 script:
-  - CXX=clang++-3.8
+  # See http://petereisentraut.blogspot.com/2011/05/ccache-and-clang.html and
+  # http://peter.eisentraut.org/blog/2014/12/01/ccache-and-clang-part-3/
+  # for the explanation why extra switches needed for clang with ccache.
+  - CXX="ccache clang++-3.8 -Qunused-arguments -fcolor-diagnostics -Wno-tautological-compare"
     CFLAGS="-march=native"
     LDFLAGS="-llapack"
     INCDIRS="$XROOT/usr/include"
     LIBDIRS="$XROOT/usr/lib"
       tools/extras/travis_script.sh
+#   To troubleshoot cache, add to above: CI_TARGETS=util CCACHE_LOGFILE=~/ccache.log
+  - cat src/base/version.h
+
+before_cache:
+  - ccache --show-stats
 
 after_failure:
   - tools/extras/travis_show_failures.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,9 +108,9 @@ clean: rmlibdir
 distclean: clean
 	-for x in $(SUBDIRS) $(EXT_SUBDIRS); do $(MAKE) -C $$x distclean; done
 
-test: $(addsuffix /test, $(SUBDIRS))
+test: $(addsuffix /test, $(SUBDIRS_LIB))
 
-ext_test: $(addsuffix /test, $(EXT_SUBDIRS))
+ext_test: $(addsuffix /test, $(EXT_SUBDIRS_LIB))
 
 # Define an implicit rule, expands to e.g.:
 #  base/test: base
@@ -149,7 +149,6 @@ $(EXT_SUBDIRS) : mklibdir ext_depend
 ### Dependency list ###
 # this is necessary for correct parallel compilation
 #1)The tools depend on all the libraries
-
 bin fstbin gmmbin fgmmbin sgmm2bin featbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin lmbin kwsbin online2bin: \
  base matrix util feat tree gmm transform sgmm2 fstext hmm \
  lm decoder lat cudamatrix nnet nnet2 nnet3 ivector chain kws online2

--- a/src/makefiles/default_rules.mk
+++ b/src/makefiles/default_rules.mk
@@ -17,6 +17,7 @@ ifeq ($(KALDI_FLAVOR), dynamic)
   else  # Platform not supported
     $(error Dynamic libraries not supported on this platform. Run configure with --static flag.)
   endif
+  XDEPENDS =
 else
   ifdef LIBNAME
     LIBFILE = $(LIBNAME).a
@@ -30,16 +31,16 @@ $(LIBFILE): $(OBJFILES)
 	$(AR) -cru $(LIBNAME).a $(OBJFILES)
 	$(RANLIB) $(LIBNAME).a
 ifeq ($(KALDI_FLAVOR), dynamic)
-ifeq ($(shell uname), Darwin)
+  ifeq ($(shell uname), Darwin)
 	$(CXX) -dynamiclib -o $@ -install_name @rpath/$@ $(LDFLAGS) $(OBJFILES) $(LDLIBS)
 	rm -f $(KALDILIBDIR)/$@; ln -s $(shell pwd)/$@ $(KALDILIBDIR)/$@
-else ifeq ($(shell uname), Linux)
-	# Building shared library from static (static was compiled with -fPIC)
+  else ifeq ($(shell uname), Linux)
+        # Building shared library from static (static was compiled with -fPIC)
 	$(CXX) -shared -o $@ -Wl,--no-undefined -Wl,--as-needed  -Wl,-soname=$@,--whole-archive $(LIBNAME).a -Wl,--no-whole-archive $(LDFLAGS) $(LDLIBS)
 	rm -f $(KALDILIBDIR)/$@; ln -s $(shell pwd)/$@ $(KALDILIBDIR)/$@
-else  # Platform not supported
+  else  # Platform not supported
 	$(error Dynamic libraries not supported on this platform. Run configure with --static flag.)
-endif
+  endif
 endif
 
 # By default (GNU) make uses the C compiler $(CC) for linking object files even
@@ -47,10 +48,12 @@ endif
 # use the C++ compiler $(CXX) instead.
 LINK.o = $(CXX) $(LDFLAGS) $(TARGET_ARCH)
 
-ifeq ($(KALDI_FLAVOR), dynamic)
-$(BINFILES): $(LIBFILE)
-else
 $(BINFILES): $(LIBFILE) $(XDEPENDS)
+
+# When building under CI, CI_NOLINKBINARIES is set to skip linking of binaries.
+ifdef CI_NOLINKBINARIES
+$(BINFILES): %: %.o
+	touch $@
 endif
 
 # Rule below would expand to, e.g.:
@@ -69,11 +72,7 @@ clean:
 distclean: clean
 	-rm -f .depend.mk
 
-ifeq ($(KALDI_FLAVOR), dynamic)
-$(TESTFILES): $(LIBFILE)
-else
 $(TESTFILES): $(LIBFILE) $(XDEPENDS)
-endif
 
 test_compile: $(TESTFILES)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,7 +7,10 @@ CC = gcc         # used for sph2pipe
 
 # Note: OpenFst requires a relatively recent C++ compiler with C++11 support,
 # e.g. g++ >= 4.7, Apple clang >= 5.0 or LLVM clang >= 3.3.
-OPENFST_VERSION = 1.6.2
+OPENFST_VERSION ?= 1.6.2
+
+# Default features configured for OpenFST; can be overridden in the make command line.
+OPENFST_CONFIGURE ?= --enable-static --enable-shared --enable-far --enable-ngram-fsts
 
 OPENFST_VER_NUM := $(shell echo $(OPENFST_VERSION) | sed 's/\./ /g' | xargs printf "%d%02d%02d")
 ifeq ("$(shell expr $(OPENFST_VER_NUM) \< 10600)","1")
@@ -64,16 +67,20 @@ openfst-$(OPENFST_VERSION)/lib: | openfst-$(OPENFST_VERSION)/Makefile
 
 # Add the -O flag to CXXFLAGS on cygwin as it can fix the compilation error
 # "file too big".
-openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION) | check_required_programs
-# Note: OSTYPE path is probably dead for latest cygwin64 (installed on 2016/11/11).
 ifeq ($(OSTYPE),cygwin)
-	cd openfst-$(OPENFST_VERSION)/; ./configure --prefix=`pwd` --enable-static --enable-shared --enable-far --enable-ngram-fsts CXX=$(CXX) CXXFLAGS="$(CXXFLAGS) -O -Wa,-mbig-obj" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
-# This new OS path is confirmed working on Windows 10 / Cygwin64
+  # Note: OSTYPE path is probably dead for latest cygwin64 (installed on 2016/11/11).
+  openfst_add_CXXFLAGS = -O -Wa,-mbig-obj
 else ifeq ($(OS),Windows_NT)
-	cd openfst-$(OPENFST_VERSION)/; ./configure --prefix=`pwd` --enable-static --enable-shared --enable-far --enable-ngram-fsts CXX=$(CXX) CXXFLAGS="$(CXXFLAGS) -O -Wa,-mbig-obj" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
+  # This new OS path is confirmed working on Windows 10 / Cygwin64.
+  openfst_add_CXXFLAGS = -O -Wa,-mbig-obj
 else
-	cd openfst-$(OPENFST_VERSION)/; ./configure --prefix=`pwd` --enable-static --enable-shared --enable-far --enable-ngram-fsts CXX=$(CXX) CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
+  openfst_add_CXXFLAGS =
 endif
+
+openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION) | check_required_programs
+	cd openfst-$(OPENFST_VERSION)/ && \
+	./configure --prefix=`pwd` $(OPENFST_CONFIGURE) CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) $(openfst_add_CXXFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
+
 
 openfst-$(OPENFST_VERSION): openfst-$(OPENFST_VERSION).tar.gz
 	tar xozf openfst-$(OPENFST_VERSION).tar.gz
@@ -87,7 +94,7 @@ sclite: sclite_compiled
 .PHONY: sclite_compiled
 sclite_compiled: sctk sctk_configured
 	cd sctk; \
-	$(MAKE) CC=$(CC) CXX=$(CXX) all && $(MAKE) install && $(MAKE) doc
+	$(MAKE) CC="$(CC)" CXX="$(CXX)" all && $(MAKE) install && $(MAKE) doc
 
 sctk_configured: sctk sctk/.configured
 

--- a/tools/extras/travis_install_bindeps.sh
+++ b/tools/extras/travis_install_bindeps.sh
@@ -21,5 +21,9 @@ add_deb http://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-ba
 add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas-dev_1.2.20110419-7_amd64.deb
 add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas3_1.2.20110419-7_amd64.deb
 
-# Show extracted packages.
+if [[ "$(ccache --version 2>/dev/null | sed -n '1{s/^[a-z ]*//;s/\./0/g;p}')" -lt 30304 ]]; then
+    add_deb http://mirrors.kernel.org/debian/pool/main/c/ccache/ccache_3.3.4-1_amd64.deb
+fi
+
+# Show extracted package files.
 find $xroot | sort

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -7,17 +7,22 @@
 #   CXX=clang++-3.8
 #   CFLAGS="-march=native -O2"
 #   LDFLAGS="-llapack"
+#
+# The CI_TARGETS variable is set in Travis environment and passed on as a list
+# of build targets to make (for making different things in separate jobs).
 
-# Maximum make parallelism. Simply -j runs out of memory on Travis VM.
-MAXPAR=6
+# Maximum make parallelism. Travis VMs have 2 cores, so a value over 3 or 4
+# would probably only cause context switching overhead.
+MAXPAR=4
 
-# Directories with code that can be tested with Travis (space-separated)
+# Directories with code that can be tested with Travis (space-separated).
 TESTABLE_DIRS="src/"
 
 # Run verbose (run and echo) and exit if failed.
 runvx() {
-  echo "\$ $@"
-  eval "$@" || exit 1
+  local cmd=$(printf ' %q' "$@"); cmd=${cmd:1}
+  echo "\$ $cmd"
+  eval -- "$cmd" || exit 1
 }
 
 # $(addsw -L foo bar) => "-Lfoo -Lbar".
@@ -27,16 +32,17 @@ addsw() {
   echo ${v[@]};
 }
 
-# $(mtoken CXX gcc) => "CXX=gcc"; # $(mtoken CXX ) => "".
-mtoken() { echo ${2+$1=\"$2\"}; }
+# $(mtoken CXX "ccache gcc") => 'CXX=ccache gcc'; $(mtoken CXX ) => ''.
+mtoken() { echo ${2+$1=$2}; }
 
 # Print machine info and environment.
 runvx uname -a
 runvx env
 
-# Check for changes in src/ only; report success right away if none.
-# However, do run tests if TRAVIS_COMMIT_RANGE does not parse. This
-# most likely means the branch was reset by --force; re-run tests then.
+# Check for changes in interesting files, normally sources and CI glue
+# scripts, and report success right away if none.  However, do run tests
+# if TRAVIS_COMMIT_RANGE does not parse. This most likely means the branch
+# was reset by --force, and any file could have changed.
 if git rev-parse "${TRAVIS_COMMIT_RANGE}" >/dev/null 2>&1 && \
    ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- ${TESTABLE_DIRS} \
    .travis.yml tools/extras/travis_*.sh | read REPLY
@@ -46,33 +52,34 @@ then
   exit 0;
 fi
 
-# Prepare environment variables
-CF="\"$CFLAGS -g $(addsw -I $INCDIRS)\""
-LDF="\"$LDFLAGS $(addsw -L $LIBDIRS)\""
-CCC="$(mtoken CXX "$CXX")"
+# Prepare environment variables.
+CF="$CFLAGS -g $(addsw -I $INCDIRS)"
+LDF="$LDFLAGS $(addsw -L $LIBDIRS)"
+CCC=$(mtoken CXX "$CXX")
 
+# TODO(kkm): Disabling single/double. If needed, use separate Travis jobs.
 # Randomly choose between single and double precision
-if [[ $(( RANDOM % 2 )) == 1 ]] ; then
-  DPF="--double-precision=yes"
-else
+#if [[ $(( RANDOM % 2 )) == 1 ]] ; then
+#  DPF="--double-precision=yes"
+#else
   DPF="--double-precision=no"
-fi
+#fi
 
 echo "Building tools..." [Time: $(date)]
 runvx cd tools
-runvx make openfst "$CCC" CXXFLAGS="$CF" -j$MAXPAR
+runvx make -j$MAXPAR openfst "$CCC" CXXFLAGS="$CF" \
+      OPENFST_CONFIGURE="--disable-static --enable-shared --disable-bin --disable-dependency-tracking"
 cd ..
 
-echo "Building src..." [Time: $(date)]
 runvx cd src
+runvx touch base/.depend.mk  # Fool make depend into skipping the dependency step.
+runvx touch .short_version   # Make version short, or else ccache will miss everything.
 runvx "$CCC" CXXFLAGS="$CF" LDFLAGS="$LDF" ./configure --shared --use-cuda=no "$DPF" --mathlib=OPENBLAS --openblas-root="$XROOT/usr"
-runvx make all -j$MAXPAR
-runvx make ext -j$MAXPAR
+runvx make -j$MAXPAR $CI_TARGETS CI_NOLINKBINARIES=1
 
-echo "Running tests..." [Time: $(date)]
-runvx make test -k -j$MAXPAR
+# Travis has a 10k line log limit, so use smaller CI_TARGETS when logging.
+if [ -r "$CCACHE_LOGFILE" ]; then
+    runvx cat "$CCACHE_LOGFILE"
+fi
 
 echo "Done." [Time: $(date)]
-
-#runvx make mklibdir base matrix -j$MAXPAR
-#runvx make matrix/test


### PR DESCRIPTION
Using ccache to cache object files. Also, the work is split into two jobs: one compiles everything (but skips linking binaries), and another compiles and runs tests only in libraries.

I am getting as low as 5 minutes in the first job without changes in source files, around 25 in the second. But Travis is quite inconsistent in performance: One run took almost 40 minutes, although the cache hit ratio was nominal.

Most of the changes are related to quoting the variable `CXX` properly.

**Notable omissions:**
 * Compiling in single precision only. Old way was randomize on each run, but that would rub ccache's fur the wrong way. Do we need both? I'll add separate jobs for the other mode if need both.
* Not running the target `ext_test`. It adds a lot to compile time, partly because portaudio, but runs only 1 test in src/online2.

Closes #1805 