### PR TITLE
[egs] Fix python syntax error by moving __future__ import to top

### DIFF
--- a/egs/hkust/s5/local/hkust_segment.py
+++ b/egs/hkust/s5/local/hkust_segment.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 #coding:utf-8
 
-import sys
 from __future__ import print_function
+import sys
 from mmseg import seg_txt
 for line in sys.stdin:
   blks = str.split(line)


### PR DESCRIPTION
Fixes ```SyntaxError: from __future__ imports must occur at the beginning of the file```.