### PR TITLE
Set default optimization level to -O1

### DIFF
--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -202,9 +202,19 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
               KaldiGetStackTrace().c_str());
     }
   }
+}
+
+FatalMessageLogger::~FatalMessageLogger() KALDI_NOEXCEPT(false) {
+  // remove trailing '\n',
+  std::string str = ss_.str();
+  while (!str.empty() && str[str.length() - 1] == '\n')
+    str.resize(str.length() - 1);
+
+  // print the mesage (or send to logging handler),
+  MessageLogger::HandleMessage(envelope_, str.c_str());
 
   // Should we throw exception, or abort?
-  switch (envelope.severity) {
+  switch (envelope_.severity) {
     case LogMessageEnvelope::kAssertFailed:
       abort(); // ASSERT_FAILED,
       break;
@@ -221,6 +231,8 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
         abort();
       }
       break;
+  default:
+    abort();
   }
 }
 
@@ -229,7 +241,7 @@ void MessageLogger::HandleMessage(const LogMessageEnvelope &envelope,
 
 void KaldiAssertFailure_(const char *func, const char *file,
                          int32 line, const char *cond_str) {
-  MessageLogger ml(LogMessageEnvelope::kAssertFailed, func, file, line);
+  FatalMessageLogger ml(LogMessageEnvelope::kAssertFailed, func, file, line);
   ml.stream() << ": '" << cond_str << "' ";
 }
 

--- a/src/base/kaldi-error.h
+++ b/src/base/kaldi-error.h
@@ -114,19 +114,27 @@ public:
   /// 'KALDI_LOG << "Message,"',
   inline std::ostream &stream() { return ss_; }
 
-private:
+protected:
   /// The logging function,
   static void HandleMessage(const LogMessageEnvelope &env, const char *msg);
 
-private:
   LogMessageEnvelope envelope_;
   std::ostringstream ss_;
 };
 
+class FatalMessageLogger: public MessageLogger {
+public:
+  FatalMessageLogger(LogMessageEnvelope::Severity severity,
+                     const char *func, const char *file, int32 line):
+    MessageLogger(severity, func, file, line) {}
+
+  [[ noreturn ]] ~FatalMessageLogger() KALDI_NOEXCEPT(false);
+};
+
 // The definition of the logging macros,
 #define KALDI_ERR \
-  ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::kError, \
-                         __func__, __FILE__, __LINE__).stream()
+  ::kaldi::FatalMessageLogger(::kaldi::LogMessageEnvelope::kError, \
+                              __func__, __FILE__, __LINE__).stream()
 #define KALDI_WARN \
   ::kaldi::MessageLogger(::kaldi::LogMessageEnvelope::kWarning, \
                          __func__, __FILE__, __LINE__).stream()
@@ -140,8 +148,8 @@ private:
 
 /***** KALDI ASSERTS *****/
 
-void KaldiAssertFailure_(const char *func, const char *file,
-                         int32 line, const char *cond_str);
+[[noreturn]] void KaldiAssertFailure_(const char *func, const char *file,
+                                      int32 line, const char *cond_str);
 
 // Note on KALDI_ASSERT and KALDI_PARANOID_ASSERT
 // The original (simple) version of the code was this

--- a/src/configure
+++ b/src/configure
@@ -42,7 +42,7 @@
 
 # This should be incremented after any significant change to the configure
 # script, i.e. any change affecting kaldi.mk or the build system as a whole.
-CONFIGURE_VERSION=8
+CONFIGURE_VERSION=9
 
 if ! [ -x "$PWD/configure" ]; then
   echo 'You must run "configure" from the src/ directory.'

--- a/src/doc/build_setup.dox
+++ b/src/doc/build_setup.dox
@@ -58,11 +58,9 @@
 
   Changes that you might want to make to kaldi.mk after running "configure" are the following:
     - Changing the debug level:
