### PR TITLE
source cmd.sh in RNNLM setups; rename some RNNLM setups

### DIFF
--- a/egs/ami/s5b/local/rnnlm/tuning/run_lstm_tdnn_1a.sh
+++ b/egs/ami/s5b/local/rnnlm/tuning/run_lstm_tdnn_1a.sh
@@ -15,15 +15,17 @@
 # Dev objf:   -10.76 -4.65 -4.45 -4.34 -4.30 -4.29 -4.28 -4.27 -4.27 -4.28 -4.28 -4.29 -4.29 -4.30 -4.31 -4.32 -4.33 -4.34
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_a
+dir=exp/rnnlm_lstm_tdnn_1a
 embedding_dim=200
 epochs=60
 mic=sdm1
 stage=-10
 train_stage=0
 
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
+
 train=data/$mic/train/text
 dev=data/$mic/dev/text
 wordlist=data/lang/words.txt
@@ -88,7 +90,7 @@ fi
 
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --stage $train_stage \
-                       --num-epochs $epochs --cmd "queue.pl" $dir
+                       --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/ami/s5b/local/rnnlm/tuning/run_lstm_tdnn_1b.sh
+++ b/egs/ami/s5b/local/rnnlm/tuning/run_lstm_tdnn_1b.sh
@@ -12,8 +12,7 @@
 # Dev objf:   -10.76 -4.68 -4.47 -4.38 -4.33 -4.29 -4.28 -4.27 -4.26 -4.26 -4.25 -4.24 -4.24 -4.24 -4.23 -4.23 -4.23 -4.23
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_b
+dir=exp/rnnlm_lstm_tdnn_1b
 embedding_dim=200
 embedding_l2=0.005 # embedding layer l2 regularize
 comp_l2=0.005 # component-level l2 regularize
@@ -23,7 +22,10 @@ mic=sdm1
 stage=-10
 train_stage=0
 
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
+
 train=data/$mic/train/text
 dev=data/$mic/dev/text
 wordlist=data/lang/words.txt
@@ -93,7 +95,7 @@ fi
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --embedding_l2 $embedding_l2 \
                        --stage $train_stage \
-                       --num-epochs $epochs --cmd "queue.pl" $dir
+                       --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/hub4_spanish/s5/local/rnnlm/tuning/run_lstm_1a.sh
+++ b/egs/hub4_spanish/s5/local/rnnlm/tuning/run_lstm_1a.sh
@@ -4,27 +4,26 @@
 #           2017  Hainan Xu
 #           2017  Ke Li
 
-# rnnlm/train_rnnlm.sh: best iteration (out of 10) was 8, linking it to final iteration.
-# rnnlm/train_rnnlm.sh: train/dev perplexity was 78.4 / 147.8.
-# Train objf: -1556.00 -5.43 -5.15 -5.00 -4.90 -4.82 -4.75 -4.69 -4.63 -4.58
-# Dev objf:   -11.92 -5.70 -5.29 -5.16 -5.08 -5.04 -5.02 -5.00 -5.00 -5.00
+# rnnlm/train_rnnlm.sh: best iteration (out of 10) was 3, linking it to final iteration.
+# rnnlm/train_rnnlm.sh: train/dev perplexity was 69.4 / 183.1.
+# Train objf: -333.60 -4.98 -4.54 -4.24 -3.98 -3.76 -3.56 -3.39 -3.25 -3.13
+# Dev objf:   -10.07 -5.53 -5.23 -5.21 -5.27 -5.37 -5.47 -5.57 -5.68 -5.77
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_a
+dir=exp/rnnlm_lstm_1a
 embedding_dim=800
-lstm_rpd=200
-lstm_nrpd=200
+epochs=160
 stage=-10
 train_stage=-10
-epochs=20
 
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 
 text=data/train/text
 wordlist=data/lang/words.txt
-dev_sents=10000
+dev_sents=3000
 text_dir=data/rnnlm/text
 mkdir -p $dir/config
 set -e
@@ -37,7 +36,7 @@ done
 if [ $stage -le 0 ]; then
   mkdir -p $text_dir
   cat $text | cut -d ' ' -f2- | head -n $dev_sents> $text_dir/dev.txt
