### PR TITLE
Remove memory leaks and unused variables (when CUDA is not enabled)

### DIFF
--- a/src/cudamatrix/cu-matrix-speed-test.cc
+++ b/src/cudamatrix/cu-matrix-speed-test.cc
@@ -1086,8 +1086,8 @@ template<typename Real> void CudaMatrixSpeedTest() {
 
 int main() {
   SetVerboseLevel(1);
-  int32 loop = 0;
 #if HAVE_CUDA == 1
+  int32 loop = 0;
   for (loop = 0; loop < 2; loop++) {
     if (loop == 0)
       CuDevice::Instantiate().SelectGpuId("no");

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -48,8 +48,10 @@ void MatrixBase<Real>::Invert(Real *log_det, Real *det_sign,
   Real *p_work;
   void *temp;
   if ((p_work = static_cast<Real*>(
-          KALDI_MEMALIGN(16, sizeof(Real)*l_work, &temp))) == NULL)
+          KALDI_MEMALIGN(16, sizeof(Real)*l_work, &temp))) == NULL) {
+    delete[] pivot;
     throw std::bad_alloc();
+  }
 
   clapack_Xgetrf2(&M, &N, data_, &LDA, pivot, &result);
   const int pivot_offset = 1;

--- a/src/matrix/sp-matrix.cc
+++ b/src/matrix/sp-matrix.cc
@@ -250,8 +250,10 @@ void SpMatrix<Real>::Invert(Real *logdet, Real *det_sign, bool need_inverse) {
   Real *p_work;  // workspace for the lapack function
   void *temp;
   if ((p_work = static_cast<Real*>(
-          KALDI_MEMALIGN(16, sizeof(Real) * rows, &temp))) == NULL)
+          KALDI_MEMALIGN(16, sizeof(Real) * rows, &temp))) == NULL) {
+    delete[] p_ipiv;
     throw std::bad_alloc();
+  }
 #ifdef HAVE_OPENBLAS
   memset(p_work, 0, sizeof(Real) * rows); // gets rid of a probably
   // spurious Valgrind warning about jumps depending upon uninitialized values.

--- a/src/nnet3/nnet-derivative-test.cc
+++ b/src/nnet3/nnet-derivative-test.cc
@@ -421,9 +421,9 @@ void UnitTestNnetInputDerivatives() {
 int main() {
   using namespace kaldi;
   using namespace kaldi::nnet3;
-  kaldi::int32 loop = 0;
   SetVerboseLevel(3);
 #if HAVE_CUDA == 1
+  int32 loop = 0;
   for (loop = 0; loop < 2; loop++) {
     CuDevice::Instantiate().SetDebugStrideMode(true);
     if (loop == 0)


### PR DESCRIPTION
Note that the memory leaks were incredibly unlikely to be encountered
anyway.

I found the unused variables by compiling with gcc without cuda, and the memory leaks by using cppcheck.