### PR TITLE
fix run_ivector_common.sh to use data/lang

### DIFF
--- a/egs/fisher_swbd/s5/local/nnet3/run_ivector_common.sh
+++ b/egs/fisher_swbd/s5/local/nnet3/run_ivector_common.sh
@@ -40,7 +40,7 @@ if [ "$speed_perturb" == "true" ]; then
   if [ $stage -le 2 ] && [ "$generate_alignments" == "true" ]; then
     #obtain the alignment of the perturbed data
     steps/align_fmllr.sh --nj 100 --cmd "$train_cmd" \
-      data/train_nodup_sp data/lang_nosp exp/tri5a exp/tri5a_ali_nodup_sp || exit 1
+      data/train_nodup_sp data/lang exp/tri5a exp/tri5a_ali_nodup_sp || exit 1
   fi
   train_set=train_nodup_sp
 fi
@@ -104,7 +104,7 @@ if [ $stage -le 5 ]; then
   steps/train_lda_mllt.sh --cmd "$train_cmd" --num-iters 13 \
     --splice-opts "--left-context=3 --right-context=3" \
     5500 90000 data/train_100k_nodup_hires \
-    data/lang_nosp exp/tri1b_ali exp/nnet3/tri2b
+    data/lang exp/tri1b_ali exp/nnet3/tri2b
 fi
 
 if [ $stage -le 6 ]; then

--- a/egs/multi_en/s5/local/nnet3/run_ivector_common.sh
+++ b/egs/multi_en/s5/local/nnet3/run_ivector_common.sh
@@ -47,7 +47,7 @@ if [ "$speed_perturb" == "true" ]; then
   if [ $stage -le 2 ] && [ "$generate_alignments" == "true" ]; then
     #obtain the alignment of the perturbed data
     steps/align_fmllr.sh --nj 100 --cmd "$train_cmd" \
-      data/$multi/tdnn_sp data/lang_nosp exp/$multi/tri5 exp/$multi/tri5_ali_sp || exit 1
+      data/$multi/tdnn_sp data/lang exp/$multi/tri5 exp/$multi/tri5_ali_sp || exit 1
   fi
   train_set=$multi/tdnn_sp
 fi
@@ -104,7 +104,7 @@ if [ $stage -le 5 ]; then
   steps/train_lda_mllt.sh --cmd "$train_cmd" --num-iters 13 \
     --splice-opts "--left-context=3 --right-context=3" \
     5500 90000 data/$multi/tdnn_100k_hires \
-    data/lang_nosp exp/$multi/tri4_ali exp/$multi/nnet3/tri2b
+    data/lang exp/$multi/tri4_ali exp/$multi/nnet3/tri2b
 fi
 
 if [ $stage -le 6 ]; then

--- a/egs/swbd/s5c/local/nnet3/run_ivector_common.sh
+++ b/egs/swbd/s5c/local/nnet3/run_ivector_common.sh
@@ -44,7 +44,7 @@ if [ "$speed_perturb" == "true" ]; then
   if [ $stage -le 2 ] && [ "$generate_alignments" == "true" ]; then
     #obtain the alignment of the perturbed data
     steps/align_fmllr.sh --nj 100 --cmd "$train_cmd" \
-      data/train_nodup_sp data/lang_nosp exp/tri4 exp/tri4_ali_nodup_sp || exit 1
+      data/train_nodup_sp data/lang exp/tri4 exp/tri4_ali_nodup_sp || exit 1
   fi
   train_set=train_nodup_sp
 fi
@@ -97,7 +97,7 @@ if [ $stage -le 5 ]; then
   steps/train_lda_mllt.sh --cmd "$train_cmd" --num-iters 13 \
     --splice-opts "--left-context=3 --right-context=3" \
     5500 90000 data/train_100k_nodup_hires \
-    data/lang_nosp exp/tri2_ali_100k_nodup exp/nnet3/tri3b
+    data/lang exp/tri2_ali_100k_nodup exp/nnet3/tri3b
 fi
 
 if [ $stage -le 6 ]; then


### PR DESCRIPTION
Check all the subdirectories in "egs" directory and use "data/lang"(with silence probs) to replace "data/lang_nosp" if it has already be gotten.
Hang