### PR TITLE
Some changes to allocate_multilingual_examples.py

### DIFF
--- a/egs/babel_multilang/s5/local/nnet3/run_tdnn_multilingual.sh
+++ b/egs/babel_multilang/s5/local/nnet3/run_tdnn_multilingual.sh
@@ -247,7 +247,6 @@ if [ $stage -le 10 ] && [ ! -z $megs_dir ]; then
   common_egs_dir="${multi_egs_dirs[@]} $megs_dir"
   steps/nnet3/multilingual/combine_egs.sh $egs_opts \
     --cmd "$decode_cmd" \
-    --samples-per-iter 400000 \
     $num_langs ${common_egs_dir[@]} || exit 1;
 fi
 

--- a/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
+++ b/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
@@ -73,9 +73,11 @@ def get_args():
 
     parser.add_argument("--samples-per-iter", type=int, default=10000,
                         help="The target number of egs in each archive of egs, "
-                        "(prior to merging egs). ")
+                        "(prior to merging the egs). ")
     parser.add_argument("--num-archives", type=int, default=None,
-                        help="Number of output archives (i.e. output scp files)."
+                        help="Number of archives to split the data into. (Note: in reality they are not "
+                        "archives, only scp files, but we use this notation by analogy with the "
+                        "conventional egs-creating script). "
                         "If not set, it will be determined using --samples-per-iter.")
     parser.add_argument("--block-size", type=int, default=512,
                         help="This relates to locality of disk access. 'block-size' is"
@@ -84,21 +86,20 @@ def get_args():
                         "Smaller values lead to more random disk access (during "
                         "the nnet3 training process).")
     parser.add_argument("--egs-prefix", type=str, default="egs.",
-                        help="option can be used to generated example scp, weight "
-                        "and output files for training and diagnostics."
-                        "If --egs-prefix=combine. , then files produced "
-                        "by the sript will be named with this prefix as "
-                        "combine.output.*.ark, combine.weight.*.ark, combine.*.scp, "
-                        "combine.ranges.*.ark.")
+                        help="This option can be used to add a prefix to the filenames "
+                        "of the output files. For e.g. "
+                        "if --egs-prefix=combine. , then the files produced "
+                        "by this script will be "
+                        "combine.output.*.ark, combine.weight.*.ark, and combine.*.scp")
     parser.add_argument("--lang2weight", type=str,
-                        help="comma-separated list of weights, one per language."
+                        help="Comma-separated list of weights, one per language. "
                         "The language order is as egs_scp_lists.")
 # now the positional arguments
     parser.add_argument("egs_scp_lists", nargs='+',
-                        help="list of egs.scp files per input language."
+                        help="List of egs.scp files per input language."
                            "e.g. exp/lang1/egs/egs.scp exp/lang2/egs/egs.scp")
     parser.add_argument("egs_dir",
-                        help="Name of egs directory e.g. exp/tdnn_multilingual_sp/egs")
+                        help="Name of output egs directory e.g. exp/tdnn_multilingual_sp/egs")
 
 
     print(sys.argv, file=sys.stderr)

--- a/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
+++ b/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-# Copyright 2017 Pegah Ghahremani
+# Copyright      2017 Pegah Ghahremani
+#                2018 Hossein Hadian
 #
 # Apache 2.0.
 
