### PR TITLE
Extend number of digits for timestamps in utt name (get_uniform_subsegments.py)

### DIFF
--- a/egs/wsj/s5/utils/data/get_uniform_subsegments.py
+++ b/egs/wsj/s5/utils/data/get_uniform_subsegments.py
@@ -59,7 +59,7 @@ def run(args):
             end = start + args.max_segment_duration
             start_relative = start - start_time
             end_relative = end - start_time
-            new_utt = "{utt_id}-{s:06d}-{e:06d}".format(
+            new_utt = "{utt_id}-{s:08d}-{e:08d}".format(
                 utt_id=utt_id, s=int(100 * start_relative),
                 e=int(100 * end_relative))
             print ("{new_utt} {utt_id} {s} {e}".format(
@@ -68,7 +68,7 @@ def run(args):
             start += args.max_segment_duration - args.overlap_duration
             dur -= args.max_segment_duration - args.overlap_duration
 
-        new_utt = "{utt_id}-{s:06d}-{e:06d}".format(
+        new_utt = "{utt_id}-{s:08d}-{e:08d}".format(
             utt_id=utt_id, s=int(100 * (start - start_time)),
             e=int(100 * (end_time - start_time)))
         print ("{new_utt} {utt_id} {s} {e}".format(


### PR DESCRIPTION
I noticed some jobs failed on validate_data_dir.sh because the timestamps were more than 6 digits.
It messes up some things with the sorting ("utt2spk is not in sorted order or has duplicates").