-  cat $text | cut -d ' ' -f2- | tail -n +$[$dev_sents+1] > $text_dir/ted.txt
+  cat $text | cut -d ' ' -f2- | tail -n +$[$dev_sents+1] > $text_dir/hub.txt
 fi
 
 if [ $stage -le 1 ]; then
@@ -50,7 +49,7 @@ if [ $stage -le 1 ]; then
   echo "<unk>" >$dir/config/oov.txt
 
   cat > $dir/config/data_weights.txt <<EOF
-ted   1   1.0
+hub   1   1.0
 EOF
 
   rnnlm/get_unigram_probs.py --vocab-file=$dir/config/words.txt \
@@ -61,18 +60,15 @@ EOF
   # choose features
   rnnlm/choose_features.py --unigram-probs=$dir/config/unigram_probs.txt \
                            --use-constant-feature=true \
-                           --top-word-features=10000 \
+                           --top-word-features 10000 \
                            --min-frequency 1.0e-03 \
                            --special-words='<s>,</s>,<brk>,<unk>' \
                            $dir/config/words.txt > $dir/config/features.txt
 
   cat >$dir/config/xconfig <<EOF
 input dim=$embedding_dim name=input
-relu-renorm-layer name=tdnn1 dim=$embedding_dim input=Append(0, IfDefined(-1))
-fast-lstmp-layer name=lstm1 cell-dim=$embedding_dim recurrent-projection-dim=$lstm_rpd non-recurrent-projection-dim=$lstm_nrpd
-relu-renorm-layer name=tdnn2 dim=$embedding_dim input=Append(0, IfDefined(-2))
-fast-lstmp-layer name=lstm2 cell-dim=$embedding_dim recurrent-projection-dim=$lstm_rpd non-recurrent-projection-dim=$lstm_nrpd
-relu-renorm-layer name=tdnn3 dim=$embedding_dim input=Append(0, IfDefined(-1))
+lstm-layer name=lstm1 cell-dim=$embedding_dim
+lstm-layer name=lstm2 cell-dim=$embedding_dim
 output-layer name=output include-log-softmax=false dim=$embedding_dim
 EOF
   rnnlm/validate_config_dir.sh $text_dir $dir/config
@@ -82,14 +78,13 @@ if [ $stage -le 2 ]; then
   # the --unigram-factor option is set larger than the default (100)
   # in order to reduce the size of the sampling LM, because rnnlm-get-egs
   # was taking up too much CPU (as much as 10 cores).
-  rnnlm/prepare_rnnlm_dir.sh --unigram-factor 200.0 \
+  rnnlm/prepare_rnnlm_dir.sh --unigram-factor 100.0 \
                              $text_dir $dir/config $dir
 fi
-echo "rnnlm dir done"
 
 if [ $stage -le 3 ]; then
-  rnnlm/train_rnnlm.sh --num-jobs-initial 1 --num-jobs-final 1 \
-                       --stage $train_stage --num-epochs $epochs --cmd "queue.pl" $dir
+  rnnlm/train_rnnlm.sh --stage $train_stage \
+                       --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/hub4_spanish/s5/local/rnnlm/tuning/run_lstm_1b.sh
+++ b/egs/hub4_spanish/s5/local/rnnlm/tuning/run_lstm_1b.sh
@@ -10,8 +10,7 @@
 # Dev objf:   -10.07 -5.52 -5.25 -5.19 -5.21 -5.24 -5.29 -5.32 -5.35 -5.39 
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_b
+dir=exp/rnnlm_lstm_1b
 embedding_dim=800
 embedding_l2=0.005 # embedding layer l2 regularize
 comp_l2=0.005 # component-level l2 regularize
@@ -20,7 +19,9 @@ epochs=160
 stage=-10
 train_stage=-10
 
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 
 text=data/train/text
@@ -90,7 +91,7 @@ fi
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --embedding_l2 $embedding_l2 \
                        --stage $train_stage \
