### PR TITLE
Missing new line character

### DIFF
--- a/egs/wsj/s5/utils/parallel/slurm.pl
+++ b/egs/wsj/s5/utils/parallel/slurm.pl
@@ -399,7 +399,7 @@ print Q "fi\n";
 print Q "time1=\`date +\"%s\"\`\n";
 print Q " ( $cmd ) &>>$logfile\n";
 print Q "ret=\$?\n";
-print Q "sync || true";
+print Q "sync || true\n";
 print Q "time2=\`date +\"%s\"\`\n";
 print Q "echo '#' Accounting: begin_time=\$time1 >>$logfile\n";
 print Q "echo '#' Accounting: end_time=\$time2 >>$logfile\n";


### PR DESCRIPTION
The sync line was created without the 'new line' character
The following instruction (time2=`date +"%s") was printed in the same line and not executed.
Information about time was incorrect (and the accuracy report fails).