### PR TITLE
Update local/score.sh to accept "iter" option passed by some decoding scripts

### DIFF
--- a/egs/fisher_swbd/s5/local/score.sh
+++ b/egs/fisher_swbd/s5/local/score.sh
@@ -13,6 +13,8 @@ stage=0
 min_lmwt=5
 max_lmwt=17
 word_ins_penalty=0.0,0.5,1.0
+iter=final # The iteration of model to use (this is ignored but the
+# option is passed in by some decoding scripts).
 #end configuration section.
 
 [ -f ./path.sh ] && . ./path.sh


### PR DESCRIPTION
fixed  a bug in the local score.sh script