### PR TITLE
Make faster ApplyFloor and ApplyCeiling variants.

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -6,6 +6,7 @@
 //                2013  Xiaohui Zhang
 //           2013-2015  Guoguo Chen
 //           2016-2017  Shiyin Kang
+//                2017  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -708,12 +709,20 @@ void cudaD_vec_apply_ceiling(int Gr, int Bl, double* v, double ceiling_val,
                              float* num, int dim);
 void cudaF_vec_apply_ceiling(int Gr, int Bl, float* v, float ceiling_val,
                              float* num, int dim);
+void cudaD_vec_apply_ceiling_no_count(int Gr, int Bl, double* v,
+                                      double ceiling_val, int dim);
+void cudaF_vec_apply_ceiling_no_count(int Gr, int Bl, float* v,
+                                      float ceiling_val, int dim);
 void cudaD_vec_apply_exp(int Gr, int Bl, double* v, int dim);
 void cudaF_vec_apply_exp(int Gr, int Bl, float* v, int dim);
 void cudaD_vec_apply_floor(int Gr, int Bl, double* v, double floor_val,
                            float* num, int dim);
 void cudaF_vec_apply_floor(int Gr, int Bl, float* v, float floor_val,
                            float* num, int dim);
+void cudaD_vec_apply_floor_no_count(int Gr, int Bl, double* v, double floor_val,
+                                    int dim);
+void cudaF_vec_apply_floor_no_count(int Gr, int Bl, float* v, float floor_val,
+                                    int dim);
 void cudaD_vec_apply_log(int Gr, int Bl, double* v, double* flag, int dim);
 void cudaF_vec_apply_log(int Gr, int Bl, float* v, float* flag, int dim);
 void cudaD_vec_copy_diag_from_packed(int Gr, int Bl, double *dst,

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -7,7 +7,7 @@
 //                2013  Xiaohui Zhang
 //           2013-2015  Guoguo Chen
 //           2016-2017  Shiyin Kang
-//                2017  Hossein Hadian
+//                2017  Hossein Hadian, Daniel Galvez
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1792,6 +1792,16 @@ static void _vec_apply_floor(Real *v, Real floor_val, float *count, int dim) {
 
 template<typename Real>
 __global__
+static void _vec_apply_floor_no_count(Real *v, Real floor_val, int dim) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < dim) {
+    v[i] = max(v[i], floor_val);
+  }
+}
+
+template<typename Real>
+__global__
 static void _vec_apply_ceiling(Real *v, Real ceiling_val, float *count,
                                int dim) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1803,6 +1813,16 @@ static void _vec_apply_ceiling(Real *v, Real ceiling_val, float *count,
     } else {
       count[i] = 0;
     }
+  }
+}
+
+template<typename Real>
+__global__
+static void _vec_apply_ceiling_no_count(Real *v, Real ceiling_val, int dim) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < dim) {
+    v[i] = min(v[i], ceiling_val);
   }
 }
 
@@ -4017,10 +4037,21 @@ void cudaF_vec_apply_floor(int Gr, int Bl, float* v, float floor_val,
   _vec_apply_floor<<<Gr,Bl>>>(v,floor_val,count,dim);
 }
 
+void cudaF_vec_apply_floor_no_count(int Gr, int Bl, float* v, float floor_val,
+				    int dim) {
+  _vec_apply_floor_no_count<<<Gr,Bl>>>(v,floor_val,dim);
+}
+
 void cudaF_vec_apply_ceiling(int Gr, int Bl, float* v, float ceiling_val,
                              float *count, int dim) {
   _vec_apply_ceiling<<<Gr,Bl>>>(v, ceiling_val,count,dim);
 }
