### PR TITLE
Removed kLinearInParameters and kLinearInInput flags (Issue #1940)

### DIFF
--- a/src/nnet3/nnet-component-itf.h
+++ b/src/nnet3/nnet-component-itf.h
@@ -47,48 +47,41 @@ enum ComponentProperties {
                                 // UpdatableComponent do not have to return this
                                 // flag, e.g.  if this instance is not really
                                 // updatable).
-  kLinearInInput = 0x004,    // true if the component's output is always a
-                             // linear function of its input, i.e. alpha times
-                             // input gives you alpha times output.
-  kLinearInParameters = 0x008, // true if an updatable component's output is always a
-                               // linear function of its parameters, i.e. alpha times
-                               // parameters gives you alpha times output.  This is true
-                               // for all updatable components we envisage.
-  kPropagateInPlace = 0x010,  // true if we can do the propagate operation in-place
+  kPropagateInPlace = 0x004,  // true if we can do the propagate operation in-place
                               // (input and output matrices are the same).
                               // Note: if doing backprop, you'd also need to check
                               // that the kBackpropNeedsInput property is not true.
-  kPropagateAdds = 0x020,  // true if the Propagate function adds to, rather
+  kPropagateAdds = 0x008,  // true if the Propagate function adds to, rather
                            // than setting, its output.  The Component chooses
                            // whether to add or set, and the calling code has to
                            // accommodate it.  This flag is incompatible with
                            // the kPropagateInPlace flag.
-  kReordersIndexes = 0x040,  // true if the ReorderIndexes function might reorder
+  kReordersIndexes = 0x010,  // true if the ReorderIndexes function might reorder
                              // the indexes (otherwise we can skip calling it).
                              // Must not be set for simple components.
-  kBackpropAdds = 0x080,   // true if the Backprop function adds to, rather than
+  kBackpropAdds = 0x020,   // true if the Backprop function adds to, rather than
                            // setting, the "in_deriv" output.  The Component
                            // chooses whether to add or set, and the calling
                            // code has to accommodate it.  Note: in the case of
                            // in-place backprop, this flag is
-  kBackpropNeedsInput = 0x100,  // true if backprop operation needs access to
+  kBackpropNeedsInput = 0x040,  // true if backprop operation needs access to
                                 // forward-pass input.
-  kBackpropNeedsOutput = 0x200,  // true if backprop operation needs access to
+  kBackpropNeedsOutput = 0x080,  // true if backprop operation needs access to
                                  // forward-pass output (e.g. true for Sigmoid).
-  kBackpropInPlace = 0x400,   // true if we can do the backprop operation in-place
+  kBackpropInPlace = 0x100,   // true if we can do the backprop operation in-place
                              // (input and output matrices may be the same).
-  kStoresStats = 0x800,      // true if the StoreStats operation stores
+  kStoresStats = 0x200,      // true if the StoreStats operation stores
                              // statistics e.g. on average node activations and
                              // derivatives of the nonlinearity, (as it does for
                              // Tanh, Sigmoid, ReLU and Softmax).
-  kInputContiguous = 0x1000,  // true if the component requires its input data (and
+  kInputContiguous = 0x400,  // true if the component requires its input data (and
                               // input derivatives) to have Stride()== NumCols().
-  kOutputContiguous = 0x2000,  // true if the component requires its input data (and
+  kOutputContiguous = 0x800,  // true if the component requires its input data (and
                                // output derivatives) to have Stride()== NumCols().
-  kUsesMemo = 0x4000,  // true if the component returns a void* pointer from its
+  kUsesMemo = 0x1000,  // true if the component returns a void* pointer from its
                        // Propagate() function that needs to be passed into the
                        // corresponding Backprop function.
-  kRandomComponent = 0x8000   // true if the component has some kind of
+  kRandomComponent = 0x2000   // true if the component has some kind of
                               // randomness, like DropoutComponent (these should
                               // inherit from class RandomComponent.
 };

--- a/src/nnet3/nnet-component-test.cc
+++ b/src/nnet3/nnet-component-test.cc
@@ -170,16 +170,11 @@ void TestNnetComponentUpdatable(Component *c) {
 // kBackpropNeedsInput, kBackpropNeedsOutput.
 void TestSimpleComponentPropagateProperties(const Component &c) {
   int32 properties = c.Properties();
-  Component *c_copy = NULL, *c_copy_scaled = NULL;
+  Component *c_copy = NULL;
   int32 rand_seed = Rand();
 
   if (RandInt(0, 1) == 0)
     c_copy = c.Copy();  // This will test backprop with an updatable component.
-  if (RandInt(0, 1) == 0 &&
-      (properties & kLinearInParameters)) {
-    c_copy_scaled = c.Copy();  // This will test backprop with an updatable component.
-    c_copy_scaled->Scale(0.5);
-  }
   MatrixStrideType input_stride_type = (c.Properties()&kInputContiguous) ?
       kStrideEqualNumCols : kDefaultStride;
   MatrixStrideType output_stride_type = (c.Properties()&kOutputContiguous) ?
@@ -191,19 +186,13 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
   CuMatrix<BaseFloat> input_data(num_rows, input_dim, kUndefined,
                                  input_stride_type);
   input_data.SetRandn();
-  CuMatrix<BaseFloat> input_data_scaled(num_rows, input_dim, kUndefined,
-                                        input_stride_type),
-      output_data3(num_rows, input_dim, kSetZero,
-                   output_stride_type);
-  input_data_scaled.CopyFromMat(input_data);
+  CuMatrix<BaseFloat> output_data3(num_rows, input_dim, kSetZero,
+                                   output_stride_type);
   output_data3.CopyFromMat(input_data);
   CuMatrix<BaseFloat>
       output_data1(num_rows, output_dim, kSetZero, output_stride_type),
-      output_data2(num_rows, output_dim, kSetZero, output_stride_type),
-      output_data4(num_rows, output_dim, kSetZero, output_stride_type),
-      output_data5(num_rows, output_dim, kSetZero, output_stride_type);
+      output_data2(num_rows, output_dim, kSetZero, output_stride_type);
   output_data2.Add(1.0);
-  input_data_scaled.Scale(2.0);
 
   if ((properties & kPropagateAdds) && (properties & kPropagateInPlace)) {
     KALDI_ERR << "kPropagateAdds and kPropagateInPlace flags are incompatible.";
@@ -225,20 +214,6 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
   if (properties & kPropagateAdds)
     output_data2.Add(-1.0); // remove the offset
   AssertEqual(output_data1, output_data2);
-
-  if (c_copy_scaled) {
-    ResetSeed(rand_seed, *c_copy_scaled);
-    c_copy_scaled->Propagate(NULL, input_data, &output_data4);
-    output_data4.Scale(2.0);  // we scaled the parameters by 0.5 above, and the
-    // output is supposed to be linear in the parameter value.
-    AssertEqual(output_data1, output_data4);
-  }
-  if (properties & kLinearInInput) {
-    ResetSeed(rand_seed, c);
-    c.DeleteMemo(c.Propagate(NULL, input_data_scaled, &output_data5));
-    output_data5.Scale(0.5);
-    AssertEqual(output_data1, output_data5);
-  }
 
 
   CuMatrix<BaseFloat> output_deriv(num_rows, output_dim, kSetZero, output_stride_type);
@@ -285,7 +260,6 @@ void TestSimpleComponentPropagateProperties(const Component &c) {
   if (properties & kBackpropInPlace)
     AssertEqual(input_deriv1, input_deriv3);
   delete c_copy;
-  delete c_copy_scaled;
 }
 
 bool TestSimpleComponentDataDerivative(const Component &c,

--- a/src/nnet3/nnet-convolutional-component.h
+++ b/src/nnet3/nnet-convolutional-component.h
@@ -220,9 +220,8 @@ class TimeHeightConvolutionComponent: public UpdatableComponent {
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual std::string Type() const { return "TimeHeightConvolutionComponent"; }
   virtual int32 Properties() const {
-    return kUpdatableComponent|kLinearInParameters|
-        kReordersIndexes|kBackpropAdds|kBackpropNeedsInput|
-        kInputContiguous|kOutputContiguous;
+    return kUpdatableComponent|kReordersIndexes|kBackpropAdds|
+        kBackpropNeedsInput|kInputContiguous|kOutputContiguous;
   }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,

--- a/src/nnet3/nnet-general-component.h
+++ b/src/nnet3/nnet-general-component.h
@@ -65,7 +65,7 @@ class DistributeComponent: public Component {
   // use the default Info() function.
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual std::string Type() const { return "DistributeComponent"; }
-  virtual int32 Properties() const { return kLinearInInput; }
+  virtual int32 Properties() const { return 0; }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
@@ -475,7 +475,7 @@ class BackpropTruncationComponent: public Component {
   virtual std::string Type() const { return "BackpropTruncationComponent"; }
 
   virtual int32 Properties() const {
-    return kLinearInInput|kPropagateInPlace|kBackpropInPlace;
+    return kPropagateInPlace|kBackpropInPlace;
   }
 
   virtual void ZeroStats();
@@ -615,7 +615,7 @@ class ConstantComponent: public UpdatableComponent {
   virtual std::string Type() const { return "ConstantComponent"; }
   virtual int32 Properties() const {
     return
-        (is_updatable_ ? kUpdatableComponent|kLinearInParameters : 0);
+        (is_updatable_ ? kUpdatableComponent : 0);
   }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,

--- a/src/nnet3/nnet-simple-component.h
+++ b/src/nnet3/nnet-simple-component.h
@@ -49,7 +49,7 @@ class PnormComponent: public Component {
     Init(input_dim, output_dim);
   }
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kBackpropNeedsInput|kBackpropNeedsOutput;
+    return kSimpleComponent|kBackpropNeedsInput|kBackpropNeedsOutput;
   }
   PnormComponent(): input_dim_(0), output_dim_(0) { }
   virtual std::string Type() const { return "PnormComponent"; }
@@ -102,7 +102,7 @@ class DropoutComponent : public RandomComponent {
   DropoutComponent(const DropoutComponent &other);
 
   virtual int32 Properties() const {
-    return kLinearInInput|kBackpropInPlace|kSimpleComponent|kBackpropNeedsInput|
+    return kBackpropInPlace|kSimpleComponent|kBackpropNeedsInput|
         kBackpropNeedsOutput|kRandomComponent;
   }
   virtual std::string Type() const { return "DropoutComponent"; }
@@ -401,8 +401,7 @@ class RectifiedLinearComponent: public NonlinearComponent {
   virtual std::string Type() const { return "RectifiedLinearComponent"; }
   virtual Component* Copy() const { return new RectifiedLinearComponent(*this); }
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kBackpropNeedsOutput|kPropagateInPlace|
-        kStoresStats;
+    return kSimpleComponent|kBackpropNeedsOutput|kPropagateInPlace|kStoresStats;
   }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
@@ -450,7 +449,7 @@ class AffineComponent: public UpdatableComponent {
   AffineComponent() { } // use Init to really initialize.
   virtual std::string Type() const { return "AffineComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kUpdatableComponent|kLinearInParameters|
+    return kSimpleComponent|kUpdatableComponent|
         kBackpropNeedsInput|kBackpropAdds;
   }
 
@@ -542,7 +541,7 @@ class BlockAffineComponent : public UpdatableComponent {
   BlockAffineComponent() { }
   virtual std::string Type() const { return "BlockAffineComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kUpdatableComponent|kLinearInParameters|
+    return kSimpleComponent|kUpdatableComponent|
       kBackpropNeedsInput|kBackpropAdds;
   }
 
@@ -607,8 +606,8 @@ class RepeatedAffineComponent: public UpdatableComponent {
   RepeatedAffineComponent() { } // use Init to really initialize.
   virtual std::string Type() const { return "RepeatedAffineComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kUpdatableComponent|kLinearInParameters|
-        kBackpropNeedsInput|kBackpropAdds|kInputContiguous|kOutputContiguous;
+    return kSimpleComponent|kUpdatableComponent|kBackpropNeedsInput|
+        kBackpropAdds|kInputContiguous|kOutputContiguous;
   }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
@@ -954,7 +953,7 @@ public:
   virtual void InitFromConfig(ConfigLine *cfl);
   SumGroupComponent() { }
   virtual std::string Type() const { return "SumGroupComponent"; }
-  virtual int32 Properties() const { return kSimpleComponent|kLinearInInput; }
+  virtual int32 Properties() const { return kSimpleComponent; }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
                          const CuMatrixBase<BaseFloat> &in,
                          CuMatrixBase<BaseFloat> *out) const;
@@ -991,7 +990,7 @@ class FixedScaleComponent: public Component {
   virtual std::string Type() const { return "FixedScaleComponent"; }
   virtual std::string Info() const;
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kPropagateInPlace|kBackpropInPlace;
+    return kSimpleComponent|kPropagateInPlace|kBackpropInPlace;
   }
 
   void Init(const CuVectorBase<BaseFloat> &scales);
@@ -1076,7 +1075,7 @@ class NoOpComponent: public NonlinearComponent {
   NoOpComponent() { }
   virtual std::string Type() const { return "NoOpComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kPropagateInPlace;
+    return kSimpleComponent|kPropagateInPlace;
   }
   virtual Component* Copy() const { return new NoOpComponent(*this); }
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
@@ -1114,7 +1113,7 @@ class SumBlockComponent: public Component {
   SumBlockComponent() { }
   virtual std::string Type() const { return "SumBlockComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kPropagateAdds|kBackpropAdds;
+    return kSimpleComponent|kPropagateAdds|kBackpropAdds;
   }
   virtual void InitFromConfig(ConfigLine *cfl);
   virtual int32 InputDim() const { return input_dim_; }
@@ -1185,7 +1184,7 @@ class ClipGradientComponent: public Component {
   virtual std::string Type() const { return "ClipGradientComponent"; }
 
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput|kPropagateInPlace|kBackpropInPlace|
+    return kSimpleComponent|kPropagateInPlace|kBackpropInPlace|
            kBackpropNeedsInput;
   }
 
@@ -1300,7 +1299,7 @@ class PermuteComponent: public Component {
   virtual std::string Type() const { return "PermuteComponent"; }
 
   virtual int32 Properties() const {
-    return kSimpleComponent|kLinearInInput;
+    return kSimpleComponent;
   }
 
   virtual void ZeroStats() {}
@@ -1354,8 +1353,8 @@ class PerElementScaleComponent: public UpdatableComponent {
   PerElementScaleComponent() { } // use Init to really initialize.
   virtual std::string Type() const { return "PerElementScaleComponent"; }
   virtual int32 Properties() const {
-    return kSimpleComponent|kUpdatableComponent|kLinearInInput|
-        kLinearInParameters|kBackpropNeedsInput|kPropagateInPlace;
+    return kSimpleComponent|kUpdatableComponent|kBackpropNeedsInput|
+        kPropagateInPlace;
   }
 
   virtual void* Propagate(const ComponentPrecomputedIndexes *indexes,
@@ -1509,7 +1508,7 @@ class ConstantFunctionComponent: public UpdatableComponent {
   virtual std::string Type() const { return "ConstantFunctionComponent"; }
   virtual int32 Properties() const {
     return kSimpleComponent|
-        (is_updatable_ ? kUpdatableComponent|kLinearInParameters : 0) |
+        (is_updatable_ ? kUpdatableComponent : 0) |
         (InputDim() == OutputDim() ? kPropagateInPlace: 0) |
         kBackpropAdds;
   }


### PR DESCRIPTION
The kLinearInParameters and kLinearInInput flags have been removed from nnet3/nnet-component-itf.h, as they are unnecessary.

The corresponding test code has been removed, and all the code using these flags has been modified accordingly.