-      - The default (which creates the easiest-to-debug binaries) is enabled by the options "-g -O0 -DKALDI_PARANOID".
-      - For faster, but still debuggable, binaries, you can change -O0 to -O1
-      - If you won't need to debug the binaries, you can remove the "-g -O0 -DKALDI_PARANOID" options, which 
-        will make it even faster.
-      - For maximum speed and no checking, you can replace the "-g -O0 -DKALDI_PARANOID" options with
+      - The default is "-O1"
+      - Easy to debug binaries can be enabled by uncommenting the options "-O0 -DKALDI_PARANOID".
+      - For maximum speed and no checking, you can replace the "-O0 -DKALDI_PARANOID" options with
         "-O2 -DNDEBUG" or "-O3 -DNDEBUG"
     - Changing the default precision
       - To test algorithms in double precision (e.g. if you suspect that roundoff is affecting

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -216,7 +216,7 @@ bool GetLinearSymbolSequence(const Fst<Arc> &fst,
 }
 
 
-// see fstext-utils.sh for comment.
+// see fstext-utils.h for comment.
 template<class Arc>
 void ConvertNbestToVector(const Fst<Arc> &fst,
                           vector<VectorFst<Arc> > *fsts_out) {

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -57,7 +57,7 @@ class LatticeWeightTpl {
 
   inline void SetValue2(T f) { value2_ = f; }
 
-  LatticeWeightTpl() { }
+  LatticeWeightTpl(): value1_{}, value2_{} { }
 
   LatticeWeightTpl(T a, T b): value1_(a), value2_(b) {}
 

--- a/src/lm/mikolov-rnnlm-lib.cc
+++ b/src/lm/mikolov-rnnlm-lib.cc
@@ -568,7 +568,7 @@ void CRnnLM::goToDelimiter(int delim, FILE *fi) {
 
 void CRnnLM::restoreNet() {   // will read whole network structure
   FILE *fi;
-  int a, b, ver;
+  int a, b, ver, unused_size;
   float fl;
   char str[MAX_STRING];
   double d;
@@ -580,7 +580,7 @@ void CRnnLM::restoreNet() {   // will read whole network structure
   }
 
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &ver);
+  unused_size = fscanf(fi, "%d", &ver);
   if ((ver == 4) && (version == 5)) {
     /* we will solve this later.. */
   } else {
@@ -590,71 +590,71 @@ void CRnnLM::restoreNet() {   // will read whole network structure
     }
   }
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &filetype);
+  unused_size = fscanf(fi, "%d", &filetype);
   goToDelimiter(':', fi);
   if (train_file_set == 0) {
-    fscanf(fi, "%s", train_file);
+    unused_size = fscanf(fi, "%s", train_file);
   } else {
-    fscanf(fi, "%s", str);
+    unused_size = fscanf(fi, "%s", str);
   }
   goToDelimiter(':', fi);
-  fscanf(fi, "%s", valid_file);
+  unused_size = fscanf(fi, "%s", valid_file);
   goToDelimiter(':', fi);
-  fscanf(fi, "%lf", &llogp);
+  unused_size = fscanf(fi, "%lf", &llogp);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &iter);
+  unused_size = fscanf(fi, "%d", &iter);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &train_cur_pos);
+  unused_size = fscanf(fi, "%d", &train_cur_pos);
   goToDelimiter(':', fi);
-  fscanf(fi, "%lf", &logp);
+  unused_size = fscanf(fi, "%lf", &logp);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &anti_k);
+  unused_size = fscanf(fi, "%d", &anti_k);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &train_words);
+  unused_size = fscanf(fi, "%d", &train_words);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &layer0_size);
+  unused_size = fscanf(fi, "%d", &layer0_size);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &layer1_size);
+  unused_size = fscanf(fi, "%d", &layer1_size);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &layerc_size);
+  unused_size = fscanf(fi, "%d", &layerc_size);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &layer2_size);
+  unused_size = fscanf(fi, "%d", &layer2_size);
   if (ver > 5) {
     goToDelimiter(':', fi);
-    fscanf(fi, "%lld", &direct_size);
+    unused_size = fscanf(fi, "%lld", &direct_size);
   }
   if (ver > 6) {
     goToDelimiter(':', fi);
-    fscanf(fi, "%d", &direct_order);
+    unused_size = fscanf(fi, "%d", &direct_order);
   }
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &bptt);
+  unused_size = fscanf(fi, "%d", &bptt);
   if (ver > 4) {
     goToDelimiter(':', fi);
-    fscanf(fi, "%d", &bptt_block);
+    unused_size = fscanf(fi, "%d", &bptt_block);
   } else {
     bptt_block = 10;
   }
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &vocab_size);
+  unused_size = fscanf(fi, "%d", &vocab_size);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &class_size);
+  unused_size = fscanf(fi, "%d", &class_size);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &old_classes);
+  unused_size = fscanf(fi, "%d", &old_classes);
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &independent);
+  unused_size = fscanf(fi, "%d", &independent);
   goToDelimiter(':', fi);
