### PR TITLE
[build] Fix paths to TensorFlow

### DIFF
--- a/src/tfrnnlm/Makefile
+++ b/src/tfrnnlm/Makefile
@@ -12,7 +12,7 @@
 
 include ../kaldi.mk
 
-TENSORFLOW = ../../tools/extras/tensorflow
+TENSORFLOW = ../../tools/tensorflow
 
 all:
 

--- a/src/tfrnnlm/Makefile
+++ b/src/tfrnnlm/Makefile
@@ -12,13 +12,14 @@
 
 include ../kaldi.mk
 
-TENSORFLOW = ../../tools/tensorflow
+TENSORFLOW = ../../tools/extras/tensorflow
 
 all:
 
 EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf/src \
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
+                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src
 
 OBJFILES = tensorflow-rnnlm.o

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -10,13 +10,14 @@
 # cd ../tfrnnlmbin/
 # make
 
-TENSORFLOW = $(shell pwd)/../../tools/tensorflow
+TENSORFLOW = $(shell pwd)/../../tools/extras/tensorflow
 
 all:
 
 EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf/src \
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
+                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src
 include ../kaldi.mk
 
@@ -32,7 +33,7 @@ ADDLIBS = ../lat/kaldi-lat.a ../lm/kaldi-lm.a ../fstext/kaldi-fstext.a \
           ../base/kaldi-base.a ../tfrnnlm/kaldi-tensorflow-rnnlm.a
 
 LDLIBS +=  -lz -ldl -fPIC -lrt
-LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc
+LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc -ltensorflow_framework
 
 LDFLAGS += -Wl,-rpath=$(shell pwd)/../../tools/tensorflow/bazel-bin/tensorflow/
 

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -10,7 +10,7 @@
 # cd ../tfrnnlmbin/
 # make
 
-TENSORFLOW = $(shell pwd)/../../tools/extras/tensorflow
+TENSORFLOW = $(shell pwd)/../../tools/tensorflow
 
 all:
 

--- a/tools/extras/install_tensorflow_cc.sh
+++ b/tools/extras/install_tensorflow_cc.sh
@@ -25,7 +25,7 @@ else
 fi
 
 
-[ ! -f bazel.zip ] && wget https://github.com/bazelbuild/bazel/releases/download/0.5.1/bazel-0.5.1-dist.zip -O bazel.zip
+[ ! -f bazel.zip ] && wget https://github.com/bazelbuild/bazel/releases/download/0.5.4/bazel-0.5.4-dist.zip -O bazel.zip
 mkdir -p bazel
 cd bazel
 unzip ../bazel.zip

--- a/tools/extras/install_tensorflow_cc.sh
+++ b/tools/extras/install_tensorflow_cc.sh
@@ -3,7 +3,7 @@
 set -e
 
 #export JAVA_HOME=/LOCATION_ON_YOUR_MACHINE/java/jdk1.8.0_121
-PATH=$PATH:$PWD/bazel/output
+PATH=$PWD/bazel/output:$PATH
 export HOME=$PWD/tensorflow_build/
 mkdir -p $HOME
 


### PR DESCRIPTION
I had to make these changes in order to successfully compile the `tfrnnlm` and `tfrnnlmbin` libraries. I also had to append the path to the TensorFlow shared libraries to the `LD_LIBRARY_PATH` in order to be able to run the `lattice-lmrescore-tf-rnnlm` binary.

Here is my OS information:

```
$ uname -a
Linux epsilon 4.10.0-35-generic #39-Ubuntu SMP Wed Sep 13 07:46:59 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```