### PR TITLE
A cosmetic change to info messages in chain training

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
@@ -240,8 +240,6 @@ def train_one_iteration(dir, iter, srand, egs_dir,
 
     # Set off jobs doing some diagnostics, in the background.
     # Use the egs dir from the previous iteration for the diagnostics
-    logger.info("Training neural net (pass {0})".format(iter))
-
     # check if different iterations use the same random seed
     if os.path.exists('{0}/srand'.format(dir)):
         try:
@@ -290,16 +288,6 @@ def train_one_iteration(dir, iter, srand, egs_dir,
         cur_max_param_change = float(max_param_change) / math.sqrt(2)
 
     raw_model_string = raw_model_string + dropout_edit_string
-
-    shrink_info_str = ''
-    if shrinkage_value != 1.0:
-        shrink_info_str = ' and shrink value is {0}'.format(shrinkage_value)
-
-    logger.info("On iteration {0}, learning rate is {1}"
-                "{shrink_info}.".format(
-                    iter, learning_rate,
-                    shrink_info=shrink_info_str))
-
     train_new_models(dir=dir, iter=iter, srand=srand, num_jobs=num_jobs,
                      num_archives_processed=num_archives_processed,
                      num_archives=num_archives,

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -450,6 +450,19 @@ def train(args, run_opts):
                                         args.shrink_saturation_threshold)
                                    else shrinkage_value)
 
+            percent = num_archives_processed * 100.0 / num_archives_to_process
+            epoch = (num_archives_processed * args.num_epochs
+                     / num_archives_to_process)
+            shrink_info_str = ''
+            if shrinkage_value != 1.0:
+                shrink_info_str = 'shrink: {0:0.5f}'.format(shrinkage_value)
+            logger.info("Iter: {0}/{1}    "
+                        "Epoch: {2:0.2f}/{3:0.1f} ({4:0.1f}% complete)    "
+                        "lr: {5:0.6f}    {6}".format(iter, num_iters - 1,
+                                                     epoch, args.num_epochs,
+                                                     percent,
+                                                     lrate, shrink_info_str))
+
             chain_lib.train_one_iteration(
                 dir=args.dir,
                 iter=iter,


### PR DESCRIPTION
This is how the messages look like during training:
```
2017-09-08 03:18:41,217 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:243 - train_one_iteration - INFO ] Training neural net (pass 219)
2017-09-08 03:18:41,237 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:301 - train_one_iteration - INFO ] On iteration 219, learning rate is 0.0017154569002.
2017-09-08 03:19:59,392 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:243 - train_one_iteration - INFO ] Training neural net (pass 220)
2017-09-08 03:19:59,403 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:301 - train_one_iteration - INFO ] On iteration 220, learning rate is 0.00170658356495 and shrink value is 0.965868328701.
2017-09-08 03:21:23,766 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:243 - train_one_iteration - INFO ] Training neural net (pass 221)
2017-09-08 03:21:23,778 [steps/libs/nnet3/train/chain_objf/acoustic_model.py:301 - train_one_iteration - INFO ] On iteration 221, learning rate is 0.00169775612772.
```

This is how they will look like with this PR:
```
2017-09-11 11:50:46,863 [steps/nnet3/chain/train.py:464 - train - INFO ] Iter: 171/261    Epoch: 1.97/4.0 (49.4% complete)    lr: 0.003530
2017-09-11 11:53:07,409 [steps/nnet3/chain/train.py:464 - train - INFO ] Iter: 172/261    Epoch: 1.99/4.0 (49.8% complete)    lr: 0.003812    shrink: 0.93613
2017-09-11 11:55:31,191 [steps/nnet3/chain/train.py:464 - train - INFO ] Iter: 173/261    Epoch: 2.01/4.0 (50.3% complete)    lr: 0.003770
```