-                       --num-epochs $epochs --cmd "queue.pl" $dir
+                       --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1a.sh
+++ b/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1a.sh
@@ -24,8 +24,8 @@ ngram_order=4 # approximate the lattice-rescoring by limiting the max-ngram-orde
               # the same ngram history and this prevents the lattice from 
               # exploding exponentially
 
-. cmd.sh
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
 
 text=data/train_nodev/text
 fisher_text=data/local/lm//fisher/text1.gz

--- a/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1b.sh
+++ b/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1b.sh
@@ -23,8 +23,8 @@ ngram_order=4 # approximate the lattice-rescoring by limiting the max-ngram-orde
               # the same ngram history and this prevents the lattice from 
               # exploding exponentially
 
-. cmd.sh
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
 
 text=data/train_nodev/text
 fisher_text=data/local/lm//fisher/text1.gz

--- a/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1c.sh
+++ b/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1c.sh
@@ -23,8 +23,8 @@ ngram_order=4 # approximate the lattice-rescoring by limiting the max-ngram-orde
               # the same ngram history and this prevents the lattice from 
               # exploding exponentially
 
-. cmd.sh
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
 
 text=data/train_nodev/text
 fisher_text=data/local/lm/fisher/text1.gz

--- a/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1d.sh
+++ b/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_1d.sh
@@ -24,8 +24,8 @@ ngram_order=4 # approximate the lattice-rescoring by limiting the max-ngram-orde
               # the same ngram history and this prevents the lattice from 
               # exploding exponentially
 
-. cmd.sh
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
 
 text=data/train_nodev/text
 fisher_text=data/local/lm/fisher/text1.gz

--- a/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_swbd.sh
+++ b/egs/swbd/s5c/local/rnnlm/tuning/run_tdnn_lstm_swbd.sh
@@ -12,7 +12,6 @@
 # Dev objf:   -10.32 -4.96 -4.53 -4.37 -4.30 -4.23 -4.20 -4.16 -4.14 -4.12 -4.15 -4.10 -4.09 -4.09 -4.10 -4.09 -4.10 -4.10 -4.11 -4.12 -4.12 -4.12 -4.13 -4.14 -4.14 -4.17 -4.17 -4.17 -4.18 -4.19
 
 # Begin configuration section.
-cmd=run.pl
 dir=exp/rnnlm_tdnn_lstm_swbd
 embedding_dim=1024
 lstm_rpd=256
@@ -26,6 +25,7 @@ train_stage=0
 
 . ./cmd.sh
 . ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 text=data/train_nodev/text
 wordlist=data/lang/words.txt
@@ -98,7 +98,7 @@ fi
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --embedding_l2 $embedding_l2 \
                        --stage $train_stage \
-                       --num-epochs $epochs --cmd "queue.pl" $dir
+                       --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/tedlium/s5_r2/local/rnnlm/tuning/run_lstm_tdnn.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/tuning/run_lstm_tdnn.sh
@@ -4,28 +4,28 @@
 #           2017  Hainan Xu
 #           2017  Ke Li
 
-# rnnlm/train_rnnlm.sh: best iteration (out of 10) was 3, linking it to final iteration.
-# rnnlm/train_rnnlm.sh: train/dev perplexity was 44.7 / 152.8.
-# Train objf: -310.30 -4.70 -4.24 -3.89 -3.58 -3.30 -3.06 -2.86 -2.69 -2.56 
-# Dev objf:   -10.07 -5.28 -5.04 -5.03 -5.08 -5.14 -5.26 -5.34 -5.43 -5.52 
+# rnnlm/train_rnnlm.sh: best iteration (out of 10) was 8, linking it to final iteration.
+# rnnlm/train_rnnlm.sh: train/dev perplexity was 78.4 / 147.8.
+# Train objf: -1556.00 -5.43 -5.15 -5.00 -4.90 -4.82 -4.75 -4.69 -4.63 -4.58
+# Dev objf:   -11.92 -5.70 -5.29 -5.16 -5.08 -5.04 -5.02 -5.00 -5.00 -5.00
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_a
+dir=exp/rnnlm_lstm_tdnn
 embedding_dim=800
