### PR TITLE
Limit warnings from SlidingWindowCmnInternal

### DIFF
--- a/src/feat/feature-functions.h
+++ b/src/feat/feature-functions.h
@@ -158,12 +158,14 @@ void InitIdftBases(int32 n_bases, int32 dimension, Matrix<BaseFloat> *mat_out);
 struct SlidingWindowCmnOptions {
   int32 cmn_window;
   int32 min_window;
+  int32 max_warnings;
   bool normalize_variance;
   bool center;
 
   SlidingWindowCmnOptions():
       cmn_window(600),
       min_window(100),
+      max_warnings(5),
       normalize_variance(false),
       center(false) { }
 
@@ -173,6 +175,8 @@ struct SlidingWindowCmnOptions {
     opts->Register("min-cmn-window", &min_window, "Minimum CMN window "
                    "used at start of decoding (adds latency only at start). "
                    "Only applicable if center == false, ignored if center==true");
+    opts->Register("max-warnings", &max_warnings, "Maximum warnings to report "
+                   "per utterance. 0 to disable, -1 to show all.");
     opts->Register("norm-vars", &normalize_variance, "If true, normalize "
                    "variance to one."); // naming this as in apply-cmvn.cc
     opts->Register("center", &center, "If true, use a window centered on the "


### PR DESCRIPTION
The function SlidingWindowCmnInternal was printing too many warning messages (https://github.com/kaldi-asr/kaldi/issues/1967), e.g.,

`WARNING (apply-cmvn-sliding:SlidingWindowCmnInternal():feature-functions.cc:326) Flooring variance When normalizing variance, floored 31 elements; num-frames was 300`

This PR adds an option called --max-warnings to SlidingWindowCmnOptions which limits the number of times the warning message is printed per utterance. This is based on a similar option in arpa-file-parser.{cc.h}.

Also fixing a few typos. 