### PR TITLE
Force vector call operator to be inlined.

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -60,6 +60,15 @@
 #  define KALDI_MEMALIGN_FREE(x) free(x)
 #endif
 
+#ifdef _MSC_VER
+#  define KALDI_FORCE_INLINE __forceinline
+#elif defined(__GNUC__)
+#  define KALDI_FORCE_INLINE __attribute__((always_inline)) inline
+#else
+#  define KALDI_FORCE_INLINE inline
+#endif
+
+
 #ifdef __ICC
 #pragma warning(disable: 383)  // ICPC remark we don't want.
 #pragma warning(disable: 810)  // ICPC remark we don't want.

--- a/src/matrix/kaldi-vector.h
+++ b/src/matrix/kaldi-vector.h
@@ -72,14 +72,14 @@ class VectorBase {
   inline const Real* Data() const { return data_; }
 
   /// Indexing  operator (const).
-  inline Real operator() (MatrixIndexT i) const {
+  KALDI_FORCE_INLINE Real operator() (MatrixIndexT i) const {
     KALDI_PARANOID_ASSERT(static_cast<UnsignedMatrixIndexT>(i) <
                  static_cast<UnsignedMatrixIndexT>(dim_));
     return *(data_ + i);
   }
 
   /// Indexing operator (non-const).
-  inline Real & operator() (MatrixIndexT i) {
+  KALDI_FORCE_INLINE Real & operator() (MatrixIndexT i) {
     KALDI_PARANOID_ASSERT(static_cast<UnsignedMatrixIndexT>(i) <
                  static_cast<UnsignedMatrixIndexT>(dim_));
     return *(data_ + i);

--- a/src/matrix/matrix-lib-speed-test.cc
+++ b/src/matrix/matrix-lib-speed-test.cc
@@ -254,6 +254,25 @@ static void UnitTestAddVecToColsSpeed() {
   CsvResult<Real>(__func__, sizes.size(), t.Elapsed(), "seconds");
 }
 
+template<typename Real>
+static void UnitTestVectorCallOperator() {
+  std::vector<MatrixIndexT> sizes;
+  for(int32 size = 1024, i = 0; i < 4; i++) {
+    sizes.push_back(size);
+    size *= 2;
+  }
+  for(MatrixIndexT size : sizes) {
+    Vector<Real> a(size);
+    Vector<Real> b(size);
+    b.SetZero();
+    Timer t;
+    for(size_t i = 0; i < size; i++) {
+      a(i) = b(i);
+    }
+    CsvResult<Real>("VectorBase::operator()", size, t.Elapsed(), "seconds");
+  }
+}
+
 template<typename Real> static void MatrixUnitSpeedTest() {
   UnitTestRealFftSpeed<Real>();
   UnitTestSplitRadixRealFftSpeed<Real>();
@@ -263,6 +282,7 @@ template<typename Real> static void MatrixUnitSpeedTest() {
   UnitTestAddColSumMatSpeed<Real>();
   UnitTestAddVecToRowsSpeed<Real>();
   UnitTestAddVecToColsSpeed<Real>();
+  UnitTestVectorCallOperator<Real>();
 }
 
 } // namespace kaldi


### PR DESCRIPTION
I noticed in a real world program that about 5% of time is spent
in this method, so this seems like a reasonable thing to force,
given the small nature of this function.

Note that I am not sure whether this will force icc to inline the
member functions. I doubt it.

See discussion at #2406