### PR TITLE
 Make faster ApplyFloor and ApplyCeiling variants for Matrix and CuMa…

### DIFF
--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -7,7 +7,7 @@
 //                2013  Xiaohui Zhang
 //           2013-2015  Guoguo Chen
 //           2016-2017  Shiyin Kang
-//                2017  Hossein Hadian
+//                2017  Hossein Hadian, Daniel Galvez
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1879,8 +1879,7 @@ static void _apply_floor(Real* mat, Real floor_val, MatrixDim d) {
   int index = i + j * d.stride;
 
   if (i < d.cols && j < d.rows) {
-    if (mat[index] < floor_val)
-      mat[index] = floor_val;
+    mat[index] = max(mat[index], floor_val);
   }
 }
 
@@ -2036,8 +2035,7 @@ static void _apply_ceiling(Real* mat, Real ceiling_val, MatrixDim d) {
   int index = i + j * d.stride;
 
   if (i < d.cols && j < d.rows) {
-    if (mat[index] > ceiling_val)
-      mat[index] = ceiling_val;
+    mat[index] = min(mat[index], ceiling_val);
   }
 }
 

--- a/src/cudamatrix/cu-vector-speed-test.cc
+++ b/src/cudamatrix/cu-vector-speed-test.cc
@@ -1,6 +1,7 @@
 // cudamatrix/cu-vector-speed-test.cc
 
 // Copyright 2013  Johns Hopkins University (author: Daniel Povey)
+// Copyright 2017  Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -256,6 +257,90 @@ template<typename Real> void TestCuVectorAddColSumMat(int32 dim, MatrixTranspose
 }
 
 
