### PR TITLE
[scripts] filter segment duration in vad_to_segments.sh

### DIFF
--- a/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
+++ b/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
@@ -11,6 +11,7 @@ nj=2
 stage=0
 cmd=run.pl
 segmentation_opts=  # E.g. set this as --segmentation-opts "--silance-proportion 0.2 --max-segment-length 10"
+min_duration=0.25
 
 # end configuration section.
 
@@ -26,6 +27,7 @@ if [ $# -ne 2 ]; then
   echo "    --stage (0|1)  # start script from part-way through"
   echo "    --cmd (run.pl|queue.pl...)  # specify how to run the sub-processes"
   echo "    --segmentation-opts '--opt1 opt1val --opt2 opt2val' # options for segmentation.pl"
+  echo "    --min-duration <m> # filtering out any generated subsegment with lower duration
   echo "e.g.:"
   echo "$0 data/train data/train_segmented"
   exit 1;
@@ -59,7 +61,7 @@ if [ $stage -le 0 ]; then
   for n in `seq $nj`; do
     cat $sdata/$n/subsegments
   done | sort | \
-  awk '{if (! (NF != 4 || $4 - $3 <= 0.25)) { print $0 }}' \
+  awk -v m=$min_duration '{if ($4 - $3 >= m) { print $0 }}' \
   > $data/subsegments || exit 1;
 fi
 

--- a/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
+++ b/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
@@ -58,7 +58,9 @@ if [ $stage -le 0 ]; then
 
   for n in `seq $nj`; do
     cat $sdata/$n/subsegments
-  done | sort > $data/subsegments || exit 1;
+  done | sort | \
+  awk '{if (! (NF != 4 || $4 - $3 <= 0.25)) { print $0 }}' \
+  > $data/subsegments || exit 1;
 fi
 
 if [ $stage -le 1 ]; then

--- a/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
+++ b/egs/callhome_diarization/v1/diarization/vad_to_segments.sh
@@ -27,7 +27,7 @@ if [ $# -ne 2 ]; then
   echo "    --stage (0|1)  # start script from part-way through"
   echo "    --cmd (run.pl|queue.pl...)  # specify how to run the sub-processes"
   echo "    --segmentation-opts '--opt1 opt1val --opt2 opt2val' # options for segmentation.pl"
-  echo "    --min-duration <m> # filtering out any generated subsegment with lower duration
+  echo "    --min-duration <m> # min duration in seconds for segments (smaller ones are discarded)
   echo "e.g.:"
   echo "$0 data/train data/train_segmented"
   exit 1;


### PR DESCRIPTION
I just came upon the following issue:
the subsegments created by `vad_to_segments.sh` contained a few of very small length (e.g. 20ms), which caused other issues down the line.

I fixed it by filtering these subsegments by duration before writing them. I chose the value 0.25 but we maybe could add a `--min-subsegment-length` option. 