### PR TITLE
use openfst 1.6.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ GSYMS
 /tools/openfst-1.6.2/
 /tools/openfst-1.6.5.tar.gz
 /tools/openfst-1.6.5/
+/tools/openfst-1.6.7.tar.gz
+/tools/openfst-1.6.7/
 /tools/BeamformIt/
 /tools/libsndfile-1.0.25.tar.gz
 /tools/libsndfile-1.0.25/

--- a/src/bin/draw-tree.cc
+++ b/src/bin/draw-tree.cc
@@ -39,7 +39,7 @@ void MakeEvent(std::string &qry, fst::SymbolTable *phone_syms,
     }
     else {
       value = static_cast<EventValueType>(phone_syms->Find(valstr.c_str()));
-      if (value == fst::SymbolTable::kNoSymbol) {
+      if (value == -1) { // fst::kNoSymbol
         KALDI_ERR << "Bad query: invalid symbol ("
                   << valstr << ')' << std::endl << std::endl;
       }
@@ -49,7 +49,7 @@ void MakeEvent(std::string &qry, fst::SymbolTable *phone_syms,
   }
   std::string valstr = qry.substr(old_found);
   EventValueType value = static_cast<EventValueType>(phone_syms->Find(valstr.c_str()));
-  if (value == fst::SymbolTable::kNoSymbol) {
+  if (value == -1) { // fst::kNoSymbol
     KALDI_ERR << "Bad query: invalid symbol ("
               << valstr << ')' << std::endl << std::endl;
   }
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         "Outputs a decision tree description in GraphViz format\n"
         "Usage: draw-tree [options] <phone-symbols> <tree>\n"
         "e.g.: draw-tree phones.txt tree | dot -Gsize=8,10.5 -Tps | ps2pdf - tree.pdf\n";
-    
+
     ParseOptions po(usage);
     po.Register("query", &qry,
                 "a query to trace through the tree"

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -621,9 +621,9 @@ class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<FloatType>, IntType> 
   }
 };
 template<>
-class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<float>, int> > {
+class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<float>, int32> > {
  public:
-  typedef CompactLatticeWeightTpl<LatticeWeightTpl<float>, int> Weight;
+  typedef CompactLatticeWeightTpl<LatticeWeightTpl<float>, int32> Weight;
 
   NaturalLess() {}
 
@@ -635,9 +635,9 @@ class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<float>, int> > {
   }
 };
 template<>
-class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<double>, int> > {
+class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<double>, int32> > {
  public:
-  typedef CompactLatticeWeightTpl<LatticeWeightTpl<double>, int> Weight;
+  typedef CompactLatticeWeightTpl<LatticeWeightTpl<double>, int32> Weight;
 
   NaturalLess() {}
 

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -330,6 +330,34 @@ class NaturalLess<LatticeWeightTpl<FloatType> > {
     return (Compare(w1, w2) == 1);
   }
 };
+template<>
+class NaturalLess<LatticeWeightTpl<float> > {
+ public:
+  typedef LatticeWeightTpl<float> Weight;
+
+  NaturalLess() {}
+
+  bool operator()(const Weight &w1, const Weight &w2) const {
+    // NaturalLess is a negative order (opposite to normal ordering).
+    // This operator () corresponds to "<" in the negative order, which
+    // corresponds to the ">" in the normal order.
+    return (Compare(w1, w2) == 1);
+  }
+};
+template<>
+class NaturalLess<LatticeWeightTpl<double> > {
+ public:
+  typedef LatticeWeightTpl<double> Weight;
+
+  NaturalLess() {}
+
+  bool operator()(const Weight &w1, const Weight &w2) const {
+    // NaturalLess is a negative order (opposite to normal ordering).
+    // This operator () corresponds to "<" in the negative order, which
+    // corresponds to the ">" in the normal order.
+    return (Compare(w1, w2) == 1);
+  }
+};
 
 template<class FloatType>
 inline LatticeWeightTpl<FloatType> Times(const LatticeWeightTpl<FloatType> &w1,
@@ -582,6 +610,34 @@ template<class FloatType, class IntType>
 class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<FloatType>, IntType> > {
  public:
   typedef CompactLatticeWeightTpl<LatticeWeightTpl<FloatType>, IntType> Weight;
+
+  NaturalLess() {}
+
+  bool operator()(const Weight &w1, const Weight &w2) const {
+    // NaturalLess is a negative order (opposite to normal ordering).
+    // This operator () corresponds to "<" in the negative order, which
+    // corresponds to the ">" in the normal order.
+    return (Compare(w1, w2) == 1);
+  }
+};
+template<>
+class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<float>, int> > {
+ public:
+  typedef CompactLatticeWeightTpl<LatticeWeightTpl<float>, int> Weight;
+
+  NaturalLess() {}
+
+  bool operator()(const Weight &w1, const Weight &w2) const {
+    // NaturalLess is a negative order (opposite to normal ordering).
+    // This operator () corresponds to "<" in the negative order, which
+    // corresponds to the ">" in the normal order.
+    return (Compare(w1, w2) == 1);
+  }
+};
+template<>
+class NaturalLess<CompactLatticeWeightTpl<LatticeWeightTpl<double>, int> > {
+ public:
+  typedef CompactLatticeWeightTpl<LatticeWeightTpl<double>, int> Weight;
 
   NaturalLess() {}
 

--- a/src/latbin/lattice-oracle.cc
+++ b/src/latbin/lattice-oracle.cc
@@ -45,7 +45,7 @@ void ReadSymbolList(const std::string &rxfilename,
                 << ", file is: " << PrintableRxfilename(rxfilename);
     }
     fst::StdArc::Label lab = word_syms->Find(sym.c_str());
-    if (lab == fst::SymbolTable::kNoSymbol) {
+    if (lab == -1) { // fst::kNoSymbol
       KALDI_ERR << "Can't find symbol in symbol table: "
                 << line << ", file is: "
                 << PrintableRxfilename(rxfilename);

--- a/src/lm/arpa-file-parser.cc
+++ b/src/lm/arpa-file-parser.cc
@@ -209,7 +209,7 @@ void ArpaFileParser::Read(std::istream &is) {
             word = symbols_->AddSymbol(col[1 + index]);
           } else {
             word = symbols_->Find(col[1 + index]);
-            if (word == fst::SymbolTable::kNoSymbol) {
+            if (word == -1) { // fst::kNoSymbol
               switch (options_.oov_handling) {
                 case ArpaParseOptions::kReplaceWithUnk:
                   word = options_.unk_symbol;

--- a/src/lmbin/arpa2fst.cc
+++ b/src/lmbin/arpa2fst.cc
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
       options.oov_handling = ArpaParseOptions::kSkipNGram;
       if (!disambig_symbol.empty()) {
         disambig_symbol_id = symbols->Find(disambig_symbol);
-        if (disambig_symbol_id == fst::SymbolTable::kNoSymbol)
+        if (disambig_symbol_id == -1) // fst::kNoSymbol
           KALDI_ERR << "Symbol table " << read_syms_filename
                     << " has no symbol for " << disambig_symbol;
       }

--- a/src/rnnlm/rnnlm-test-utils.cc
+++ b/src/rnnlm/rnnlm-test-utils.cc
@@ -79,7 +79,7 @@ void ConvertToInteger(
     (*int_sentences)[i].resize(string_sentences[i].size());
     for (int j = 0; j < string_sentences[i].size(); j++) {
       kaldi::int64 key = symbol_table.Find(string_sentences[i][j]);
-      KALDI_ASSERT(key != fst::SymbolTable::kNoSymbol);
+      KALDI_ASSERT(key != -1); // fst::kNoSymbol
       (*int_sentences)[i][j] = static_cast<int32>(key);
     }
   }

--- a/src/rnnlm/sampling-lm-test.cc
+++ b/src/rnnlm/sampling-lm-test.cc
@@ -64,7 +64,7 @@ void SamplingLmTest::ReadHistories(std::istream &is, bool binary,
     BaseFloat hist_weight = 0;
     for (int32 i = 0; i < tokens.size() - 1; ++i) {
       word = sym->Find(tokens[i]);
-      if (word == fst::SymbolTable::kNoSymbol) {
+      if (word == -1) { // fst::kNoSymbol
         KALDI_ERR << "Found history contains word that is not in Arpa LM";
       }
       history.push_back(word);

--- a/src/tfrnnlm/tensorflow-rnnlm.cc
+++ b/src/tfrnnlm/tensorflow-rnnlm.cc
@@ -49,7 +49,7 @@ void SetUnkPenalties(const string &filename,
   float count, total_count = 0;
   while (ifile >> word >> count) {
     int id = fst_word_symbols.Find(word);
-    KALDI_ASSERT(id != fst::SymbolTable::kNoSymbol);
+    KALDI_ASSERT(id != -1); // fst::kNoSymbol
     (*out)[id] = count;
     total_count += count;
   }
@@ -145,7 +145,7 @@ KaldiTfRnnlmWrapper::KaldiTfRnnlmWrapper(
       rnn_label_to_word_.push_back(word);  // vector[i] = word
 
       int fst_label = fst_word_symbols->Find(word);
-      if (fst::SymbolTable::kNoSymbol == fst_label) {
+      if (fst_label == -1) { // fst::kNoSymbol
         if (id == eos_)
           continue;
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,7 +7,7 @@ CC = gcc         # used for sph2pipe
 
 # Note: OpenFst requires a relatively recent C++ compiler with C++11 support,
 # e.g. g++ >= 4.7, Apple clang >= 5.0 or LLVM clang >= 3.3.
-OPENFST_VERSION ?= 1.6.5
+OPENFST_VERSION ?= 1.6.7
 
 # Default features configured for OpenFST; can be overridden in the make command line.
 OPENFST_CONFIGURE ?= --enable-static --enable-shared --enable-far --enable-ngram-fsts
@@ -84,7 +84,7 @@ openfst-$(OPENFST_VERSION): openfst-$(OPENFST_VERSION).tar.gz
 	tar xozf openfst-$(OPENFST_VERSION).tar.gz
 
 openfst-$(OPENFST_VERSION).tar.gz:
-	wget -T 10 -t 1 http://openfst.cs.nyu.edu/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
+	wget -T 10 -t 1 http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
 	wget -T 10 -t 3 http://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz
 
 sclite: sclite_compiled


### PR DESCRIPTION
@danpovey for your consideration
I wasn't able to come up with another solution than explicit full specialization of the templates. 
I left the original template there so that the error will be triggered again if someone uses other types than int and double/float