### PR TITLE
[src] Fix compilation issue on Windows/MSVC (std::accumulate not defined)

### DIFF
--- a/src/rnnlm/sampling-lm-estimate.cc
+++ b/src/rnnlm/sampling-lm-estimate.cc
@@ -18,6 +18,7 @@
 // limitations under the License.
 
 #include <iomanip>
+#include <numeric>
 #include "rnnlm/sampling-lm-estimate.h"
 
 namespace kaldi {


### PR DESCRIPTION
This PR fixes a compilation issue with `sampling-lm-estimate.cc` on Windows/MSVC (Visual Studio 17, MSVC 19.11.25547.0).

`std::accumulate` is defined in `<numeric>` (see http://en.cppreference.com/w/cpp/algorithm/accumulate), but `<numeric>` is not included (nor is it included in any of the included headers as far as I can see). I'm not sure why this only appears with MSVC and not with GCC. After the change it compiles fine under Linux (Ubuntu 16.04, gcc) and Windows.