### PR TITLE
[WIP] [egs] port tdnn_7m23t script to librispeech

### DIFF
--- a/egs/librispeech/s5/local/chain/run_chain_common.sh
+++ b/egs/librispeech/s5/local/chain/run_chain_common.sh
@@ -13,6 +13,8 @@ gmm_dir=
 ali_dir=
 lores_train_data_dir=
 
+num_leaves=6000
+
 # output directory names. They are also compulsory.
 lang=
 lat_dir=
@@ -74,7 +76,7 @@ if [ $stage -le 13 ]; then
   fi
   steps/nnet3/chain/build_tree.sh --frame-subsampling-factor 3 \
       --context-opts "--context-width=2 --central-position=1" \
-      --cmd "$train_cmd" 6000 ${lores_train_data_dir} $lang $ali_dir $tree_dir
+      --cmd "$train_cmd" $num_leaves ${lores_train_data_dir} $lang $ali_dir $tree_dir
 fi
 
 exit 0;

--- a/egs/librispeech/s5/local/chain/run_tdnn.sh
+++ b/egs/librispeech/s5/local/chain/run_tdnn.sh
@@ -1,1 +1,1 @@
-tuning/run_tdnn_1b.sh
+tuning/run_tdnn_1c.sh

--- a/egs/librispeech/s5/local/chain/tuning/run_tdnn_7m23t.sh
+++ b/egs/librispeech/s5/local/chain/tuning/run_tdnn_7m23t.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+## Adapted from swbd for librispeech by David van Leeuwen
+
+# 7m23t is as 7m23r but with 1280 instead of 1536 as the dim.
+# Differernce vs. 23r is unclear (maybe slightly worse), but it
+# seems slightly better than 23h, and it's nice that it has fewer parameters.
+
+# steps/info/chain_dir_info.pl exp/chain/tdnn_7m_sp
+# exp/chain/tdnn_7m_sp: num-iters=262 nj=3..16 num-params=16.3M dim=40+100->6034 combine=-0.103->-0.103 xent:train/valid[173,261,final]=(-1.28,-1.21,-1.21/-1.32,-1.27,-1.27) logprob:train/valid[173,261,final]=(-0.093,-0.084,-0.084/-0.109,-0.104,-0.103)
+
+set -e
+
+# configs for 'chain'
+stage=0
+train_stage=-10
+get_egs_stage=-10
+speed_perturb=true
+affix=7m23t
+suffix=
+$speed_perturb && suffix=_sp
+tree_affix=7m
+train_set=train_960_cleaned
+gmm=tri6b_cleaned
+nnet3_affix=_cleaned
+
+dir=exp/chain/tdnn${affix}${suffix}
+decode_iter=
+decode_nj=50
+
+# training options
+min_seg_len=1.55
+frames_per_eg=150,110,100
+remove_egs=false
+common_egs_dir=
+xent_regularize=0.1
+
+test_online_decoding=true  # if true, it will run the last decoding stage.
+
+# End configuration section.
+echo "$0 $@"  # Print the command line for logging
+
+. ./cmd.sh
+. ./path.sh
+. ./utils/parse_options.sh
+
+if ! cuda-compiled; then
+  cat <<EOF && exit 1
+This script is intended to be used with GPUs but you have not compiled Kaldi with CUDA
+If you want to use GPUs (and have them), go to src/, and configure and make on a machine
+where "nvcc" is installed.
+EOF
+fi
+
+# The iVector-extraction and feature-dumping parts are the same as the standard
+# nnet3 setup, and you can skip them by setting "--stage 8" if you have already
+# run those things.
+
+local/nnet3/run_ivector_common.sh --stage $stage \
+                                  --min-seg-len $min_seg_len \
+                                  --train-set $train_set \
+                                  --gmm $gmm \
+				  --num-threads-ubm 6 --num-processes 3 \
+                                  --nnet3-affix "$nnet3_affix" || exit 1;
+
+gmm_dir=exp/$gmm
+ali_dir=exp/${gmm}_ali_${train_set}_sp_comb
+tree_dir=exp/chain${nnet3_affix}/tree_sp${tree_affix:+_$tree_affix}
+lang=data/lang_chain
+lat_dir=exp/chain${nnet3_affix}/${gmm}_${train_set}_sp_comb_lats
+train_data_dir=data/${train_set}_sp_hires_comb
+lores_train_data_dir=data/${train_set}_sp_comb
+train_ivector_dir=exp/nnet3${nnet3_affix}/ivectors_${train_set}_sp_hires_comb
+
+# if we are using the speed-perturbed data we need to generate
+# alignments for it.
+
+for f in $gmm_dir/final.mdl $train_data_dir/feats.scp $train_ivector_dir/ivector_online.scp \
+    $lores_train_data_dir/feats.scp $ali_dir/ali.1.gz; do
+  [ ! -f $f ] && echo "$0: expected file $f to exist" && exit 1
+done
+
+# Please take this as a reference on how to specify all the options of
+# local/chain/run_chain_common.sh
+local/chain/run_chain_common.sh --stage $stage \
+                                --gmm-dir $gmm_dir \
+                                --ali-dir $ali_dir \
+                                --lores-train-data-dir ${lores_train_data_dir} \
+                                --lang $lang \
+                                --lat-dir $lat_dir \
+				--num-leaves 7000 \
+                                --tree-dir $tree_dir || exit 1;
+
+if [ $stage -le 14 ]; then
+  echo "$0: creating neural net configs using the xconfig parser";
+
+  num_targets=$(tree-info $tree_dir/tree | grep num-pdfs | awk '{print $2}')
+  learning_rate_factor=$(echo "print 0.5/$xent_regularize" | python)
+  opts="l2-regularize=0.002"
+  linear_opts="orthonormal-constraint=1.0"
+  output_opts="l2-regularize=0.0005 bottleneck-dim=256"
+
+  mkdir -p $dir/configs
+
+  cat <<EOF > $dir/configs/network.xconfig
+  input dim=100 name=ivector
+  input dim=40 name=input
+
+  # please note that it is important to have input layer with the name=input
+  # as the layer immediately preceding the fixed-affine-layer to enable
+  # the use of short notation for the descriptor
+  fixed-affine-layer name=lda input=Append(-1,0,1,ReplaceIndex(ivector, t, 0)) affine-transform-file=$dir/configs/lda.mat
+
+  # the first splicing is moved before the lda layer, so no splicing here
+  relu-batchnorm-layer name=tdnn1 $opts dim=1280
+  linear-component name=tdnn1l dim=256 $linear_opts input=Append(-1,0)
+  relu-batchnorm-layer name=tdnn2 $opts input=Append(0,1) dim=1280
+  linear-component name=tdnn2l dim=256 $linear_opts
+  relu-batchnorm-layer name=tdnn3 $opts dim=1280
+  linear-component name=tdnn3l dim=256 $linear_opts input=Append(-1,0)
+  relu-batchnorm-layer name=tdnn4 $opts input=Append(0,1) dim=1280
+  linear-component name=tdnn4l dim=256 $linear_opts
+  relu-batchnorm-layer name=tdnn5 $opts dim=1280 input=Append(tdnn4l, tdnn2l)
+  linear-component name=tdnn5l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn6 $opts input=Append(0,3) dim=1280
+  linear-component name=tdnn6l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn7 $opts input=Append(0,3,tdnn5l,tdnn3l,tdnn1l) dim=1280
+  linear-component name=tdnn7l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn8 $opts input=Append(0,3) dim=1280
+  linear-component name=tdnn8l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn9 $opts input=Append(0,3,tdnn7l,tdnn5l,tdnn3l) dim=1280
+  linear-component name=tdnn9l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn10 $opts input=Append(0,3) dim=1280
+  linear-component name=tdnn10l dim=256 $linear_opts input=Append(-3,0)
+  relu-batchnorm-layer name=tdnn11 $opts input=Append(0,3,tdnn9l,tdnn7l,tdnn5l) dim=1280
+  linear-component name=tdnn11l dim=256 $linear_opts
+
+  relu-batchnorm-layer name=prefinal-chain input=tdnn11l $opts dim=1280
+  output-layer name=output include-log-softmax=false dim=$num_targets $output_opts
+
+  relu-batchnorm-layer name=prefinal-xent input=tdnn11l $opts dim=1280
+  output-layer name=output-xent dim=$num_targets learning-rate-factor=$learning_rate_factor $output_opts
+EOF
+  steps/nnet3/xconfig_to_configs.py --xconfig-file $dir/configs/network.xconfig --config-dir $dir/configs/
+fi
+
+if [ $stage -le 15 ]; then
+  steps/nnet3/chain/train.py --stage $train_stage \
+    --cmd "$decode_cmd" \
+    --feat.online-ivector-dir $train_ivector_dir \
+    --feat.cmvn-opts "--norm-means=false --norm-vars=false" \
+    --chain.xent-regularize $xent_regularize \
+    --chain.leaky-hmm-coefficient 0.1 \
+    --chain.l2-regularize 0.0 \
+    --chain.apply-deriv-weights false \
+    --chain.lm-opts="--num-extra-lm-states=2000" \
+    --egs.dir "$common_egs_dir" \
+    --egs.stage $get_egs_stage \
+    --egs.opts "--frames-overlap-per-eg 0" \
+    --egs.chunk-width $frames_per_eg \
+    --trainer.num-chunk-per-minibatch 128 \
+    --trainer.frames-per-iter 1500000 \
+    --trainer.num-epochs 6 \
+    --trainer.optimization.num-jobs-initial 3 \
+    --trainer.optimization.num-jobs-final 16 \
+    --trainer.optimization.initial-effective-lrate 0.001 \
+    --trainer.optimization.final-effective-lrate 0.0001 \
+    --trainer.max-param-change 2.0 \
+    --cleanup.remove-egs $remove_egs \
+    --feat-dir $train_data_dir \
+    --tree-dir $tree_dir \
+    --lat-dir $lat_dir \
+    --dir $dir  || exit 1;
+
+fi
+
+graph_dir=$dir/graph_tgsmall
+if [ $stage -le 16 ]; then
+  # Note: it might appear that this $lang directory is mismatched, and it is as
+  # far as the 'topo' is concerned, but this script doesn't read the 'topo' from
+  # the lang directory.
+  utils/mkgraph.sh --self-loop-scale 1.0 --remove-oov data/lang_test_tgsmall $dir $graph_dir
+  # remove <UNK> from the graph, and convert back to const-FST.
+  fstrmsymbols --apply-to-output=true --remove-arcs=true "echo 3|" $graph_dir/HCLG.fst - | \
+    fstconvert --fst_type=const > $graph_dir/temp.fst
+  mv $graph_dir/temp.fst $graph_dir/HCLG.fst
+fi
+
+iter_opts=
+if [ ! -z $decode_iter ]; then
+  iter_opts=" --iter $decode_iter "
+fi
+if [ $stage -le 17 ]; then
+  rm $dir/.error 2>/dev/null || true
+  for decode_set in test_clean test_other dev_clean dev_other; do
+      (
+      steps/nnet3/decode.sh --acwt 1.0 --post-decode-acwt 10.0 \
+          --nj $decode_nj --cmd "$decode_cmd" $iter_opts \
+          --online-ivector-dir exp/nnet3${nnet3_affix}/ivectors_${decode_set}_hires \
+          $graph_dir data/${decode_set}_hires $dir/decode_${decode_set}${decode_iter:+_$decode_iter}_tgsmall || exit 1
+      steps/lmrescore.sh --cmd "$decode_cmd" --self-loop-scale 1.0 data/lang_test_{tgsmall,tgmed} \
+          data/${decode_set}_hires $dir/decode_${decode_set}${decode_iter:+_$decode_iter}_{tgsmall,tgmed} || exit 1
+      steps/lmrescore_const_arpa.sh \
+          --cmd "$decode_cmd" data/lang_test_{tgsmall,tglarge} \
+          data/${decode_set}_hires $dir/decode_${decode_set}${decode_iter:+_$decode_iter}_{tgsmall,tglarge} || exit 1
+      steps/lmrescore_const_arpa.sh \
+          --cmd "$decode_cmd" data/lang_test_{tgsmall,fglarge} \
+          data/${decode_set}_hires $dir/decode_${decode_set}${decode_iter:+_$decode_iter}_{tgsmall,fglarge} || exit 1
+      ) || touch $dir/.error &
+  done
+  wait
+  if [ -f $dir/.error ]; then
+    echo "$0: something went wrong in decoding"
+    exit 1
+  fi
+fi
+
+if $test_online_decoding && [ $stage -le 18 ]; then
+  # note: if the features change (e.g. you add pitch features), you will have to
+  # change the options of the following command line.
+  steps/online/nnet3/prepare_online_decoding.sh \
+       --mfcc-config conf/mfcc_hires.conf \
+       $lang exp/nnet3${nnet3_affix}/extractor $dir ${dir}_online
+
+  rm $dir/.error 2>/dev/null || true
+  for data in test_clean test_other dev_clean dev_other; do
+    (
+      nspk=$(wc -l <data/${data}_hires/spk2utt)
+      # note: we just give it "data/${data}" as it only uses the wav.scp, the
+      # feature type does not matter.
+      steps/online/nnet3/decode.sh \
+          --acwt 1.0 --post-decode-acwt 10.0 \
+          --nj $nspk --cmd "$decode_cmd" \
+          $graph_dir data/${data} ${dir}_online/decode_${data}_tgsmall || exit 1
+
+    ) || touch $dir/.error &
+  done
+  wait
+  if [ -f $dir/.error ]; then
+    echo "$0: something went wrong in decoding"
+    exit 1
+  fi
+fi
+
+
+exit 0;

