### PR TITLE
disable warning about undefined variable

### DIFF
--- a/egs/wsj/s5/utils/create_data_link.pl
+++ b/egs/wsj/s5/utils/create_data_link.pl
@@ -79,12 +79,11 @@ for (my $x = 1; $x <= $num_storage; $x++) {
 
 # Second, get the coprime list.
 my @coprimes;
-for (my $n = 1; $n < $num_storage; $n++) {
+for (my $n = 1; $n <= $num_storage; $n++) {
   if (GetGCD($n, $num_storage) == 1) {
     push(@coprimes, $n);
   }
 }
-
 my $ret = 0;
 
 foreach my $fullpath (@ARGV) {

--- a/egs/wsj/s5/utils/create_data_link.pl
+++ b/egs/wsj/s5/utils/create_data_link.pl
@@ -84,6 +84,7 @@ for (my $n = 1; $n <= $num_storage; $n++) {
     push(@coprimes, $n);
   }
 }
+
 my $ret = 0;
 
 foreach my $fullpath (@ARGV) {


### PR DESCRIPTION
this should resolve
```
Use of uninitialized value in multiplication (*) at utils/create_data_link.pl line 106.
```
when there is only one directory target in the storage split dir.
NB, I might not get the real meaning of the coprimes right, so my proposed solution might be faulty.