### PR TITLE
added an option in the configure script to build with -fPIC

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -61,6 +61,7 @@ Configuration options:
   --version             Display the version of 'configure' and exit
   --static              Build and link against static libraries [default=no]
   --shared              Build and link against shared libraries [default=no]
+  --fPIC				Compile with position independent code (-fPIC) even if building static libraries [default=no]
   --use-cuda            Build with CUDA [default=yes]
   --cudatk-dir=DIR      CUDA toolkit directory
   --double-precision    Build with BaseFloat set to double if yes [default=no],
@@ -847,6 +848,7 @@ static_math=false
 threaded_atlas=false
 mkl_threading=sequential
 android=false
+PIC=false
 
 MATHLIB='ATLAS'
 ATLASROOT=`rel2abs ../tools/ATLAS_headers/`
@@ -869,8 +871,12 @@ do
     shift ;;
   --shared)
     dynamic_kaldi=true;
+    PIC=true;
     static_math=false;
     static_fst=false;
+    shift ;;
+  --fPIC)
+    PIC=true;
     shift ;;
   --double-precision)
     double_precision=true;
@@ -1071,6 +1077,9 @@ if $dynamic_kaldi ; then
   KALDILIBDIR=`pwd`/lib
   echo "KALDI_FLAVOR := dynamic" >> kaldi.mk
   echo "KALDILIBDIR := $KALDILIBDIR" >> kaldi.mk
+fi
+if $PIC ; then
+  echo "PIC := true" >> kaldi.mk
 fi
 if $double_precision; then
   echo "DOUBLE_PRECISION = 1" >> kaldi.mk

--- a/src/makefiles/android_openblas.mk
+++ b/src/makefiles/android_openblas.mk
@@ -34,7 +34,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -mfpu=neon -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/cygwin.mk
+++ b/src/makefiles/cygwin.mk
@@ -18,7 +18,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -msse -msse2 \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/darwin.mk
+++ b/src/makefiles/darwin.mk
@@ -18,7 +18,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -msse -msse2 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -24,7 +24,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -msse -msse2 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_atlas_arm.mk
+++ b/src/makefiles/linux_atlas_arm.mk
@@ -24,7 +24,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_atlas_ppc64le.mk
+++ b/src/makefiles/linux_atlas_ppc64le.mk
@@ -25,7 +25,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -18,7 +18,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -msse -msse2 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_clapack_arm.mk
+++ b/src/makefiles/linux_clapack_arm.mk
@@ -18,7 +18,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -24,7 +24,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -msse -msse2 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_openblas_arm.mk
+++ b/src/makefiles/linux_openblas_arm.mk
@@ -24,7 +24,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_openblas_ppc64le.mk
+++ b/src/makefiles/linux_openblas_ppc64le.mk
@@ -25,7 +25,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -32,7 +32,7 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -m64 -msse -msse2 -pthread \
            -g # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
+ifeq ($(PIC), true)
 CXXFLAGS += -fPIC
 endif
 


### PR DESCRIPTION
I personally need that option because I statically link kaldi into a shared library so kaldi has to be built with `-fPIC`.
To achieve that I'd have to manually change the `kaldi.mk` every time I built kaldi which because redundant and frustrating especially when I forget to do it.

Hopefully other people would find this useful as well.