### PR TITLE
prevent crash when input_model is None

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -218,7 +218,7 @@ def process_args(args):
 
     if (not os.path.exists(args.dir)
             or (not os.path.exists(args.dir+"/configs") and
-                not os.path.exists(args.input_model))):
+                (args.input_model is None or not os.path.exists(args.input_model)))):
         raise Exception("This script expects {0} to exist. Also either "
                         "--trainer.input-model option as initial 'raw' model "
                         "(used as 0.raw in the script) should be supplied or "


### PR DESCRIPTION
This prevents throwing the following error instead of a meaningful message:
```
Traceback (most recent call last):
  File "steps/nnet3/chain/train.py", line 612, in <module>
    main()
  File "steps/nnet3/chain/train.py", line 596, in main
    [args, run_opts] = get_args()
  File "steps/nnet3/chain/train.py", line 189, in get_args
    [args, run_opts] = process_args(args)
  File "steps/nnet3/chain/train.py", line 221, in process_args
    not os.path.exists(args.input_model))):
  File "/usr/lib/python2.7/genericpath.py", line 18, in exists
    os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```