### PR TITLE
[egs] Fix sed regex in scoring of TED-LIUM recipe

### DIFF
--- a/egs/tedlium/s5_r2/local/score_basic.sh
+++ b/egs/tedlium/s5_r2/local/score_basic.sh
@@ -45,7 +45,7 @@ $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring/log/best_path.LMWT.log \
 $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring/log/score.LMWT.log \
    cat $dir/scoring/LMWT.tra \| \
     utils/int2sym.pl -f 2- $symtab \| \
-    sed 's:\\<unk>\\]::g' \| \
+    sed 's:\<unk\>::g' \| \
     compute-wer --text --mode=present \
      ark:$dir/scoring/test_filt.txt  ark,p:- ">&" $dir/wer_LMWT || exit 1;
 


### PR DESCRIPTION
This is a minor change to fix a problem I encountered when running `score_basic.sh` for the TED-LIUM recipe (version `s5_r2`). Before the change, I got the following error:

```bash
$ cat exp/chain_cleaned/tdnn1f_sp_bi/decode_test/scoring/log/score.7.log
# cat exp/chain_cleaned/tdnn1f_sp_bi/decode_test/scoring/7.tra | utils/int2sym.pl -f 2- data/lang/words.txt | sed s:\\<unk>\\]::g | compute-wer --text --mode=present ark:exp/chain_cleaned/tdnn1f_sp_bi/decode_test/scoring/test_filt.txt ark,p:- >& exp/chain_cleaned/tdnn1f_sp_bi/decode_test/wer_7
# Started at Tue Nov  7 13:49:09 EET 2017
#
bash: line 1: unk: No such file or directory
# Accounting: time=0 threads=1
# Ended (code 0) at Tue Nov  7 13:49:09 EET 2017, elapsed time 0 seconds
```