### PR TITLE
Ignore first iteration while looking for the best model

### DIFF
--- a/scripts/rnnlm/get_best_model.py
+++ b/scripts/rnnlm/get_best_model.py
@@ -38,7 +38,7 @@ if num_iters is None:
 
 best_objf=-2000
 best_iter=-1
-for i in range(num_iters):
+for i in range(1, num_iters):
     this_logfile = "{0}/log/compute_prob.{1}.log".format(args.rnnlm_dir, i)
     try:
         f = open(this_logfile, 'r', encoding='utf-8')

--- a/scripts/rnnlm/train_rnnlm.sh
+++ b/scripts/rnnlm/train_rnnlm.sh
@@ -247,11 +247,11 @@ fi
 # Now get some diagnostics about the evolution of the objective function.
 if [ $stage -le $[num_iters+1] ]; then
   (
-    logs=$(for iter in $(seq 0 $[$num_iters-1]); do echo -n $dir/log/train.$iter.1.log ''; done)
+    logs=$(for iter in $(seq 1 $[$num_iters-1]); do echo -n $dir/log/train.$iter.1.log ''; done)
     # in the non-sampling case the exact objf is printed and we plot that
     # in the sampling case we print the approximated objf for training.
     grep 'Overall objf' $logs | awk 'BEGIN{printf("Train objf: ")} /exact/{printf("%.2f ", $NF);next} {printf("%.2f ", $10)} END{print "";}'
-    logs=$(for iter in $(seq 0 $[$num_iters-1]); do echo -n $dir/log/compute_prob.$iter.log ''; done)
+    logs=$(for iter in $(seq 1 $[$num_iters-1]); do echo -n $dir/log/compute_prob.$iter.log ''; done)
     grep 'Overall objf' $logs | awk 'BEGIN{printf("Dev objf:   ")} {printf("%.2f ", $NF)} END{print "";}'
   ) > $dir/report.txt
   cat $dir/report.txt


### PR DESCRIPTION
During rnnlm training the log for the first iteration looks like this:

`LOG (rnnlm-compute-prob[5.4.83-c2d79]:PrintStatsOverall():rnnlm-core-training.cc:118) Overall objf is (0 + -2.44e+05) = -2.44e+05 over 1.33e+04 words (weighted) in 4 minibatches; exact = (0 + 0) = 0`

as a result, get_best_model.py script selects the first iteration as the best one, since logprob is 0.

The proposed patch starts selection of the best model from the first iteration where objf is reliable.