### PR TITLE
Updating contributor list in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -57,30 +57,72 @@ License v 2.0 are set forth below.
 
 Individual Contributors (in alphabetical order)
       
-      Mohit Agarwal      
+      Mohit Agarwal
+      Tanel Alumae
       Gilles Boulianne
       Lukas Burget
+      Dogan Can
+      Guoguo Chen
+      Gaofeng Cheng
       Cisco Corporation
-      Ondrej Glembek
+      Pavel Denisov
+      Ilya Edrenkin
+      Ewald Enzinger
+      Joachim Fainberg
+      Daniel Galvez
+      Pegah Ghahremani
       Arnab Ghoshal
+      Ondrej Glembek
       Go Vivace Inc.
+      Allen Guo
+      Hossein Hadian
+      Lv Hang
       Mirko Hannemann
+      Hendy Irawan
       Navdeep Jaitly
       Johns Hopkins University
+      Shiyin Kang
+      Kirill Katsnelson
+      Tom Ko
+      Danijel Korzinek
+      Gaurav Kumar
+      Ke Li
+      Matthew Maciejewski
+      Vimal Manohar
       Yajie Miao
       Microsoft Corporation
       Petr Motlicek
+      Xingyu Na
+      Vincent Nguyen
+      Lucas Ondel
       Vassil Panayotov
+      Vijayaditya Peddinti
+      Phonexia s.r.o.
+      Ondrej Platek
+      Daniel Povey
+      Yanmin Qian
       Ariya Rastrow
       Saarland University
-      Petr Schwarz      
-      Georg Stemmer
+      Omid Sadjadi
+      Petr Schwarz
+      Yiwen Shao
+      Nickolay V. Shmyrev
       Jan Silovsky
-      Phonexia s.r.o.
-      Yanmin Qian
-      Lucas Ondel
+      Eduardo Silva
+      Peter Smit
+      David Snyder
+      Alexander Solovets
+      Georg Stemmer
+      Pawel Swietojanski
+      Jan "Yenda" Trmal
+      Albert Vernon
       Karel Vesely
+      Yiming Wang
+      Shinji Watanabe
+      Minhua Wu
       Haihua Xu
+      Hainan Xu
+      Xiaohui Zhang
       
 Other Source Material
 


### PR DESCRIPTION
Updating contributor list in COPYING to contain the top 66 contributors in Kaldi. Thanks to Yishay Carmiel for compiling this info.

The list is alphabetized by last name or company name. 