@@ -70,7 +71,7 @@ def get_args():
         'output-2'.""",
         epilog="Called by steps/nnet3/multilingual/combine_egs.sh")
 
-    parser.add_argument("--samples-per-iter", type=int, default=40000,
+    parser.add_argument("--samples-per-iter", type=int, default=10000,
                         help="The target number of egs in each archive of egs, "
                         "(prior to merging egs). ")
     parser.add_argument("--num-archives", type=int, default=None,
@@ -178,12 +179,12 @@ def process_multilingual_egs(args):
     for archive_index in range(num_archives):
         logger.info("Generating archive {}...".format(archive_index))
 
-        out_scp_file_handle = open('{0}/{1}{2}.scp'.format(args.egs_dir, args.egs_prefix,
-                                                           archive_index + 1), 'w')
+        out_scp_file_handle = open('{0}/{1}{2}.scp'.format(args.egs_dir,
+                                                           args.egs_prefix, archive_index + 1), 'w')
         eg_to_output_file_handle = open("{0}/{1}output.{2}.ark".format(args.egs_dir,
                                                                        args.egs_prefix, archive_index + 1), 'w')
-        eg_to_weight_file_handle = open("{0}/{1}weight.{2}.ark".format(
-            args.egs_dir, args.egs_prefix, archive_index + 1), 'w')
+        eg_to_weight_file_handle = open("{0}/{1}weight.{2}.ark".format(args.egs_dir,
+                                                                       args.egs_prefix, archive_index + 1), 'w')
 
         for round_index in range(args.shuffle_factor):
             # Read 'block_size' examples from each lang and write them to the current output scp file:

--- a/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
+++ b/egs/wsj/s5/steps/nnet3/multilingual/allocate_multilingual_examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 Pegah Ghahremani
 #
@@ -14,25 +14,6 @@
     egs.output.*.ark map from the key of the example to the name of
     the output-node in the neural net for that specific language, e.g.
     'output-2'.
-
-    This script additionally produces temporary files -- egs.ranges.*.txt,
-    which are consumed by this script itself.
-    There is one egs.ranges.*.txt file for each of the egs.*.scp files.
-    Each line in egs.ranges.*.txt corresponds to ranges of examples
-    selected from one of the input languages's scp files as:
-    <lang> <local-scp-line> <num-examples>
-
-    That can be interpreted as selecting <num-example> examples starting from
-    <local-scp-line> line from {lang}_th 'egs' file in "egs_scp_list".
-    (note that <local-scp-line> is the zero-based line number.)
-
-    Example lines might look like:
-    0 0 256
-    2 1024 256
-
-    egs.*.scp is generated using egs.ranges.*.txt as following:
-    "<num-examples>" consecutive examples starting from line "<local-scp-line>"
-    from {lang}_th input scp-file is copied to egs.*.scp.
 
     --egs-prefix option can be used to generate train and diagnostics egs files.
     If --egs-prefix=train_diagnostics. is passed, then the files produced by the
@@ -50,16 +31,10 @@
     allocate_multilingual_examples.py [opts] example-scp-lists
         multilingual-egs-dir
 
-    allocate_multilingual_examples.py --minibatch-size 128
+    allocate_multilingual_examples.py --shuffle-factor 2
         --lang2weight  "0.2,0.8" exp/lang1/egs.scp exp/lang2/egs.scp
         exp/multi/egs
 
-    To avoid loading whole scp files from all languages in memory,
-    input egs.scp files are processed line by line using readline() for input
-    languages. To have more randomization across different archives,
-    "num-jobs * num-archives" temporary scp.<job>.<archive_index> files are created
-    in egs/temp dir and all "num_jobs" scp.*.<archive_index> combined into
-    egs.<archive_index>.scp.
 """
 
 from __future__ import print_function
@@ -68,7 +43,7 @@ import logging
 import traceback
 
 sys.path.insert(0, 'steps')
-import libs.common as common_lib
+#import libs.common as common_lib
 
 logger = logging.getLogger('libs')
 logger.setLevel(logging.INFO)
@@ -98,24 +73,15 @@ def get_args():
     parser.add_argument("--samples-per-iter", type=int, default=40000,
                         help="The target number of egs in each archive of egs, "
                         "(prior to merging egs). ")
