### PR TITLE
Properly count num jobs even for non-initial stage

### DIFF
--- a/scripts/rnnlm/train_rnnlm.sh
+++ b/scripts/rnnlm/train_rnnlm.sh
@@ -220,12 +220,12 @@ while [ $x -lt $num_iters ]; do
       fi
     )
 
-    num_splits_processed=$[num_splits_processed+this_num_jobs]
     # the error message below is not that informative, but $cmd will
     # have printed a more specific one.
     [ -f $dir/.error ] && echo "$0: error with diagnostics on iteration $x of training" && exit 1;
   fi
   x=$[x+1]
+  num_splits_processed=$[num_splits_processed+this_num_jobs]
 done
 
 wait # wait for diagnostic jobs in the background.


### PR DESCRIPTION
Since learning rate depends on num_jobs_processed

```
  ilr=$initial_effective_lrate; flr=$final_effective_lrate; np=$num_splits_processed; nt=$num_splits_to_process;
  this_learning_rate=$(perl -e "print (($x + 1 >= $num_iters ? $flr : $ilr*exp($np*log($flr/$ilr)/$nt))*$this_num_jobs);");
```

it is important to properly increase num_splits_processed even if some stages are skipped due to --stage parameter.