### PR TITLE
Tighten exclude rules to ignore dot files in /src/*/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Compiled extensionless executable files in /src/*/
 # This stanza must precede wildcard patterns below!
 /src/*/*
-!/src/*/*.*
+!/src/*/?*.*
 !/src/doc/*
 !/src/*/Makefile
 !/src/*/README


### PR DESCRIPTION
The original rule was meant to include files such as
src/nnet3/nnet-computation.cc, but this also ended up including files
beginning with "." (aka, "dot files"), since * matches 0 or more
characters. ?*, meanwhile must match at least one character.

In my case, my environment creates .history files in each directory I
enter, logging every command I run in there with timestamps. This
litters my src/ subdirectories with untracked .history files.

I cannot override this with .git/info/exclude or a global
"core.excludesFile" because .gitignore (and `!/src/*/*.*` within it)
takes higher precedence than those files.

This should be fine since no dot files are tracked under src/ anyway.