### PR TITLE
[scripts] Fix to get_saturation.pl, to regex bug introduced around Jan 1 2018.

### DIFF
--- a/egs/wsj/s5/steps/nnet3/get_saturation.pl
+++ b/egs/wsj/s5/steps/nnet3/get_saturation.pl
@@ -35,7 +35,7 @@ while (<STDIN>) {
     # deriv-avg=[percentiles(0,1,2,5 10,20,50,80,90
     # 95,98,99,100)=(0.0001,0.003,0.004,0.03 0.12,0.18,0.22,0.24,0.25
     # 0.25,0.25,0.25,0.25), mean=0.198, stddev=0.0591]
-    if (m/deriv-avg=.+mean=([^,]+),/) {
+    if (m/deriv-avg=[^m]+mean=([^,]+),/) {
       $num_nonlinearities += 1;
       my $this_saturation = 1.0 - ($1 / 0.25);
       $total_saturation += $this_saturation;
@@ -43,7 +43,7 @@ while (<STDIN>) {
       print STDERR "$0: could not make sense of line (no deriv-avg?): $_";
     }
   } elsif (m/type=TanhComponent/) {
-    if (m/deriv-avg=.+mean=([^,]+),/) {
+    if (m/deriv-avg=[^m]+mean=([^,]+),/) {
       $num_nonlinearities += 1;
       my $this_saturation = 1.0 - ($1 / 1.0);
       $total_saturation += $this_saturation;


### PR DESCRIPTION
Affects shrinkage of nnets.
(The bug is: due to change in progress-log output, the regex was matching the wrong thing, leading to spuriously high 'saturation' value being reported, which would have caused 'shrinkage' code to be activated when it should not, during training of non-fast nnet3 LSTMs and similar nnets.  But this shouldn't affect many, or maybe any, checked-in recipes, since we normally use the 'fast' LSTM).

If you have this bug, which is only normally relevant when training recurrent networks (but not those involving fast-lstm or fast-lstmp), it would show up by: on every iteration it would say something like "shrinkage coefficient: 0.99", and the resulting networks would underfit.

thanks: @GaofengCheng.