### PR TITLE
TokenHolder warns on failed read; print only printable buffer

### DIFF
--- a/src/base/io-funcs.cc
+++ b/src/base/io-funcs.cc
@@ -161,7 +161,7 @@ void ReadToken(std::istream &is, bool binary, std::string *str) {
   }
   if (!isspace(is.peek())) {
     KALDI_ERR << "ReadToken, expected space after token, saw instead "
-              << static_cast<char>(is.peek())
+              << CharToString(static_cast<char>(is.peek()))
               << ", at file position " << is.tellg();
   }
   is.get();  // consume the space.

--- a/src/base/kaldi-utils.cc
+++ b/src/base/kaldi-utils.cc
@@ -28,6 +28,8 @@
 #endif
 
 #include <string>
+#include <sstream>
+#include "base/kaldi-utils.h"
 #include "base/kaldi-common.h"
 
 
@@ -40,6 +42,17 @@ std::string CharToString(const char &c) {
   else
     snprintf(buf, sizeof(buf), "[character %d]", static_cast<int>(c));
   return (std::string) buf;
+}
+
+std::string StringToReadable(const std::string& s) {
+  std::stringstream ss;
+  for (size_t i = 0; i < s.length(); ++i) {
+    if (std::isprint(s[i]))
+      ss << s[i];
+    else
+      ss << "[character " << static_cast<int>(s[i]) << "]";
+  }
+  return ss.str();
 }
 
 void Sleep(float seconds) {

--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -75,6 +75,8 @@ namespace kaldi {
 // CharToString prints the character in a human-readable form, for debugging.
 std::string CharToString(const char &c);
 
+// StringToReadable ensures the string can show up on console, for debugging.
+std::string StringToReadable(const std::string& str);
 
 inline int MachineIsLittleEndian() {
   int check = 1;

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -21,6 +21,7 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/kaldi-utils.h"
 #include "matrix/kaldi-matrix.h"
 #include "matrix/sp-matrix.h"
 #include "matrix/jama-svd.h"
@@ -1487,7 +1488,8 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
     std::string token;
     ReadToken(is, binary, &token);
     if (token != my_token) {
-      specific_error << ": Expected token " << my_token << ", got " << token;
+      specific_error << ": Expected token " << my_token
+                     << ", got " << StringToReadable(token);
       goto bad;
     }
     int32 rows, cols;
@@ -1520,7 +1522,8 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
     // }
     if (str == "[]") { Resize(0, 0); return; } // Be tolerant of variants.
     else if (str != "[") {
-      specific_error << ": Expected \"[\", got \"" << str << '"';
+      specific_error << ": Expected \"[\", got \""
+                     << StringToReadable(str) << '"';
       goto bad;
     }
     // At this point, we have read "[".
@@ -1591,7 +1594,8 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
           cur_row->push_back(std::numeric_limits<Real>::quiet_NaN());
           KALDI_WARN << "Reading NaN value into matrix.";
         } else {
-          specific_error << "Expecting numeric matrix data, got " << str;
+          specific_error << "Expecting numeric matrix data, got "
+                         << StringToReadable(str);
           goto cleanup;
         }
       }

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 #include <string>
+
+#include "base/kaldi-utils.h"
 #include "matrix/cblas-wrappers.h"
 #include "matrix/kaldi-vector.h"
 #include "matrix/kaldi-matrix.h"
@@ -1122,7 +1124,8 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
     std::string token;
     ReadToken(is, binary, &token);
     if (token != my_token) {
-      specific_error << ": Expected token " << my_token << ", got " << token;
+      specific_error << ": Expected token " << my_token
+                     << ", got " << StringToReadable(token);
       goto bad;
     }
     int32 size;
@@ -1145,7 +1148,10 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
     // }
     if (is.fail()) { specific_error << "EOF while trying to read vector."; goto bad; }
     if (s.compare("[]") == 0) { Resize(0); return; } // tolerate this variant.
-    if (s.compare("[")) { specific_error << "Expected \"[\" but got " << s; goto bad; }
+    if (s.compare("[")) {
+      specific_error << "Expected \"[\" but got " << StringToReadable(s);
+      goto bad;
+    }
     std::vector<Real> data;
     while (1) {
       int i = is.peek();
@@ -1192,7 +1198,8 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
           data.push_back(std::numeric_limits<Real>::quiet_NaN());
           KALDI_WARN << "Reading NaN value into vector.";
         } else {
-          specific_error << "Expecting numeric vector data, got " << s;
+          specific_error << "Expecting numeric vector data, got "
+                         << StringToReadable(s);
           goto  bad;
         }
       }

--- a/src/util/kaldi-holder-inl.h
+++ b/src/util/kaldi-holder-inl.h
@@ -26,6 +26,8 @@
 #include <vector>
 #include <utility>
 #include <string>
+
+#include "base/kaldi-utils.h"
 #include "util/kaldi-io.h"
 #include "util/text-utils.h"
 #include "matrix/kaldi-matrix.h"
@@ -287,7 +289,7 @@ template<class BasicType> class BasicVectorHolder {
         return true;
       } catch(const std::exception &e) {
         KALDI_WARN << "BasicVectorHolder::Read, could not interpret line: "
-                   << "'" << line << "'" << "\n" << e.what();
+                   << "'" << StringToReadable(line) << "'" << "\n" << e.what();
         return false;
       }
     } else {  // binary mode.
@@ -655,9 +657,9 @@ class TokenHolder {
     char c;
     while (isspace(c = is.peek()) && c!= '\n') is.get();
     if (is.peek() != '\n') {
-      KALDI_ERR << "TokenHolder::Read, expected newline, got char " <<
-          CharToString(is.peek())
-                << ", at stream pos " << is.tellg();
+      KALDI_WARN << "TokenHolder::Read, expected newline, got char "
+                 << CharToString(is.peek())
+                 << ", at stream pos " << is.tellg();
       return false;
     }
     is.get();  // get '\n'


### PR DESCRIPTION
- TokenHolder::Read would call KALDI_ERR instead of KALDI_WARN,
  which causes unexpected segfaults when trying to open sequential
  readers. Switched to KALDI_WARN.
- A number of Read methods would print out parts of a failed read
  with no guarantee that the buffer is printable. StringToReadable
  acts like CharToString in that it prints non-printable
  characters as integers. Doesn't handle encodings, but better
  than a segfault.