### PR TITLE
updated dockerfile for Ubuntu and cuda

### DIFF
--- a/misc/docker/ubuntu-cuda/Dockerfile
+++ b/misc/docker/ubuntu-cuda/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:9.1-devel-ubuntu16.04
+
+MAINTAINER sih4sing5hong5
+
+ENV CPU_CORE 4
+
+RUN \
+  apt-get update -qq && \
+  apt-get install -y \
+    git bzip2 wget \
+    g++ make python python3 \
+    zlib1g-dev automake autoconf libtool subversion \
+    libatlas-base-dev
+
+
+WORKDIR /usr/local/
+# Use the newest kaldi version
+RUN git clone https://github.com/kaldi-asr/kaldi.git
+
+
+WORKDIR /usr/local/kaldi/tools
+RUN extras/check_dependencies.sh
+RUN make -j $CPU_CORE
+
+WORKDIR /usr/local/kaldi/src
+RUN ./configure && make depend -j $CPU_CORE && make -j $CPU_CORE
+
+

--- a/misc/docker/ubuntu/Dockerfile
+++ b/misc/docker/ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     git bzip2 wget \
     g++ make python python3 \
     zlib1g-dev automake autoconf libtool subversion \
-    libatlas-dev libatlas-base-dev
+    libatlas-base-dev
 
 
 WORKDIR /usr/local/


### PR DESCRIPTION
Updated packages, because of ubuntu 18.04 release.

I added a cuda version for [ installiation Kaldi eccur error ](https://groups.google.com/d/msg/kaldi-help/MShMOoUCdd8/-DJFyYfrAwAJ).
```
# After compilation
root@a0acc5f0a4df:/usr/local/kaldi/src# grep CUDA kaldi.mk 
# CUDA configuration
CUDA = true
CUDATKDIR = /usr/local/cuda
...
```


By the way, I found Dockerhub's auto-build service is convenient.
It will be triggered when master branch is updated.
It's worth a shot.

#### Step 1 - Create Automated Build
![default](https://user-images.githubusercontent.com/5996555/39795507-22f44858-5383-11e8-9122-cdffe279d374.png)

#### Step 2 - Setting path for every docker version
![2018-05-09 12-24-54](https://user-images.githubusercontent.com/5996555/39795637-06089036-5384-11e8-86a9-7a82bfe07522.png)

#### Step 3 - Done
When trigger or merge a PR, Dockerhub will build these images!