### PR TITLE
[#2448] Adding the missing 'fst::Connect(.)',

### DIFF
--- a/src/latbin/lattice-determinize-pruned-parallel.cc
+++ b/src/latbin/lattice-determinize-pruned-parallel.cc
@@ -62,6 +62,7 @@ class DeterminizeLatticeTask {
     }
     delete lat_; // This is no longer needed so we can delete it now;
     lat_ = NULL;
+    fst::Connect(&det_clat_); // remove states not leading to any final state,
     if (minimize_) {
       PushCompactLatticeStrings(&det_clat_);
       PushCompactLatticeWeights(&det_clat_);


### PR DESCRIPTION
- need to remove partial paths not leading to any final state
- fixes the bug in RNN-LM rescoring #2448