### PR TITLE
Force source to use local path.sh, not any path.sh found on PATH.

### DIFF
--- a/egs/ami/s5/local/ami_format_data.sh
+++ b/egs/ami/s5/local/ami_format_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 if [ $# -ne 1 ]; then
   echo 'Usage: $0 <arpa-lm>'

--- a/egs/ami/s5b/local/ami_format_data.sh
+++ b/egs/ami/s5b/local/ami_format_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 if [ $# -ne 1 ]; then
   echo 'Usage: $0 <arpa-lm>'

--- a/egs/aspire/s5/local/fisher_create_test_lang.sh
+++ b/egs/aspire/s5/local/fisher_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/babel/s5c/local/ali_to_rttm.sh
+++ b/egs/babel/s5c/local/ali_to_rttm.sh
@@ -28,7 +28,7 @@ beam=10
 retry_beam=40
 boost_silence=1.0
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 
 if [ $# != 3 ]; then

--- a/egs/babel/s5d/local/ali_to_rttm.sh
+++ b/egs/babel/s5d/local/ali_to_rttm.sh
@@ -28,7 +28,7 @@ beam=10
 retry_beam=40
 boost_silence=1.0
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 
 if [ $# != 3 ]; then

--- a/egs/babel/s5d/local/run_asr_segmentation.sh
+++ b/egs/babel/s5d/local/run_asr_segmentation.sh
@@ -46,7 +46,7 @@ nj=80
 . ./lang.conf || exit 1;
 
 . ./path.sh
-. cmd.sh 
+. ./cmd.sh
 
 set -e -u -o pipefail
 . utils/parse_options.sh 

--- a/egs/callhome_egyptian/s5/local/callhome_create_test_lang.sh
+++ b/egs/callhome_egyptian/s5/local/callhome_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/fisher_callhome_spanish/s5/local/fsp_create_test_lang.sh
+++ b/egs/fisher_callhome_spanish/s5/local/fsp_create_test_lang.sh
@@ -2,7 +2,7 @@
 # Copyright 2014  Gaurav Kumar.   Apache 2.0
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/fisher_english/s5/local/fisher_create_test_lang.sh
+++ b/egs/fisher_english/s5/local/fisher_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/fisher_english/s5/run.sh
+++ b/egs/fisher_english/s5/run.sh
@@ -73,19 +73,19 @@ utils/subset_data_dir.sh --speakers data/train 100000 data/train_100k
 # The next commands are not necessary for the scripts to run, but increase 
 # efficiency of data access by putting the mfcc's of the subset 
 # in a contiguous place in a file.
-( . path.sh; 
+( . ./path.sh; 
   # make sure mfccdir is defined as above..
   cp data/train_10k_nodup/feats.scp{,.bak} 
   copy-feats scp:data/train_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_10k_nodup.ark,$mfccdir/kaldi_fish_10k_nodup.scp \
   && cp $mfccdir/kaldi_fish_10k_nodup.scp data/train_10k_nodup/feats.scp
 )
-( . path.sh; 
+( . ./path.sh; 
   # make sure mfccdir is defined as above..
   cp data/train_30k/feats.scp{,.bak} 
   copy-feats scp:data/train_30k/feats.scp  ark,scp:$mfccdir/kaldi_fish_30k.ark,$mfccdir/kaldi_fish_30k.scp \
   && cp $mfccdir/kaldi_fish_30k.scp data/train_30k/feats.scp
 )
-( . path.sh; 
+( . ./path.sh; 
   # make sure mfccdir is defined as above..
   cp data/train_100k/feats.scp{,.bak} 
   copy-feats scp:data/train_100k/feats.scp  ark,scp:$mfccdir/kaldi_fish_100k.ark,$mfccdir/kaldi_fish_100k.scp \

--- a/egs/fisher_swbd/s5/local/eval2000_data_prep.sh
+++ b/egs/fisher_swbd/s5/local/eval2000_data_prep.sh
@@ -33,7 +33,7 @@ tdir=$2
 [ ! -d $tdir/reference ] \
   && echo Expecting directory $tdir/reference to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval2000
 mkdir -p $dir

--- a/egs/fisher_swbd/s5/local/fisher_create_test_lang.sh
+++ b/egs/fisher_swbd/s5/local/fisher_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/fisher_swbd/s5/local/fisher_create_test_lang_fsh.sh
+++ b/egs/fisher_swbd/s5/local/fisher_create_test_lang_fsh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test_fsh
 

--- a/egs/fisher_swbd/s5/run.sh
+++ b/egs/fisher_swbd/s5/run.sh
@@ -126,19 +126,19 @@ utils/data/remove_dup_utts.sh 300 data/train data/train_nodup
 # The next commands are not necessary for the scripts to run, but increase
 # efficiency of data access by putting the mfcc's of the subset
 # in a contiguous place in a file.
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_10k_nodup/feats.scp{,.bak}
   copy-feats scp:data/train_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_10k_nodup.ark,$mfccdir/kaldi_fish_10k_nodup.scp \
   && cp $mfccdir/kaldi_fish_10k_nodup.scp data/train_10k_nodup/feats.scp
 )
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_30k_nodup/feats.scp{,.bak}
   copy-feats scp:data/train_30k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_30k_nodup.ark,$mfccdir/kaldi_fish_30k_nodup.scp \
   && cp $mfccdir/kaldi_fish_30k_nodup.scp data/train_30k_nodup/feats.scp
 )
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_100k_nodup/feats.scp{,.bak}
   copy-feats scp:data/train_100k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_100k_nodup.ark,$mfccdir/kaldi_fish_100k_nodup.scp \

--- a/egs/gale_arabic/s5/local/gale_format_data.sh
+++ b/egs/gale_arabic/s5/local/gale_format_data.sh
@@ -4,7 +4,7 @@
 # Apache 2.0
 
 if [ -f path.sh ]; then
-  . path.sh; else
+  . ./path.sh; else
    echo "missing path.sh"; exit 1;
 fi
 

--- a/egs/gale_arabic/s5/run.sh
+++ b/egs/gale_arabic/s5/run.sh
@@ -6,7 +6,7 @@ set -e
 # Apache 2.0
 
 . ./path.sh
-. cmd.sh   ## You'll want to change cmd.sh to something that will work on your system.
+. ./cmd.sh ## You'll want to change cmd.sh to something that will work on your system.
            ## This relates to the queue.
 nJobs=120
 nDecodeJobs=40

--- a/egs/gale_arabic/s5b/local/gale_format_data.sh
+++ b/egs/gale_arabic/s5b/local/gale_format_data.sh
@@ -4,7 +4,7 @@
 # Apache 2.0
 
 if [ -f path.sh ]; then
-  . path.sh; else
+  . ./path.sh; else
    echo "$0: missing path.sh"; exit 1;
 fi
 

--- a/egs/gale_arabic/s5b/run.sh
+++ b/egs/gale_arabic/s5b/run.sh
@@ -4,7 +4,7 @@
 # Apache 2.0
 
 . ./path.sh
-. cmd.sh   ## You'll want to change cmd.sh to something that will work on your system.
+. ./cmd.sh ## You'll want to change cmd.sh to something that will work on your system.
            ## This relates to the queue.
 num_jobs=120
 num_decode_jobs=40

--- a/egs/gale_mandarin/s5/local/gale_format_data.sh
+++ b/egs/gale_mandarin/s5/local/gale_format_data.sh
@@ -4,7 +4,7 @@
 # Apache 2.0
 
 if [ -f path.sh ]; then
-  . path.sh; else
+  . ./path.sh; else
    echo "missing path.sh"; exit 1;
 fi
 

--- a/egs/gp/s1/local/gp_data_prep.sh
+++ b/egs/gp/s1/local/gp_data_prep.sh
@@ -65,7 +65,7 @@ cd $CONFDIR
 [ -f lang_codes.txt ] || error_exit "$PROG: Mapping for language name to 2-letter code not found.";
 
 cd $WDIR
-[ -f path.sh ] && . path.sh  # Sets the PATH to contain necessary executables
+[ -f path.sh ] && . ./path.sh  # Sets the PATH to contain necessary executables
 
 # (2) get the various file lists (for audio, transcription, etc.) for the
 # specified language.

--- a/egs/gp/s1/local/gp_train_multi_ubm.sh
+++ b/egs/gp/s1/local/gp_train_multi_ubm.sh
@@ -72,7 +72,7 @@ numcomps=$1
 dir=$2
 
 LANGUAGES='GE PO SP SW'  # Languages processed
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 mkdir -p $dir/{data,log}
 for f in feats.scp spk2utt utt2spk text wav.scp; do
   for L in $LANGUAGES; do

--- a/egs/gp/s1/steps/align_deltas.sh
+++ b/egs/gp/s1/steps/align_deltas.sh
@@ -80,7 +80,7 @@ if [ $# != 4 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 data=$1
 lang=$2

--- a/egs/gp/s1/steps/make_mfcc.sh
+++ b/egs/gp/s1/steps/make_mfcc.sh
@@ -63,7 +63,7 @@ if [ $# != 3 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 data=$1
 logdir=$2

--- a/egs/gp/s1/steps/train_deltas.sh
+++ b/egs/gp/s1/steps/train_deltas.sh
@@ -111,7 +111,7 @@ if [ $# != 6 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 numleaves=$1
 totgauss=$2

--- a/egs/gp/s1/steps/train_mono.sh
+++ b/egs/gp/s1/steps/train_mono.sh
@@ -74,7 +74,7 @@ data=$1
 lang=$2
 dir=$3
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 # Configuration:
 scale_opts="--transition-scale=1.0 --acoustic-scale=0.1 --self-loop-scale=0.1"

--- a/egs/gp/s1/steps/train_trees.sh
+++ b/egs/gp/s1/steps/train_trees.sh
@@ -107,7 +107,7 @@ if [ $# != 5 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 numleaves=$1
 data=$2

--- a/egs/gp/s1/steps/train_ubm_deltas.sh
+++ b/egs/gp/s1/steps/train_ubm_deltas.sh
@@ -68,7 +68,7 @@ if [ $# != 4 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 numcomps=$1
 data=$2

--- a/egs/gp/s1/utils/decode.sh
+++ b/egs/gp/s1/utils/decode.sh
@@ -93,7 +93,7 @@ shift;shift;shift;shift;
 # Remaining args will be supplied to decoding script.
 extra_args=$* 
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 for file in $script $scp $data/utt2spk; do
   if [ ! -f "$file" ]; then

--- a/egs/gp/s1/utils/htk2kaldi_feats.sh
+++ b/egs/gp/s1/utils/htk2kaldi_feats.sh
@@ -62,7 +62,7 @@ if [ $# != 4 ]; then
   error_exit $usage;
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 htklist=$1
 logdir=$2

--- a/egs/gp/s1/utils/lmrescore.sh
+++ b/egs/gp/s1/utils/lmrescore.sh
@@ -69,7 +69,7 @@ if [ $# != 5 ]; then
   error_exit $usage
 fi
 
-[ -f path.sh ] && . path.sh
+[ -f path.sh ] && . ./path.sh
 
 oldlang=$1
 newlang=$2

--- a/egs/gp/s1/utils/mkgraph.sh
+++ b/egs/gp/s1/utils/mkgraph.sh
@@ -49,7 +49,7 @@ if [ $# != 3 ]; then
    exit 1;
 fi
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 lang=$1
 tree=$2/tree

--- a/egs/gp/s1/utils/submit_jobs.sh
+++ b/egs/gp/s1/utils/submit_jobs.sh
@@ -105,7 +105,7 @@ function submit_sync () {
   local qlog=$qdir/queue.log
 
   printf "#!/bin/bash\n#\$ -S /bin/bash\n#\$ -V -cwd -j y\n" > $batch_file
-  { printf "{ cd $PWD\n  . path.sh\n  echo Running on: \`hostname\`\n";
+  { printf "{ cd $PWD\n  . ./path.sh\n  echo Running on: \`hostname\`\n";
     printf "  echo Started at: \`date\`\n  $command\n  ret=\$\?\n";
     printf "  echo Finished at: \`date\`\n} >& %s\nexit \$ret\n" "$logfile"
     printf "# Submitted with:\n"
@@ -124,7 +124,7 @@ function submit_nosync () {
   local qlog=$qdir/queue.log
 
   printf "#!/bin/bash\n#\$ -S /bin/bash\n#\$ -V -cwd -j y\n" > $batch_file
-  { printf "{ cd $PWD\n  . path.sh\n  echo Running on: \`hostname\`\n";
+  { printf "{ cd $PWD\n  . ./path.sh\n  echo Running on: \`hostname\`\n";
     printf "  echo Started at: \`date\`\n";
     printf "  $command || { echo \$SGE_TASK_ID >> $qdir/error; ret=1; }\n";
     printf "  echo Finished at: \`date\`\n} >& %s\nexit \$ret\n" "$logfile"

--- a/egs/gp/s5/local/gp_data_prep.sh
+++ b/egs/gp/s5/local/gp_data_prep.sh
@@ -63,7 +63,7 @@ pushd $CONFDIR > /dev/null
 [ -f lang_codes.txt ] || error_exit "$PROG: Mapping for language name to 2-letter code not found.";
 
 popd > /dev/null
-[ -f path.sh ] && . path.sh  # Sets the PATH to contain necessary executables
+[ -f path.sh ] && . ./path.sh  # Sets the PATH to contain necessary executables
 
 # (2) get the various file lists (for audio, transcription, etc.) for the
 # specified language.

--- a/egs/gp/s5/local/gp_dict_prep.sh
+++ b/egs/gp/s5/local/gp_dict_prep.sh
@@ -65,7 +65,7 @@ pushd $config_dir > /dev/null
 [ -f lang_codes.txt ] || error_exit "$PROG: Mapping for language name to 2-letter code not found.";
 
 popd > /dev/null
-[ -f path.sh ] && . path.sh  # Sets the PATH to contain necessary executables
+[ -f path.sh ] && . ./path.sh  # Sets the PATH to contain necessary executables
 
 # (1) Normalize the dictionary
 for L in $LANGUAGES; do

--- a/egs/gp/s5/local/gp_prep_flists.sh
+++ b/egs/gp/s5/local/gp_prep_flists.sh
@@ -60,7 +60,7 @@ do
   esac
 done
 
-[ -f path.sh ] && . path.sh  # Sets the PATH to contain necessary executables
+[ -f path.sh ] && . ./path.sh  # Sets the PATH to contain necessary executables
 
 tmpdir=$(mktemp -d /tmp/kaldi.XXXX);
 trap 'rm -rf "$tmpdir"' EXIT

--- a/egs/gp/s5/run.sh
+++ b/egs/gp/s5/run.sh
@@ -39,7 +39,7 @@ that you run the commands one by one by copying and pasting into the shell."
 #  If they are not found, the local/gp_install.sh script will install them.
 #local/gp_check_tools.sh $PWD path.sh || exit 1;
 
-. path.sh || { echo "Cannot source path.sh"; exit 1; }
+. ./path.sh || { echo "Cannot source path.sh"; exit 1; }
 
 # Set the locations of the GlobalPhone corpus and language models
 GP_CORPUS=/idiap/resource/database/GLOBALPHONE

--- a/egs/librispeech/s5/local/g2p.sh
+++ b/egs/librispeech/s5/local/g2p.sh
@@ -5,7 +5,7 @@
 
 # Auto-generates pronunciations using Sequitur G2P
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 [ -z "$PYTHON" ] && PYTHON=python2.7 
 

--- a/egs/librispeech/s5/local/g2p/train_g2p.sh
+++ b/egs/librispeech/s5/local/g2p/train_g2p.sh
@@ -9,7 +9,7 @@
 stage=1
 
 . utils/parse_options.sh || exit 1
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 if [ $# -ne "2" ]; then
   echo "Usage: $0 <cmudict-download-dir> <g2p-dir>"

--- a/egs/librispeech/s5/local/lm/install_festival.sh
+++ b/egs/librispeech/s5/local/lm/install_festival.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 # use to skip some of steps in this script
 stage=1
@@ -12,7 +12,7 @@ makejobs=4
 # see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=667377
 apply_gcc_patch=true
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 . utils/parse_options.sh || exit 1
 
 mkdir -p $FEST_ROOT

--- a/egs/librispeech/s5/local/lm/normalize_text.sh
+++ b/egs/librispeech/s5/local/lm/normalize_text.sh
@@ -7,7 +7,7 @@
 
 echo $@
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <input-book-dirs> <output-root>"

--- a/egs/librispeech/s5/local/lm/train_lm.sh
+++ b/egs/librispeech/s5/local/lm/train_lm.sh
@@ -5,8 +5,8 @@
 
 # This is the top-level LM training script
 
-. path.sh || exit 1
-. cmd.sh || exit 1
+. ./path.sh || exit 1
+. ./cmd.sh || exit 1
 
 # use to skip some of the initial steps
 stage=1

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -12,7 +12,7 @@ cmd=run.pl
 
 
 . utils/parse_options.sh || exit 1;
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 
 if [ $# -ne 3 ]; then

--- a/egs/lre07/v2/local/dnn/fisher_create_test_lang.sh
+++ b/egs/lre07/v2/local/dnn/fisher_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash 
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/lre07/v2/local/dnn/train_dnn.sh
+++ b/egs/lre07/v2/local/dnn/train_dnn.sh
@@ -78,19 +78,19 @@ utils/subset_data_dir.sh --speakers data/train_asr 100000 data/train_asr_100k
 # The next commands are not necessary for the scripts to run, but increase 
 # efficiency of data access by putting the mfcc's of the subset 
 # in a contiguous place in a file.
-( . path.sh; 
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_10k_nodup/feats.scp{,.bak} 
   copy-feats scp:data/train_asr_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_10k_nodup.ark,$mfccdir/kaldi_fish_10k_nodup.scp \
   && cp $mfccdir/kaldi_fish_10k_nodup.scp data/train_asr_10k_nodup/feats.scp
 )
-( . path.sh; 
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_30k/feats.scp{,.bak} 
   copy-feats scp:data/train_asr_30k/feats.scp  ark,scp:$mfccdir/kaldi_fish_30k.ark,$mfccdir/kaldi_fish_30k.scp \
   && cp $mfccdir/kaldi_fish_30k.scp data/train_asr_30k/feats.scp
 )
-( . path.sh; 
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_100k/feats.scp{,.bak} 
   copy-feats scp:data/train_asr_100k/feats.scp  ark,scp:$mfccdir/kaldi_fish_100k.ark,$mfccdir/kaldi_fish_100k.scp \

--- a/egs/multi_en/s5/local/swbd1_prepare_dict.sh
+++ b/egs/multi_en/s5/local/swbd1_prepare_dict.sh
@@ -12,7 +12,7 @@
 
 # To be run from one directory above this script.
 
-. path.sh
+. ./path.sh
 
 #check existing directories
 [ $# != 0 ] && echo "Usage: local/swbd1_data_prep.sh" && exit 1;

--- a/egs/rm/s5/local/nnet2/run_5c.sh
+++ b/egs/rm/s5/local/nnet2/run_5c.sh
@@ -11,7 +11,7 @@
 
 stage=0
 train_stage=-100
-. cmd.sh || exit 1;
+. ./cmd.sh || exit 1;
 . utils/parse_options.sh || exit 1;
 
 # We increase the beam relative to the defaults; this is just for this RM setup,

--- a/egs/rm/s5/local/run_raw_fmllr.sh
+++ b/egs/rm/s5/local/run_raw_fmllr.sh
@@ -49,7 +49,7 @@ exit 0;
 
 
 # (# get scaled-by-30 versions of the vecs to be used for nnet training.
-#   . path.sh 
+#   . ./path.sh
 #   mkdir -p exp/sgmm2_4c_x30
 #   cat exp/sgmm2_4c/vecs.* | copy-vector ark:- ark,t:- | \
 #    awk -v scale=30.0 '{printf("%s [ ", $1); for (n=3;n<NF;n++) { printf("%f ", scale*$n); } print "]"; }' > exp/sgmm2_4c_x30/vecs.1

--- a/egs/sre10/v1/local/dnn/fisher_create_test_lang.sh
+++ b/egs/sre10/v1/local/dnn/fisher_create_test_lang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 mkdir -p data/lang_test
 

--- a/egs/sre10/v1/local/dnn/train_dnn.sh
+++ b/egs/sre10/v1/local/dnn/train_dnn.sh
@@ -77,19 +77,19 @@ utils/subset_data_dir.sh --speakers data/train_asr 100000 data/train_asr_100k
 # The next commands are not necessary for the scripts to run, but increase
 # efficiency of data access by putting the mfcc's of the subset
 # in a contiguous place in a file.
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_10k_nodup/feats.scp{,.bak}
   copy-feats scp:data/train_asr_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_fish_10k_nodup.ark,$mfccdir/kaldi_fish_10k_nodup.scp \
   && cp $mfccdir/kaldi_fish_10k_nodup.scp data/train_asr_10k_nodup/feats.scp
 )
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_30k/feats.scp{,.bak}
   copy-feats scp:data/train_asr_30k/feats.scp  ark,scp:$mfccdir/kaldi_fish_30k.ark,$mfccdir/kaldi_fish_30k.scp \
   && cp $mfccdir/kaldi_fish_30k.scp data/train_asr_30k/feats.scp
 )
-( . path.sh;
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_asr_100k/feats.scp{,.bak}
   copy-feats scp:data/train_asr_100k/feats.scp  ark,scp:$mfccdir/kaldi_fish_100k.ark,$mfccdir/kaldi_fish_100k.scp \

--- a/egs/swbd/s5/local/eval1997_data_prep_edin.sh
+++ b/egs/swbd/s5/local/eval1997_data_prep_edin.sh
@@ -26,7 +26,7 @@ sdir=$1
 [ ! -d $sdir/transcr ] \
   && echo Expecting directory $sdir/transcr to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval1997
 mkdir -p $dir

--- a/egs/swbd/s5/local/eval2000_data_prep_edin.sh
+++ b/egs/swbd/s5/local/eval2000_data_prep_edin.sh
@@ -33,7 +33,7 @@ tdir=$2
 [ ! -d $tdir/reference ] \
   && echo Expecting directory $tdir/reference to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval2000
 mkdir -p $dir

--- a/egs/swbd/s5/local/eval2001_data_prep_edin.sh
+++ b/egs/swbd/s5/local/eval2001_data_prep_edin.sh
@@ -25,7 +25,7 @@ glm=$3
 [ ! -d $sdir/english ] \
   && echo Expecting directory $sdir/english to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval2001
 mkdir -p $dir

--- a/egs/swbd/s5/local/swbd_p1_format_data.sh
+++ b/egs/swbd/s5/local/swbd_p1_format_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 silprob=0.5
 mkdir -p data/lang_test data/train

--- a/egs/swbd/s5/run.sh
+++ b/egs/swbd/s5/run.sh
@@ -80,13 +80,13 @@ utils/data/remove_dup_utts.sh 200 data/train_100k data/train_100k_nodup
 # The next commands are not necessary for the scripts to run, but increase 
 # efficiency of data access by putting the mfcc's of the subset 
 # in a contiguous place in a file.
-( . path.sh; 
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_10k_nodup/feats.scp{,.bak} 
   copy-feats scp:data/train_10k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_swbd_10k_nodup.ark,$mfccdir/kaldi_swbd_10k_nodup.scp \
   && cp $mfccdir/kaldi_swbd_10k_nodup.scp data/train_10k_nodup/feats.scp
 )
-( . path.sh; 
+( . ./path.sh;
   # make sure mfccdir is defined as above..
   cp data/train_30k_nodup/feats.scp{,.bak} 
   copy-feats scp:data/train_30k_nodup/feats.scp  ark,scp:$mfccdir/kaldi_swbd_30k_nodup.ark,$mfccdir/kaldi_swbd_30k_nodup.scp \

--- a/egs/swbd/s5b/local/eval1997_data_prep.sh
+++ b/egs/swbd/s5b/local/eval1997_data_prep.sh
@@ -26,7 +26,7 @@ sdir=$1
 [ ! -d $sdir/transcr ] \
   && echo Expecting directory $sdir/transcr to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval1997
 mkdir -p $dir

--- a/egs/swbd/s5b/local/eval2000_data_prep.sh
+++ b/egs/swbd/s5b/local/eval2000_data_prep.sh
@@ -33,7 +33,7 @@ tdir=$2
 [ ! -d $tdir/reference ] \
   && echo Expecting directory $tdir/reference to be present && exit 1;
 
-. path.sh 
+. ./path.sh
 
 dir=data/local/eval2000
 mkdir -p $dir

--- a/egs/swbd/s5c/local/run_asr_segmentation.sh
+++ b/egs/swbd/s5c/local/run_asr_segmentation.sh
@@ -41,7 +41,7 @@ stage=-1
 nj=80
 
 . ./path.sh
-. cmd.sh 
+. ./cmd.sh
 
 set -e -u -o pipefail
 . utils/parse_options.sh 

--- a/egs/tedlium/s5/local/prepare_lm.sh
+++ b/egs/tedlium/s5/local/prepare_lm.sh
@@ -4,7 +4,7 @@
 # Apache 2.0
 
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 arpa_lm=db/cantab-TEDLIUM/cantab-TEDLIUM-pruned.lm3.gz
 [ ! -f $arpa_lm ] && echo No such file $arpa_lm && exit 1;

--- a/egs/tedlium/s5_r2/local/format_lms.sh
+++ b/egs/tedlium/s5_r2/local/format_lms.sh
@@ -3,7 +3,7 @@
 # Copyright  2014 Nickolay V. Shmyrev
 # Apache 2.0
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 
 small_arpa_lm=data/local/local_lm/data/arpa/4gram_small.arpa.gz

--- a/egs/tedlium/s5_r2_wsj/local/format_lms.sh
+++ b/egs/tedlium/s5_r2_wsj/local/format_lms.sh
@@ -3,7 +3,7 @@
 # Copyright  2014 Nickolay V. Shmyrev
 # Apache 2.0
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 small_arpa_lm=data/local/local_lm/data/arpa/4gram_small.arpa.gz
 big_arpa_lm=data/local/local_lm/data/arpa/4gram_big.arpa.gz

--- a/egs/voxforge/s5/local/voxforge_data_prep.sh
+++ b/egs/voxforge/s5/local/voxforge_data_prep.sh
@@ -6,7 +6,7 @@
 
 # Makes train/test splits
 
-source path.sh
+. ./path.sh
 
 echo "=== Starting initial VoxForge data preparation ..."
 

--- a/egs/voxforge/s5/local/voxforge_prepare_dict.sh
+++ b/egs/voxforge/s5/local/voxforge_prepare_dict.sh
@@ -3,7 +3,7 @@
 # Copyright 2012 Vassil Panayotov
 # Apache 2.0
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 locdata=data/local
 locdict=$locdata/dict

--- a/egs/voxforge/s5/local/voxforge_prepare_lm.sh
+++ b/egs/voxforge/s5/local/voxforge_prepare_lm.sh
@@ -3,7 +3,7 @@
 # Copyright 2012 Vassil Panayotov
 # Apache 2.0
 
-. path.sh || exit 1
+. ./path.sh || exit 1
 
 echo "=== Building a language model ..."
 

--- a/egs/wsj/s5/steps/nnet/make_bn_feats.sh
+++ b/egs/wsj/s5/steps/nnet/make_bn_feats.sh
@@ -32,7 +32,7 @@ if [ $# != 5 ]; then
    exit 1;
 fi
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 data=$1
 srcdata=$2

--- a/egs/wsj/s5/steps/nnet/make_priors.sh
+++ b/egs/wsj/s5/steps/nnet/make_priors.sh
@@ -29,7 +29,7 @@ if [ $# != 2 ]; then
    exit 1;
 fi
 
-if [ -f path.sh ]; then . path.sh; fi
+if [ -f path.sh ]; then . ./path.sh; fi
 
 data=$1
 nndir=$2

--- a/egs/wsj/s5/steps/nnet/train_mmi.sh
+++ b/egs/wsj/s5/steps/nnet/train_mmi.sh
@@ -221,7 +221,7 @@ if [ -e $dir/prior_counts ]; then
   echo "Priors are already re-estimated, skipping... ($dir/prior_counts)"
 else
   echo "Re-estimating priors by forwarding 10k utterances from training set."
-  . cmd.sh
+  . ./cmd.sh
   nj=$(cat $alidir/num_jobs)
   steps/nnet/make_priors.sh --cmd "$train_cmd" --nj $nj \
     ${ivector:+ --ivector "$ivector"} $data $dir

--- a/egs/wsj/s5/steps/nnet/train_mpe.sh
+++ b/egs/wsj/s5/steps/nnet/train_mpe.sh
@@ -213,7 +213,7 @@ if [ -e $dir/prior_counts ]; then
   echo "Priors are already re-estimated, skipping... ($dir/prior_counts)"
 else
   echo "Re-estimating priors by forwarding 10k utterances from training set."
-  . cmd.sh
+  . ./cmd.sh
   nj=$(cat $alidir/num_jobs)
   steps/nnet/make_priors.sh --cmd "$train_cmd" --nj $nj \
     ${ivector:+ --ivector "$ivector"} $data $dir


### PR DESCRIPTION
PR #1953 was not aggressive enough.

The secret sauce:

```
find ./ -type f -iname '*.sh' -exec sed -i "s;[.]\s\+path.sh;. ./path.sh;g" "{}" \;
find ./ -type f -iname '*.sh' -exec sed -i "s;source\s\+path.sh;. ./path.sh;g" "{}" \;
find ./ -type f -iname '*.sh' -exec sed -i "s;[.]\s\+cmd.sh;. ./cmd.sh;g" "{}" \;
find ./ -type f -iname '*.sh' -exec sed -i "s;source\s\+cmd.sh;. ./cmd.sh;g" "{}" \;
```

Only one innocuous false positive, which I fixed manually (a comment said
"could not source path.sh" or something like that).