### PR TITLE
Fix to decode context option in egs/swbd for OPGRU

### DIFF
--- a/egs/swbd/s5c/local/chain/tuning/run_tdnn_opgru_1a.sh
+++ b/egs/swbd/s5c/local/chain/tuning/run_tdnn_opgru_1a.sh
@@ -239,6 +239,8 @@ if [ $stage -le 15 ]; then
           --nj 50 --cmd "$decode_cmd" $iter_opts \
           --extra-left-context $extra_left_context  \
           --extra-right-context $extra_right_context  \
+          --extra-left-context-initial 0 \
+          --extra-right-context-final 0 \
           --frames-per-chunk "$frames_per_chunk" \
           --online-ivector-dir exp/nnet3/ivectors_${decode_set} \
          $graph_dir data/${decode_set}_hires \


### PR DESCRIPTION
I have double checked my decode logs. I decoded in the match condition (train with initial = 0, decode with initial =0). This is a small bug in scripts.
Also, my experiments showed TDNN-NormOPGRU was not sensitive to different decode extra initial/final context setup.