### PR TITLE
[egs,scripts] Use command passed as --egs.cmd for get_egs.sh instead of command passed as --cmd

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
@@ -94,7 +94,7 @@ def generate_chain_egs(dir, data, lat_dir, egs_dir,
                 --frames-per-eg {frames_per_eg_str} \
                 --srand {srand} \
                 {data} {dir} {lat_dir} {egs_dir}""".format(
-                    command=run_opts.command,
+                    command=run_opts.egs_command,
                     cmvn_opts=cmvn_opts if cmvn_opts is not None else '',
                     transform_dir=(transform_dir
                                    if transform_dir is not None

--- a/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/chain_objf/acoustic_model.py
@@ -61,7 +61,7 @@ def create_denominator_fst(dir, tree_dir, run_opts):
 
 
 def generate_chain_egs(dir, data, lat_dir, egs_dir,
-                       left_context, right_context,
+                       left_context, right_context, cmd,
                        run_opts, stage=0,
                        left_tolerance=None, right_tolerance=None,
                        left_context_initial=-1, right_context_final=-1,
@@ -94,7 +94,7 @@ def generate_chain_egs(dir, data, lat_dir, egs_dir,
                 --frames-per-eg {frames_per_eg_str} \
                 --srand {srand} \
                 {data} {dir} {lat_dir} {egs_dir}""".format(
-                    command=run_opts.egs_command,
+                    command=cmd,
                     cmvn_opts=cmvn_opts if cmvn_opts is not None else '',
                     transform_dir=(transform_dir
                                    if transform_dir is not None

--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -922,8 +922,7 @@ class CommonParser(object):
                                  """, default="queue.pl")
         self.parser.add_argument("--egs.cmd", type=str, dest="egs_command",
                                  action=common_lib.NullstrToNoneAction,
-                                 help="Script to launch egs jobs",
-                                 default="queue.pl")
+                                 help="Script to launch egs jobs")
         self.parser.add_argument("--use-gpu", type=str,
                                  action=common_lib.StrToBoolAction,
                                  choices=["true", "false"],

--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -922,7 +922,8 @@ class CommonParser(object):
                                  """, default="queue.pl")
         self.parser.add_argument("--egs.cmd", type=str, dest="egs_command",
                                  action=common_lib.NullstrToNoneAction,
-                                 help="Script to launch egs jobs")
+                                 help="Script to launch egs jobs",
+                                 default="queue.pl")
         self.parser.add_argument("--use-gpu", type=str,
                                  action=common_lib.StrToBoolAction,
                                  choices=["true", "false"],

--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/acoustic_model.py
@@ -47,7 +47,7 @@ def generate_egs(data, alidir, egs_dir,
                 --frames-per-eg {frames_per_eg_str} \
                 --srand {srand} \
                 {data} {alidir} {egs_dir}
-        """.format(command=run_opts.command,
+        """.format(command=run_opts.egs_command,
                    cmvn_opts=cmvn_opts if cmvn_opts is not None else '',
                    transform_dir=(transform_dir
                                   if transform_dir is not None else

--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/acoustic_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/acoustic_model.py
@@ -19,7 +19,7 @@ logger.addHandler(logging.NullHandler())
 
 
 def generate_egs(data, alidir, egs_dir,
-                 left_context, right_context,
+                 left_context, right_context, cmd,
                  run_opts, stage=0,
                  left_context_initial=-1, right_context_final=-1,
                  online_ivector_dir=None,
@@ -47,7 +47,7 @@ def generate_egs(data, alidir, egs_dir,
                 --frames-per-eg {frames_per_eg_str} \
                 --srand {srand} \
                 {data} {alidir} {egs_dir}
-        """.format(command=run_opts.egs_command,
+        """.format(command=cmd,
                    cmvn_opts=cmvn_opts if cmvn_opts is not None else '',
                    transform_dir=(transform_dir
                                   if transform_dir is not None else

--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/raw_model.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/raw_model.py
@@ -18,7 +18,7 @@ logger.addHandler(logging.NullHandler())
 
 
 def generate_egs_using_targets(data, targets_scp, egs_dir,
-                               left_context, right_context,
+                               left_context, right_context, cmd,
                                run_opts, stage=0,
                                left_context_initial=-1, right_context_final=-1,
                                online_ivector_dir=None,
@@ -65,7 +65,7 @@ def generate_egs_using_targets(data, targets_scp, egs_dir,
                 --target-type {target_type} \
                 --num-targets {num_targets} \
                 {data} {targets_scp} {egs_dir}
-        """.format(command=run_opts.egs_command,
+        """.format(command=cmd,
                    cmvn_opts=cmvn_opts if cmvn_opts is not None else '',
                    transform_dir=(transform_dir
                                   if transform_dir is not None

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -366,6 +366,7 @@ def train(args, run_opts):
             right_context=egs_right_context,
             left_context_initial=egs_left_context_initial,
             right_context_final=egs_right_context_final,
+            cmd=(args.egs_command if args.egs_command is not None else args.command),
             run_opts=run_opts,
             left_tolerance=args.left_tolerance,
             right_tolerance=args.right_tolerance,

--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -251,9 +251,6 @@ def process_args(args):
         run_opts.combine_queue_opt = ""
 
     run_opts.command = args.command
-    run_opts.egs_command = (args.egs_command
-                            if args.egs_command is not None else
-                            args.command)
 
     return [args, run_opts]
 

--- a/egs/wsj/s5/steps/nnet3/train_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_dnn.py
@@ -142,9 +142,6 @@ def process_args(args):
         run_opts.prior_queue_opt = ""
 
     run_opts.command = args.command
-    run_opts.egs_command = (args.egs_command
-                            if args.egs_command is not None else
-                            args.command)
     run_opts.num_jobs_compute_prior = args.num_jobs_compute_prior
 
     return [args, run_opts]
@@ -218,6 +215,7 @@ def train(args, run_opts):
         train_lib.acoustic_model.generate_egs(
             data=args.feat_dir, alidir=args.ali_dir, egs_dir=default_egs_dir,
             left_context=left_context, right_context=right_context,
+            cmd=(args.egs_command if args.egs_command is not None else args.command),
             run_opts=run_opts,
             frames_per_eg_str=str(args.frames_per_eg),
             srand=args.srand,

--- a/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
@@ -151,9 +151,6 @@ def process_args(args):
         run_opts.prior_queue_opt = ""
 
     run_opts.command = args.command
-    run_opts.egs_command = (args.egs_command
-                            if args.egs_command is not None else
-                            args.command)
     run_opts.num_jobs_compute_prior = args.num_jobs_compute_prior
 
     return [args, run_opts]
@@ -239,6 +236,7 @@ def train(args, run_opts):
             data=args.feat_dir, targets_scp=args.targets_scp,
             egs_dir=default_egs_dir,
             left_context=left_context, right_context=right_context,
+            cmd=(args.egs_command if args.egs_command is not None else args.command),
             run_opts=run_opts,
             frames_per_eg_str=str(args.frames_per_eg),
             srand=args.srand,

--- a/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
@@ -204,9 +204,6 @@ def process_args(args):
         run_opts.prior_queue_opt = ""
 
     run_opts.command = args.command
-    run_opts.egs_command = (args.egs_command
-                            if args.egs_command is not None else
-                            args.command)
     run_opts.num_jobs_compute_prior = args.num_jobs_compute_prior
 
     return [args, run_opts]
@@ -293,6 +290,7 @@ def train(args, run_opts):
             right_context=right_context,
             left_context_initial=left_context_initial,
             right_context_final=right_context_final,
+            cmd=(args.egs_command if args.egs_command is not None else args.command),
             run_opts=run_opts,
             frames_per_eg_str=args.chunk_width,
             srand=args.srand,

--- a/egs/wsj/s5/steps/nnet3/train_rnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_rnn.py
@@ -198,9 +198,6 @@ def process_args(args):
         run_opts.prior_queue_opt = ""
 
     run_opts.command = args.command
-    run_opts.egs_command = (args.egs_command
-                            if args.egs_command is not None else
-                            args.command)
     run_opts.num_jobs_compute_prior = args.num_jobs_compute_prior
 
     return [args, run_opts]
@@ -281,6 +278,7 @@ def train(args, run_opts):
             right_context=right_context,
             left_context_initial=left_context_initial,
             right_context_final=right_context_final,
+            cmd=(args.egs_command if args.egs_command is not None else args.command),
             run_opts=run_opts,
             frames_per_eg_str=args.chunk_width,
             srand=args.srand,


### PR DESCRIPTION
This PR fixes a minor issue with the acoustic model training libraries. The command passed as --egs.cmd was not passed to get_egs.sh. In raw_model.py, the command passed as --egs.cmd is being passed correctly to get_egs_targets.sh.