### PR TITLE
add mmseg to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,6 @@ GSYMS
 /tools/sequitur-g2p/
 /tools/phonetisaurus-g2p
 /tools/phonetisaurus-g2p/
+/tools/mmseg-1.3.0.tar.gz
+/tools/mmseg-1.3.0/
 /kaldiwin_vs*


### PR DESCRIPTION
mmseg (Mandarin word segmentation tool?) does not have its entry in .gitignore