### PR TITLE
Sorted nonsilence_phones.txt

### DIFF
--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -120,7 +120,7 @@ if [ $stage -le 3 ]; then
     perl -e 'while(<>){
       chop; m:^([^\d]+)(\d*)$: || die "Bad phone $_";
       $phones_of{$1} .= "$_ "; }
-      foreach $list (values %phones_of) {print $list . "\n"; } ' \
+      foreach $list (values %phones_of) {print $list . "\n"; } ' | sort \
       > $nonsil_phones || exit 1;
   # A few extra questions that will be added to those obtained by automatically clustering
   # the "real" phones.  These ask about stress; there's also one for silence.


### PR DESCRIPTION
Outputting non-silence phones in sorted order to avoid discrepancies between different runs of the training script.