-    parser.add_argument("--num-jobs", type=int, default=20,
-                        help="This can be used for better randomization in distributing "
-                        "examples for different languages across egs.*.scp files, "
-                        "where egs.<job>.*.scp are generated "
-                        "randomly and combined across all jobs in egs.*.scp files.")
-    parser.add_argument("--random-lang", type=str, action=common_lib.StrToBoolAction,
-                        help="If true, egs.ranges.*.txt are generated "
-                        "randomly w.r.t distribution of remaining examples in "
-                        "each language, otherwise it is generated sequentially.",
-                        default=True, choices = ["false", "true"])
-    parser.add_argument("--max-archives", type=int, default=1000,
-                        help="max number of archives used to generate egs.*.scp")
+    parser.add_argument("--num-archives", type=int, default=None,
+                        help="number of output archives. If not set, it will be "
+                        "determined using --samples-per-iter.")
     parser.add_argument("--seed", type=int, default=1,
                         help="Seed for random number generator")
-    parser.add_argument("--minibatch-size", type=int, default=512,
-                        help="It is the number of consecutive egs that is taken "
-                        "from each input scp source, and it only affects locality "
-                        "of disk access. This does not have to be actual minibatch size.")
+    parser.add_argument("--shuffle-factor", type=int, default=1,
+                        help="shuffle-factor N means for each output scp file, we read exactly "
+                        "N block of examples from each input scp file in a round-robin manner."
+                        "Larger values mean more shuffling and more random disk access.")
     parser.add_argument("--egs-prefix", type=str, default="egs.",
                         help="option can be used to generated example scp, weight "
                         "and output files for training and diagnostics."
@@ -140,45 +106,32 @@ def get_args():
     return args
 
 
-def select_random_lang(lang_len, tot_egs, random_selection):
-    """ Returns a random language index w.r.t
-        amount of examples in each language.
-        It works based on sampling from a
-        discrete distribution, where it returns i
-        with prob(i) = (num_egs in lang(i)/ tot_egs).
-        tot_egs is sum of lang_len.
-    """
-    assert(tot_egs > 0)
-    rand_int = random.randint(0, tot_egs - 1)
-    count = 0
-    for l in range(len(lang_len)):
-        if random_selection:
-            if  rand_int <= (count + lang_len[l]):
-                return l
-            else:
-                count += lang_len[l]
-        else:
-            if (lang_len[l] > 0):
-                return l
-    return -1
+
+
+def read_lines(file_handle, num_lines):
+    n_read = 0
+    lines = []
+    while n_read < num_lines:
+        line = file_handle.readline()
+        if not line:
+            break
+        lines.append(line.strip())
+        n_read += 1
+    return lines
 
 
 def process_multilingual_egs(args):
     args = get_args()
-    random.seed(args.seed)
-    rand_select = args.random_lang
 
-    # read egs.scp for input languages
     scp_lists = args.egs_scp_lists
     num_langs = len(scp_lists)
 
-    scp_files = [open(scp_lists[lang], 'r') for lang in range(num_langs)]
-
-    lang2len = [0] * num_langs
+    lang_to_num_examples = [0] * num_langs
     for lang in range(num_langs):
-        lang2len[lang] = sum(1 for line in open(scp_lists[lang]))
+        with open(scp_lists[lang]) as fh:
+            lang_to_num_examples[lang] = sum([1 for line in fh])
         logger.info("Number of examples for language {0} "
-                    "is {1}.".format(lang, lang2len[lang]))
+                    "is {1}.".format(lang, lang_to_num_examples[lang]))
 
     # If weights are not provided, the weights are 1.0.
     if args.lang2weight is None:
@@ -187,121 +140,68 @@ def process_multilingual_egs(args):
         lang2weight = args.lang2weight.split(",")
         assert(len(lang2weight) == num_langs)
 
-    if not os.path.exists("{0}/temp".format(args.egs_dir)):
-        os.makedirs("{0}/temp".format(args.egs_dir))
-    num_lang_file = open("{0}/info/{1}num_tasks".format(args.egs_dir, args.egs_prefix), "w")
-    print("{0}".format(num_langs), file=num_lang_file)
+    if not os.path.exists(os.path.join(args.egs_dir, 'info')):
+        os.makedirs(os.path.join(args.egs_dir, 'info'))
 
