### PR TITLE
Use KALDI_ROOT env if it's initialized

### DIFF
--- a/egs/csj/s5/local/csj_train_lms.sh
+++ b/egs/csj/s5/local/csj_train_lms.sh
@@ -42,7 +42,7 @@ fi
 text=$1    
 lexicon=$2 
 dir=$3     
-. path.sh
+. ./path.sh
 
 for f in "$text" "$lexicon"; do
   [ ! -f $x ] && echo "$0: No such file $f" && exit 1;

--- a/egs/csj/s5/local/csj_train_lms.sh
+++ b/egs/csj/s5/local/csj_train_lms.sh
@@ -50,9 +50,9 @@ done
 loc=`which ngram-count`;
 if [ -z $loc ]; then
   if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-    sdir=`pwd`/../../../tools/srilm/bin/i686-m64 
+    sdir=${KALDI_ROOT:-`pwd`/../../..}/tools/srilm/bin/i686-m64 
   else
-    sdir=`pwd`/../../../tools/srilm/bin/i686
+    sdir=${KALDI_ROOT:-`pwd`/../../..}/tools/srilm/bin/i686
   fi
   if [ -f $sdir/ngram-count ]; then
     echo Using SRILM tools from $sdir

--- a/egs/csj/s5/local/csj_train_lms.sh
+++ b/egs/csj/s5/local/csj_train_lms.sh
@@ -42,6 +42,7 @@ fi
 text=$1    
 lexicon=$2 
 dir=$3     
+. path.sh
 
 for f in "$text" "$lexicon"; do
   [ ! -f $x ] && echo "$0: No such file $f" && exit 1;
@@ -50,9 +51,9 @@ done
 loc=`which ngram-count`;
 if [ -z $loc ]; then
   if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-    sdir=${KALDI_ROOT:-`pwd`/../../..}/tools/srilm/bin/i686-m64 
+    sdir=${KALDI_ROOT}/tools/srilm/bin/i686-m64 
   else
-    sdir=${KALDI_ROOT:-`pwd`/../../..}/tools/srilm/bin/i686
+    sdir=${KALDI_ROOT}/tools/srilm/bin/i686
   fi
   if [ -f $sdir/ngram-count ]; then
     echo Using SRILM tools from $sdir


### PR DESCRIPTION
Previous script, used relative PATH that used `pwd`.
When cloning only CSJ-recipe for tuning it,  it is hard to keep the directory structure.

IMO, we should use KALDI_ROOT env that initialized in `path.sh` instead of `pwd`'s relative path.