### PR TITLE
let wsj finish

### DIFF
--- a/egs/wsj/s5/run.sh
+++ b/egs/wsj/s5/run.sh
@@ -148,8 +148,6 @@ if [ $stage -le 2 ]; then
   fi
 fi
 
-exit 0 ## TEMP
-
 if [ $stage -le 3 ]; then
   # tri2b.  there is no special meaning in the "b"-- it's historical.
   if $train; then


### PR DESCRIPTION
`egs/wsj/s5/run.sh` exits prematurely.