-    # Each element of all_egs (one per num_archive * num_jobs) is
-    # an array of 3-tuples (lang-id, local-start-egs-line, num-egs)
-    all_egs = []
-    lang_len = lang2len[:]
-    # total num of egs in all languages
-    tot_num_egs = sum(lang2len[i] for i in range(len(lang2len)))
-    num_archives = max(1, min(args.max_archives, tot_num_egs / args.samples_per_iter))
+    with open("{0}/info/{1}num_tasks".format(args.egs_dir, args.egs_prefix), "w") as fh:
+        print("{0}".format(num_langs), file=fh)
 
-    num_arch_file = open("{0}/info/{1}num_archives".format(
-                            args.egs_dir,
-                            args.egs_prefix),
-                         "w")
-    print("{0}".format(num_archives), file=num_arch_file)
-    num_arch_file.close()
-    this_num_egs_per_archive = tot_num_egs / (num_archives * args.num_jobs)
+    # Total number of egs in all languages
+    tot_num_egs = sum(lang_to_num_examples[i] for i in range(num_langs))
+    if args.num_archives is not None:
+        num_archives = args.num_archives
+    else:
+        num_archives = tot_num_egs // args.samples_per_iter + 1
 
-    logger.info("Generating {0}scp.<job>.<archive_index> temporary files used to "
-                "generate {0}<archive_index>.scp.".format(args.egs_prefix))
-    for job in range(args.num_jobs):
-        for archive_index in range(num_archives):
-            archfile = open("{0}/temp/{1}scp.{2}.{3}"
-                            "".format(args.egs_dir, args.egs_prefix,
-                                      job + 1, archive_index + 1),
-                            "w")
-            this_egs = [] # this will be array of 2-tuples (lang-id start-frame num-frames)
 
-            num_egs = 0
-            while num_egs <= this_num_egs_per_archive:
-                num_left_egs = sum(num_left_egs_per_lang for
-                                   num_left_egs_per_lang in lang_len)
-                if num_left_egs > 0:
-                    lang_id = select_random_lang(lang_len, num_left_egs, rand_select)
-                    start_egs = lang2len[lang_id] - lang_len[lang_id]
-                    this_egs.append((lang_id, start_egs, args.minibatch_size))
-                    for scpline in range(args.minibatch_size):
-                        scp_key = scp_files[lang_id].readline().splitlines()[0]
-                        print("{0} {1}".format(scp_key, lang_id),
-                              file=archfile)
+    with open("{0}/info/{1}num_archives".format(args.egs_dir, args.egs_prefix), "w") as fh:
+        print("{0}".format(num_archives), file=fh)
 
-                    lang_len[lang_id] = lang_len[lang_id] - args.minibatch_size
-                    num_egs = num_egs + args.minibatch_size
-                    # If num of remaining egs in each lang is less than minibatch_size,
-                    # they are discarded.
-                    if lang_len[lang_id] < args.minibatch_size:
-                        lang_len[lang_id] = 0
-                        logger.info("Done processing data for language {0}".format(
-                            lang_id))
-                else:
-                    logger.info("Done processing data for all languages.")
-                    break
-            all_egs.append(this_egs)
-            archfile.close()
+    egs_per_archive = tot_num_egs // num_archives
+    base_block_size = egs_per_archive // args.shuffle_factor
 
-    logger.info("combining egs.<job>.*.scp across all jobs into egs.*.scp file.")
-    for archive in range(num_archives):
-        logger.info("Combine {0}job.{1}.scp across all jobs into "
-                    "{0}{1}.scp.".format(args.egs_prefix, archive))
-        this_ranges = []
-        f = open("{0}/temp/{1}ranges.{2}.txt".format(
-                    args.egs_dir, args.egs_prefix, archive + 1),
-                 'w')
-        o = open("{0}/{1}output.{2}.ark".format(
-                    args.egs_dir, args.egs_prefix, archive + 1),
-                 'w')
-        w = open("{0}/{1}weight.{2}.ark".format(
-                    args.egs_dir, args.egs_prefix, archive + 1),
-                 'w')
-        scp_per_archive_file = open("{0}/{1}{2}.scp"
-                                    "".format(args.egs_dir,
-                                              args.egs_prefix, archive + 1),
-                                    'w')
+    # The block size for each lang is calculated based on its size
+    lang_to_block_size = [int(lang_to_num_examples[i] / tot_num_egs * base_block_size) for i in range(num_langs)]
 
