### PR TITLE
fixing LM issue in CHiME5

### DIFF
--- a/egs/chime5/s5/local/train_lms_srilm.sh
+++ b/egs/chime5/s5/local/train_lms_srilm.sh
@@ -99,7 +99,7 @@ fi
 # Kaldi transcript files contain Utterance_ID as the first word; remove it
 # We also have to avoid skewing the LM by incorporating  the same sentences
 # from different channels
-sed -e "s/\.CH.//" -e "s/_.\-./_/" $train_text | sort -u | \
+sed -e "s/\.CH.//" -e "s/_.\-./_/" -e "s/NOLOCATION\(\.[LR]\)*-//" -e "s/U[0-9][0-9]_//" $train_text | sort -u | \
   perl -ane 'print join(" ", @F[1..$#F]) . "\n" if @F > 1' > $tgtdir/train.txt
 if (($?)); then
     echo "Failed to create $tgtdir/train.txt from $train_text"


### PR DESCRIPTION
due working with several channels having the same transcription (several microphone recording the same conversation), the training data look very artificial from the POV of LM methods, so we have to remove the duplicate transcriptions. This script that does this wasn't modified after changing the format of the utterance ids. 