### PR TITLE
Minor fix to comment in BatchNormComponent

### DIFF
--- a/src/nnet3/nnet-general-component.h
+++ b/src/nnet3/nnet-general-component.h
@@ -281,7 +281,7 @@ class StatisticsExtractionComponentPrecomputedIndexes:
   // element is a (start, end) range of inputs, that is summed over.
   CuArray<Int32Pair> forward_indexes;
 
-  // this vector stores the number of inputs for each output.  Normally this will be
+  // This vector stores the number of inputs for each output.  Normally this will be
   // the same as the component's output_period_ / input_period_, but could be less
   // due to edge effects at the utterance boundary.
   CuVector<BaseFloat> counts;

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -6008,7 +6008,7 @@ void BatchNormComponent::InitFromConfig(ConfigLine *cfl) {
          x2sum = sum_i x(i)^2
           mean = xsum / n
            var = x2sum / n - (mean*mean)
-         scale = sqrt(var + epsilon)^{-0.5}
+         scale = (var + epsilon)^{-0.5}
         offset = -mean * scale
 
       y(i) = scale * x(i) + offset
@@ -6021,7 +6021,7 @@ void BatchNormComponent::InitFromConfig(ConfigLine *cfl) {
   We are given y'(i).  Propagating the derivatives backward:
      offset' = sum_i y'(i)
      scale' = (sum_i y'(i) * x(i)) - offset' * mean
-       var' = scale' * -0.5 * sqrt(var + epsilon)^{-1.5}
+       var' = scale' * -0.5 * (var + epsilon)^{-1.5}
             = -0.5 * scale' * scale^3
       mean' = -offset' * scale - 2 * mean * var'
       xsum' = mean' / n


### PR DESCRIPTION
This is about https://github.com/kaldi-asr/kaldi/issues/1861. @ytyeung found a typo in a comment describing BatchNormComponent. 