### PR TITLE
[WIP] Added pre-caching memory on GPU

### DIFF
--- a/src/cudamatrix/cu-allocator.h
+++ b/src/cudamatrix/cu-allocator.h
@@ -54,7 +54,7 @@ struct CuAllocatorOptions {
   // is a constant overhead proportional to the number of buckets.
   BaseFloat delete_factor;
 
-  CuAllocatorOptions(): memory_factor(1.3),
+  CuAllocatorOptions(): memory_factor(1.1),
                         delete_factor(0.001) { }
 
   void Check() {
@@ -110,6 +110,11 @@ class CuMemoryAllocator {
 
   CuMemoryAllocator(CuAllocatorOptions opts);
  private:
+  size_t GetDeviceMemoryMarker() const;
+  void ReportAllocCallStats(int64 row_bytes,
+                             int64 num_rows,
+                             int64 pitch,
+                             size_t marker) const;
 
   void FreeSomeCachedMemory(size_t bytes_to_free);
 

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -410,6 +410,7 @@ void CuDevice::AccuProfile(const char *function_name,
   }
 }
 
+
 void CuDevice::PrintMemoryUsage() const {
   if (Enabled()) {
     allocator_.PrintMemoryUsage();

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -74,6 +74,9 @@ class CuDevice {
           pitch);
     } else {
       return allocator_.MallocPitch(row_bytes, num_rows, pitch);
+      //void *tmp =  allocator_.Malloc(row_bytes * num_rows);
+      //*pitch = row_bytes;
+      //return tmp;
     }
   }
   inline void Free(void *ptr) {

--- a/src/nnet3/nnet-chain-training.h
+++ b/src/nnet3/nnet-chain-training.h
@@ -69,6 +69,7 @@ class NnetChainTrainer {
   void PrintMaxChangeStats() const;
 
   ~NnetChainTrainer();
+  friend class ChainTrainerMemoryHolder;
  private:
   // The internal function for doing one step of conventional SGD training.
   void TrainInternal(const NnetChainExample &eg,


### PR DESCRIPTION
A lot of the changes have to be removed before this committing, I guess, but for debugging and tuning this, I think the logs are very useful.

The changes lead to
```
Total GPU time: 45.4942s (may involve some double-counting)
-----
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-allocator.cc:127) Memory usage: 3533918816 bytes currently allocated (max: 3573514948); 62005496 currently in use by user (max: 3248682204); 10870/87098 calls to Malloc* resulted in CUDA calls.
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-allocator.cc:136) Time taken in cudaMallocPitch=0.448115, in cudaMalloc=0.0951378, in cudaFree=0.296628, in this->MallocPitch()=0.929231
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-device.cc:418) Memory used (according to the device): 6798966784 bytes.
LOG (nnet3-chain-train[5.4]:main():nnet3-chain-train.cc:97) Wrote raw model to exp/chain_cleaned/tdnnx2_5.4_sp/2.3.raw
```
to
```
Total GPU time: 49.6038s (may involve some double-counting)
-----
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-allocator.cc:154) Memory usage: 3533918816 bytes currently allocated (max: 3573540444); 62005496 currently in use by user (max: 3248682204); 12061/87538 calls to Malloc* resulted in CUDA calls.
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-allocator.cc:163) Time taken in cudaMallocPitch=0.346041, in cudaMalloc=0.0912335, in cudaFree=0.225591, in
this->MallocPitch()=7.39817
LOG (nnet3-chain-train[5.4]:PrintMemoryUsage():cu-device.cc:419) Memory used (according to the device): 4519362560 bytes.
LOG (nnet3-chain-train[5.4]:main():nnet3-chain-train.cc:97) Wrote raw model to exp/chain_cleaned/tdnnx2_5.4_sp/2.3.raw
```