### PR TITLE
[scripts] Fix typo in comment

### DIFF
--- a/egs/wsj/s5/steps/train_lda_mllt.sh
+++ b/egs/wsj/s5/steps/train_lda_mllt.sh
@@ -5,7 +5,7 @@
 # LDA+MLLT refers to the way we transform the features after computing
 # the MFCCs: we splice across several frames, reduce the dimension (to 40
 # by default) using Linear Discriminant Analysis), and then later estimate,
-# over multiple iterations, a diagonalizing transform known as MLLT or CTC.
+# over multiple iterations, a diagonalizing transform known as MLLT or STC.
 # See http://kaldi-asr.org/doc/transform.html for more explanation.
 #
 # Apache 2.0.


### PR DESCRIPTION
According to http://kaldi-asr.org/doc/transform.html#transform_mllt it should be "STC" instead of "CTC".