### PR TITLE
[not-for-merge]: support multi GPU and Thread

### DIFF
--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -79,6 +79,12 @@ class CuDevice {
   ///  (more comments in cu-device.cc)
   void SelectGpuId(std::string use_gpu);
 
+  /// Similar as SelectGpuId(use_gpu), but forcibly use specified GPU.
+  ///  "yes"      -- Use specified GPU and die if this fails.
+  ///  "optional" -- Do as above, but if it fails, back off to CPU.
+  ///  "no"       -- Run on CPU.
+  void SelectGpuId(std::string use_gpu, int32 forced_gpu_id);
+
   /// Check if the CUDA GPU is selected for use
   bool Enabled() const {
     return (active_gpu_id_ > -1);
@@ -138,7 +144,7 @@ class CuDevice {
   CuDevice &operator=(CuDevice&);  // Disallow.
 
 
-  static CuDevice global_device_;
+  static thread_local CuDevice global_device_;
   cublasHandle_t handle_;
 
   /// Check if the GPU run in compute exclusive mode Returns true if it is


### PR DESCRIPTION
kaldi's cudamatrix is not support multi GPU:
It make gpu-config(CuDevice) singleton, so all thread in the process will get same config.
And according cuda's doc, all thread must call cudaSetDevice(). If not, new thread will use the default GPU.
The cublas's cublasCreate init context according specified GPU. So all thread should call cublasCreate afte cudaSetDevice.

I fix it without change origin API and keep CuDevice singleton. So all other kaldi's code need NO change. All I have done:
- make CuDevice thread_local, so each thread will use its own config.
- move the device reset code out of IsComputeExclusive(). Origin version is bugly and the reset behavior should be done by caller.
- add a new function SelectGpuId(use_gpu, forced_gpu_id). This version will keep try use given gpu_id.

I make a simple test on my own server and everything is OK.