### PR TITLE
[scripts] bugfix for 'steps/cleanup/clean_and_segment_data.sh',

### DIFF
--- a/egs/wsj/s5/steps/cleanup/lattice_oracle_align.sh
+++ b/egs/wsj/s5/steps/cleanup/lattice_oracle_align.sh
@@ -72,9 +72,9 @@ fi
 nj=$(cat $latdir/num_jobs)
 oov=$(cat $lang/oov.int)
 
-utils/split_data.sh --per-utt $data $nj
+utils/split_data.sh $data $nj
 
-sdata=$data/split${nj}utt
+sdata=$data/split$nj;
 
 if [ $stage -le 1 ]; then
   $cmd JOB=1:$nj $dir/log/get_oracle.JOB.log \


### PR DESCRIPTION
- make sure that lattice-generation, and subsequent search of 'oracle-transcript' in them uses the same data-split,
- i.e. this PR removes the inconsitency, in which lattice-generation used 'per-speaker' split, while oracle-search used 'per-utt' splitting...