-  fscanf(fi, "%lf", &d);
+  unused_size = fscanf(fi, "%lf", &d);
   starting_alpha = d;
   goToDelimiter(':', fi);
   if (alpha_set == 0) {
-    fscanf(fi, "%lf", &d);
+    unused_size = fscanf(fi, "%lf", &d);
     alpha = d;
   } else {
-    fscanf(fi, "%lf", &d);
+    unused_size = fscanf(fi, "%lf", &d);
   }
   goToDelimiter(':', fi);
-  fscanf(fi, "%d", &alpha_divide);
+  unused_size = fscanf(fi, "%d", &alpha_divide);
 
   // read normal vocabulary
   if (vocab_max_size < vocab_size) {
@@ -666,11 +666,11 @@ void CRnnLM::restoreNet() {   // will read whole network structure
   }
   goToDelimiter(':', fi);
   for (a = 0; a < vocab_size; a++) {
-    // fscanf(fi, "%d%d%s%d", &b, &vocab[a].cn,
+    // unused_size = fscanf(fi, "%d%d%s%d", &b, &vocab[a].cn,
     // vocab[a].word, &vocab[a].class_index);
-    fscanf(fi, "%d%d", &b, &vocab[a].cn);
+    unused_size = fscanf(fi, "%d%d", &b, &vocab[a].cn);
     readWord(vocab[a].word, fi);
-    fscanf(fi, "%d", &vocab[a].class_index);
+    unused_size = fscanf(fi, "%d", &vocab[a].class_index);
     // printf("%d  %d  %s  %d\n", b, vocab[a].cn,
     // vocab[a].word, vocab[a].class_index);
   }
@@ -679,14 +679,14 @@ void CRnnLM::restoreNet() {   // will read whole network structure
   if (filetype == TEXT) {
     goToDelimiter(':', fi);
     for (a = 0; a < layer1_size; a++) {
-      fscanf(fi, "%lf", &d);
+      unused_size = fscanf(fi, "%lf", &d);
       neu1[a].ac = d;
     }
   }
   if (filetype == BINARY) {
     fgetc(fi);
     for (a = 0; a < layer1_size; a++) {
-      fread(&fl, 4, 1, fi);
+      unused_size = fread(&fl, 4, 1, fi);
       neu1[a].ac = fl;
     }
   }
@@ -694,7 +694,7 @@ void CRnnLM::restoreNet() {   // will read whole network structure
     goToDelimiter(':', fi);
     for (b = 0; b < layer1_size; b++) {
       for (a = 0; a < layer0_size; a++) {
-        fscanf(fi, "%lf", &d);
+        unused_size = fscanf(fi, "%lf", &d);
         syn0[a + b * layer0_size].weight = d;
       }
     }
@@ -702,7 +702,7 @@ void CRnnLM::restoreNet() {   // will read whole network structure
   if (filetype == BINARY) {
     for (b = 0; b < layer1_size; b++) {
       for (a = 0; a < layer0_size; a++) {
-        fread(&fl, 4, 1, fi);
+        unused_size = fread(&fl, 4, 1, fi);
         syn0[a + b * layer0_size].weight = fl;
       }
     }
@@ -712,14 +712,14 @@ void CRnnLM::restoreNet() {   // will read whole network structure
     if (layerc_size == 0) {  // no compress layer
       for (b = 0; b < layer2_size; b++) {
         for (a = 0; a < layer1_size; a++) {
-          fscanf(fi, "%lf", &d);
+          unused_size = fscanf(fi, "%lf", &d);
           syn1[a + b * layer1_size].weight = d;
         }
       }
     } else {        // with compress layer
       for (b = 0; b < layerc_size; b++) {
         for (a = 0; a < layer1_size; a++) {
-          fscanf(fi, "%lf", &d);
+          unused_size = fscanf(fi, "%lf", &d);
           syn1[a + b * layer1_size].weight = d;
         }
       }
@@ -728,7 +728,7 @@ void CRnnLM::restoreNet() {   // will read whole network structure
 
       for (b = 0; b < layer2_size; b++) {
         for (a = 0; a < layerc_size; a++) {
-          fscanf(fi, "%lf", &d);
+          unused_size = fscanf(fi, "%lf", &d);
           sync[a + b * layerc_size].weight = d;
         }
       }
@@ -738,21 +738,21 @@ void CRnnLM::restoreNet() {   // will read whole network structure
     if (layerc_size == 0) {  // no compress layer
       for (b = 0; b < layer2_size; b++) {
         for (a = 0; a < layer1_size; a++) {
-          fread(&fl, 4, 1, fi);
+          unused_size = fread(&fl, 4, 1, fi);
           syn1[a + b * layer1_size].weight = fl;
         }
       }
     } else {        // with compress layer
       for (b = 0; b < layerc_size; b++) {
         for (a = 0; a < layer1_size; a++) {
-          fread(&fl, 4, 1, fi);
+          unused_size = fread(&fl, 4, 1, fi);
           syn1[a + b * layer1_size].weight = fl;
         }
       }
 
       for (b = 0; b < layer2_size; b++) {
         for (a = 0; a < layerc_size; a++) {
-          fread(&fl, 4, 1, fi);
+          unused_size = fread(&fl, 4, 1, fi);
           sync[a + b * layerc_size].weight = fl;
         }
       }
@@ -762,23 +762,26 @@ void CRnnLM::restoreNet() {   // will read whole network structure
     goToDelimiter(':', fi);    // direct conenctions
     long long aa;
     for (aa = 0; aa < direct_size; aa++) {
-      fscanf(fi, "%lf", &d);
+      unused_size = fscanf(fi, "%lf", &d);
       syn_d[aa] = d;
     }
   }
   if (filetype == BINARY) {
     long long aa;
     for (aa = 0; aa < direct_size; aa++) {
-      fread(&fl, 4, 1, fi);
+      unused_size = fread(&fl, 4, 1, fi);
       syn_d[aa] = fl;
 
-      /*fread(&si, 2, 1, fi);
+      /*unused_size = fread(&si, 2, 1, fi);
         fl = si/(float)(4*256);
         syn_d[aa] = fl;*/
     }
   }
 
   saveWeights();
+
+  // idiom to "use" an unused variable
+  (void) unused_size;
 
   fclose(fi);
 }

--- a/src/makefiles/android_openblas.mk
+++ b/src/makefiles/android_openblas.mk
@@ -25,7 +25,7 @@ $(error Android build does not support compiling with $(CXX).
         Supported compilers: clang++)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self -Wno-mismatched-tags \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/cygwin.mk
+++ b/src/makefiles/cygwin.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -U__STRICT_ANSI__ -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -U__STRICT_ANSI__ -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/darwin.mk
+++ b/src/makefiles/darwin.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas_arm.mk
+++ b/src/makefiles/linux_atlas_arm.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas_arm.mk
+++ b/src/makefiles/linux_atlas_arm.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas_ppc64le.mk
+++ b/src/makefiles/linux_atlas_ppc64le.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_atlas_ppc64le.mk
+++ b/src/makefiles/linux_atlas_ppc64le.mk
@@ -16,7 +16,7 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_clapack_arm.mk
+++ b/src/makefiles/linux_clapack_arm.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_clapack_arm.mk
+++ b/src/makefiles/linux_clapack_arm.mk
@@ -10,7 +10,7 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas_arm.mk
+++ b/src/makefiles/linux_openblas_arm.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas_arm.mk
+++ b/src/makefiles/linux_openblas_arm.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas_ppc64le.mk
+++ b/src/makefiles/linux_openblas_ppc64le.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_openblas_ppc64le.mk
+++ b/src/makefiles/linux_openblas_ppc64le.mk
@@ -16,7 +16,7 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -24,7 +24,7 @@ endif
 
 MKLLIB ?= $(MKLROOT)/lib/em64t
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -24,7 +24,7 @@ endif
 
 MKLLIB ?= $(MKLROOT)/lib/em64t
 
-CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \

--- a/src/nnet2/combine-nnet-fast.cc
+++ b/src/nnet2/combine-nnet-fast.cc
@@ -384,7 +384,7 @@ int32 FastNnetCombiner::GetInitialModel(
   int32 num_nnets = static_cast<int32>(nnets.size());
   KALDI_ASSERT(!nnets.empty());
   int32 best_n = -1;
-  double best_objf;
+  double best_objf = -std::numeric_limits<double>::infinity();
   Vector<double> objfs(nnets.size());
   for (int32 n = 0; n < num_nnets; n++) {
     double num_frames;

--- a/src/nnet2/combine-nnet.cc
+++ b/src/nnet2/combine-nnet.cc
@@ -54,7 +54,7 @@ static int32 GetInitialModel(
   KALDI_ASSERT(!nnets.empty());
   BaseFloat tot_frames = validation_set.size();
   int32 best_n = -1;
-  BaseFloat best_objf;
+  BaseFloat best_objf = -std::numeric_limits<BaseFloat>::infinity();
   Vector<BaseFloat> objfs(nnets.size());
   for (int32 n = 0; n < num_nnets; n++) {
     BaseFloat objf = ComputeNnetObjf(nnets[n], validation_set,

--- a/src/nnet3/nnet-optimize-utils.cc
+++ b/src/nnet3/nnet-optimize-utils.cc
@@ -4928,14 +4928,15 @@ void OptimizeMemoryCompression(const Nnet &nnet,
   }
   if (memory_compression_level >= 1) {
     int64 bytes_used_initial, bytes_used_final;
-    if (GetVerboseLevel() >= 2)
+    bool verbose_ge_2 = GetVerboseLevel() >= 2;
+    if (verbose_ge_2)
       bytes_used_initial = GetMaxMemoryUse(*computation);
 
     MemoryCompressionOptimizer opt(nnet, memory_compression_level,
                                    middle_command, computation);
     opt.Optimize();
 
-    if (GetVerboseLevel() >= 2) {
+    if (verbose_ge_2) {
       bytes_used_final = GetMaxMemoryUse(*computation);
       if (bytes_used_final != bytes_used_initial) {
         KALDI_VLOG(2) << "Memory compression reduced  memory use from "


### PR DESCRIPTION
Previously, we were building at -O0 by default.

Since gcc uses only the rightmost command line -O flag, override this
by setting the environment variable EXTRA_CXXFLAGS.