+template<typename Real> void TestCuVectorApplyFloor(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    MatrixIndexT dummy_count;
+    v.ApplyFloor(threshold, &dummy_count);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyFloor" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyFloorNoCount(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    v.ApplyFloor(threshold, nullptr);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyFloor (no count variety)" << NameOf<Real>()
+	    << ", for dim = " << dim << ", speed was " << gflops
+	    << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyCeiling(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    MatrixIndexT dummy_count;
+    v.ApplyCeiling(threshold, &dummy_count);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyCeiling" << NameOf<Real>() << ", for dim = "
+            << dim << ", speed was " << gflops << " gigaflops.";
+
+}
+
+
+template<typename Real> void TestCuVectorApplyCeilingNoCount(int32 dim) {
+  BaseFloat time_in_secs = 0.02;
+  CuVector<Real> v(dim);
+  v.SetRandn();
+  Real threshold = RandInt(-35000, 35000) / Real(100);
+
+  Timer tim;
+  int32 iter = 0;
+  for (;tim.Elapsed() < time_in_secs; iter++) {
+    v.ApplyCeiling(threshold, nullptr);
+  }
+
+  BaseFloat fdim = dim;
+  BaseFloat gflops = (fdim * iter) / (tim.Elapsed() * 1.0e+09);
+  KALDI_LOG << "For CuVector::ApplyCeiling (no count variety)" << NameOf<Real>()
+	    << ", for dim = " << dim << ", speed was " << gflops
+	    << " gigaflops.";
+
+}
+
+
 template<typename Real> void CudaVectorSpeedTest() {
   std::vector<int32> sizes;
   sizes.push_back(16);
@@ -295,6 +380,14 @@ template<typename Real> void CudaVectorSpeedTest() {
   for (int32 s = 0; s < ns; s++) {
     TestCuVectorAddColSumMat<Real>(sizes[s], kNoTrans);
     TestCuVectorAddColSumMat<Real>(sizes[s], kTrans);
+  }
+  for (int32 s = 0; s < ns; s++) {
+    TestCuVectorApplyFloor<Real>(sizes[s]);
+    TestCuVectorApplyFloorNoCount<Real>(sizes[s]);
+  }
+  for (int32 s = 0; s < ns; s++) {
+    TestCuVectorApplyCeiling<Real>(sizes[s]);
+    TestCuVectorApplyCeilingNoCount<Real>(sizes[s]);
   }
 
 }

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -2,7 +2,7 @@
 
 // Copyright 2013 Lucas Ondel
 //           2013 Johns Hopkins University (author: Daniel Povey)
-//           2017 Hossein Hadian
+//           2017 Hossein Hadian, Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -550,8 +550,9 @@ template<typename Real> void CuVectorUnitTestApplyFloor() {
 
     Vector<Real> vector(cu_vector);
     BaseFloat floor = 0.33 * (-5 + Rand() % 10);
-    int32 i = cu_vector.ApplyFloor(floor);
-    int32 j = vector.ApplyFloor(floor);
+    MatrixIndexT i, j;
+    cu_vector.ApplyFloor(floor, &i);
+    vector.ApplyFloor(floor, &j);
 
     CuVector<Real> cu2(vector);
 
@@ -563,6 +564,21 @@ template<typename Real> void CuVectorUnitTestApplyFloor() {
   }
 }
 
+template<typename Real> void CuVectorUnitTestApplyFloorNoCount() {
+  for (int32 l = 0; l < 10; l++) {
+    int32 dim = 100 + Rand() % 700;
+    CuVector<Real> cu_vector1(dim);
+    cu_vector1.SetRandn();
+    CuVector<Real> cu_vector2(cu_vector1);
+
+    BaseFloat floor = 0.33 * (-5 + Rand() % 10);
+    MatrixIndexT dummy_count;
+    cu_vector1.ApplyFloor(floor, &dummy_count);
+    cu_vector2.ApplyFloor(floor, nullptr);
+    AssertEqual(cu_vector1, cu_vector2);
+  }
+}
+
 template<typename Real> void CuVectorUnitTestApplyCeiling() {
   for (int32 l = 0; l < 10; l++) {
     int32 dim = 100 + Rand() % 700;
@@ -571,8 +587,9 @@ template<typename Real> void CuVectorUnitTestApplyCeiling() {
 
     Vector<Real> vector(cu_vector);
     BaseFloat floor = 0.33 * (-5 + Rand() % 10);
-    int32 i = cu_vector.ApplyCeiling(floor);
-    int32 j = vector.ApplyCeiling(floor);
+    MatrixIndexT i, j;
+    cu_vector.ApplyCeiling(floor, &i);
+    vector.ApplyCeiling(floor, &j);
 
     CuVector<Real> cu2(vector);
 
@@ -581,6 +598,21 @@ template<typename Real> void CuVectorUnitTestApplyCeiling() {
       KALDI_WARN << "ApplyCeiling return code broken...";
     }
     KALDI_ASSERT(i==j);
+  }
+}
+
+template<typename Real> void CuVectorUnitTestApplyCeilingNoCount() {
+  for (int32 l = 0; l < 10; l++) {
+    int32 dim = 100 + Rand() % 700;
+    CuVector<Real> cu_vector1(dim);
+    cu_vector1.SetRandn();
+    CuVector<Real> cu_vector2(cu_vector1);
+
+    BaseFloat floor = 0.33 * (-5 + Rand() % 10);
+    MatrixIndexT dummy_count;
+    cu_vector1.ApplyCeiling(floor, &dummy_count);
+    cu_vector2.ApplyCeiling(floor, nullptr);
+    AssertEqual(cu_vector1, cu_vector2);
   }
 }
 
@@ -770,6 +802,8 @@ template<typename Real> void CuVectorUnitTest() {
   CuVectorUnitTestApplyExp<Real>();
   CuVectorUnitTestApplyLog<Real>();
   CuVectorUnitTestApplyFloor<Real>();
+  CuVectorUnitTestApplyFloorNoCount<Real>();
+  CuVectorUnitTestApplyCeilingNoCount<Real>();
   CuVectorUnitTestApplyCeiling<Real>();
   CuVectorUnitTestApplyPow<Real>();
   CuVectorUnitTestAddMatVec<Real>();

--- a/src/cudamatrix/cu-vector.h
+++ b/src/cudamatrix/cu-vector.h
@@ -5,6 +5,7 @@
 //                      Lucas Ondel
 //           2013       Xiaohui Zhang
 //           2015       Guoguo Chen
+//           2017       Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -133,8 +134,8 @@ class CuVectorBase {
   void ApplySoftMax();
   void ApplyExp();
   void ApplyLog();
-  MatrixIndexT ApplyFloor(Real floor_val);
-  MatrixIndexT ApplyCeiling(Real ceiling_val);
+  void ApplyFloor(Real floor_val, MatrixIndexT *floored_count = NULL);
+  void ApplyCeiling(Real ceiling_val, MatrixIndexT *ceiled_count = NULL);
   void ApplyPow(Real power);
   Real Sum() const;
 

--- a/src/feat/feature-functions.cc
+++ b/src/feat/feature-functions.cc
@@ -321,7 +321,8 @@ void SlidingWindowCmnInternal(const SlidingWindowCmnOptions &opts,
         variance.AddVec2(-1.0 / (window_frames * window_frames), cur_sum);
         // now "variance" is the variance of the features in the window,
         // around their own mean.
-        int32 num_floored = variance.ApplyFloor(1.0e-10);
+        int32 num_floored;
+	variance.ApplyFloor(1.0e-10, &num_floored);
         if (num_floored > 0 && num_frames > 1) {
           if (opts.max_warnings == warning_count) {
             KALDI_WARN << "Suppressing the remaining variance flooring "

--- a/src/gmm/mle-diag-gmm.cc
+++ b/src/gmm/mle-diag-gmm.cc
@@ -343,7 +343,7 @@ void MleDiagGmmUpdate(const MleDiagGmmOptions &config,
         if (config.variance_floor_vector.Dim() != 0) {
           floored = var.ApplyFloor(config.variance_floor_vector);
         } else {
-          floored = var.ApplyFloor(config.min_variance);
+          var.ApplyFloor(config.min_variance, &floored);
         }
         if (floored != 0) {
           elements_floored += floored;

--- a/src/ivector/ivector-extractor.cc
+++ b/src/ivector/ivector-extractor.cc
@@ -348,7 +348,8 @@ static double GetLogDetNoFailure(const SpMatrix<double> &var) {
   } catch (...) {
     Vector<double> eigs(var.NumRows());
     var.Eig(&eigs);
-    int32 floored = eigs.ApplyFloor(1.0e-20);
+    int32 floored;
+    eigs.ApplyFloor(1.0e-20, &floored);
     if (floored > 0)
       KALDI_WARN << "Floored " << floored << " eigenvalues of variance.";
     eigs.ApplyLog();
@@ -1579,7 +1580,8 @@ double IvectorExtractorStats::UpdatePrior(
   covar.Eig(&s, &P);
   KALDI_LOG << "Eigenvalues of iVector covariance range from "
             << s.Min() << " to " << s.Max();
-  int32 num_floored = s.ApplyFloor(1.0e-07);
+  int32 num_floored;
+  s.ApplyFloor(1.0e-07, &num_floored);
   if (num_floored > 0)
     KALDI_WARN << "Floored " << num_floored << " eigenvalues of covar "
                << "of iVectors.";

--- a/src/ivector/plda.cc
+++ b/src/ivector/plda.cc
@@ -488,7 +488,8 @@ void PldaEstimator::GetOutput(Plda *plda) {
   between_var_proj.Eig(&s, &U);
 
   KALDI_ASSERT(s.Min() >= 0.0);
-  int32 n = s.ApplyFloor(0.0);
+  int32 n;
+  s.ApplyFloor(0.0, &n);
   if (n > 0) {
     KALDI_WARN << "Floored " << n << " eigenvalues of between-class "
                << "variance to zero.";

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -5,6 +5,7 @@
 //                      Petr Schwarz;  Yanmin Qian;  Jan Silovsky;
 //                      Haihua Xu; Wei Shi
 //                2015  Guoguo Chen
+//                2017  Daniel Galvez
 
 
 // See ../../COPYING for clarification regarding multiple authors
@@ -811,29 +812,40 @@ void VectorBase<Real>::ApplyAbs() {
 }
 
 template<typename Real>
-MatrixIndexT VectorBase<Real>::ApplyFloor(Real floor_val) {
-  MatrixIndexT num_floored = 0;
-  for (MatrixIndexT i = 0; i < dim_; i++) {
-    if (data_[i] < floor_val) {
-      data_[i] = floor_val;
-      num_floored++;
+void VectorBase<Real>::ApplyFloor(Real floor_val, MatrixIndexT *floored_count) {
+  if (floored_count == nullptr) {
+    for (MatrixIndexT i = 0; i < dim_; i++) {
+      data_[i] = std::max(data_[i], floor_val);
     }
+  } else {
+    MatrixIndexT num_floored = 0;
+    for (MatrixIndexT i = 0; i < dim_; i++) {
+      if (data_[i] < floor_val) {
+	data_[i] = floor_val;
+	num_floored++;
+      }
+    }
+    *floored_count = num_floored;
   }
-  return num_floored;
 }
 
 template<typename Real>
-MatrixIndexT VectorBase<Real>::ApplyCeiling(Real ceil_val) {
-  MatrixIndexT num_changed = 0;
-  for (MatrixIndexT i = 0; i < dim_; i++) {
-    if (data_[i] > ceil_val) {
-      data_[i] = ceil_val;
-      num_changed++;
+void VectorBase<Real>::ApplyCeiling(Real ceil_val, MatrixIndexT *ceiled_count) {
+  if (ceiled_count == nullptr) {
+    for (MatrixIndexT i = 0; i < dim_; i++) {
+      data_[i] = std::min(data_[i], ceil_val);
     }
+  } else {
+    MatrixIndexT num_changed = 0;
+    for (MatrixIndexT i = 0; i < dim_; i++) {
+      if (data_[i] > ceil_val) {
+	data_[i] = ceil_val;
+	num_changed++;
+      }
+    }
+    *ceiled_count = num_changed;
   }
-  return num_changed;
 }
-
 
 template<typename Real>
 MatrixIndexT VectorBase<Real>::ApplyFloor(const VectorBase<Real> &floor_vec) {

--- a/src/matrix/kaldi-vector.h
+++ b/src/matrix/kaldi-vector.h
@@ -6,6 +6,7 @@
 //                       Karel Vesely;  Go Vivace Inc.;  Arnab Ghoshal
 //                       Wei Shi;
 //                2015   Guoguo Chen
+//                2017   Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -133,11 +134,13 @@ class VectorBase {
   /// Take absolute value of each of the elements
   void ApplyAbs();
 
-  /// Applies floor to all elements. Returns number of elements floored.
-  MatrixIndexT ApplyFloor(Real floor_val);
+  /// Applies floor to all elements. Returns number of elements
+  /// floored in floored_count if it is non-null.
+  void ApplyFloor(Real floor_val, MatrixIndexT *floored_count = nullptr);
 
-  /// Applies ceiling to all elements. Returns number of elements changed.
-  MatrixIndexT ApplyCeiling(Real ceil_val);
+  /// Applies ceiling to all elements. Returns number of elements
+  /// changed in ceiled_count if it is non-null.
+  void ApplyCeiling(Real ceil_val, MatrixIndexT *ceiled_count = nullptr);
 
   /// Applies floor to all elements. Returns number of elements floored.
   MatrixIndexT ApplyFloor(const VectorBase<Real> &floor_vec);

--- a/src/matrix/matrix-lib-test.cc
+++ b/src/matrix/matrix-lib-test.cc
@@ -6,6 +6,7 @@
 //                       Johns Hopkins University (Author: Daniel Povey);
 //                       Haihua Xu; Wei Shi
 //                2015   Guoguo Chen
+//                2017   Daniel Galvez
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -2286,8 +2287,10 @@ template<typename Real> static void  UnitTestFloorCeiling() {
     v.SetRandn();
     Real pivot = v(5);
     Vector<Real> f(v), f2(v), c(v), c2(v);
-    MatrixIndexT floored2 = f.ApplyFloor(pivot),
-        ceiled2 = c.ApplyCeiling(pivot);
+    MatrixIndexT floored2;
+    f.ApplyFloor(pivot, &floored2);
+    MatrixIndexT ceiled2;
+    c.ApplyCeiling(pivot, &ceiled2);
     MatrixIndexT floored = 0, ceiled = 0;
     for (MatrixIndexT d = 0; d < dimM; d++) {
       if (f2(d) < pivot) { f2(d) = pivot; floored++; }
@@ -2297,6 +2300,16 @@ template<typename Real> static void  UnitTestFloorCeiling() {
     AssertEqual(c, c2);
     KALDI_ASSERT(floored == floored2);
     KALDI_ASSERT(ceiled == ceiled2);
+
+    // Check that the non-counting variants are equivalent to the counting
+    // variants.
+    Vector<Real> f3(v);
+    f3.ApplyFloor(pivot);
+    AssertEqual(f2, f3);
+
+    Vector<Real> c3(v);
+    c3.ApplyCeiling(pivot);
+    AssertEqual(c2, c3);
   }
 }
 

--- a/src/nnet2/get-feature-transform.cc
+++ b/src/nnet2/get-feature-transform.cc
@@ -111,7 +111,8 @@ void FeatureTransformEstimate::EstimateInternal(
     Vector<BaseFloat> s(min_dim);
     M->Svd(&s, &U, &Vt); // decompose m = U diag(s) Vt.
     BaseFloat max_s = s.Max();
-    int32 n = s.ApplyCeiling(opts.max_singular_value);
+    int32 n;
+    s.ApplyCeiling(opts.max_singular_value, &n);
     if (n > 0) {
       KALDI_LOG << "Applied ceiling to " << n << " out of " << s.Dim()
                 << " singular values of transform using ceiling "

--- a/src/nnet2/nnet-precondition-online-test.cc
+++ b/src/nnet2/nnet-precondition-online-test.cc
@@ -170,7 +170,8 @@ void OnlinePreconditionerSimple::PreconditionDirectionsCpu(
   Z_t.Eig(&c_t, &U_t);
   SortSvd(&c_t, &U_t);
   double c_t_floor = pow(rho_t_ * (1.0 - eta), 2);
-  int32 nf = c_t.ApplyFloor(c_t_floor);
+  int32 nf;
+  c_t.ApplyFloor(c_t_floor, &nf);
   if (nf > 0) {
     KALDI_WARN << "Floored " << nf << " elements of c_t.";
   }
@@ -198,7 +199,7 @@ void OnlinePreconditionerSimple::PreconditionDirectionsCpu(
     KALDI_WARN << "flooring rho_{t+1} to " << floor_val << ", was " << rho_t1;
     rho_t1 = floor_val;
   }
-  nf = d_t1.ApplyFloor(floor_val);
+  d_t1.ApplyFloor(floor_val, &nf);
   if (nf > 0) {
     KALDI_VLOG(3) << "d_t1 was " << d_t1;
     KALDI_WARN << "Floored " << nf << " elements of d_{t+1}.";

--- a/src/nnet2/nnet-precondition-online.cc
+++ b/src/nnet2/nnet-precondition-online.cc
@@ -416,7 +416,8 @@ void OnlinePreconditioner::PreconditionDirectionsInternal(
   bool must_reorthogonalize = (c_t(0) > condition_threshold * c_t(R - 1));
 
   BaseFloat c_t_floor = pow(rho_t * (1 - eta), 2);
-  int32 nf = c_t.ApplyFloor(c_t_floor);
+  int32 nf;
+  c_t.ApplyFloor(c_t_floor, &nf);
   if (nf > 0)
     must_reorthogonalize = true;
   if (nf > 0 && self_debug_) {

--- a/src/nnet3/natural-gradient-online-test.cc
+++ b/src/nnet3/natural-gradient-online-test.cc
@@ -170,7 +170,8 @@ void OnlineNaturalGradientSimple::PreconditionDirectionsCpu(
   Z_t.Eig(&c_t, &U_t);
   SortSvd(&c_t, &U_t);
   double c_t_floor = pow(rho_t_ * (1.0 - eta), 2);
-  int32 nf = c_t.ApplyFloor(c_t_floor);
+  int32 nf;
+  c_t.ApplyFloor(c_t_floor, &nf);
   if (nf > 0) {
     KALDI_WARN << "Floored " << nf << " elements of c_t.";
   }
@@ -198,7 +199,7 @@ void OnlineNaturalGradientSimple::PreconditionDirectionsCpu(
     KALDI_WARN << "flooring rho_{t+1} to " << floor_val << ", was " << rho_t1;
     rho_t1 = floor_val;
   }
-  nf = d_t1.ApplyFloor(floor_val);
+  d_t1.ApplyFloor(floor_val, &nf);
   if (nf > 0) {
     KALDI_VLOG(3) << "d_t1 was " << d_t1;
     KALDI_WARN << "Floored " << nf << " elements of d_{t+1}.";

--- a/src/nnet3/natural-gradient-online.cc
+++ b/src/nnet3/natural-gradient-online.cc
@@ -450,7 +450,8 @@ void OnlineNaturalGradient::PreconditionDirectionsInternal(
   bool must_reorthogonalize = (c_t(0) > condition_threshold * c_t(R - 1));
 
   BaseFloat c_t_floor = pow(rho_t * (1 - eta), 2);
-  int32 nf = c_t.ApplyFloor(c_t_floor);
+  int32 nf;
+  c_t.ApplyFloor(c_t_floor, &nf);
   if (nf > 0)
     must_reorthogonalize = true;
   if (nf > 0 && self_debug_) {

--- a/src/nnet3/nnet-general-component.cc
+++ b/src/nnet3/nnet-general-component.cc
@@ -1127,7 +1127,8 @@ void BackpropTruncationComponent::Backprop(const std::string &debug_info,
                               kNoTrans, 0.0);
   // now clipping_scales contains the squared (norm of each row divided by
   //  clipping_threshold)
-  int32 num_not_scaled = clipping_scales.ApplyFloor(1.0);
+  int32 num_not_scaled;
+  clipping_scales.ApplyFloor(1.0, &num_not_scaled);
   // now clipping_scales contains min(1, squared-(norm/clipping_threshold))
   clipping_scales.ApplyPow(-0.5);
   // now clipping_scales contains max(1, clipping_threshold/vector_norm)

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -788,7 +788,8 @@ void ClipGradientComponent::Backprop(const std::string &debug_info,
                                   kNoTrans, 0.0);
      // now clipping_scales contains the squared (norm of each row divided by
      //  clipping_threshold)
-      int32 num_not_scaled = clipping_scales.ApplyFloor(1.0);
+      int32 num_not_scaled;
+      clipping_scales.ApplyFloor(1.0, &num_not_scaled);
      // now clipping_scales contains min(1,
      //    squared-(norm/clipping_threshold))
       if (num_not_scaled != clipping_scales.Dim()) {

--- a/src/sgmm2/am-sgmm2.cc
+++ b/src/sgmm2/am-sgmm2.cc
@@ -1045,7 +1045,8 @@ void AmSgmm2::ComputeFmllrPreXform(const Vector<BaseFloat> &state_occs,
   tmpB.Eig(diag_mean_scatter, &U);  // Eq. (B.5): B = U D V^T
 
   int32 n;
-  if ((n = diag_mean_scatter->ApplyFloor(1.0e-04)) != 0)
+  diag_mean_scatter->ApplyFloor(1.0e-04, &n);
+  if (n != 0)
     KALDI_WARN << "Floored " << n << " elements of the mean-scatter matrix.";
 
   // Eq. (B.6): A_{pre} = U^T * L^{-1}


### PR DESCRIPTION
…trix.

This breaks backwards compatibility, since the signatures of these
methods change. Any code that uses Kaldi as a library will have a
compiler error if they use these methods and update to this version.

By not counting how many elements are floored or ceiled, respectively,
they take advantage of min and max intrinsic instructions (FMNMX on
Maxwell) on the GPU, eliminating all warp divergence.

This commit also speeds up the ApplyFloor and ApplyCount methods in
the CuMatrix class as well, because they leverage the same kernel
which I modified to use the min and max intrinsic functions.

cu-vector-speed-test results. NoCount variants are 2-3x faster.

```
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 16, speed was 0.000675051 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 16, speed was 0.001669 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 32, speed was 0.00136058 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 32, speed was 0.00317551 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 64, speed was 0.00256844 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 64, speed was 0.00672224 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 128, speed was 0.00522488 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 128, speed was 0.0134725 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 256, speed was 0.00974919 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 256, speed was 0.0261401 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<float>, for dim = 1024, speed was 0.0315874 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<float>, for dim = 1024, speed was 0.10304 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 16, speed was 0.000672568 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 16, speed was 0.0016879 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 32, speed was 0.00134266 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 32, speed was 0.00333197 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 64, speed was 0.00267668 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 64, speed was 0.00617961 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 128, speed was 0.00505546 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 128, speed was 0.013461 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 256, speed was 0.0101639 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 256, speed was 0.0271122 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<float>, for dim = 1024, speed was 0.0352663 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<float>, for dim = 1024, speed was 0.105313 gigaflops.

LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 16, speed was 0.000717387 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 16, speed was 0.00152129 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 32, speed was 0.00126388 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 32, speed was 0.00318206 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 64, speed was 0.00276731 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 64, speed was 0.00634364 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 128, speed was 0.00537088 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 128, speed was 0.0126457 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 256, speed was 0.0102421 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 256, speed was 0.0249449 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloor():cu-vector-speed-test.cc:275) For CuVector::ApplyFloor<double>, for dim = 1024, speed was 0.0372933 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyFloorNoCount():cu-vector-speed-test.cc:295) For CuVector::ApplyFloor (no count variety)<double>, for dim = 1024, speed was 0.10263 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 16, speed was 0.000703967 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 16, speed was 0.00171008 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 32, speed was 0.00143572 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 32, speed was 0.0031794 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 64, speed was 0.00269706 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 64, speed was 0.00669561 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 128, speed was 0.00548735 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 128, speed was 0.0136107 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 256, speed was 0.0107387 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 256, speed was 0.0261014 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeiling():cu-vector-speed-test.cc:317) For CuVector::ApplyCeiling<double>, for dim = 1024, speed was 0.0345135 gigaflops.
LOG ([5.3.42~19-3c21]:TestCuVectorApplyCeilingNoCount():cu-vector-speed-test.cc:337) For CuVector::ApplyCeiling (no count variety)<double>, for dim = 1024, speed was 0.10671 gigaflops.
```