-        # check files before writing.
-        if f is None:
-            raise Exception("Error opening file {0}".format(f))
-        if o is None:
-            raise Exception("Error opening file {0}".format(o))
-        if w is None:
-            raise Exception("Error opening file {0}".format(w))
-        if scp_per_archive_file is None:
-            raise Exception("Error opening file {0}".format(scp_per_archive_file))
+    logger.info("egs-per-archive for the output scp files is {}".format(egs_per_archive))
 
-        for job in range(args.num_jobs):
-            scp = ("{0}/temp/{1}scp.{2}.{3}".format(args.egs_dir, args.egs_prefix,
-                                                    job + 1, archive + 1))
-            with open(scp, "r") as scpfile:
-                for line in scpfile:
-                    scp_line = line.splitlines()[0].split()
-                    print("{0} {1}".format(scp_line[0], scp_line[1]),
-                          file=scp_per_archive_file)
-                    print("{0} output-{1}".format(scp_line[0], scp_line[2]),
-                          file=o)
-                    print("{0} {1}".format(
-                            scp_line[0],
-                            lang2weight[int(scp_line[2])]),
-                          file=w)
-            os.remove(scp)
+    for lang in range(num_langs):
+        logger.info("egs per block for lang {} is {}".format(lang, lang_to_block_size[lang]))
 
-        for (lang_id, start_eg_line, num_egs) in all_egs[num_archives * job + archive]:
-            this_ranges.append((lang_id, start_eg_line, num_egs))
+    in_scp_file_handles = [open(scp_lists[lang], 'r') for lang in range(num_langs)]
 
-        # write egs.ranges.*.txt
-        for (lang_id, start_eg_line, num_egs) in this_ranges:
-            print("{0} {1} {2}".format(lang_id, start_eg_line, num_egs), file=f)
 
