### PR TITLE
CSJ: Replace Zenkaku-Space to Zenkaku-Underscore

### DIFF
--- a/egs/csj/s5/local/csj_make_trans/csj2kaldi4m.pl
+++ b/egs/csj/s5/local/csj_make_trans/csj2kaldi4m.pl
@@ -245,6 +245,11 @@ while (<IN>) {
     $morph =~ s/\/\//\//g;
     $morph =~ s/\/\//\//g;
     $morph =~ s/\/$//g;
+    # Replace Zenkaku-Space to Zenkaku-Underscore
+    # Input: っしゃっ+動詞/ラ行五段/連用形/促音便　省略 r a q sh a q
+    # ->
+    # Output: っしゃっ+動詞/ラ行五段/連用形/促音便＿省略 r a q sh a q
+    $morph =~ s/　/＿/g;
 
     unless( $word =~ /skip_word/){
 	if ($word && $pos){


### PR DESCRIPTION
`utils/prepare_lang.sh` called `utils/validate_dict_dir.pl` in it.
If `lexicon.txt` contained disallowed UTF-8 whitespace character such as "Zenkaku-Space", failed validation.

So, I fixed csj file parser to remove disallowed UTF-8 whitespace character (Zenkaku-Space).