### PR TITLE
Remove CuDevice destructor.

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -547,14 +547,6 @@ CuDevice::CuDevice() :
     multi_threaded_(false) { }
 
 
-CuDevice::~CuDevice() {
-  if (Enabled()) {
-    cublasDestroy(handle_);
-    cusparseDestroy(cusparse_handle_);
-    cudaDeviceReset();
-  }
-}
-
 // The instance of the static singleton
 CuDevice CuDevice::global_device_;
 }

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -47,7 +47,6 @@ class CuTimer;
 class CuDevice {
  // Singleton object (there should only be one instantiated per program)
  public:
-  ~CuDevice();
   static inline CuDevice& Instantiate() { return global_device_; }
 
   inline cublasHandle_t GetHandle() { return handle_; }


### PR DESCRIPTION
This caused spurious warnings from cuda-memcheck. See #2178 for details.

The destructor gets called only when the process exits, so the memory
leak is harmless.