### PR TITLE
Fix small typo with path script

### DIFF
--- a/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
+++ b/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
@@ -16,7 +16,7 @@ segmentation_opts=  # E.g. set this as --segmentation-opts "--silance-proportion
 
 echo "$0 $@"  # Print the command line for logging
 
-[ -f .path.sh ] && . ./path.sh
+if [ -f path.sh ]; then . ./path.sh; fi
 . parse_options.sh || exit 1;
 
 if [ $# -ne 2 ]; then


### PR DESCRIPTION
It is checking .path.sh with the dot instead of conventional path.sh