--- a/egs/librispeech/s5/local/nnet3/run_ivector_common.sh
+++ b/egs/librispeech/s5/local/nnet3/run_ivector_common.sh
@@ -16,6 +16,7 @@ train_set=train_960_cleaned    # you might set this to e.g. train_960
 gmm=tri6b_cleaned         # This specifies a GMM-dir from the features of the type you're training the system on;
                          # it should contain alignments for 'train_set'.
 num_threads_ubm=32
+num_processes=4
 nnet3_affix=_cleaned     # affix for exp/nnet3 directory to put iVector stuff in, so it
                          # becomes exp/nnet3_cleaned or whatever.
 
@@ -161,7 +162,7 @@ if [ $stage -le 8 ]; then
   # this one has a fairly small dim (defaults to 100) so we don't use all of it,
   # we use just the 60k subset (about one fifth of the data, or 200 hours).
   echo "$0: training the iVector extractor"
-  steps/online/nnet2/train_ivector_extractor.sh --cmd "$train_cmd" --nj 10 \
+  steps/online/nnet2/train_ivector_extractor.sh --cmd "$train_cmd" --nj 10 --num-processes $num_processes \
     data/${train_set}_sp_mixed_hires_60k exp/nnet3${nnet3_affix}/diag_ubm exp/nnet3${nnet3_affix}/extractor || exit 1;
 fi
 

