### PR TITLE
[src] Speed fix to online decoding (thanks: David van Leeuwen)

### DIFF
--- a/src/nnet3/decodable-simple-looped.cc
+++ b/src/nnet3/decodable-simple-looped.cc
@@ -60,9 +60,10 @@ void DecodableNnetSimpleLoopedInfo::Init(
   KALDI_ASSERT(IsSimpleNnet(*nnet));
   has_ivectors = (nnet->InputDim("ivector") > 0);
   int32 left_context, right_context;
+  int32 extra_right_context = 0;
   ComputeSimpleNnetContext(*nnet, &left_context, &right_context);
   frames_left_context = left_context + opts.extra_left_context_initial;
-  frames_right_context = right_context;
+  frames_right_context = right_context + extra_right_context;
   frames_per_chunk = GetChunkSize(*nnet, opts.frame_subsampling_factor,
                                   opts.frames_per_chunk);
   output_dim = nnet->OutputDim("output");
@@ -73,14 +74,14 @@ void DecodableNnetSimpleLoopedInfo::Init(
     ModifyNnetIvectorPeriod(ivector_period, nnet);
 
   int32 num_sequences = 1;  // we're processing one utterance at a time.
-  int32 extra_right_context = 0;
-  CreateLoopedComputationRequestSimple(*nnet, frames_per_chunk,
-                                       opts.frame_subsampling_factor,
-                                       ivector_period,
-                                       opts.extra_left_context_initial,
-                                       extra_right_context,
-                                       num_sequences,
-                                       &request1, &request2, &request3);
+
+  CreateLoopedComputationRequest(*nnet, frames_per_chunk,
+                                 opts.frame_subsampling_factor,
+                                 ivector_period,
+                                 frames_left_context,
+                                 frames_right_context,
+                                 num_sequences,
+                                 &request1, &request2, &request3);
 
   CompileLooped(*nnet, opts.optimize_config, request1, request2, request3,
                 &computation);

--- a/src/nnet3/nnet-compile-looped.cc
+++ b/src/nnet3/nnet-compile-looped.cc
@@ -150,26 +150,24 @@ static void CreateComputationRequestInternal(
 }
 
 
-void CreateLoopedComputationRequestSimple(const Nnet &nnet,
-                                          int32 chunk_size,
-                                          int32 frame_subsampling_factor,
-                                          int32 ivector_period,
-                                          int32 extra_left_context_begin,
-                                          int32 extra_right_context,
-                                          int32 num_sequences,
-                                          ComputationRequest *request1,
-                                          ComputationRequest *request2,
-                                          ComputationRequest *request3) {
+void CreateLoopedComputationRequest(const Nnet &nnet,
+                                    int32 chunk_size,
+                                    int32 frame_subsampling_factor,
+                                    int32 ivector_period,
+                                    int32 left_context_begin,
+                                    int32 right_context,
+                                    int32 num_sequences,
+                                    ComputationRequest *request1,
+                                    ComputationRequest *request2,
+                                    ComputationRequest *request3) {
   bool has_ivector = (nnet.InputDim("ivector") > 0);
-  int32 left_context, right_context;
-  ComputeSimpleNnetContext(nnet, &left_context, &right_context);
   KALDI_ASSERT(chunk_size % frame_subsampling_factor == 0 &&
                chunk_size % nnet.Modulus() == 0 &&
                chunk_size % ivector_period == 0);
-  KALDI_ASSERT(extra_left_context_begin >= 0 && extra_right_context >= 0);
+  KALDI_ASSERT(left_context_begin >= 0 && right_context >= 0);
   // note, 'end' is one past the last one.
-  int32 chunk1_input_begin_t = - left_context - extra_left_context_begin,
-      chunk1_input_end_t = chunk_size + right_context + extra_right_context,
+  int32 chunk1_input_begin_t = - left_context_begin,
+      chunk1_input_end_t = chunk_size + right_context,
       chunk2_input_begin_t = chunk1_input_end_t,
       chunk2_input_end_t = chunk2_input_begin_t + chunk_size,
       chunk3_input_begin_t = chunk2_input_end_t,
@@ -349,10 +347,26 @@ void CompileLooped(const Nnet &nnet,
 }
 
 
+void CreateLoopedComputationRequestSimple(const Nnet &nnet,
+                                          int32 chunk_size,
+                                          int32 frame_subsampling_factor,
+                                          int32 ivector_period,
+                                          int32 extra_left_context_begin,
+                                          int32 extra_right_context,
+                                          int32 num_sequences,
+                                          ComputationRequest *request1,
+                                          ComputationRequest *request2,
+                                          ComputationRequest *request3) {
+  bool has_ivector = (nnet.InputDim("ivector") > 0);
+  int32 left_context, right_context;
+  ComputeSimpleNnetContext(nnet, &left_context, &right_context);
 
-
-
-
+  CreateLoopedComputationRequest(nnet, chunk_size, frame_subsampling_factor,
+                                 ivector_period,
+                                 extra_left_context_begin + left_context,
+                                 extra_right_context + right_context,
+                                 num_sequences, request1, request2, request3);
+}
 
 } // namespace nnet3
 } // namespace kaldi

--- a/src/nnet3/nnet-compile-looped.h
+++ b/src/nnet3/nnet-compile-looped.h
@@ -132,10 +132,17 @@ void ModifyNnetIvectorPeriod(int32 ivector_period,
                'nnet' before calling this function; otherwise the neural net
                will most likely not actually be able to consume the iVector with
                this frequency.
-   @param [in] extra_left_context_begin  The additional left-context that
-               should be supplied to the network on top of the minimum
-               that the network requires.  We call this extra_left_context_begin
-               because this only relates to the start of the utterance (t=0).
+   @param [in] left_context_begin This should be the left-context of the network
+               plus any additional left-context (provided via the option
+               --extra-left-context-begin) that should be supplied to the
+               network on top of the minimum that the network requires.  We call
+               this left_context_begin because this only relates to the
+               start of the utterance (t=0).
+   @param [in] right_context This should be the right-context of the network,
+               plus any additional right-context ("extra-right-context") that
+               should be supplied to the network on top of the minimum that the
+               network requires (currently extra-right-context != 0 is is not
+               supported at the command-line level).
    @param [in] num_sequences  The number of separate 'n' values to put in the computation;
                normally this will be just 1, but it can be increased to allow
                simultaneous operation on multiple streams of input.
@@ -151,6 +158,25 @@ void ModifyNnetIvectorPeriod(int32 ivector_period,
                Caution: none of the inputs and outputs should overlap.
    @param [out] request3  The third of the 3 requests that this function generates.
                 It will be the same as request2, except for a time offset.
+*/
+void CreateLoopedComputationRequest(const Nnet &nnet,
+                                    int32 chunk_size,
+                                    int32 frame_subsampling_factor,
+                                    int32 ivector_period,
+                                    int32 left_context_begin,
+                                    int32 right_context,
+                                    int32 num_sequences,
+                                    ComputationRequest *request1,
+                                    ComputationRequest *request2,
+                                    ComputationRequest *request3);
+
+
+/**
+   This function is deprecated.  It has the same interface as
+   CreateLoopedComputationRequest(), except that the left and right context are
+   specified in a different way (as just the 'extra' part).  It is deprecated because
+   this function has to work out the left and right context of the network, which
+   turns out to be quite slow if it's done after you call ModifyNnetIvectorPeriod().
 */
 void CreateLoopedComputationRequestSimple(const Nnet &nnet,
                                           int32 chunk_size,

--- a/src/nnet3bin/nnet3-am-copy.cc
+++ b/src/nnet3bin/nnet3-am-copy.cc
@@ -50,6 +50,7 @@ int main(int argc, char *argv[]) {
     std::string set_raw_nnet = "";
     bool convert_repeated_to_block = false;
     BaseFloat scale = 1.0;
+    bool prepare_for_test = false;
     std::string nnet_config, edits_config, edits_str;
 
     ParseOptions po(usage);
@@ -81,7 +82,11 @@ int main(int argc, char *argv[]) {
                 " are set to this value.");
     po.Register("scale", &scale, "The parameter matrices are scaled"
                 " by the specified value.");
-
+    po.Register("prepare-for-test", &prepare_for_test,
+                "If true, prepares the model for test time (may reduce model size "
+                "slightly.  Involves setting test mode in dropout and batch-norm "
+                "components, and calling CollapseModel() which may remove some "
+                "components.");
 
     po.Read(argc, argv);
 
@@ -134,6 +139,12 @@ int main(int argc, char *argv[]) {
 
     if (scale != 1.0)
       ScaleNnet(scale, &(am_nnet.GetNnet()));
+
+    if (prepare_for_test) {
+      SetBatchnormTestMode(true, &am_nnet.GetNnet());
+      SetDropoutTestMode(true, &am_nnet.GetNnet());
+      CollapseModel(CollapseModelConfig(), &am_nnet.GetNnet());
+    }
 
     if (raw) {
       WriteKaldiObject(am_nnet.GetNnet(), nnet_wxfilename, binary_write);


### PR DESCRIPTION

This is a fix to a problem I discovered due to this kaldi-help conversation:

https://groups.google.com/d/msgid/kaldi-help/d362c3b1-24af-41c5-8ead-7a9cea212681%40googlegroups.com

It turns out that the call to ComputeSimpleNnetContext() is slow after you call
ModifyNnetIvectorPeriod(), because the Modulus() of the network increases
(and as it happens it causes a bunch of unnecessary computation because
that relates to the ivectors, not the main input).  This patch should fix the slowness
by computing the context before ModifyNnetIvectorPeriod().