### PR TITLE
issue 2123: eliminating global symbols leak (like 'float' etc)

### DIFF
--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -26,6 +26,7 @@
 #include "matrix/kaldi-vector.h"
 #include "matrix/kaldi-matrix.h"
 #include "matrix/matrix-functions.h"
+#include "matrix/kaldi-blas.h"
 
 // Do not include this file directly.  It is to be included
 // by .cc files in this directory.
@@ -335,6 +336,9 @@ inline void cblas_Xsbmv1(
               1, x, 1, beta, y, 1);
 }
 
+inline void cblas_compile_time_assert (){
+	  KALDI_COMPILE_TIME_ASSERT (kNoTrans == CblasNoTrans && kTrans == CblasTrans);
+}
 
 /// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
 /// extend this somehow.

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -336,10 +336,6 @@ inline void cblas_Xsbmv1(
               1, x, 1, beta, y, 1);
 }
 
-inline void cblas_compile_time_assert (){
-	  KALDI_COMPILE_TIME_ASSERT (kNoTrans == CblasNoTrans && kTrans == CblasTrans);
-}
-
 /// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
 /// extend this somehow.
 inline void mul_elements(

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -28,6 +28,9 @@
 #include "matrix/compressed-matrix.h"
 #include "matrix/sparse-matrix.h"
 
+static_assert(int(kaldi::kNoTrans) == int(CblasNoTrans) && int(kaldi::kTrans) == int(CblasTrans), 
+    "kaldi::kNoTrans and kaldi::kTrans must be equal to the appropriate CBLAS library constants!");
+
 namespace kaldi {
 
 template<typename Real>

--- a/src/matrix/matrix-common.h
+++ b/src/matrix/matrix-common.h
@@ -26,11 +26,12 @@
 #include "base/kaldi-common.h"
 
 namespace kaldi {
-// this enums equal to CblasTrans and SblasNoTrans constants from CBLAS library
-// we are writing them as numbers because we didn't include that library headers here  
+// this enums equal to CblasTrans and CblasNoTrans constants from CBLAS library
+// we are writing them as literals because we don't want to include here matrix/kaldi-blas.h,
+// which puts many symbols into global scope (like "real") via the header f2c.h 
 typedef enum {
-  kTrans    = 112,
-  kNoTrans  = 111
+  kTrans    = 112, // = CblasTrans
+  kNoTrans  = 111  // = CblasNoTrans
 } MatrixTransposeType;
 
 typedef enum {

--- a/src/matrix/matrix-common.h
+++ b/src/matrix/matrix-common.h
@@ -24,12 +24,11 @@
 // files in this directory.
 
 #include "base/kaldi-common.h"
-#include "matrix/kaldi-blas.h"
 
 namespace kaldi {
 typedef enum {
-  kTrans    = CblasTrans,
-  kNoTrans = CblasNoTrans
+  kTrans    = 112,
+  kNoTrans  = 111
 } MatrixTransposeType;
 
 typedef enum {

--- a/src/matrix/matrix-common.h
+++ b/src/matrix/matrix-common.h
@@ -26,6 +26,8 @@
 #include "base/kaldi-common.h"
 
 namespace kaldi {
+// this enums equal to CblasTrans and SblasNoTrans constants from CBLAS library
+// we are writing them as numbers because we didn't include that library headers here  
 typedef enum {
   kTrans    = 112,
   kNoTrans  = 111

--- a/src/matrix/matrix-lib-test.cc
+++ b/src/matrix/matrix-lib-test.cc
@@ -27,6 +27,7 @@
 #include "util/stl-utils.h"
 #include <numeric>
 #include <time.h> // This is only needed for UnitTestSvdSpeed, you can
+#include <matrix/cblas-wrappers.h>
 // comment it (and that function) out if it causes problems.
 
 namespace kaldi {
@@ -4740,8 +4741,6 @@ template<typename Real> static void MatrixUnitTest(bool full_test) {
 
 int main() {
   using namespace kaldi;
-  static_assert(int(kNoTrans) != int(CblasNoTrans) && int(kTrans) == int(CblasTrans), 
-    "kNoTrans and kTrans must be equal to the appropriate CBLAS library constants!");
   bool full_test = false;
   SetVerboseLevel(5);
   kaldi::MatrixUnitTest<float>(full_test);

--- a/src/matrix/matrix-lib-test.cc
+++ b/src/matrix/matrix-lib-test.cc
@@ -27,8 +27,8 @@
 #include "util/stl-utils.h"
 #include <numeric>
 #include <time.h> // This is only needed for UnitTestSvdSpeed, you can
+// comment it (and that function) out if it causes problems.  
 #include <matrix/cblas-wrappers.h>
-// comment it (and that function) out if it causes problems.
 
 namespace kaldi {
 

--- a/src/matrix/matrix-lib-test.cc
+++ b/src/matrix/matrix-lib-test.cc
@@ -4740,10 +4740,11 @@ template<typename Real> static void MatrixUnitTest(bool full_test) {
 
 int main() {
   using namespace kaldi;
+  static_assert(int(kNoTrans) != int(CblasNoTrans) && int(kTrans) == int(CblasTrans), 
+    "kNoTrans and kTrans must be equal to the appropriate CBLAS library constants!");
   bool full_test = false;
   SetVerboseLevel(5);
   kaldi::MatrixUnitTest<float>(full_test);
   kaldi::MatrixUnitTest<double>(full_test);
   KALDI_LOG << "Tests succeeded.";
-
 }

--- a/src/matrix/matrix-lib.h
+++ b/src/matrix/matrix-lib.h
@@ -22,7 +22,6 @@
 #ifndef KALDI_MATRIX_MATRIX_LIB_H_
 #define KALDI_MATRIX_MATRIX_LIB_H_
 
-#include "matrix/cblas-wrappers.h"
 #include "base/kaldi-common.h"
 #include "matrix/kaldi-vector.h"
 #include "matrix/kaldi-matrix.h"


### PR DESCRIPTION
https://github.com/kaldi-asr/kaldi/issues/2123
Compile time assert could be placed in some test file like matrix/matrix-lib-test.cc, but it seems not compiled by default