### PR TITLE
[src] Fix bug in matrix compression RE stride type.  Thx:@LvHang

### DIFF
--- a/egs/iam/v1/local/check_tools.sh
+++ b/egs/iam/v1/local/check_tools.sh
@@ -18,7 +18,7 @@
 [ -f ./path.sh ] && . ./path.sh
 set +e
 
-command -v python3 2>/dev/null \
+command -v python3 >&/dev/null \
   || { echo  >&2 "python3 not found on PATH. You will have to install Python3, preferably >= 3.6"; exit 1; }
 
 python3 -c "import numpy"
@@ -41,5 +41,3 @@ fi
 
 
 exit  0
-
-

--- a/src/nnet3/nnet-compute.cc
+++ b/src/nnet3/nnet-compute.cc
@@ -411,7 +411,8 @@ void NnetComputer::ExecuteCommand() {
                        matrices_[m].NumRows() == 0);
           matrices_[m].Resize(compressed_matrix->NumRows(),
                               compressed_matrix->NumCols(),
-                              kUndefined);
+                              kUndefined,
+                              computation_.matrices[m].stride_type);
           compressed_matrix->CopyToMat(&(matrices_[m]));
           delete compressed_matrix;
           compressed_matrices_[m] = NULL;


### PR DESCRIPTION
This fixes a crash that can occur if you use the memory-compression-level option with certain network topologies.