### PR TITLE
[build] set 'rpath' for ATLAS shared libraries,

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -800,6 +800,7 @@ function linux_configure_dynamic {
 
   echo ATLASINC = $ATLASROOT/include >> kaldi.mk
   echo ATLASLIBS = $ATLASLIBS >> kaldi.mk
+  echo ATLASLDFLAGS = -Wl,-rpath,$ATLASLIBDIR >> kaldi.mk
   echo >> kaldi.mk
   if [[ "$TARGET_ARCH" == arm* ]]; then
     cat makefiles/linux_atlas_arm.mk >> kaldi.mk

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -35,5 +35,5 @@ ifeq ($(findstring clang,$(COMPILER)),clang)
 CXXFLAGS += -Wno-mismatched-tags
 endif
 
-LDFLAGS = $(EXTRA_LDFLAGS) $(OPENFSTLDFLAGS) -rdynamic
+LDFLAGS = $(EXTRA_LDFLAGS) $(OPENFSTLDFLAGS) $(ATLASLDFLAGS) -rdynamic
 LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl


### PR DESCRIPTION
- in BUT we have installed both ATLAS (includes LAPACK 3.0) and
  standalone LAPACK 3.4.2
- the standalone LAPACK 3.4.2 had priorty over LAPACK from ATLAS,
  which was causing runtime errors
- we cannot remove standalone LAPACK, as other programs are using it
- Hence we propose to select the LAPACK from ATLAS by using 'rpath',
  which stores the library location in the binaries.
  (if on other systems $(ATLASLDFLAGS) remains undefined, it causes no harm)