### PR TITLE
babel: print only one path when generating language configs

### DIFF
--- a/egs/babel/s5d/conf/lang/104-pashto.FLP.official.conf
+++ b/egs/babel/s5d/conf/lang/104-pashto.FLP.official.conf
@@ -1,5 +1,5 @@
 # config file generated automatically by calling
-#   ./local/nist_eval/create_new_language_configs.FLP.sh --language "104-pashto" --corpus "/export/babel/data"  --indus "/export/babel/data/scoring/IndusDB"
+#   local/nist_eval/create_new_language_configs.FLP.sh --language "104-pashto" --corpus "/export/babel/data"  --indus "/export/babel/data/scoring/IndusDB"
 
 
 # include common settings for fullLP systems.
@@ -44,7 +44,7 @@ dev10h_nj=32
 
 
 #Official EVAL period evaluation data files
-eval_data_dir=/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
+eval_data_dir=/export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 eval_data_list=./conf/lists/104-pashto/eval.list
 eval_ecf_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-eval.ecf.xml
 eval_kwlists=(
@@ -57,7 +57,7 @@ eval_nj=32
 
 
 #Official post-EVAL period data files
-evalpart1_data_dir=/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
+evalpart1_data_dir=/export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 evalpart1_data_list=./conf/lists/104-pashto/evalpart1.list
 evalpart1_rttm_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-evalpart1/IARPA-babel104b-v0.4bY_conv-evalpart1.mitllfa3.rttm
 evalpart1_ecf_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-evalpart1/IARPA-babel104b-v0.4bY_conv-evalpart1.scoring.ecf.xml
@@ -75,7 +75,6 @@ evalpart1_nj=32
 shadow_data_dir=(
     /export/babel/data/104-pashto/release-current/conversational/dev
     /export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
-/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 ) # shadow_data_dir
 shadow_data_list=(
     ./conf/lists/104-pashto/dev.list

--- a/egs/babel/s5d/conf/lang/104-pashto.LLP.official.conf
+++ b/egs/babel/s5d/conf/lang/104-pashto.LLP.official.conf
@@ -45,7 +45,6 @@ dev10h_nj=32
 
 #Official EVAL period evaluation data files
 eval_data_dir=/export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
-/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 eval_data_list=./conf/lists/104-pashto/eval.list
 eval_ecf_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-eval.ecf.xml
 eval_kwlists=(
@@ -59,7 +58,6 @@ eval_nj=32
 
 #Official post-EVAL period data files
 evalpart1_data_dir=/export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
-/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 evalpart1_data_list=./conf/lists/104-pashto/evalpart1.list
 evalpart1_rttm_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-evalpart1/IARPA-babel104b-v0.4bY_conv-evalpart1.mitllfa3.rttm
 evalpart1_ecf_file=/export/babel/data/scoring/IndusDB/IARPA-babel104b-v0.4bY_conv-evalpart1/IARPA-babel104b-v0.4bY_conv-evalpart1.scoring.ecf.xml
@@ -77,7 +75,6 @@ evalpart1_nj=32
 shadow_data_dir=(
     /export/babel/data/104-pashto/release-current/conversational/dev
     /export/babel/data/104-pashto/release-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
-/export/babel/data/104-pashto/IARPA-babel104b-v0.4bY-eval/BABEL_BP_104/conversational/eval
 ) # shadow_data_dir
 shadow_data_list=(
     ./conf/lists/104-pashto/dev.list

--- a/egs/babel/s5d/local/nist_eval/create_new_language_configs.FLP.sh
+++ b/egs/babel/s5d/local/nist_eval/create_new_language_configs.FLP.sh
@@ -20,7 +20,7 @@ set -o nounset                              # Treat unset variables as an error
 corpus=$corpus/$language
 lists=./conf/lists/$language
 
-corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current-b" \) \( -type d -o -type l \) ) 
+corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current-b" \) \( -type d -o -type l \) )
 [ -z "$corpusdir" ] && corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current"  \) \( -type d -o -type l \) )
 [ -z "$corpusdir" ] && corpusdir=$(find -L $corpus -maxdepth 1 -name "*-build" -type d)
 [ -z "$corpusdir" ] && echo >&2 "Corpus directory for $language not found!" && exit 1
@@ -130,7 +130,7 @@ echo "dev10h_nj=32"
 echo -e "\n"
 
 dataset="eval"
-eval_dir=$(find -L $corpus -ipath "*-eval/*/conversational/*" -name "$dataset" -type d) || exit 1
+eval_dir=$(find -L $corpus -ipath "*-eval/*/conversational/*" -name "$dataset" -type d -print -quit) || exit 1
 [ -z "$eval_dir" ] && { eval_dir=$(find -L $corpusdir -ipath "*/conversational/*" -name "eval" -type d) || exit 1; }
 if [ ! -z "$eval_dir" ] ; then
   indus_set=$(find -L $indus/ -maxdepth 1 -name "$indusid*$dataset" -type d)

--- a/egs/babel/s5d/local/nist_eval/create_new_language_configs.LLP.sh
+++ b/egs/babel/s5d/local/nist_eval/create_new_language_configs.LLP.sh
@@ -20,7 +20,7 @@ set -o nounset                              # Treat unset variables as an error
 corpus=$corpus/$language
 lists=./conf/lists/$language
 
-corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current-b" \) \( -type d -o -type l \) ) 
+corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current-b" \) \( -type d -o -type l \) )
 [ -z "$corpusdir" ] && corpusdir=$(find -L $corpus -maxdepth 1 \( -name "release-current"  \) \( -type d -o -type l \) )
 [ -z "$corpusdir" ] && corpusdir=$(find -L $corpus -maxdepth 1 -name "*-build" -type d)
 [ -z "$corpusdir" ] && echo >&2 "Corpus directory for $language not found!" && exit 1
@@ -42,8 +42,14 @@ echo -e "\n"
 
 echo "#speech corpora files location"
 echo "train_data_dir=$train_dir"
-[  -f "$lists/sub-train.list" ] && echo "train_data_list=$lists/sub-train.list"
-[ ! -f "$lists/sub-train.list" ] && echo "train_data_list=$lists/train.LimitedLP.list"
+if [  -f "$lists/sub-train.list" ] ; then
+  echo "train_data_list=$lists/sub-train.list"
+elif [ -f "$lists/train.LimitedLP.list" ] ; then
+  echo "train_data_list=$lists/train.LimitedLP.list"
+else
+  echo >&2 "Training list $lists/sub-train.list not found"
+fi
+
 echo "train_nj=16"
 echo -e "\n"
 
@@ -124,7 +130,7 @@ echo "dev10h_nj=32"
 echo -e "\n"
 
 dataset="eval"
-eval_dir=$(find -L $corpus -ipath "*-eval/*/conversational/*" -name "$dataset" -type d) || exit 1
+eval_dir=$(find -L $corpus -ipath "*-eval/*/conversational/*" -name "$dataset" -type d -print -quit) || exit 1
 [ -z "$eval_dir" ] && { eval_dir=$(find -L $corpusdir -ipath "*/conversational/*" -name "eval" -type d) || exit 1; }
 if [ ! -z "$eval_dir" ] ; then
   indus_set=$(find -L $indus/ -maxdepth 1 -name "$indusid*$dataset" -type d)
@@ -260,12 +266,12 @@ else
   echo -e "\n"
 fi
 
-lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.sub-train.txt" -type f) 
-[ -z "$lexicon" ] && lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.sub-train1.txt" -type f) 
+lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.sub-train.txt" -type f)
+[ -z "$lexicon" ] && lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.sub-train1.txt" -type f)
 if [ -z "$lexicon" ]; then
   echo >&2 "LLP Lexicon not found in $corpusdir -- looking for FLP one"
-  lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.txt" -type f) 
-   [ -z "$lexicon" ] && echo >&2 "Neither LLP nor FLP lexicon not found in $corpusdir" 
+  lexicon=$(find -L $corpusdir -ipath "*/conversational/*" -name "lexicon.txt" -type f)
+   [ -z "$lexicon" ] && echo >&2 "Neither LLP nor FLP lexicon not found in $corpusdir"
 fi
 echo "lexicon_file=$lexicon"
 


### PR DESCRIPTION
originally, when the corpus was messy (for example multiple symlinks to the same directory), all found paths were printed. This modifies the search statement so that only first match is used.