### PR TITLE
[WIP] Speed up VectorBase<Real>::Sum() by about 3.4x when Real=double

### DIFF
--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -345,7 +345,7 @@ template<typename Real> void CuVectorUnitTestSum() {
     A.SetRandn();
     ones.Set(1.0);
 
-    AssertEqual(VecVec(A, ones), A.Sum());
+    AssertEqual(VecVec(A, ones), A.Sum(), 0.0012);
   }
 }
 

--- a/src/cudamatrix/cu-vector-test.cc
+++ b/src/cudamatrix/cu-vector-test.cc
@@ -345,7 +345,16 @@ template<typename Real> void CuVectorUnitTestSum() {
     A.SetRandn();
     ones.Set(1.0);
 
-    AssertEqual(VecVec(A, ones), A.Sum(), 0.0012);
+    Real x = VecVec(A, ones);
+    Real y = A.Sum();
+    Real diff = std::abs(x - y);
+    // Note: CuVectorBase<> does not have an ApplyAbs() member
+    // function, so we copy back to a host vector for simplicity in
+    // this test case.
+    Vector<Real> A_host(A);
+    A_host.ApplyAbs();
+    Real s = A_host.Sum();
+    KALDI_ASSERT ( diff <= 1.0e-04 * s);
   }
 }
 

--- a/src/matrix/kaldi-vector.cc
+++ b/src/matrix/kaldi-vector.cc
@@ -691,9 +691,11 @@ void VectorBase<Real>::CopyDiagFromPacked(const PackedMatrix<Real> &M) {
 
 template<typename Real>
 Real VectorBase<Real>::Sum() const {
-  double sum = 0.0;
-  for (MatrixIndexT i = 0; i < dim_; i++) { sum += data_[i]; }
-  return sum;
+  // Do a dot-product with a size-1 array with a stride of 0 to
+  // implement sum. This allows us to access SIMD operations in a
+  // cross-platform way via your BLAS library.
+  Real one(1);
+  return cblas_Xdot(dim_, data_, 1, &one, 0);
 }
 
 template<typename Real>


### PR DESCRIPTION
Using ATLAS. Similar speed up should apply for Real=float as well.

Using a cblas routine gives portable access to SIMD instructions
unique to each processor.

Motivation was that I saw that 5% of one of my real world programs was spent doing Sum(). I noticed that there were two optimizations: (1) Don't use double to accumulate (since you will return a float, when Real=float), and (2) Use SIMD instructions to speed up the summation.

WIP because this surprisingly breaks a test in cu-vector-test.cc. See backtrace below:

```
galv@training-Silverback-WS:~/development/kaldi-public/src/cudamatrix$ gdb ./cu-vector-test 
GNU gdb (Ubuntu 7.11.1-0ubuntu1~16.5) 7.11.1
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./cu-vector-test...done.
(gdb) run
Starting program: /home/galv/development/kaldi-public/src/cudamatrix/cu-vector-test 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
/home/galv/development/kaldi-public/src/cudamatrix/cu-vector-test 
LOG (cu-vector-test[5.4.116~2-5bac9]:SelectGpuId():cu-device.cc:123) Manually selected to compute on CPU.
ASSERTION_FAILED (cu-vector-test[5.4.116~2-5bac9]:AssertEqual():base/kaldi-math.h:276) : 'ApproxEqual(a, b, relative_tolerance)' 

[ Stack-Trace: ]
/home/galv/development/kaldi-public/src/cudamatrix/cu-vector-test() [0x6422b2]
kaldi::MessageLogger::HandleMessage(kaldi::LogMessageEnvelope const&, char const*)
kaldi::MessageLogger::~MessageLogger()
kaldi::KaldiAssertFailure_(char const*, char const*, int, char const*)
/home/galv/development/kaldi-public/src/cudamatrix/cu-vector-test() [0x4de3d1]
void kaldi::CuVectorUnitTestSum<float>()
void kaldi::CuVectorUnitTest<float>()
main
__libc_start_main
_start


Program received signal SIGABRT, Aborted.
0x00007fffeb91c428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
54      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007fffeb91c428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007fffeb91e02a in __GI_abort () at abort.c:89
#2  0x0000000000642c3e in kaldi::MessageLogger::HandleMessage (envelope=..., message=0x10c6820 ": 'ApproxEqual(a, b, relative_tolerance)' ") at kaldi-error.cc:209
#3  0x0000000000642899 in kaldi::MessageLogger::~MessageLogger (this=0x7fffffffd220, __in_chrg=<optimized out>) at kaldi-error.cc:157
#4  0x0000000000642dab in kaldi::KaldiAssertFailure_ (func=0x644da8 <kaldi::AssertEqual(float, float, float)::__func__> "AssertEqual", file=0x6445fe "../base/kaldi-math.h", line=276, 
    cond_str=0x6445d8 "ApproxEqual(a, b, relative_tolerance)") at kaldi-error.cc:232
#5  0x00000000004de3d1 in kaldi::AssertEqual (a=6.731462, b=6.74610186, relative_tolerance=0.00100000005) at ../base/kaldi-math.h:276
#6  0x00000000004e416e in kaldi::CuVectorUnitTestSum<float> () at cu-vector-test.cc:348
#7  0x00000000004e2a00 in kaldi::CuVectorUnitTest<float> () at cu-vector-test.cc:784
#8  0x00000000004de648 in main (argc=1, argv=0x7fffffffdcf8) at cu-vector-test.cc:847
```

This could be fixed by increasing the tolerance. Surprisingly, this is due to removing the use of a double type as the accumulator in the CPU Sum() function, meaning that a float does not have enough precision for this test case's accumulation. We may want to reject this pull request for this reason. However, note that the corresponding CUDA Sum() implementation never uses double to accumulate into, so this must be a subtle case having to do with the unassociativity of floating point addition. Let me know if you have questions about this.