### PR TITLE
[scripts] zero-fill indexes in segment_ctm_edits scripts

### DIFF
--- a/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
+++ b/egs/wsj/s5/steps/cleanup/clean_and_segment_data.sh
@@ -192,6 +192,9 @@ if [ $stage -le 8 ]; then
   echo "$0: based on the segments and text file in $dir/segments and $dir/text, creating new data-dir in $data_out"
   padding=$(cat $dir/segment_end_padding)  # e.g. 0.02
   utils/data/subsegment_data_dir.sh --segment-end-padding $padding ${data} $dir/segments $dir/text $data_out
+  # utils/data/subsegment_data_dir.sh can output directories that have e.g. to many entries left in wav.scp
+  # Clean this up with the fix_dat_dir.sh script
+  utils/fix_data_dir.sh $data_out
 fi
 
 if [ $stage -le 9 ]; then

--- a/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits.py
+++ b/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits.py
@@ -807,10 +807,13 @@ def TimeToString(time, frame_length):
 
 def WriteSegmentsForUtterance(text_output_handle, segments_output_handle,
                               old_utterance_name, segments):
+    num_digits = len(str(len(segments)))
     for n in range(len(segments)):
         segment = segments[n]
         # split utterances will be named foo-bar-1 foo-bar-2, etc.
-        new_utterance_name = old_utterance_name + "-" + str(n + 1)
+        new_utterance_name = "{old}-{index:0{width}}".format(
+                                 old=old_utterance_name, index=n+1,
+                                 width=num_digits)
         # print a line to the text output of the form like
         # <new-utterance-id> <text>
         # like:

--- a/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits_mild.py
+++ b/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits_mild.py
@@ -1769,9 +1769,12 @@ def time_to_string(time, frame_length):
 def write_segments_for_utterance(text_output_handle, segments_output_handle,
                                  old_utterance_name, segments, oov_symbol,
                                  eps_symbol="<eps>", frame_length=0.01):
+    num_digits = len(str(len(segments)))
     for n, segment in enumerate(segments):
         # split utterances will be named foo-bar-1 foo-bar-2, etc.
-        new_utterance_name = old_utterance_name + "-" + str(n + 1)
+        new_utterance_name = "{old}-{index:0{width}}".format(
+                                 old=old_utterance_name, index=n+1,
+                                 width=num_digits)
         # print a line to the text output of the form like
         # <new-utterance-id> <text>
         # like:


### PR DESCRIPTION
Fixes main problem of #1892

I have not added any fix_data_dir.sh calls, but can do that if so desired. I would at least suggest to add a validate_data_dir.sh call on the end of clean_and_segment_data.sh to capture any other bugs that might come up.