### PR TITLE
using KALDI_ROOT instead of relative path

### DIFF
--- a/egs/csj/s5/path.sh
+++ b/egs/csj/s5/path.sh
@@ -1,8 +1,11 @@
-export KALDI_ROOT=`pwd`/../../..
+if [ -z $KALDI_ROOT ]; then
+    export KALDI_ROOT=`pwd`/../../..
+fi
 
 export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$PWD:$PATH
 [ ! -f $KALDI_ROOT/tools/config/common_path.sh ] && echo >&2 "The standard file $KALDI_ROOT/tools/config/common_path.sh is not present -> Exit!" && exit 1
 . $KALDI_ROOT/tools/config/common_path.sh
+
 export PATH=$PATH:/usr/local/cuda/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/lib64:/usr/local/cuda/bin/nvcc
 

--- a/egs/wsj/s5/steps/cleanup/make_segmentation_graph.sh
+++ b/egs/wsj/s5/steps/cleanup/make_segmentation_graph.sh
@@ -61,9 +61,9 @@ if [ $ngram_order -gt 1 ]; then
   ngram_count=`which ngram-count` || true
   if [ -z $ngram_count ]; then
     if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-      sdir=`pwd`/../../../tools/srilm/bin/i686-m64
+      sdir=$KALDI_ROOT/tools/srilm/bin/i686-m64
     else
-      sdir=`pwd`/../../../tools/srilm/bin/i686
+      sdir=$KALDI_ROOT/tools/srilm/bin/i686
     fi
     if [ -f $sdir/ngram-count ]; then
       echo Using SRILM tools from $sdir

--- a/egs/wsj/s5/steps/cleanup/make_utterance_graph.sh
+++ b/egs/wsj/s5/steps/cleanup/make_utterance_graph.sh
@@ -62,9 +62,9 @@ if [ $ngram_order -gt 1 ]; then
   ngram_count=`which ngram-count` || true
   if [ -z $ngram_count ]; then
     if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-      sdir=`pwd`/../../../tools/srilm/bin/i686-m64
+      sdir=$KALDI_ROOT/tools/srilm/bin/i686-m64
     else
-      sdir=`pwd`/../../../tools/srilm/bin/i686
+      sdir=$KALDI_ROOT/tools/srilm/bin/i686
     fi
     if [ -f $sdir/ngram-count ]; then
       echo Using SRILM tools from $sdir

--- a/egs/wsj/s5/steps/make_phone_graph.sh
+++ b/egs/wsj/s5/steps/make_phone_graph.sh
@@ -46,9 +46,9 @@ done
 loc=`which ngram-count`;
 if [ -z $loc ]; then
   if uname -a | grep 64 >/dev/null; then # some kind of 64 bit...
-    sdir=`pwd`/../../../tools/srilm/bin/i686-m64
+    sdir=$KALDI_ROOT/tools/srilm/bin/i686-m64
   else
-    sdir=`pwd`/../../../tools/srilm/bin/i686
+    sdir=$KALDI_ROOT/tools/srilm/bin/i686
   fi
   if [ -f $sdir/ngram-count ]; then
     echo Using SRILM tools from $sdir


### PR DESCRIPTION
KALDI_ROOT refers environmet variables first. if it is not set, then refers relative path.
srilm path refers KALDI_ROOT instead of relative path.