### PR TITLE
Fix bug when compiling with flag -DNDEBUG

### DIFF
--- a/src/lat/compose-lattice-pruned.cc
+++ b/src/lat/compose-lattice-pruned.cc
@@ -757,7 +757,8 @@ void PrunedCompactLatticeComposer::ProcessTransition(int32 src_composed_state,
     if (ret.second) {
       // Successfully inserted.  Most of the rest of this block deals with the
       // consequences of adding a new state.
-      KALDI_ASSERT(clat_out_->AddState() == new_composed_state);
+      int32 ans = clat_out_->AddState();
+      KALDI_ASSERT(ans == new_composed_state);
       dest_composed_state = new_composed_state;
       composed_state_info_.resize(dest_composed_state + 1);
       dest_info = &(composed_state_info_[dest_composed_state]);


### PR DESCRIPTION
When compiling with the flag -DNDEBUG binaries such as lattice-lmrescore-kaldi-rnnlm-pruned causes a segmentation fault. This commit fix this by pulling the clat_out_->AddState() out of KALDI_ASSERT