-embedding_l2=0.005 # embedding layer l2 regularize
-comp_l2=0.005 # component-level l2 regularize
-output_l2=0.005 # output-layer l2 regularize
-epochs=160
+lstm_rpd=200
+lstm_nrpd=200
 stage=-10
 train_stage=-10
+epochs=20
 
+. ./cmd.sh
 . utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 
 text=data/train/text
 wordlist=data/lang/words.txt
-dev_sents=3000
+dev_sents=10000
 text_dir=data/rnnlm/text
 mkdir -p $dir/config
 set -e
@@ -38,7 +38,7 @@ done
 if [ $stage -le 0 ]; then
   mkdir -p $text_dir
   cat $text | cut -d ' ' -f2- | head -n $dev_sents> $text_dir/dev.txt
-  cat $text | cut -d ' ' -f2- | tail -n +$[$dev_sents+1] > $text_dir/hub.txt
+  cat $text | cut -d ' ' -f2- | tail -n +$[$dev_sents+1] > $text_dir/ted.txt
 fi
 
 if [ $stage -le 1 ]; then
@@ -51,7 +51,7 @@ if [ $stage -le 1 ]; then
   echo "<unk>" >$dir/config/oov.txt
 
   cat > $dir/config/data_weights.txt <<EOF
-hub   1   1.0
+ted   1   1.0
 EOF
 
   rnnlm/get_unigram_probs.py --vocab-file=$dir/config/words.txt \
@@ -62,21 +62,19 @@ EOF
   # choose features
   rnnlm/choose_features.py --unigram-probs=$dir/config/unigram_probs.txt \
                            --use-constant-feature=true \
-                           --top-word-features 10000 \
+                           --top-word-features=10000 \
                            --min-frequency 1.0e-03 \
                            --special-words='<s>,</s>,<brk>,<unk>' \
                            $dir/config/words.txt > $dir/config/features.txt
 
-lstm_opts="l2-regularize=$comp_l2"
-tdnn_opts="l2-regularize=$comp_l2"
-output_opts="l2-regularize=$output_l2"
-
   cat >$dir/config/xconfig <<EOF
 input dim=$embedding_dim name=input
-lstm-layer name=lstm1 cell-dim=$embedding_dim $lstm_opts
-relu-renorm-layer name=tdnn dim=$embedding_dim $tdnn_opts input=Append(0, IfDefined(-1))
-lstm-layer name=lstm2 cell-dim=$embedding_dim $lstm_opts
-output-layer name=output $output_opts include-log-softmax=false dim=$embedding_dim
+relu-renorm-layer name=tdnn1 dim=$embedding_dim input=Append(0, IfDefined(-1))
+fast-lstmp-layer name=lstm1 cell-dim=$embedding_dim recurrent-projection-dim=$lstm_rpd non-recurrent-projection-dim=$lstm_nrpd
+relu-renorm-layer name=tdnn2 dim=$embedding_dim input=Append(0, IfDefined(-2))
+fast-lstmp-layer name=lstm2 cell-dim=$embedding_dim recurrent-projection-dim=$lstm_rpd non-recurrent-projection-dim=$lstm_nrpd
+relu-renorm-layer name=tdnn3 dim=$embedding_dim input=Append(0, IfDefined(-1))
+output-layer name=output include-log-softmax=false dim=$embedding_dim
 EOF
   rnnlm/validate_config_dir.sh $text_dir $dir/config
 fi
@@ -85,14 +83,14 @@ if [ $stage -le 2 ]; then
   # the --unigram-factor option is set larger than the default (100)
   # in order to reduce the size of the sampling LM, because rnnlm-get-egs
   # was taking up too much CPU (as much as 10 cores).
-  rnnlm/prepare_rnnlm_dir.sh --unigram-factor 100.0 \
+  rnnlm/prepare_rnnlm_dir.sh --unigram-factor 200.0 \
                              $text_dir $dir/config $dir
 fi
+echo "rnnlm dir done"
 
 if [ $stage -le 3 ]; then
