### PR TITLE
[scripts] Fix bug in steps/libs/nnet3/train/frame_level_objf/common.py

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/frame_level_objf/common.py
@@ -9,7 +9,7 @@ deep neural network acoustic model and raw model (i.e., generic neural
 network without transition model) with frame-level objectives.
 """
 
-from __future__ import print_statement
+from __future__ import print_function
 from __future__ import division
 import glob
 import logging


### PR DESCRIPTION
Fixes the following error:

```
Traceback (most recent call last):
  File "steps/nnet3/train_raw_rnn.py", line 23, in <module>
    import libs.nnet3.train.frame_level_objf as train_lib
  File "steps/libs/nnet3/train/frame_level_objf/__init__.py", line 10, in <module>
    import common
  File "steps/libs/nnet3/train/frame_level_objf/common.py", line 12
    from __future__ import print_statement
SyntaxError: future feature print_statement is not defined
```

`from __future__ import print_function` seems to be the correct form and works in python 2.7, 3.5, and 3.6. 