### PR TITLE
Make installation of pocolm and irstlm idempotent.

### DIFF
--- a/tools/extras/install_irstlm.sh
+++ b/tools/extras/install_irstlm.sh
@@ -11,7 +11,7 @@ errcho() { echo "$@" 1>&2; }
 
 errcho "****() Installing IRSTLM"
 
-if [ ! -x ./irstlm ] ; then
+if [ ! -d ./irstlm ] ; then
   svn=`which git`
   if [ $? != 0 ]  ; then
     errcho "****() You need to have git installed"
@@ -28,6 +28,7 @@ else
   echo "****() Assuming IRSTLM is already installed. Please delete"
   echo "****() the directory ./irstlm if you need us to download"
   echo "****() the sources again."
+  exit 0
 fi
 
 (

--- a/tools/extras/install_pocolm.sh
+++ b/tools/extras/install_pocolm.sh
@@ -16,6 +16,12 @@ fi
 ! [ `basename $PWD` == tools ] && \
   echo "You must call this script from the tools/ directory" && exit 1;
 
+if [ -d pocolm ]; then
+  echo "$0: Assuming pocolm is already installed Please delete the directory"
+  echo "./pocolm if you need to reinstall."
+  exit 0
+fi
+
 echo Downloading and installing the pocolm tools
 git clone https://github.com/danpovey/pocolm.git || exit 1;
 cd pocolm/src


### PR DESCRIPTION
Previously, executing extras/install_irstlm.sh a second time would
pause, asking the user whether to apply fully a patch that doesn't
apply properly (because it was applied the first time).

Executing extras/install_pocolm.sh would error out in some other way
I've forgotten.

This is helpful when including Kaldi as an external project to another
project. This also matches existing the behavior of the Makefile in
tools/.

This won't detect when the user, e.g., changes irstlm or pocolm in
order to rebuild intelligently, but that didn't happen previously
anyway, and almost no users will do this anyway.