### PR TITLE
check for source and target directory is the same

### DIFF
--- a/egs/wsj/s5/utils/format_lm.sh
+++ b/egs/wsj/s5/utils/format_lm.sh
@@ -36,6 +36,10 @@ mkdir -p $out_dir
 
 echo "Converting '$lm' to FST"
 
+# the -ef test checks if  source and target directory
+# are two different directories in the filesystem
+# if they are the same, the section guarded by the test
+# would be actually harmfull (deleting the phones/ subdirectory)
 if [ -e $out_dir ] && [ ! $lang_dir -ef $out_dir ] ; then
   if [ -e $out_dir/phones ] ; then
     rm -r $out_dir/phones

--- a/egs/wsj/s5/utils/format_lm.sh
+++ b/egs/wsj/s5/utils/format_lm.sh
@@ -36,13 +36,15 @@ mkdir -p $out_dir
 
 echo "Converting '$lm' to FST"
 
-if [ -e $out_dir/phones ]; then
-  rm -r $out_dir/phones
-fi
+if [ -e $out_dir ] && [ ! $lang_dir -ef $out_dir ] ; then
+  if [ -e $out_dir/phones ] ; then
+    rm -r $out_dir/phones
+  fi
 
-for f in phones.txt words.txt topo L.fst L_disambig.fst phones oov.int oov.txt; do
-  cp -r $lang_dir/$f $out_dir
-done
+  for f in phones.txt words.txt topo L.fst L_disambig.fst phones oov.int oov.txt; do
+     cp -r $lang_dir/$f $out_dir
+  done
+fi
 
 lm_base=$(basename $lm '.gz')
 gunzip -c $lm \


### PR DESCRIPTION
@danpovey this is not what we usually do, but I believe the change makes sense to simplify the workflow...
the typical use case the benefit becomes more visible is explicit UNK model:
```
  utils/lang/make_unk_lm.sh data/local/dict exp/make_unk
  utils/prepare_lang.sh \
    --unk-fst exp/make_unk/unk_fst.txt --phone-symbol-table data/lang/phones.txt \
    data/local/dict "<oov>" data/local/lang_test data/lang_test
  utils/format_lm.sh \
    data/lang_test data/srilm/best_3gram.gz data/local/dict/lexicon.txt data/lang_test
```

without this change, we'd have to create one intermediary lang directory to stand between prepare_lang and format_lm -- no big deal but maybe this is slightly nicer.