### PR TITLE
Update gst-plugin Makefile

### DIFF
--- a/egs/voxforge/gst_demo/run-simulated.sh
+++ b/egs/voxforge/gst_demo/run-simulated.sh
@@ -26,8 +26,8 @@ ac_model=${data_file}/models/$ac_model_type
 trans_matrix=""
 audio=${data_file}/audio
 
-if [ ! -s $KALDI_ROOT/src/gst-plugin/libgstkaldi.so ]; then
-    echo "Kaldi Gstreamer plugin libarary $KALDI_ROOT/src/gst-plugin/libgstkaldi.so not present, make it first"
+if [ ! -s $KALDI_ROOT/src/gst-plugin/libgstonlinegmmdecodefaster.so ]; then
+    echo "Kaldi Gstreamer plugin libarary $KALDI_ROOT/src/gst-plugin/libgstonlinegmmdecodefaster.so not present, make it first"
     exit 1
 fi
 

--- a/src/doc/online_programs.dox
+++ b/src/doc/online_programs.dox
@@ -163,7 +163,7 @@ repository (http://backports.debian.org). Install the 'good' GStreamer plugins (
 and GStreamer 1.0 tools (package `gstreamer1.0-tools`). A demo program also requires the PulseAudio Gstreamer plugins 
 (package gstreamer1.0-pulseaudio).
 
-Finally, run `make depend` and `make` in the `src/gst-plugin` directory. This should result in a file `src/gst-plugin/libgstkaldi.so`
+Finally, run `make depend` and `make` in the `src/gst-plugin` directory. This should result in a file `src/gst-plugin/libgstonlinegmmdecodefaster.so`
 which contains the GStreamer plugin.
 
 To make GStreamer able to find the Kaldi plugin, you have to add the `src/gst-plugin` directory to its plugin search path. To do this,

--- a/src/gst-plugin/Makefile
+++ b/src/gst-plugin/Makefile
@@ -22,7 +22,7 @@ EXTRA_LDLIBS += -lkaldi-online -lkaldi-lat -lkaldi-decoder -lkaldi-feat -lkaldi-
 
 OBJFILES = gst-audio-source.o gst-online-gmm-decode-faster.o
 
-LIBNAME=gstkaldi
+LIBNAME=gstonlinegmmdecodefaster
 
 LIBFILE = lib$(LIBNAME).so
 BINFILES= $(LIBFILE)

--- a/src/gst-plugin/README
+++ b/src/gst-plugin/README
@@ -31,7 +31,7 @@ Now, run:
 make depend
 make
 
-This should result in libgstkaldi.so which contains the GStreamer plugin
+This should result in libgstonlinegmmdecodefaster.so which contains the GStreamer plugin
 
 == Usage ==
 


### PR DESCRIPTION
The plugin is not recognised as valid when using the master gstreamer branch because the symname is extracted from the filename, https://github.com/GStreamer/gstreamer/blob/master/gst/gstplugin.c#L685