### PR TITLE
UW3 minor fix: make sure scoring opts are passed to score_cer.sh

### DIFF
--- a/egs/uw3/v1/local/score.sh
+++ b/egs/uw3/v1/local/score.sh
@@ -143,7 +143,9 @@ if [ $stage -le 1 ]; then
   fi
 fi
 
-steps/scoring/score_kaldi_cer.sh --cmd "$cmd" --stage 2 $data $lang_or_graph $dir
+steps/scoring/score_kaldi_cer.sh --cmd "$cmd" --stage 2 --min-lmwt $min_lmwt \
+                                 --max-lmwt $max_lmwt --word-ins-penalty $word_ins_penalty \
+                                 $data $lang_or_graph $dir
 
 # If we got here, the scoring was successful.
 # As a  small aid to prevent confusion, we remove all wer_{?,??} files;


### PR DESCRIPTION
Min-lmwt and max-lmwt were not passed to `score_kaldi_cer.sh`
which is called at the end of `local/score.sh` and this caused some error messages during CER scoring.
This does not affect the results.