### PR TITLE
Use generic fst::Fst<Arc> superclass when fst.Type() is not const or vector

### DIFF
--- a/src/decoder/lattice-faster-decoder.cc
+++ b/src/decoder/lattice-faster-decoder.cc
@@ -870,7 +870,7 @@ void LatticeFasterDecoder::ProcessNonemittingWrapper(BaseFloat cost_cutoff) {
   } else if (fst_.Type() == "vector") {
     return LatticeFasterDecoder::ProcessNonemitting<fst::VectorFst<Arc>>(cost_cutoff);
   } else {
-    return LatticeFasterDecoder::ProcessNonemitting<fst::ConstFst<Arc>>(cost_cutoff);
+    return LatticeFasterDecoder::ProcessNonemitting<fst::Fst<Arc>>(cost_cutoff);
   }
 }
 

--- a/src/decoder/lattice-faster-online-decoder.cc
+++ b/src/decoder/lattice-faster-online-decoder.cc
@@ -1054,7 +1054,7 @@ void LatticeFasterOnlineDecoder::ProcessNonemittingWrapper(
         ProcessNonemitting<fst::VectorFst<Arc>>(cost_cutoff);
   } else {
     return LatticeFasterOnlineDecoder::
-        ProcessNonemitting<fst::ConstFst<Arc>>(cost_cutoff);
+        ProcessNonemitting<fst::Fst<Arc>>(cost_cutoff);
   }
 }
 


### PR DESCRIPTION
There was a typo made when the lattice decoders were being updated to support const FSTs.  When the fst.Type() is not "vector" or "const" the code is defaulting to fst::ConstFst.  This is incorrect.  It should default to fst::Fst.  I made minimal changes to fix this mistake.