### PR TITLE
Updates related to refactoring of the phonetisaurus build system.

### DIFF
--- a/tools/extras/install_phonetisaurus.sh
+++ b/tools/extras/install_phonetisaurus.sh
@@ -60,7 +60,6 @@ fi
     cd phonetisaurus-g2p
     #checkout the current kaldi tag
     git checkout -b kaldi kaldi
-    cd src
     ./configure --with-openfst-includes=${TOOLS}/openfst/include --with-openfst-libs=${TOOLS}/openfst/lib
     make
 )
@@ -80,7 +79,7 @@ fi
   wd=`readlink -f $wd || pwd`
 
   echo "export PHONETISAURUS=\"$wd/phonetisaurus-g2p\""
-  echo "export PATH=\"\$PATH:\${PHONETISAURUS}/src/bin\""
+  echo "export PATH=\"\$PATH:\${PHONETISAURUS}:\${PHONETISAURUS}/src/scripts\""
 ) >> env.sh
 
 echo >&2 "Installation of PHONETISAURUS finished successfully"


### PR DESCRIPTION
These changes reflect some minor refactoring of the g2p build system as contributed by @giuliopaci .  There are two changes which entailed updating the ```install_phonetisaurus.sh``` build script: 

1. The configure scripting and location have been updated
2. The compiled binaries and ```phonetisaurus-apply``` scripts have been moved to more canonical locations.  

Note also that the wrapper scripts, ```phonetisaurus_apply```, and ```phonetisaurus_train``` have been renamed to ```phonetisaurus-apply```, and ```phonetisaurus-train```.  While this last does not affect the ```install_phonetisaurus.sh``` script directly, it may affect any egs/experiments that used the old names.