-        f.close()
-        o.close()
-        w.close()
-        scp_per_archive_file.close()
-    logger.info("finished generating {0}*.scp, {0}output.*.ark "
+    # For each output scp file, read the examples in a round-robin fashion
+    # from the inputs scp files. Each time a block is read, where the size of the
+    # block is proportional to the total number of egs in the corresponding lang,
+    # so that there is a bit of each lang in each generated scp file.
+    for archive_index in range(num_archives):
+        logger.info("Generating archive {}...".format(archive_index))
+
+        out_scp_file_handle = open('{0}/{1}{2}.scp'.format(args.egs_dir, args.egs_prefix,
+                                                           archive_index + 1), 'w')
+        eg_to_output_file_handle = open("{0}/{1}output.{2}.ark".format(args.egs_dir,
+                                                                       args.egs_prefix, archive_index + 1), 'w')
+        eg_to_weight_file_handle = open("{0}/{1}weight.{2}.ark".format(
+            args.egs_dir, args.egs_prefix, archive_index + 1), 'w')
+
+        for round_index in range(args.shuffle_factor):
+            # Read 'block_size' examples from each lang and write them to the current output scp file:
+            for lang_index in range(num_langs):
+                example_lines  = read_lines(in_scp_file_handles[lang_index], lang_to_block_size[lang_index])
+
+                for eg_line in example_lines:
+                    eg_id = eg_line.split()[0]
+
+                    print(eg_line, file=out_scp_file_handle)
+                    print("{0} output-{1}".format(eg_id, lang_index), file=eg_to_output_file_handle)
+                    print("{0} {1}".format(eg_id, lang2weight[lang_index]), file=eg_to_weight_file_handle)
+
+        out_scp_file_handle.close()
+        eg_to_output_file_handle.close()
+        eg_to_weight_file_handle.close()
+
+    logger.info("Finished generating {0}*.scp, {0}output.*.ark "
                 "and {0}weight.*.ark files.".format(args.egs_prefix))
 
 

--- a/egs/wsj/s5/steps/nnet3/multilingual/combine_egs.sh
+++ b/egs/wsj/s5/steps/nnet3/multilingual/combine_egs.sh
@@ -14,9 +14,9 @@
 #
 # Begin configuration section.
 cmd=run.pl
-minibatch_size=512      # it is the number of consecutive egs that we take from 
-                        # each source, and it only affects the locality of disk 
-                        # access. This does not have to be the actual minibatch size;
+block_size=512          # This is the number of consecutive egs that we take from
+                        # each source, and it only affects the locality of disk
+                        # access.
 num_jobs=10             # helps for better randomness across languages
                         # per archive.
 samples_per_iter=400000 # this is the target number of egs in each archive of egs
@@ -98,7 +98,7 @@ if [ $stage -le 0 ]; then
   # Generate egs.*.scp for multilingual setup.
   $cmd $megs_dir/log/allocate_multilingual_examples_train.log \
   steps/nnet3/multilingual/allocate_multilingual_examples.py $egs_opt \
-      --minibatch-size $minibatch_size \
+      --block-size $block_size \
       --samples-per-iter $samples_per_iter \
       $train_scp_list $megs_dir || exit 1;
 fi
@@ -108,9 +108,8 @@ if [ $stage -le 1 ]; then
   # Generate combine.scp for multilingual setup.
   $cmd $megs_dir/log/allocate_multilingual_examples_combine.log \
   steps/nnet3/multilingual/allocate_multilingual_examples.py \
-      --random-lang false \
-      --max-archives 1 --num-jobs 1 \
-      --minibatch-size $minibatch_size \
+      --num-archives 1 \
+      --block-size $block_size \
       --egs-prefix "combine." \
       $combine_scp_list $megs_dir || exit 1;
 
@@ -118,9 +117,8 @@ if [ $stage -le 1 ]; then
   # Generate train_diagnostic.scp for multilingual setup.
   $cmd $megs_dir/log/allocate_multilingual_examples_train_diagnostic.log \
   steps/nnet3/multilingual/allocate_multilingual_examples.py \
-      --random-lang false \
-      --max-archives 1 --num-jobs 1 \
-      --minibatch-size $minibatch_size \
+      --num-archives 1 \
+      --block-size $block_size \
       --egs-prefix "train_diagnostic." \
       $train_diagnostic_scp_list $megs_dir || exit 1;
 
@@ -129,8 +127,8 @@ if [ $stage -le 1 ]; then
   # Generate valid_diagnostic.scp for multilingual setup.
   $cmd $megs_dir/log/allocate_multilingual_examples_valid_diagnostic.log \
   steps/nnet3/multilingual/allocate_multilingual_examples.py \
-      --random-lang false --max-archives 1 --num-jobs 1\
-      --minibatch-size $minibatch_size \
+      --num-archives 1 \
+      --block-size $block_size \
       --egs-prefix "valid_diagnostic." \
       $valid_diagnostic_scp_list $megs_dir || exit 1;
 


### PR DESCRIPTION
I've not done extensive testing. If someone has a multilingual setup ready, I could use their setup to run a test.
Please let me know if this needs more documentation.
The main changes are:

- No temporary files are created
- The shuffling approach is round robin. So for each output archive (i.e. output scp file), we read **block**s of examples from each input lang (in the same order as they appear on the command line) in a round-robin fashion and write them to the output archive (we do as many rounds as needed until the archive reaches the desired size). 
- The block size for each lang is proportional to the number of egs in that lang (with the average block size being equal to the `--block-size` option) so that each output scp file will have a constant proportion of examples from each input lang. I guess this is not the case in original @pegahgh 's version so I'm not sure if this provides as much randomness as the original script did.
