### PR TITLE
[egs] Fix incorrect syntax to send text to stderr.

### DIFF
--- a/egs/wsj/s5/steps/nnet2/check_ivectors_compatible.sh
+++ b/egs/wsj/s5/steps/nnet2/check_ivectors_compatible.sh
@@ -7,8 +7,8 @@
 
 #echo >&2 "$0 $@"  # Print the command line for logging
 if [ $# != 2 ] ; then
-  echo >$2 "Usage: $0  <first-dir> <second-dir>"
-  echo >$2 " e.g.: $0 exp/nnet3/extractor exp/nnet3/ivectors_dev10h.pem"
+  echo >&2 "Usage: $0  <first-dir> <second-dir>"
+  echo >&2 " e.g.: $0 exp/nnet3/extractor exp/nnet3/ivectors_dev10h.pem"
 fi
 
 dir_a=$1

--- a/egs/wsj/s5/steps/nnet2/get_ivector_id.sh
+++ b/egs/wsj/s5/steps/nnet2/get_ivector_id.sh
@@ -16,8 +16,8 @@ if [ -f path.sh ]; then . ./path.sh; fi
 
 
 if [ $# != 1 ]; then
-  echo >$2 "Usage: $0 <directory>"
-  echo >$2 " e.g.: $0 exp/nnet3/extractor"
+  echo >&2 "Usage: $0 <directory>"
+  echo >&2 " e.g.: $0 exp/nnet3/extractor"
   exit 1
 fi
 


### PR DESCRIPTION
First case (check_ivectors_compatible.sh) is an error in bash because
argument $2 happens to be a directory here. (Error message is
"bash: $2: Is a directory".) The scripts still worked in the past
because there was no `set -e` command, though.

The second case (get_ivector_id.sh) is an error as well, with the
message: "bash: $2: ambiguous redirect".