### PR TITLE
Sanitize console strings

### DIFF
--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -148,10 +148,12 @@ MessageLogger::MessageLogger(LogMessageEnvelope::Severity severity,
 
 
 MessageLogger::~MessageLogger() KALDI_NOEXCEPT(false) {
-  // sanitize string and remove trailing '\n',
-  std::string str = StringToReadable(ss_.str());
+  // remove trailing '\n',
+  std::string str = ss_.str();
   while (!str.empty() && str[str.length() - 1] == '\n')
     str.resize(str.length() - 1);
+  // sanitization comes after - newlines aren't printable
+  str = StringToReadable(str);
 
   // print the mesage (or send to logging handler),
   MessageLogger::HandleMessage(envelope_, str.c_str());

--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -148,8 +148,8 @@ MessageLogger::MessageLogger(LogMessageEnvelope::Severity severity,
 
 
 MessageLogger::~MessageLogger() KALDI_NOEXCEPT(false) {
-  // remove trailing '\n',
-  std::string str = ss_.str();
+  // sanitize string and remove trailing '\n',
+  std::string str = StringToReadable(ss_.str());
   while (!str.empty() && str[str.length() - 1] == '\n')
     str.resize(str.length() - 1);
 

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -21,7 +21,6 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#include "base/kaldi-utils.h"
 #include "matrix/kaldi-matrix.h"
 #include "matrix/sp-matrix.h"
 #include "matrix/jama-svd.h"
@@ -1488,8 +1487,7 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
     std::string token;
     ReadToken(is, binary, &token);
     if (token != my_token) {
-      specific_error << ": Expected token " << my_token
-                     << ", got " << StringToReadable(token);
+      specific_error << ": Expected token " << my_token << ", got " << token;
       goto bad;
     }
     int32 rows, cols;
@@ -1522,8 +1520,7 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
     // }
     if (str == "[]") { Resize(0, 0); return; } // Be tolerant of variants.
     else if (str != "[") {
-      specific_error << ": Expected \"[\", got \""
-                     << StringToReadable(str) << '"';
+      specific_error << ": Expected \"[\", got \"" << str << '"';
       goto bad;
     }
     // At this point, we have read "[".
@@ -1594,8 +1591,7 @@ void Matrix<Real>::Read(std::istream & is, bool binary, bool add) {
           cur_row->push_back(std::numeric_limits<Real>::quiet_NaN());
           KALDI_WARN << "Reading NaN value into matrix.";
         } else {
-          specific_error << "Expecting numeric matrix data, got "
-                         << StringToReadable(str);
+          specific_error << "Expecting numeric matrix data, got " << str;
           goto cleanup;
         }
       }

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -24,8 +24,6 @@
 
 #include <algorithm>
 #include <string>
-
-#include "base/kaldi-utils.h"
 #include "matrix/cblas-wrappers.h"
 #include "matrix/kaldi-vector.h"
 #include "matrix/kaldi-matrix.h"
@@ -1124,8 +1122,7 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
     std::string token;
     ReadToken(is, binary, &token);
     if (token != my_token) {
-      specific_error << ": Expected token " << my_token
-                     << ", got " << StringToReadable(token);
+      specific_error << ": Expected token " << my_token << ", got " << token;
       goto bad;
     }
     int32 size;
@@ -1148,10 +1145,7 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
     // }
     if (is.fail()) { specific_error << "EOF while trying to read vector."; goto bad; }
     if (s.compare("[]") == 0) { Resize(0); return; } // tolerate this variant.
-    if (s.compare("[")) {
-      specific_error << "Expected \"[\" but got " << StringToReadable(s);
-      goto bad;
-    }
+    if (s.compare("[")) { specific_error << "Expected \"[\" but got " << s; goto bad; }
     std::vector<Real> data;
     while (1) {
       int i = is.peek();
@@ -1198,8 +1192,7 @@ void Vector<Real>::Read(std::istream & is,  bool binary, bool add) {
           data.push_back(std::numeric_limits<Real>::quiet_NaN());
           KALDI_WARN << "Reading NaN value into vector.";
         } else {
-          specific_error << "Expecting numeric vector data, got "
-                         << StringToReadable(s);
+          specific_error << "Expecting numeric vector data, got " << s;
           goto  bad;
         }
       }

--- a/src/util/kaldi-holder-inl.h
+++ b/src/util/kaldi-holder-inl.h
@@ -27,7 +27,6 @@
 #include <utility>
 #include <string>
 
-#include "base/kaldi-utils.h"
 #include "util/kaldi-io.h"
 #include "util/text-utils.h"
 #include "matrix/kaldi-matrix.h"
@@ -289,7 +288,7 @@ template<class BasicType> class BasicVectorHolder {
         return true;
       } catch(const std::exception &e) {
         KALDI_WARN << "BasicVectorHolder::Read, could not interpret line: "
-                   << "'" << StringToReadable(line) << "'" << "\n" << e.what();
+                   << "'" << line << "'" << "\n" << e.what();
         return false;
       }
     } else {  // binary mode.


### PR DESCRIPTION
In #2044, StringToReadable was employed to ensure invalid buffer
strings were actually printable on console. However, there are many
more places where error messages could contain unprintable chars
than just kaldi-matrix and kaldi-vector (e.g. keys, rxfilenames
from corrupted scp files, etc.). As part of the debug process in
I/O, these partial results are printed all over the place, which
lead to segfaults.

This commit pushes the work to the destructor of
kaldi::MessageLogger. It uses the function StringToReadable to
sanitize the strings before sending them off to callbacks or
stderr.

A couple of reasons why this might _not_ be desirable to merge:
- Every message will have an additional overhead incurred as
  StringToReadable reconstructs a printable string, even when
  it's already printable.
- Whitespace and control characters are sanitized to
  ``[character <int>]``.