+
+void cudaF_vec_apply_ceiling_no_count(int Gr, int Bl, float* v, float floor_val,
+				      int dim) {
+  _vec_apply_ceiling_no_count<<<Gr,Bl>>>(v,floor_val,dim);
+}
+
 
 void cudaF_vec_apply_exp(int Gr, int Bl, float* v, int dim) {
   _vec_apply_exp<<<Gr,Bl>>>(v,dim);
@@ -4699,10 +4730,21 @@ void cudaD_vec_apply_floor(int Gr, int Bl, double* v, double floor_val,
   _vec_apply_floor<<<Gr,Bl>>>(v,floor_val,count,dim);
 }
 
+void cudaD_vec_apply_floor_no_count(int Gr, int Bl, double* v, double floor_val,
+				    int dim) {
+  _vec_apply_floor_no_count<<<Gr,Bl>>>(v,floor_val,dim);
+}
+
 void cudaD_vec_apply_ceiling(int Gr, int Bl, double* v, double ceiling_val,
                              float *count, int dim) {
   _vec_apply_ceiling<<<Gr,Bl>>>(v,ceiling_val,count,dim);
 }
+
+void cudaD_vec_apply_ceiling_no_count(int Gr, int Bl, double* v, double ceiling_val,
+				      int dim) {
+  _vec_apply_ceiling_no_count<<<Gr,Bl>>>(v,ceiling_val,dim);
+}
+
 
 void cudaD_vec_apply_exp(int Gr, int Bl, double* v, int dim) {
   _vec_apply_exp<<<Gr,Bl>>>(v,dim);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -7,6 +7,7 @@
 //                2013  Xiaohui Zhang
 //           2013-2015  Guoguo Chen
 //           2016-2017  Shiyin Kang
+//                2017  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -1395,6 +1396,14 @@ inline void cuda_vec_apply_ceiling(int Gr, int Bl, float* v, float floor_val,
                                    float* num, int dim) {
   cudaF_vec_apply_ceiling(Gr, Bl, v, floor_val, num, dim);
 }
+inline void cuda_vec_apply_ceiling_no_count(int Gr, int Bl, double* v,
+                                            double ceiling_val, int dim) {
+  cudaD_vec_apply_ceiling_no_count(Gr, Bl, v, ceiling_val, dim);
+}
+inline void cuda_vec_apply_ceiling_no_count(int Gr, int Bl, float* v,
+                                            float ceiling_val, int dim) {
+  cudaF_vec_apply_ceiling_no_count(Gr, Bl, v, ceiling_val, dim);
+}
 inline void cuda_vec_apply_exp(int Gr, int Bl, double* v, int dim) {
   cudaD_vec_apply_exp(Gr, Bl, v, dim);
 }
@@ -1408,6 +1417,14 @@ inline void cuda_vec_apply_floor(int Gr, int Bl, double* v, double floor_val,
 inline void cuda_vec_apply_floor(int Gr, int Bl, float* v, float floor_val,
                                  float* num, int dim) {
   cudaF_vec_apply_floor(Gr, Bl, v, floor_val, num, dim);
+}
+inline void cuda_vec_apply_floor_no_count(int Gr, int Bl, double* v,
+                                          double floor_val, int dim) {
+  cudaD_vec_apply_floor_no_count(Gr, Bl, v, floor_val, dim);
+}
+inline void cuda_vec_apply_floor_no_count(int Gr, int Bl, float* v,
+                                          float floor_val, int dim) {
+  cudaF_vec_apply_floor_no_count(Gr, Bl, v, floor_val, dim);
 }
 inline void cuda_vec_apply_log(int Gr, int Bl, double* v, double* flag,
                                int dim) {

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -1,6 +1,7 @@
 // cudamatrix/cu-vector-speed-test.cc
 
 // Copyright 2013  Johns Hopkins University (author: Daniel Povey)
+// Copyright 2017  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -256,6 +257,86 @@ template<typename Real> void TestCuVectorAddColSumMat(int32 dim, MatrixTranspose
 }
 
 
+template<typename Real> void TestCuVectorApplyFloor(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    (void) v.ApplyFloor(threshold);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyFloor" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyFloorNoCount(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    v.ApplyFloorNoCount(threshold);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyFloorNoCount" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyCeiling(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    (void) v.ApplyCeiling(threshold);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyCeiling" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyCeilingNoCount(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    v.ApplyCeilingNoCount(threshold);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyCeilingNoCount" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
 template<typename Real> void CudaVectorSpeedTest() {
   std::vector<int32> sizes;
   sizes.push_back(16);
@@ -295,6 +376,14 @@ template<typename Real> void CudaVectorSpeedTest() {
   for (int32 s = 0; s < ns; s++) {
     TestCuVectorAddColSumMat<Real>(sizes[s], kNoTrans);
     TestCuVectorAddColSumMat<Real>(sizes[s], kTrans);
+  }
+  for (int32 s = 0; s < ns; s++) {
+    TestCuVectorApplyFloor<Real>(sizes[s]);
+    TestCuVectorApplyFloorNoCount<Real>(sizes[s]);
+  }
+  for (int32 s = 0; s < ns; s++) {
+    TestCuVectorApplyCeiling<Real>(sizes[s]);
+    TestCuVectorApplyCeilingNoCount<Real>(sizes[s]);
   }
 
 }

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -2,7 +2,7 @@
 
 // Copyright 2013 Lucas Ondel
 //           2013 Johns Hopkins University (author: Daniel Povey)
-//           2017 Hossein Hadian
+//           2017 Hossein Hadian, Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -563,6 +563,34 @@ template<typename Real> void CuVectorUnitTestApplyFloor() {
   }
 }
 
+template<typename Real> void CuVectorUnitTestApplyFloorNoCount() {
+  for (int32 l = 0; l < 10; l++) {
+    int32 dim = 100 + Rand() % 700;
+    CuVector<Real> cu_vector1(dim);
+    cu_vector1.SetRandn();
+    CuVector<Real> cu_vector2(cu_vector1);
+
+    BaseFloat floor = 0.33 * (-5 + Rand() % 10);
+    (void) cu_vector1.ApplyFloor(floor);
+    cu_vector2.ApplyFloorNoCount(floor);
+    AssertEqual(cu_vector1, cu_vector2);
+  }
+}
+
+template<typename Real> void CuVectorUnitTestApplyCeilingNoCount() {
+  for (int32 l = 0; l < 10; l++) {
+    int32 dim = 100 + Rand() % 700;
+    CuVector<Real> cu_vector1(dim);
+    cu_vector1.SetRandn();
+    CuVector<Real> cu_vector2(cu_vector1);
+
+    BaseFloat floor = 0.33 * (-5 + Rand() % 10);
+    (void) cu_vector1.ApplyCeiling(floor);
+    cu_vector2.ApplyCeilingNoCount(floor);
+    AssertEqual(cu_vector1, cu_vector2);
+  }
+}
+
 template<typename Real> void CuVectorUnitTestApplyCeiling() {
   for (int32 l = 0; l < 10; l++) {
     int32 dim = 100 + Rand() % 700;
@@ -770,6 +798,8 @@ template<typename Real> void CuVectorUnitTest() {
   CuVectorUnitTestApplyExp<Real>();
   CuVectorUnitTestApplyLog<Real>();
   CuVectorUnitTestApplyFloor<Real>();
+  CuVectorUnitTestApplyFloorNoCount<Real>();
+  CuVectorUnitTestApplyCeilingNoCount<Real>();
   CuVectorUnitTestApplyCeiling<Real>();
   CuVectorUnitTestApplyPow<Real>();
   CuVectorUnitTestAddMatVec<Real>();

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -2,6 +2,7 @@
 
 // Copyright 2012-2013  Karel Vesely
 //           2012-2014  Johns Hopkins University (author: Daniel Povey)
+//                2017  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -367,6 +368,25 @@ MatrixIndexT CuVectorBase<Real>::ApplyFloor(Real floor_val) {
 }
 
 template<typename Real>
+void CuVectorBase<Real>::ApplyFloorNoCount(Real floor_val) {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    if (dim_ == 0) return;
+    CuTimer tim;
+    int dimBlock(CU1DBLOCK);
+    int dimGrid(n_blocks(dim_,CU1DBLOCK));
+
+    cuda_vec_apply_floor_no_count(dimGrid, dimBlock, data_, floor_val, dim_);
+    CU_SAFE_CALL(cudaGetLastError());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyFloorNoCount", tim);
+  } else
+#endif
+  {
+    Vec().ApplyFloorNoCount(floor_val);
+  }
+}
+
+template<typename Real>
 MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
   MatrixIndexT num_ceiled = 0;
 #if HAVE_CUDA == 1
@@ -388,6 +408,25 @@ MatrixIndexT CuVectorBase<Real>::ApplyCeiling(Real ceiling_val) {
     num_ceiled = Vec().ApplyCeiling(ceiling_val);
   }
   return num_ceiled;
+}
+
+template<typename Real>
+void CuVectorBase<Real>::ApplyCeilingNoCount(Real ceiling_val) {
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
+    if (dim_ == 0) return;
+    CuTimer tim;
+    int dimBlock(CU1DBLOCK);
+    int dimGrid(n_blocks(dim_,CU1DBLOCK));
+
+    cuda_vec_apply_ceiling_no_count(dimGrid, dimBlock, data_, ceiling_val, dim_);
+    CU_SAFE_CALL(cudaGetLastError());
+    CuDevice::Instantiate().AccuProfile("CuVectorBase::ApplyCeilingNoCount", tim);
+  } else
+#endif
+  {
+    Vec().ApplyCeilingNoCount(ceiling_val);
+  }
 }
 
 template<typename Real>

--- a/src/cudamatrix/cu-vector.h
+++ b/src/cudamatrix/cu-vector.h
@@ -5,6 +5,7 @@
 //                      Lucas Ondel
 //           2013       Xiaohui Zhang
 //           2015       Guoguo Chen
+//           2017       Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -134,7 +135,9 @@ class CuVectorBase {
   void ApplyExp();
   void ApplyLog();
   MatrixIndexT ApplyFloor(Real floor_val);
+  void ApplyFloorNoCount(Real floor_val);
   MatrixIndexT ApplyCeiling(Real ceiling_val);
+  void ApplyCeilingNoCount(Real ceiling_val);
   void ApplyPow(Real power);
   Real Sum() const;
 

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -5,6 +5,7 @@
 //                      Petr Schwarz;  Yanmin Qian;  Jan Silovsky;
 //                      Haihua Xu; Wei Shi
 //                2015  Guoguo Chen
+//                2017  Daniel Galvez
 
 
 // See ../../COPYING for clarification regarding multiple authors
@@ -823,6 +824,13 @@ MatrixIndexT VectorBase<Real>::ApplyFloor(Real floor_val) {
 }
 
 template<typename Real>
+void VectorBase<Real>::ApplyFloorNoCount(Real floor_val) {
+  for (MatrixIndexT i = 0; i < dim_; i++) {
+    data_[i] = std::max(data_[i], floor_val);
+  }
+}
+
+template<typename Real>
 MatrixIndexT VectorBase<Real>::ApplyCeiling(Real ceil_val) {
   MatrixIndexT num_changed = 0;
   for (MatrixIndexT i = 0; i < dim_; i++) {
@@ -834,6 +842,12 @@ MatrixIndexT VectorBase<Real>::ApplyCeiling(Real ceil_val) {
   return num_changed;
 }
 
+template<typename Real>
+void VectorBase<Real>::ApplyCeilingNoCount(Real ceiling_val) {
+  for (MatrixIndexT i = 0; i < dim_; i++) {
+    data_[i] = std::min(data_[i], ceiling_val);
+  }
+}
 
 template<typename Real>
 MatrixIndexT VectorBase<Real>::ApplyFloor(const VectorBase<Real> &floor_vec) {

--- a/src/matrix/kaldi-vector.h
+++ b/src/matrix/kaldi-vector.h
@@ -6,6 +6,7 @@
 //                       Karel Vesely;  Go Vivace Inc.;  Arnab Ghoshal
 //                       Wei Shi;
 //                2015   Guoguo Chen
+//                2017   Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -136,8 +137,14 @@ class VectorBase {
   /// Applies floor to all elements. Returns number of elements floored.
   MatrixIndexT ApplyFloor(Real floor_val);
 
+  /// Applies floor to all elements. Slightly faster than ApplyFloor
+  void ApplyFloorNoCount(Real floor_val);
+
   /// Applies ceiling to all elements. Returns number of elements changed.
   MatrixIndexT ApplyCeiling(Real ceil_val);
+
+  /// Applies ceiling to all elements. Slightly faster than ApplyFloor
+  void ApplyCeilingNoCount(Real ceil_val);
 
   /// Applies floor to all elements. Returns number of elements floored.
   MatrixIndexT ApplyFloor(const VectorBase<Real> &floor_vec);

--- a/src/matrix/matrix-lib-test.cc
+++ b/src/matrix/matrix-lib-test.cc
@@ -6,6 +6,7 @@
 //                       Johns Hopkins University (Author: Daniel Povey);
 //                       Haihua Xu; Wei Shi
 //                2015   Guoguo Chen
+//                2017   Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -2297,6 +2298,14 @@ template<typename Real> static void  UnitTestFloorCeiling() {
     AssertEqual(c, c2);
     KALDI_ASSERT(floored == floored2);
     KALDI_ASSERT(ceiled == ceiled2);
+
+    Vector<Real> f3(v);
+    f3.ApplyFloorNoCount(pivot);
+    AssertEqual(f2, f3);
+
+    Vector<Real> c3(v);
+    c3.ApplyCeilingNoCount(pivot);
+    AssertEqual(c2, c3);
   }
 }
 


### PR DESCRIPTION
They are called ApplyFloorNoCount and ApplyCeilingNoCount. By not
counting how many elements are floored or ceiled, respectively, they
take advantage of min and max intrinsic instructions (FMNMX on Maxwell)
on the GPU, eliminating all warp divergence.

cu-vector-speed-test results. NoCount variants are 2-3x faster.
```
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 16, speed was 0.000715013 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 16, speed was 0.00170341 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 32, speed was 0.00133973 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 32, speed was 0.00338192 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 64, speed was 0.00271212 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 64, speed was 0.00687755 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 128, speed was 0.0055066 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 128, speed was 0.0139386 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 256, speed was 0.0108702 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 256, speed was 0.0285611 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:274)
For CuVector::ApplyFloor<float>, for dim = 1024, speed was 0.0367944 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:294)
For CuVector::ApplyFloorNoCount<float>, for dim = 1024, speed was 0.106562 gigaflops.

LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 16, speed was 0.000675397 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 16, speed was 0.00172152 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 32, speed was 0.00135252 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 32, speed was 0.00347483 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 64, speed was 0.00284072 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 64, speed was 0.00711039 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 128, speed was 0.00558162 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 128, speed was 0.0133227 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 256, speed was 0.00985542 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 256, speed was 0.0270051 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:314)
For CuVector::ApplyCeiling<float>, for dim = 1024, speed was 0.0346773 gigaflops.
LOG ([5.3.42~11-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:334)
For CuVector::ApplyCeilingNoCount<float>, for dim = 1024, speed was 0.107533 gigaflops.
```