-  rnnlm/train_rnnlm.sh --embedding_l2 $embedding_l2 \
-                       --stage $train_stage \
-                       --num-epochs $epochs --cmd "queue.pl" $dir
+  rnnlm/train_rnnlm.sh --num-jobs-initial 1 --num-jobs-final 1 \
+                       --stage $train_stage --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/wsj/s5/local/rnnlm/tuning/run_lstm_tdnn_1a.sh
+++ b/egs/wsj/s5/local/rnnlm/tuning/run_lstm_tdnn_1a.sh
@@ -5,8 +5,7 @@
 #           2017  Ke Li
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_a
+dir=exp/rnnlm_lstm_tdnn_1a
 embedding_dim=800
 lstm_rpd=200
 lstm_nrpd=200
@@ -14,8 +13,9 @@ epochs=20
 stage=-10
 train_stage=-10
 
-. utils/parse_options.sh
-
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 text=data/local/dict_nosp_larger/cleaned.gz
 wordlist=data/lang_nosp/words.txt
@@ -85,7 +85,7 @@ fi
 
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --num-jobs-initial 1 --num-jobs-final 3 \
-                       --stage $train_stage --num-epochs $epochs --cmd "queue.pl" $dir
+                       --stage $train_stage --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/egs/wsj/s5/local/rnnlm/tuning/run_lstm_tdnn_1b.sh
+++ b/egs/wsj/s5/local/rnnlm/tuning/run_lstm_tdnn_1b.sh
@@ -10,8 +10,7 @@
 # Dev objf:   -11.73 -5.66 -5.18 -4.96 -4.82 -4.73 -4.66 -4.59 -4.54 -4.51 -4.47 -4.44 -4.40 -4.38 -4.36 -4.34 -4.32 -4.30 -4.28 -4.27 -4.26 -4.21 -4.19 -4.18 -4.16 -4.15 -4.14 -4.13 -4.12 -4.12 -4.11 -4.09 -4.09 -4.08 -4.07 -4.07 -4.06 -4.06 -4.05 -4.04 -4.04 -4.04 -4.03 -4.02 -4.02 -4.01 -4.01 -4.00 -4.00 -4.00 -3.99 -3.99 -3.98 -3.98 -3.98 -3.98 -3.97 -3.97 -3.97 -3.97 -3.96 -3.95 -3.95 -3.94 -3.94 -3.94 -3.94 -3.93 -3.93 -3.93 -3.93 -3.93 -3.93 -3.92 -3.92 -3.92 -3.92 -3.92 -3.91 -3.91 
 
 # Begin configuration section.
-cmd=run.pl
-dir=exp/rnnlm_lstm_tdnn_b
+dir=exp/rnnlm_lstm_tdnn_1b
 embedding_dim=800
 lstm_rpd=200
 lstm_nrpd=200
@@ -22,7 +21,9 @@ epochs=20
 stage=-10
 train_stage=-10
 
-. utils/parse_options.sh
+. ./cmd.sh
+. ./utils/parse_options.sh
+[ -z "$cmd" ] && cmd=$train_cmd
 
 
 text=data/local/dict_nosp_larger/cleaned.gz
@@ -98,7 +99,7 @@ fi
 if [ $stage -le 3 ]; then
   rnnlm/train_rnnlm.sh --num-jobs-initial 1 --num-jobs-final 3 \
                        --embedding_l2 $embedding_l2 \
-                       --stage $train_stage --num-epochs $epochs --cmd "queue.pl" $dir
+                       --stage $train_stage --num-epochs $epochs --cmd "$cmd" $dir
 fi
 
 exit 0

--- a/scripts/rnnlm/get_special_symbol_opts.py
+++ b/scripts/rnnlm/get_special_symbol_opts.py
@@ -3,6 +3,7 @@
 # Copyright  2017  Jian Wang
 # License: Apache 2.0.
 
+import io
 import os
 import argparse
 import sys
@@ -24,7 +25,8 @@ upper_special_symbols = [key.upper() for key in special_symbols]
 
 lower_ids = {}
 upper_ids = {}
-for line in sys.stdin:
+input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+for line in input_stream:
     fields = line.split()
     sym = fields[0]
     if sym in special_symbols:


### PR DESCRIPTION
sourcing cmd.sh instead of taking the cmd option as a command line argument in RNNLM example scripts. 