### PR TITLE
xvector extractor cache config

### DIFF
--- a/src/nnet3bin/nnet3-xvector-compute.cc
+++ b/src/nnet3bin/nnet3-xvector-compute.cc
@@ -91,6 +91,8 @@ int main(int argc, char *argv[]) {
     Timer timer;
 
     NnetSimpleComputationOptions opts;
+    CachingOptimizingCompilerOptions compiler_config;
+
     opts.acoustic_scale = 1.0; // by default do no scaling in this recipe.
 
     std::string use_gpu = "no";
@@ -98,6 +100,8 @@ int main(int argc, char *argv[]) {
       min_chunk_size = 100;
 
     opts.Register(&po);
+    compiler_config.Register(&po);
+
     po.Register("use-gpu", &use_gpu,
       "yes|no|optional|wait, only has effect if compiled with CUDA");
     po.Register("chunk-size", &chunk_size,
@@ -127,7 +131,7 @@ int main(int argc, char *argv[]) {
     SetDropoutTestMode(true, &nnet);
     CollapseModel(CollapseModelConfig(), &nnet);
 
-    CachingOptimizingCompiler compiler(nnet, opts.optimize_config);
+    CachingOptimizingCompiler compiler(nnet, opts.optimize_config, compiler_config);
 
     BaseFloatVectorWriter vector_writer(vector_wspecifier);
 


### PR DESCRIPTION
Following the discussion in
https://groups.google.com/forum/#!topic/kaldi-help/ROtSHHe3Z_I

Using larger cache speeds up extraction if equal length segments have already been processed