--- a/egs/wsj/s5/utils/parallel/slurm.pl
+++ b/egs/wsj/s5/utils/parallel/slurm.pl
@@ -477,7 +477,7 @@ if (! $sync) { # We're not submitting with -sync y, so we
         # the following (.kick) commands are basically workarounds for NFS bugs.
         if (rand() < 0.25) { # don't do this every time...
           if (rand() > 0.5) {
-            system("touch $qdir/.kick");
+            system("touch $qdir/.kick 2>/dev/null");
           } else {
             system("rm $qdir/.kick 2>/dev/null");
           }


### PR DESCRIPTION
This is the port of the tdnn_7m23t.sh script from swbd to librispeech.  It took a while, since I wanted to verify all steps actually run.  Still I added one/two things afterwards (e.g., the num_leaves parameter).  I didn't make it to PR2114 in time, so therefore this is just a PR to master.  

Results measured are:
```
for d in exp/chain/tdnn7m23t_sp/decode_*; do ../bin/best $d; done
exp/chain/tdnn7m23t_sp/decode_dev_clean_fglarge/wer_12_0.5:%WER 3.40 [ 1851 / 54402, 229 ins, 155 del, 1467 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_clean_tglarge/wer_12_1.0:%WER 3.51 [ 1910 / 54402, 202 ins, 199 del, 1509 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_clean_tgmed/wer_12_0.0:%WER 4.28 [ 2327 / 54402, 265 ins, 206 del, 1856 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_clean_tgsmall/wer_12_0.0:%WER 4.84 [ 2635 / 54402, 277 ins, 263 del, 2095 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_other_fglarge/wer_14_0.5:%WER 8.77 [ 4468 / 50948, 484 ins, 500 del, 3484 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_other_tglarge/wer_14_0.0:%WER 9.24 [ 4709 / 50948, 598 ins, 435 del, 3676 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_other_tgmed/wer_14_0.0:%WER 11.31 [ 5760 / 50948, 604 ins, 678 del, 4478 sub ]
exp/chain/tdnn7m23t_sp/decode_dev_other_tgsmall/wer_14_0.0:%WER 12.45 [ 6342 / 50948, 596 ins, 829 del, 4917 sub ]
exp/chain/tdnn7m23t_sp/decode_test_clean_fglarge/wer_11_0.5:%WER 3.87 [ 2036 / 52576, 317 ins, 157 del, 1562 sub ]
exp/chain/tdnn7m23t_sp/decode_test_clean_tglarge/wer_10_0.5:%WER 4.04 [ 2126 / 52576, 336 ins, 164 del, 1626 sub ]
exp/chain/tdnn7m23t_sp/decode_test_clean_tgmed/wer_12_0.0:%WER 4.90 [ 2575 / 52576, 345 ins, 229 del, 2001 sub ]
exp/chain/tdnn7m23t_sp/decode_test_clean_tgsmall/wer_12_0.0:%WER 5.35 [ 2811 / 52576, 340 ins, 269 del, 2202 sub ]
exp/chain/tdnn7m23t_sp/decode_test_other_fglarge/wer_13_0.5:%WER 8.97 [ 4694 / 52343, 564 ins, 481 del, 3649 sub ]
exp/chain/tdnn7m23t_sp/decode_test_other_tglarge/wer_13_0.5:%WER 9.42 [ 4931 / 52343, 581 ins, 542 del, 3808 sub ]
exp/chain/tdnn7m23t_sp/decode_test_other_tgmed/wer_13_0.0:%WER 11.56 [ 6053 / 52343, 690 ins, 659 del, 4704 sub ]
exp/chain/tdnn7m23t_sp/decode_test_other_tgsmall/wer_13_0.0:%WER 12.64 [ 6615 / 52343, 678 ins, 791 del, 5146 sub ]

for d in exp/chain/tdnn7m23t_sp_online/decode_*; do ../bin/best $d; done
exp/chain/tdnn7m23t_sp_online/decode_dev_clean_tgsmall/wer_12_0.0:%WER 4.83 [ 2630 / 54402, 272 ins, 262 del, 2096 sub ]
exp/chain/tdnn7m23t_sp_online/decode_dev_other_tgsmall/wer_14_0.0:%WER 12.52 [ 6381 / 50948, 598 ins, 828 del, 4955 sub ]
exp/chain/tdnn7m23t_sp_online/decode_test_clean_tgsmall/wer_12_0.0:%WER 5.33 [ 2802 / 52576, 343 ins, 265 del, 2194 sub ]
exp/chain/tdnn7m23t_sp_online/decode_test_other_tgsmall/wer_13_0.0:%WER 12.67 [ 6630 / 52343, 657 ins, 799 del, 5174 sub ]
```