### PR TITLE
timit: fixing awk compatibility issue, replacing 'gensub' by 'gsub'...

### DIFF
--- a/egs/timit/s5/local/timit_data_prep.sh
+++ b/egs/timit/s5/local/timit_data_prep.sh
@@ -113,7 +113,7 @@ for x in train dev test; do
      print ";; LABEL \"F\" \"Female\" \"Female speakers\"";
      print ";; LABEL \"M\" \"Male\" \"Male speakers\"";
    }
-   { wav=$1; spk=gensub(/_.*/,"",1,wav); $1=""; ref=$0;
+   { wav=$1; spk=wav; sub(/_.*/,"",spk); $1=""; ref=$0;
      gender=(substr(spk,0,1) == "f" ? "F" : "M");
      printf("%s 1 %s 0.0 %f <O,%s> %s\n", wav, spk, durH[wav], gender, ref);
    }


### PR DESCRIPTION
Resolving this gawk/awk issue: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kaldi-help/Sw3TMkxCyds/qtCeSf1oAAAJ

(awk does not have 'gensub'...)