### PR TITLE
Added dumping/non-dumping option and a pointer to copy decoded output on it to kaldi decoder.

### DIFF
--- a/src/decoder/decoder-wrappers.h
+++ b/src/decoder/decoder-wrappers.h
@@ -137,7 +137,9 @@ class DecodeUtteranceLatticeFasterClass {
       int64 *frame_sum, // on success, adds #frames to this.
       int32 *num_done, // on success (including partial decode), increments this.
       int32 *num_err,  // on failure, increments this.
-      int32 *num_partial);  // If partial decode (final-state not reached), increments this.
+      int32 *num_partial,  // If partial decode (final-state not reached), increments this.
+      CompactLattice* lat_out = NULL,  // pointer passed by user to copy stored output on it.
+	  bool write = true);  // stored output dumping option.
   void operator () (); // The decoding happens here.
   ~DecodeUtteranceLatticeFasterClass(); // Output happens here.
  private:
@@ -159,7 +161,8 @@ class DecodeUtteranceLatticeFasterClass {
   int32 *num_done_;
   int32 *num_err_;
   int32 *num_partial_;
-
+  bool write_;
+  CompactLattice* lat_out_;
   // The following variables are stored by the computation.
   bool computed_; // operator ()  was called.
   bool success_; // decoding succeeded (possibly partial)


### PR DESCRIPTION
added dumping option for decoded features and a pointer passed by user to copy information on it when you use class "DecodeUtteranceLatticeFaster".
before that, the user was forced to pass a valid path to a dump file to receive output on it. now you have an option to pass to its constructor either:
- "compact lattice writer"/"lattice writer" as NULL, dumping option as false and an instantiated pointer to receive output on it.
- or "compact lattice writer"/"lattice writer" as an absolute path to a dump file you want to create, dumping option as true and NULL pointer. 