### PR TITLE
distinct egs in archive for xvector(WIP)

### DIFF
--- a/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
+++ b/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 Johns Hopkins University (author: Hang Lyu)
+
+"""This is a new version allocate_egs code for xvector.
+
+In previous xvector setup, the different examples in the same archive are equvalent
+length and it uses ranges.* files to control archives, which contains local and
+global archive index and example description in each line.
+In this version, we hope the length of different examples in the same archive is
+different, so that the randomness of data is increased. At the same time, we use
+'ranges in script-file lines' method to extract the submatrix directly so that
+it is similar to conventional 'nnet3-get-egs' setup uses separate input and 
+output files to generate examples directly. 
+
+(In order to be compatible with previous version, we provide the method to 
+generate equvalent length egs in same archive. For details, the number of
+egs for each kind of length is same, but since the length is different, so the
+total number of frames is different. We assign the option "frames_per_iter", it
+looks like a upperbound. We use "total_frames"/"frames_per_iter" to decide how
+many archives is assigned to each kind of length.)
+
+The common ground of the version is as follows.
+We generate new feats.scp in data_len_i directory. The data_len_i directory means
+the length of all the utterances in this directory is "len_i". In practise, "len_i"
+will be replaced by a specific value. For example, if a directory names "data_284",
+the length of all the egs in this directory is 284 frames.
+(To describle clearly, we denote the feats.scp in data_len_i directory as feats_len_i.scp)
+
+In this mode, the startpoint is "num_egs_per_speaker_per_length" as we think
+the balance of each speaker's egs maybe important for xvector.
+
+In this mode, we provide the "average_method":
+For details, if the "average_method" is true, when we generate new utt,
+we will consider average choose the utterance from the uttlist of the speaker(
+it means assume we want 12 egs for each speaker, and each speaker has 6 utterances,
+we will generate 2 egs from each utterance. If we encounter decimal, we generate
+it in probability), otherwise, we will randomly choose utterance from 
+the uttlist of the spekaer.
+
+When we generate valid set or train_sub set, we can set the option 
+"generate-validate" to true. In this way, we will only generate one eg for each
+utterance. Most of time, we recommond to use geomatric distance for different 
+kinds of length.
+"""
+
+from __future__ import print_function
+import re, os, argparse, sys, math, warnings, random
+
+def get_args():
+    parser = argparse.ArgumentParser(description="In previous xvector setup, "
+            "the different examples in the same archive are equvalent length."
+            "Now, we hope the length of different examples in the same archive is "
+            "different. This script modifies the feats.scp in original data directory "
+            "to generate some new feats.scp which corresponds "
+            "to a specific length. After then, we can combine the new files, "
+            "shuffle the list and split it into pieces. At last, we use "
+            "nnet3-xvector-get-egs-seg to dump egs. The format of new feats_len_i.scp"
+            "(In acutal, it is feats.scp in data_len_i directory, we call it "
+            "feats_len_i.scp so that it looks meaningful)is "
+            "<original_uttid-startpoint-len> <extend-filename-of-features[startpoint, startpoint+len-1]>.",
+            epilog="Called by sid/nnet3/xvector/get_egs_seg.sh")
+    parser.add_argument("--min-frames-per-chunk", type=int, default=50,
+            help="Minimum number of frames-per-chunk used for any archive.")
+    parser.add_argument("--max-frames-per-chunk", type=int, default=300,
+            help="Maximum number of frames-per-chunk used for any archive")
+    parser.add_argument("--kinds-of-length", type=int, default=4,
+            help="Number of length types.")
+    parser.add_argument("--generate-validate", type=str,
+            help="If true, for each utterance-id, we just generate one segment."
+            "This method will be used in generating validate egs.",
+            default="false", choices = ["false", "true"])
+    parser.add_argument("--randomize-chunk-length", type=str,
+            help="If true, randomly pick a chunk length in [min-frames-per-chunk, max-frames-per-chunk]."
+            "If false, the chunk length varies from min-frames-per-chunk to "
+            "max-frames-per-chunk according to a geometric sequence.",
+            default="true", choices = ["false", "true"])
+    parser.add_argument("--seed", type=int, default=123,
+            help="Seed for random number generator.")
+           
+    parser.add_argument("--num-egs-per-speaker-per-length", type=int, default=-1,
+            help="Number of egs for per speaker per kind of length")
+    parser.add_argument("--average-method", type=str,
+            help="If true, randomly select a utterance of a speaker. If false,"
+            "divid it equally. For example, a sepaker has 8 utterance and "
+            "--num-egs-per-speaker-per-length is 50. 50/8=6.25, that means each "
+            "utterance will generate 6 egs and it has 25% to generate extra one.",
+            default="false", choices = ["false", "true"])
+    
+    parser.add_argument("--data-dir", type=str, required=True,
+            help="The location of original data directory which contains "
+            "feats.scp ,utt2num_frames and utt2spk.")
+    parser.add_argument("--output-dir", type=str, required=True,
+            help="The name of output-dir. In it, there are 'kinds-of-length' directories. "
+            "In each subdirectory, it will contains the new generated feats_li.scp and new utt2spk.")
+
+    print(' '.join(sys.argv), file=sys.stderr)
+    print(sys.argv, file=sys.stderr)
+    args = parser.parse_args()
+    args = process_args(args)
+    return args
+
+
+def process_args(args):
+    if not args.generate_validate and args.num_egs_per_speaker_per_length < 0:
+        raise Exception("--num-egs-per-speaker-per-length should be set.")
+    if not os.path.exists(args.data_dir):
+        raise Exception("This script expects --data-dir to exist")
+    if not os.path.exists(args.data_dir+"/utt2num_frames"):
+        raise Exception("This script expects the utt2num_frames file to exist")
+    if not os.path.exists(args.data_dir+"/feats.scp"):
+        raise Exception("This script expects the original feats.scp to exist")
+    if not os.path.exists(args.data_dir+"/utt2spk"):
+        raise Exception("This script expects the original utt2spk to exist")
+    if args.min_frames_per_chunk <= 1:
+        raise Exception("--min-frames-per-chunk is invalid")
+    if args.max_frames_per_chunk < args.min_frames_per_chunk:
+        raise Exception("--max-frames-per-chunk is invalid")
+    if args.kinds_of_length < 1:
+        raise Exception("--kinds-of-length is invalid")
+    if ((args.max_frames_per_chunk-args.min_frames_per_chunk) < args.kinds_of_length) :
+        raise Exception("--kinds-of-length is too large")
+    return args
+
+
+def get_utt2spk(utt2spk_filename):
+    """This function collect utt2spk and spk2utt information from a utt2spk file
+    Example usage:
+    utt2spk, spk2utt = get_utt2spk(utt2spk_filename)
+    """
+    utt2spk = {}
+    spk2utt = {}
+    with open(utt2spk_filename, "r") as f:
+        for line in f:
+            tokens = line.split()
+            if len(tokens) != 2:
+                raise Exception("Bad line in utt2spk file " + line)
+            utt = tokens[0]
+            spk = tokens[1]
+            utt2spk[utt] = spk
+            if spk not in spk2utt:
+                spk2utt[spk] = [utt]
+            else:
+                spk2utt[spk].append(utt)
+    return utt2spk, spk2utt
+
+
+def get_utt2len(utt2len_filename):
+    """ The function reads a utt2len file so that it generae utt2len list.
+    Example usage:
+    utt2len = get_utt2len(utt2len_filename)
+    """
+    utt2len = {}
+    with open(utt2len_filename, "r") as f:
+        for line in f:
+            tokens = line.split()
+            if len(tokens) != 2:
+                raise Exception("Bad line in utt2len file {0}".format(line))
+            utt2len[tokens[0]] = int(tokens[1])
+    return utt2len
+
+
+def get_utt2feat(utt2feat_filename):
+    """The function generate a utt_id list and a dict mapping utt_id to 
+    corresponding feature_extension from a feats.scp file.
+    Example usage:
+    utt_ids, utt2feat = get_utt2feat(utt2feat_filename)
+    """
+    utt2feat = {}
+    with open(utt2feat_filename, "r") as f:
+        utt_ids = []
+        for line in f:
+            tokens = line.split()
+            if len(tokens) != 2:
+                raise Exception("Bad line in utt2len file {0}".format(line))
+            utt2feat[tokens[0]] = tokens[1]
+            utt_ids.append(tokens[0])
+    return utt_ids, utt2feat
+
+
+def random_chunk_length(min_frames_per_chunk, max_frames_per_chunk, kinds_of_len):
+    """The function randomly generate N numbers which represent N kinds of 
+    length without repetition.
+    """
+    ans = []
+    while(len(ans) < kinds_of_len):
+      x=random.randint(min_frames_per_chunk, max_frames_per_chunk)
+      if x not in ans:
+          ans.append(x)
+    return ans
+
+
+def deterministic_chunk_length(min_frames_per_chunk, max_frames_per_chunk, kinds_of_len):
+    """This function returns a geometric sequence in the range
+    min-frames-per-chunk, max-frames-per-chunk]. For example, suppose min-frames-per-chunk
+    is 50, and max-frames-per-chunk is 200, and kinds-of-len is 3. The output will
+    be [50, 100, 200]
+    """
+    ans = []
+    if min_frames_per_chunk == max_frames_per_chunk:
+        ans = [ max_frames_per_chunk ] * kinds_of_len
+    elif kinds_of_len == 1:
+        ans = [ max_frames_per_chunk ]
+    else:
+        for i in range(0, kinds_of_len):
+            ans.append(
+                int(math.pow(float(max_frames_per_chunk)/min_frames_per_chunk,
+                    float(i)/(kinds_of_len-1)) * min_frames_per_chunk + 0.5))
+    return ans
+
+def print_newline(utt_id, start_point, length, utt_extend, spk_id, feats_f, spk_f):
+    new_utt_id = "{0}-{1}-{2}".format(utt_id, start_point, length)
+    new_extend = "{0}[{1}:{2}]".format(utt_extend, start_point, start_point+length-1)
+    print("{0} {1}".format(new_utt_id, new_extend), file=feats_f)
+    print("{0} {1}".format(new_utt_id, spk_id), file=spk_f)
+
+
+def create_newdir(dir_name, length):
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+    feats_filename = dir_name + "/feats.scp"
+    try:
+        feats_f = open(feats_filename, "w")
+    except Exception as e:
+        sys.exit("{0}: error opening file '{1}'. Error was {2}".format(
+            sys.argv[0], feats_filename, repr(e)))
+        
+    utt2spk_filename = dir_name + "/utt2spk"
+    try:
+        spk_f = open(utt2spk_filename, "w")
+    except Exception as e:
+        sys.exit("{0}: error opening file '{1}'. Error was {2}".format(
+            sys.argv[0], utt2spk_filename, repr(e)))
+    return feats_f, spk_f
+
+
+def main():
+    args = get_args()
+    random.seed(args.seed)
+    #utt2len is a dict: key=uttid, value=num_of_frames
+    utt2len_filename = args.data_dir + "/utt2num_frames"
+    utt2len = get_utt2len(utt2len_filename)
+    #utt2feat is a dict: key=uttid, value=extend_filename_of_featue
+    #utt_list is a list cotains all the original uttid
+    feats_filename = args.data_dir + "/feats.scp"
+    utt_list, utt2feat = get_utt2feat(feats_filename)
+    #utt2spk is a dict: key=uttid, value=spkid
+    utt2spk_filename = args.data_dir + "/utt2spk"
+    utt2spk, spk2utt = get_utt2spk(utt2spk_filename)
+    spks = list(spk2utt.keys())
+
+    length_types = []
+    # Generate l1 ... ln
+    if args.randomize_chunk_length == "true":
+        length_types = random_chunk_length(args.min_frames_per_chunk, 
+                args.max_frames_per_chunk, args.kinds_of_length)
+    else:
+        length_types = deterministic_chunk_length(args.min_frames_per_chunk,
+                args.max_frames_per_chunk, args.kinds_of_length)
+
+    if (args.generate_validate == "false") :
+        for this_length in length_types:
+            num_err = 0
+
+            this_dir_name =  args.output_dir + "/data_" + str(this_length)
+            feats_f, spk_f = create_newdir(this_dir_name, this_length)
+            
+            for j in range(len(spks)):
+                if (args.average_method == "false") :
+                    this_speaker = spks[j]
+                    this_utts = spk2utt[this_speaker]
+                    this_num_utts = len(this_utts)
+                    for k in range(args.num_egs_per_speaker_per_length):
+                        x = random.randint(0, this_num_utts-1)
+                        this_utt_id = this_utts[x]
+                        this_spk_id = utt2spk[this_utt_id]
+                        this_extend = utt2feat[this_utt_id]
+                        this_utt_len = utt2len[this_utt_id]
+                        # check the error
+                        if this_utt_len < this_length:
+                            num_err = num_err + 1
+                            if num_err > (0.1 * len(spks) * args.num_egs_per_speaker_per_length):
+                                raise Exception("{0} is not a suitable length".format(
+                                    this_length))
+                        else :
+                            this_utt_boundary = int(this_utt_len - this_length)
+                            start_point = random.randint(0, this_utt_boundary)
+                            print_newline(this_utt_id, start_point, this_length,
+                                    this_extend, this_spk_id, feats_f, spk_f)
+                else :
+                    # Ensure which speaker, then get the number of utterance of this speaker.
+                    # For each utterance, generate "num_this_segments" segments.
+                    this_spekaer = spks[j]
+                    this_utts = spk2utt[this_speaker]
+                    this_num_utts = len(this_utts)
+                    num_this_segments = round(args.num_egs_per_speaker_per_length / this_utts, 2)
+                    #integral part and decimal part
+                    integral_part = int(num_this_segments)
+                    decimal_part = num_this_segments - integral_part
+                    
+                    for k in range(this_num_utts):
+                        this_utt_id = this_utts[k]
+                        this_spk_id = utt2spk[this_utt_id]
+                        this_extend = utt2feat[this_utt_id]
+                        this_utt_len = utt2len[this_utt_id]
+                        # check the error
+                        if this_utt_len < this_length:
+                            num_err = num_err + 1
+                            if num_err > (0.1 * len(spks) * args.num_egs_per_speaker_per_length):
+                                raise Exception("{0} is not a suitable length".format(
+                                    this_length))
+                        else :
+                            this_utt_boundary = int(this_utt_len - this_length)
+                            for l in range(integral_part):
+                                start_point = random.randint(0, this_utt_boundary)
+                                print_newline(this_utt_id, start_point, this_length,
+                                        this_extend, this_spk_id, feats_f, spk_f)
+                            if ((random.randint(0,100)) * 1.0 /100.0) < decimal_part :
+                                start_point = random.randint(0, this_utt_boundary)
+                                print_newline(this_utt_id, start_point, this_length,
+                                        this_extend, this_spk_id, feats_f, spk_f)
+            feats_f.close()
+            spk_f.close()
+    else:
+        #For each utterance, generate one segment. It always be used in validate or diagnose.
+        for i in range(0, args.kinds_of_length):
+            num_err = 0
+            this_length = length_types[i]
+            num_this_segments = 1
+
+            this_dir_name =  args.output_dir + "/data_" + str(this_length)
+            feats_f, spk_f = create_newdir(this_dir_name, this_length)
+
+            for this_utt_id in utt2spk:
+                this_spk_id = utt2spk[this_utt_id]
+                this_extend = utt2feat[this_utt_id]
+                this_utt_len = utt2len[this_utt_id]
+                if this_utt_len < this_length:
+                    num_err = num_err + 1
+                    if num_err > (0.1 * len(utt_list)):
+                        raise Exception("{0} is not a suitable length".format(
+                            this_length))
+                    break
+                else:
+                    this_utt_boundary = int(this_utt_len - this_length)
+                    start_point = random.randint(0, this_utt_boundary)
+                    print_newline(this_utt_id, start_point, this_length,
+                            this_extend, this_spk_id, feats_f, spk_f)
+            feats_f.close()
+            spk_f.close()
+    print("allocate_egs_seg.py: finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
+++ b/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
@@ -4,7 +4,7 @@
 
 """This is a new version allocate_egs code for xvector.
 
-In previous xvector setup, the different examples in the same archive are equvalent
+In previous xvector setup, the different examples in the same archive are equivalent
 length and it uses ranges.* files to control archives, which contains local and
 global archive index and example description in each line.
 In this version, we hope the length of different examples in the same archive is
@@ -14,7 +14,7 @@ it is similar to conventional 'nnet3-get-egs' setup uses separate input and
 output files to generate examples directly. 
 
 (In order to be compatible with previous version, we provide the method to 
-generate equvalent length egs in same archive. For details, the number of
+generate equivalent length egs in same archive. For details, the number of
 egs for each kind of length is same, but since the length is different, so the
 total number of frames is different. We assign the option "frames_per_iter", it
 looks like a upperbound. We use "total_frames"/"frames_per_iter" to decide how
@@ -31,12 +31,18 @@ In this mode, the startpoint is "num_egs_per_speaker_per_length" as we think
 the balance of each speaker's egs maybe important for xvector.
 
 In this mode, we provide the "average_method":
-For details, if the "average_method" is true, when we generate new utt,
-we will consider average choose the utterance from the uttlist of the speaker(
-it means assume we want 12 egs for each speaker, and each speaker has 6 utterances,
-we will generate 2 egs from each utterance. If we encounter decimal, we generate
-it in probability), otherwise, we will randomly choose utterance from 
-the uttlist of the spekaer.
+For details, if the "average_method == true" when we generate new utterance,
+we will consider average choose the utterance from the uttlist of the speaker.
+(For example, assume we want 12 egs for each speaker. According to "spk2utt",
+we can know the number of utterances belongs to some speaker. Assume some speaker
+has 5 utterances. 12/5=2.4. We are certain to generate 2 egs from each utterance. 
+And we generate another one eg for each utterance in probability[0.4].) 
+Otherwise, if "average_method == false", we will randomly choose utterance from
+the uttlist of the speaker to generate new entry.
+(For example, assume we want 12 egs for each speaker. According to "spk2utt",
+we can know the number of utterances belongs to some speaker. Assume some speaker
+has 5 utterances. We choose one utterance from the 5 utterances randomly and
+then generate one eg. This process will iterate 12 times.)
 
 When we generate valid set or train_sub set, we can set the option 
 "generate-validate" to true. In this way, we will only generate one eg for each
@@ -49,7 +55,7 @@ import re, os, argparse, sys, math, warnings, random
 
 def get_args():
     parser = argparse.ArgumentParser(description="In previous xvector setup, "
-            "the different examples in the same archive are equvalent length."
+            "the different examples in the same archive are equivalent length."
             "Now, we hope the length of different examples in the same archive is "
             "different. This script modifies the feats.scp in original data directory "
             "to generate some new feats.scp which corresponds "

--- a/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
+++ b/egs/sre08/v1/sid/nnet3/xvector/allocate_egs_seg.py
@@ -332,7 +332,6 @@ def main():
         for i in range(0, args.kinds_of_length):
             num_err = 0
             this_length = length_types[i]
-            num_this_segments = 1
 
             this_dir_name =  args.output_dir + "/data_" + str(this_length)
             feats_f, spk_f = create_newdir(this_dir_name, this_length)
@@ -346,7 +345,7 @@ def main():
                     if num_err > (0.1 * len(utt_list)):
                         raise Exception("{0} is not a suitable length".format(
                             this_length))
-                    break
+                    continue
                 else:
                     this_utt_boundary = int(this_utt_len - this_length)
                     start_point = random.randint(0, this_utt_boundary)

--- a/egs/sre08/v1/sid/nnet3/xvector/get_egs_seg.sh
+++ b/egs/sre08/v1/sid/nnet3/xvector/get_egs_seg.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+
+stage=0
+cmd=run.pl
+nj=60
+data=data/swbd_sre_combined_no_sil
+dir=exp/xvector_nnet/egs
+
+#some options
+num_heldout_utts=1000       # number of utterances held out for training subset
+                            # and validation set
+min_frames_per_chunk=200
+max_frames_per_chunk=400
+
+kinds_of_length_train=100   # number of the kinds of lengths in train set
+kinds_of_length_valid=3     # number of the kinds of lengths in valiation set
+                            # and training subset
+
+frames_per_iter=70000000    # target number of frames per archive. If it is null,
+                            # each new directory corresponds to an archive
+distinct_length_ark=false   # If true, all the egs will combine and shuffle; if false
+                            # only the same length egs will be allocated to the same
+                            # archive. Otherwise, if "frames_per_iter" is supplied,
+                            # each kind of length egs will average few archives, otherwise 
+                            # the egs which has the same length will store in one archive.
+num_egs_per_speaker=5000    # number of egs for each speaker
+average_method=false
+#end of options
+
+# Something need to be mentioned. When we allocate the whole egs into different
+# archives, we provide three ways. You can choose what you like according to
+# assign "distinct_length_ark" and "frames_per_iter" options.
+# (1) If the "distinct_length_ark" is true, you must set a value to "frames_per_iter"
+# and it means the egs in the same archive will have distinct lengths. We will
+# count the frames and allocate them into pieces in average.
+# If the "distinct_length_ark" is false, you can set a value to "frames_per_iter" or not.
+# (2) If the "distinct_length_ark" is false and "frames_per_iter" is set. It means
+# in the same archive, the length of egs is same. And the capacity of certain 
+# archive will be smaller than "frames_per_iter". We will count the amount of
+# frames of each kind of length, and allocate them into pieces in average.
+# (3) If the "distinct_length_ark" is false and "frames_per_iter" is not set.
+# It means all the data which has the same length will be assign to one archive.
+
+echo "$0 $@"  # Print the command line for logging
+
+if [ -f path.sh ]; then . ./path.sh; fi
+. parse_options.sh || exit 1;
+
+if [ $# != 2 ]; then
+  echo "Usage: $0 [opts] <data> <egs-dir>"
+  echo " e.g.: $0 data/train exp/xvector_a/egs"
+  echo ""
+  echo "Main options (for others, see top of script file)"
+  echo "  --config <config-file>                           # config file containing options"
+  echo "  --nj <nj>                                        # The maximum number of jobs you want to run in"
+  echo "                                                   # parallel (increase this only if you have good disk and"
+  echo "                                                   # network speed).  default=6"
+  echo "  --cmd (utils/run.pl;utils/queue.pl <queue opts>) # how to run jobs."
+  echo "  --min-frames-per-eg <#frames;50>                 # The minimum number of frames per chunk that we dump"
+  echo "  --max-frames-per-eg <#frames;200>                # The maximum number of frames per chunk that we dump"
+  echo "  --frames-per-iter <#samples;1000000>             # Target number of frames per archive"
+  echo "  --num-diagnostic-archives <#archives;3>          # Option that controls how many different versions of"
+  echo "                                                   # the train and validation archives we create (e.g."
+  echo "                                                   # train_subset.{1,2,3}.egs and valid.{1,2,3}.egs by default;"
+  echo "                                                   # they contain different utterance lengths."
+  echo "  --stage <stage|0>                                # Used to run a partially-completed training process from somewhere in"
+  echo "                                                   # the middle."
+  exit 1;
+fi
+
+data=$1
+dir=$2
+
+for f in $data/utt2spk $data/utt2num_frames $data/feats.scp ; do
+  [ ! -f $f ] && echo "$0: expected file $f" && exit 1;
+done
+
+num_egs_per_speaker_per_length=$[$num_egs_per_speaker/$kinds_of_length_train]
+feat_dim=$(feat-to-dim scp:$data/feats.scp -) || exit 1;
+
+mkdir -p $dir/log $dir/info $dir/temp $dir/train_set/temp $dir/valid_set/temp $dir/train_subset/temp
+temp=$dir/temp
+
+echo $feat_dim > $dir/info/feat_dim
+echo '0' > $dir/info/left_context
+echo $min_frames_per_chunk > $dir/info/right_context
+echo '1' > $dir/info/frames_per_eg
+
+if [ $stage -le 0 ]; then
+  echo "$0: Preparing train and validation lists"
+  # Pick a list of heldout utterances for validation egs
+  cat $data/utt2spk | utils/shuffle_list.pl | head -$num_heldout_utts > $dir/valid_set/utt2spk || exit 1;
+  cp $dir/valid_set/utt2spk $temp/uttlist_valid
+  utils/filter_scp.pl $dir/valid_set/utt2spk $data/utt2num_frames > $dir/valid_set/utt2num_frames
+  utils/filter_scp.pl $dir/valid_set/utt2spk $data/feats.scp > $dir/valid_set/feats.scp
+
+  # The remaining utterances are used for training egs
+  utils/filter_scp.pl --exclude $dir/valid_set/utt2spk $data/utt2spk > $dir/train_set/utt2spk
+  cp $dir/train_set/utt2spk $temp/uttlist_train
+  utils/filter_scp.pl --exclude $dir/valid_set/utt2spk $data/utt2num_frames > $dir/train_set/utt2num_frames
+  utils/filter_scp.pl --exclude $dir/valid_set/utt2spk $data/feats.scp > $dir/train_set/feats.scp
+
+  # Pick a subset of the training list for diagnostics
+  cat $dir/train_set/utt2spk | utils/shuffle_list.pl | head -$num_heldout_utts > $dir/train_subset/utt2spk || exit 1;
+  cp $dir/train_subset/utt2spk $temp/uttlist_train_subset
+  utils/filter_scp.pl $temp/uttlist_train_subset <$data/utt2num_frames > $dir/train_subset/utt2num_frames
+  utils/filter_scp.pl $temp/uttlist_train_subset <$data/feats.scp > $dir/train_subset/feats.scp
+
+  # Create a mapping from utterance to speaker ID (an integer)
+  awk -v id=0 '{print $1, id++}' $data/spk2utt > $temp/spk2int
+  utils/sym2int.pl -f 2 $temp/spk2int $data/utt2spk > $temp/utt2int
+  utils/filter_scp.pl $dir/train_set/utt2spk $temp/utt2int > $dir/train_set/utt2int
+  utils/filter_scp.pl $dir/valid_set/utt2spk $temp/utt2int > $dir/valid_set/utt2int
+  utils/filter_scp.pl $dir/train_subset/utt2spk $temp/utt2int > $dir/train_subset/utt2int
+  #Above, prepare the "utt2num_frames, utt2spk and utt2int" for each data set.
+fi
+
+num_pdfs=$(awk '{print $2}' $temp/utt2int | sort | uniq -c | wc -l)
+num_train_set_frames=$(awk '{n += $2} END{print n}' <$dir/train_set/utt2num_frames)
+num_train_subset_frames=$(awk '{n += $2} END{print n}' <$dir/train_subset/utt2num_frames)
+echo $num_train_set_frames > $dir/info/num_frames
+echo $num_pdfs > $dir/info/num_pdfs
+
+num_egs_per_speaker_per_length=$[$num_egs_per_speaker/$kinds_of_length_train]
+echo $kinds_of_length_train > $dir/info/kinds_of_length
+echo $num_egs_per_speaker_per_length > $dir/info/num_egs_per_speaker_per_length
+
+temp_dir=$dir/train_set/temp
+if [ $stage -le 1 ]; then
+  echo "$0: Allocating training egs"
+  #Generate data_li/feat.scp and utt2spk
+  $cmd $dir/log/allocate_examples.log \
+    sid/nnet3/xvector/allocate_egs_seg.py \
+      --min-frames-per-chunk=$min_frames_per_chunk \
+      --max-frames-per-chunk=$max_frames_per_chunk \
+      --kinds-of-length=$kinds_of_length_train \
+      --generate-validate=false \
+      --randomize-chunk-length=true \
+      --num-egs-per-speaker-per-length=$num_egs_per_speaker_per_length \
+      --average-method=$average_method \
+      --data-dir=$dir/train_set \
+      --output-dir=$temp_dir || exit 1
+  #sort and uniq
+  for subdir in `dir $temp_dir`; do
+    utils/fix_data_dir.sh $temp_dir/$subdir
+    utils/sym2int.pl -f 2 $dir/temp/spk2int $temp_dir/$subdir/utt2spk \
+      > $temp_dir/$subdir/utt2int
+    this_length=`echo $subdir | cut -d_ -f 2`
+    this_num_utts=$(cat $temp_dir/$subdir/feats.scp | wc -l)
+    this_frames=$[$this_length*$this_num_utts]
+    echo "$this_frames" > $temp_dir/$subdir/num_frames
+  done
+fi
+
+num_train_archives=0
+
+if [ $stage -le 2 ];then
+  echo "$0: Combine, shuffle and split list for training set"
+  #the lengths of egs in the same archive are same.
+  if [ -e $temp_dir/combine ] && rm -rf $temp_dir/combine
+  dir_list=`dir $temp_dir | shuf`
+  if [ $distinct_length_ark ==  "false" ]; then 
+    
+    #combine feats.scp
+    mkdir -p $temp_dir/combine
+    data_combine=$temp_dir/combine
+
+    utils/combine_data.sh $data_combine $temp_dir/data_*
+    utils/sym2int.pl -f 2 $dir/temp/spk2int ${data_combine}/utt2spk \
+      > ${data_combine}/utt2int
+
+    if [ -z "$frames_per_iter" ]; then
+      # each new directory corresponds to an archive, shuffle the order so that
+      # the order of archives is not same with the order of `dir $temp_dir`
+      for subdir in $dir_list; do
+        num_train_archives=$[$num_train_archives+1]
+        cp $temp_dir/$subdir/feats.scp ${data_combine}/shuffled_feats.${num_train_archives}.scp
+      done
+    else 
+      # the option "frames_per_iter" limits the capacity of each archive
+      for subdir in $dir_list; do
+        current_frames=`cat $temp_dir/$subdir/num_frames`
+        current_archives=$[$current_frames/$frames_per_iter+1]
+        # split feats.scp
+        feat_scps=$(for n in `seq $[$num_train_archives+1] $[$num_train_archives+$current_archives]`; do echo ${data_combine}/shuffled_feats.${n}.scp; done)
+        utils/split_scp.pl $temp_dir/$subdir/feats.scp $feat_scps
+        num_train_archives=$[$num_train_archives+$current_archives]
+      done
+    fi
+  else 
+    if [ -z "$frames_per_iter" ]; then
+      echo "For distinct length egs in one archive method, we need option --frames-per-iter"
+    fi
+    num_train_frames=0
+    for subdir in $dir_list; do
+      current_frames=`cat $temp_dir/$subdir/num_frames`
+      num_train_frames=$[$num_train_frames+$current_frames]
+    done
+    num_train_archives=$[$num_train_frames/$frames_per_iter+1]
+
+    #combine feats.scp and shuffle
+    mkdir -p $temp_dir/combine
+    data_combine=$temp_dir/combine
+
+    utils/combine_data.sh $data_combine $temp_dir/data_*
+    utils/shuffle_list.pl $data_combine/feats.scp > $data_combine/shuffled_feats.scp
+    utils/sym2int.pl -f 2 $dir/temp/spk2int ${data_combine}/utt2spk \
+      > ${data_combine}/utt2int
+
+    feat_scps=$(for n in `seq $num_train_archives`; do echo $data_combine/shuffled_feats.${n}.scp; done)
+    utils/split_scp.pl ${data_combine}/shuffled_feats.scp $feat_scps
+  fi
+fi
+
+if [ $stage -le 3 ]; then
+  echo "$0: Dump Egs for training set"
+  if [ -e $dir/storage ]; then
+    echo "$0: creating data links"
+    utils/create_data_link.pl $(for x in $(seq $num_train_archives); do echo $dir/egs.$x.ark; done)
+  fi
+  #Note: if --num-pdfs options is not supply, you must use global utt2int,
+  #because we will compute the num-pdfs from utt2label file.
+  $cmd --max-jobs-run $nj JOB=1:$num_train_archives $dir/log/dump_egs.JOB.log \
+    nnet3-xvector-get-egs-seg \
+      --num-pdfs=$num_pdfs \
+      $temp_dir/combine/utt2int \
+      scp:$temp_dir/combine/shuffled_feats.JOB.scp \
+      ark,scp:$dir/egs.JOB.ark,$dir/egs.JOB.scp
+fi
+
+temp_dir=$dir/valid_set/temp
+if [ $stage -le 4 ]; then
+  echo "$0: Dealing with validation set"
+  #Generate data_li/feat.scp and utt2spk
+  $cmd $dir/log/allocate_examples_validate.log \
+    sid/nnet3/xvector/allocate_egs_seg.py \
+      --min-frames-per-chunk=$min_frames_per_chunk \
+      --max-frames-per-chunk=$max_frames_per_chunk \
+      --kinds-of-length=$kinds_of_length_valid \
+      --generate-validate=true \
+      --randomize-chunk-length=false \
+      --data-dir=$dir/valid_set \
+      --output-dir=$temp_dir || exit 1
+  #Generate data_li/spk2utt and utt2label
+  for subdir in `dir $temp_dir`; do
+    utils/fix_data_dir.sh $temp_dir/$subdir
+    utils/sym2int.pl -f 2 $dir/temp/spk2int $temp_dir/$subdir/utt2spk \
+      > $temp_dir/$subdir/utt2int
+  done
+
+  echo "$0: combine and shuffle (valid)"
+  #combine feats.scp and shuffle
+  mkdir -p $temp_dir/combine
+  data_combine=$temp_dir/combine
+
+  utils/combine_data.sh $data_combine $temp_dir/data_*
+  utils/shuffle_list.pl $data_combine/feats.scp > $data_combine/shuffled_feats.scp
+  utils/sym2int.pl -f 2 $dir/temp/spk2int ${data_combine}/utt2spk \
+    > ${data_combine}/utt2int
+
+  feat_scps=$(for n in `seq $kinds_of_length_valid`; do echo $data_combine/shuffled_feats.${n}.scp; done)
+  utils/split_scp.pl ${data_combine}/shuffled_feats.scp $feat_scps
+
+  echo "$0: dump egs (valid)"
+  #dump egs
+  $cmd --max-jobs-run $nj JOB=1:$kinds_of_length_valid $dir/log/dump_egs_valid.JOB.log \
+    nnet3-xvector-get-egs-seg \
+      --num-pdfs=$num_pdfs \
+      $temp_dir/combine/utt2int \
+      scp:$temp_dir/combine/shuffled_feats.JOB.scp \
+      ark,scp:$dir/valid_egs.JOB.ark,$dir/valid_egs.JOB.scp
+  cat $dir/valid_egs.*.scp > $dir/valid_diagnostic.scp
+fi
+
+temp_dir=$dir/train_subset/temp
+if [ $stage -le 5 ]; then
+  echo "$0: Dealing with train_diagnostic set"
+  #Generate data_li/feat.scp and utt2spk
+  $cmd $dir/log/allocate_examples_diagnostic.log \
+    sid/nnet3/xvector/allocate_egs_seg.py \
+      --min-frames-per-chunk=$min_frames_per_chunk \
+      --max-frames-per-chunk=$max_frames_per_chunk \
+      --kinds-of-length=$kinds_of_length_valid \
+      --generate-validate=true \
+      --randomize-chunk-length=false \
+      --data-dir=$dir/train_subset \
+      --output-dir=$temp_dir || exit 1
+  #Generate data_li/spk2utt and utt2label
+  for subdir in `dir $temp_dir`; do
+    utils/fix_data_dir.sh $temp_dir/$subdir
+    utils/sym2int.pl -f 2 $dir/temp/spk2int $temp_dir/$subdir/utt2spk \
+      > $temp_dir/$subdir/utt2int
+  done
+
+  echo "$0: combine and shuffle (diagnostic)"
+  #combine feats.scp and shuffle
+  mkdir -p $temp_dir/combine
+  data_combine=$temp_dir/combine
+
+  utils/combine_data.sh $data_combine $temp_dir/data_*
+  utils/shuffle_list.pl $data_combine/feats.scp > $data_combine/shuffled_feats.scp
+  utils/sym2int.pl -f 2 $dir/temp/spk2int ${data_combine}/utt2spk \
+    > ${data_combine}/utt2int
+
+  feat_scps=$(for n in `seq $kinds_of_length_valid`; do echo $data_combine/shuffled_feats.${n}.scp; done)
+  utils/split_scp.pl ${data_combine}/shuffled_feats.scp $feat_scps
+
+  echo "$0: dump egs (diagnostic)"
+  #dump egs
+  $train_cmd --max-jobs-run $nj JOB=1:$kinds_of_length_valid $dir/log/dump_egs_diagnostic.JOB.log \
+    nnet3-xvector-get-egs-seg \
+      --num-pdfs=$num_pdfs \
+      $temp_dir/combine/utt2int \
+      scp:$temp_dir/combine/shuffled_feats.JOB.scp \
+      ark,scp:$dir/train_diagnostic_egs.JOB.ark,$dir/train_diagnostic_egs.JOB.scp
+  cat $dir/train_diagnostic_egs.*.scp > $dir/train_diagnostic.scp
+  if [ -e $dir/combine.scp ]; then
+    rm -rf $dir/combine.scp
+    ln -s $dir/train_diagnostic.scp $dir/combine.scp
+  fi
+fi

--- a/egs/sre08/v1/sid/nnet3/xvector/get_egs_seg.sh
+++ b/egs/sre08/v1/sid/nnet3/xvector/get_egs_seg.sh
@@ -316,6 +316,6 @@ if [ $stage -le 5 ]; then
   cat $dir/train_diagnostic_egs.*.scp > $dir/train_diagnostic.scp
   if [ -e $dir/combine.scp ]; then
     rm -rf $dir/combine.scp
-    ln -s $dir/train_diagnostic.scp $dir/combine.scp
   fi
+    ln -s $dir/train_diagnostic.scp $dir/combine.scp
 fi

--- a/src/nnet3bin/Makefile
+++ b/src/nnet3bin/Makefile
@@ -18,7 +18,8 @@ BINFILES = nnet3-init nnet3-info nnet3-get-egs nnet3-copy-egs nnet3-subset-egs \
    nnet3-discriminative-compute-objf nnet3-discriminative-train \
    nnet3-discriminative-subset-egs nnet3-get-egs-simple \
    nnet3-discriminative-compute-from-egs nnet3-latgen-faster-looped \
-   nnet3-egs-augment-image nnet3-xvector-get-egs nnet3-xvector-compute
+   nnet3-egs-augment-image nnet3-xvector-get-egs nnet3-xvector-compute \
+   nnet3-xvector-get-egs-seg
 
 OBJFILES =
 

--- a/src/nnet3bin/nnet3-xvector-get-egs-seg.cc
+++ b/src/nnet3bin/nnet3-xvector-get-egs-seg.cc
@@ -1,0 +1,167 @@
+// nnet3bin/nnet3-xvector-get-egs-seg.cc
+
+// Copyright 2016-2017  Johns Hopkins University (author:  Hang Lyu)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+#include "util/common-utils.h"
+#include "nnet3/nnet-example.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+// Process the utt2label file and store it as a map from utt_id to
+// label
+static void ProcessUttToLabelFile(const std::string &utt2label_rxfilename, 
+    unordered_map<std::string, int32, StringHasher> *utt_to_label) {
+  Input utt2label_input(utt2label_rxfilename);
+  if (!utt2label_rxfilename.empty()) {
+    std::string line;
+    while (std::getline(utt2label_input.Stream(), line)) {
+      std::vector<std::string> fields;
+      SplitStringToVector(line, " \t\n\r", true, &fields);
+      if (fields.size() != 2) {
+        KALDI_ERR << "Expected 2 fields in line of utt2label file, got "
+                  << fields.size() << " instead.";
+      }
+      std::string utt_id = fields[0];
+      int32 label_id;
+      if (!ConvertStringToInteger(fields[1], &label_id)) {
+        KALDI_ERR << "Expect integer for label_id";
+      }
+      // Add to map
+      (*utt_to_label)[utt_id] = label_id;
+    } // end of while 
+  } // end of if
+}
+
+
+static void WriteExample(const MatrixBase<BaseFloat> &feats,
+  const int32 this_pdf_id, const std::string &key,
+  bool compress, int32 num_pdfs, int32 &num_egs_written,
+  NnetExampleWriter *example_writer) {
+
+  NnetIo nnet_input = NnetIo("input", 0, feats);
+  for (std::vector<Index>::iterator indx_it = nnet_input.indexes.begin();
+      indx_it != nnet_input.indexes.end(); ++indx_it) {
+    indx_it->n = 0;
+  }
+  Posterior label;
+  std::vector<std::pair<int32, BaseFloat> > post;
+  post.push_back(std::pair<int32, BaseFloat>(this_pdf_id, 1.0));
+  label.push_back(post);
+  NnetExample eg;
+  eg.io.push_back(nnet_input);
+  eg.io.push_back(NnetIo("output", num_pdfs, 0, label));
+  if (compress) {
+    eg.Compress();
+  }
+
+  example_writer->Write(key, eg);
+  num_egs_written++;
+}
+
+
+} // namespace nnet3
+} // namespace kaldi
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::nnet3;
+    typedef kaldi::int32 int32;
+
+    const char *usage =
+        "In previous xvector setup, the different examples in the same archive\n"
+        "are equvalent length. Now, we hope the length of different examples in\n"
+        "the same archive is different, so that the randomness of data is increased\n"
+        "For this binary, it deals with the variable length feats.scp file.\n"
+        "Generate the variable length egs into egs.ark file.\n"
+        "Usage: nnet3-xvector-get-egs [options] <utt2label-rxfilename>"
+        "<features-rspecifier> <egs-wspecifier>\n"
+        "For example:\n"
+        "nnet3-xvector-get-egs-seg data/utt2label scp:data/feats.scp ark,t:egs.ark\n";
+
+    bool compress = true;
+    int32 num_pdfs = -1;
+
+    ParseOptions po(usage);
+    po.Register("compress", &compress, "If true, write egs in "
+                "compressed format.");
+    po.Register("num-pdfs", &num_pdfs, "Number of speakers in the training "
+                "list.");
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 3) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    std::string utt2label_rxfilename = po.GetArg(1),
+                feature_rspecifier = po.GetArg(2),
+                egs_wspecifier = po.GetArg(3);
+
+    unordered_map<std::string, int32, StringHasher> utt_to_label;
+    ProcessUttToLabelFile(utt2label_rxfilename, &utt_to_label);
+
+    SequentialBaseFloatMatrixReader feat_reader(feature_rspecifier);
+    NnetExampleWriter egs_writer(egs_wspecifier);
+
+    int32 num_done = 0,
+          num_err = 0,
+          num_egs_written = 0;
+
+    if (num_pdfs == -1) {
+      for(unordered_map<std::string, int32, StringHasher>::const_iterator 
+          iter= utt_to_label.begin(); iter != utt_to_label.end(); iter++) {
+        if(num_pdfs < iter->second) {
+          num_pdfs = iter->second;
+        }
+      }
+      num_pdfs = num_pdfs + 1;
+    }
+
+    for (; !feat_reader.Done(); feat_reader.Next()) {
+      std::string key = feat_reader.Key();
+      const Matrix<BaseFloat> &feats = feat_reader.Value();
+      
+      // Now the format is <uttid>_<startpoint>_<length> 
+      unordered_map<std::string, int32, StringHasher>::iterator got_label;
+      got_label = utt_to_label.find(key);
+      if (got_label == utt_to_label.end()) {
+        KALDI_WARN << "Could not find the label of this utterance:" << key;
+        num_err++;
+      } else {
+        int32 this_pdf_id = got_label->second;
+        KALDI_ASSERT(this_pdf_id < num_pdfs);
+        WriteExample(feats, this_pdf_id, key, compress, num_pdfs,
+            num_egs_written, &egs_writer);
+        num_done++;
+      }
+    }
+
+    KALDI_LOG << "Finished generating examples, "
+              << "successfully processed " << num_done
+              << " feature files, wrote " << num_egs_written << " examples; "
+              << num_err << " files had errors.";
+    return (num_egs_written == 0 || num_err > num_done ? 1 : 0);
+  } catch(const std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return -1;
+  }
+}


### PR DESCRIPTION
@david-ryan-snyder @pegahgh 
The PR is dealing with new method about generating egs for xvector.

The "allocate_egs_seg_v1" can be used in the scenario whose size is not very big. It is designed for TS learning, age or emotion id.
The "allocate_egs_seg_v2" is what we are testing now. (David). In addition to the egs in the same archive is distinct length, it matches the original David's setup, such as kinds of length, number of archives and so on.
The "allocate_egs_seg_v3" is depends on "num_egs_per_speaker_per_length". The specific scheme is shown in the email. Its functions are more abandant.

The "get_egs_v2.sh" will use "allocate_egs_seg_v2.py". The "get_egs_v3.sh" is prepared for "allocate_egs_seg_v3.py"

As --compiler.cache-capacity option is very helpful to speed up, so I add few codes in steps/libs.

The scripts use the method --"ranges in script-file lines for taking sub-parts of matrice", so it needn't range.* files. 
