### PR TITLE
Fix to fgmm-global-acc-stats-post readers

### DIFF
--- a/egs/sre10/v2/run.sh
+++ b/egs/sre10/v2/run.sh
@@ -47,10 +47,10 @@ utils/combine_data.sh data/train \
   data/swbd_cellular1_train data/swbd_cellular2_train \
   data/swbd2_phase2_train data/swbd2_phase3_train data/sre
 
-cp -r data/train data/train_dnn
-cp -r data/sre data/sre_dnn
-cp -r data/sre10_train data/sre10_train_dnn
-cp -r data/sre10_test data/sre10_test_dnn
+utils/copy_data_dir.sh data/train data/train_dnn
+utils/copy_data_dir.sh data/sre data/sre_dnn
+utils/copy_data_dir.sh data/sre10_train data/sre10_train_dnn
+utils/copy_data_dir.sh data/sre10_test data/sre10_test_dnn
 
 # Extract speaker recogntion features.
 steps/make_mfcc.sh --mfcc-config conf/mfcc.conf --nj 40 --cmd "$train_cmd" \


### PR DESCRIPTION
This is based on a discussion on Kaldi help. Dan said:

> fgmm-global-acc-stats-post is doing random access on the posterior input, but it is specified as "ark:-", it should be "ark,s,cs:-".  David, can you fix this?
There is supposed to be a convention that the inputs that are accessed sequentially come before those that are accessed randomly, but it seems not to have been followed in this case.  If it had been followed, I would have noticed the script bug earlier.  It would be disruptive to fix this now though.

+ The PR changes the binary so that the posteriors are read sequentially and the features are read random access. 

+ I don't think this will be a disruptive fix, as the binary is only used in sid/init_full_ubm_from_dnn.sh, and it's usage doesn't need to be changed there.