### PR TITLE
rnnlm dataprep: the only valid 2-col splitter is: ' ' (space)

### DIFF
--- a/scripts/rnnlm/choose_features.py
+++ b/scripts/rnnlm/choose_features.py
@@ -10,6 +10,8 @@ import math
 from collections import defaultdict
 sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
+import re
+tab_or_space = re.compile('[ \t]')
 
 parser = argparse.ArgumentParser(description="This script chooses the sparse feature representation of words. "
                                              "To be more specific, it chooses the set of features-- you compute "
@@ -86,7 +88,7 @@ def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert len(fields) == 2
             if fields[0] in vocab:
                 sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
@@ -115,7 +117,7 @@ def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
     with open(unigram_probs_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert len(fields) == 2
             idx = int(fields[0])
             if idx >= len(unigram_probs):

--- a/scripts/rnnlm/choose_features.py
+++ b/scripts/rnnlm/choose_features.py
@@ -8,7 +8,7 @@ import argparse
 import sys
 import math
 from collections import defaultdict
-sys.stdout = open(1, 'w', encoding='utf-8', closefd=False)
+sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
 
 parser = argparse.ArgumentParser(description="This script chooses the sparse feature representation of words. "
@@ -84,7 +84,7 @@ SPECIAL_SYMBOLS = ["<eps>", "<s>", "<brk>"]
 #  and 'wordlist' is a list indexed by integer id, that returns the string-valued word.
 def read_vocab(vocab_file):
     vocab = {}
-    with open(vocab_file, 'r', encoding="utf-8") as f:
+    with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert len(fields) == 2
@@ -113,7 +113,7 @@ def read_vocab(vocab_file):
 # id of the word, which evaluates to the unigram prob of the word.
 def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
-    with open(unigram_probs_file, 'r', encoding="utf-8") as f:
+    with open(unigram_probs_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert len(fields) == 2

--- a/scripts/rnnlm/get_best_model.py
+++ b/scripts/rnnlm/get_best_model.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 
 num_iters=None
 try:
-    with open(args.rnnlm_dir + "/info.txt", encoding="utf-8") as f:
+    with open(args.rnnlm_dir + "/info.txt", encoding="latin-1") as f:
         for line in f:
             a = line.split("=")
             if a[0] == "num_iters":
@@ -41,7 +41,7 @@ best_iter=-1
 for i in range(1, num_iters):
     this_logfile = "{0}/log/compute_prob.{1}.log".format(args.rnnlm_dir, i)
     try:
-        f = open(this_logfile, 'r', encoding='utf-8')
+        f = open(this_logfile, 'r', encoding='latin-1')
     except:
         sys.exit(sys.argv[0] + ": could not open log-file {0}".format(this_logfile))
     this_objf=-1000

--- a/scripts/rnnlm/get_embedding_dim.py
+++ b/scripts/rnnlm/get_embedding_dim.py
@@ -45,7 +45,7 @@ output_dim=-1
 left_context=0
 right_context=0
 for line in out_lines:
-    line = line.decode('utf-8')
+    line = line.decode('latin-1')
     m = re.search(r'input-node name=input dim=(\d+)', line)
     if m is not None:
         try:

--- a/scripts/rnnlm/get_special_symbol_opts.py
+++ b/scripts/rnnlm/get_special_symbol_opts.py
@@ -25,9 +25,10 @@ upper_special_symbols = [key.upper() for key in special_symbols]
 
 lower_ids = {}
 upper_ids = {}
-input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='latin-1')
 for line in input_stream:
     fields = line.split()
+    assert(len(fields) == 2)
     sym = fields[0]
     if sym in special_symbols:
         assert sym not in lower_ids

--- a/scripts/rnnlm/get_special_symbol_opts.py
+++ b/scripts/rnnlm/get_special_symbol_opts.py
@@ -8,6 +8,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script checks whether the special symbols "
                                  "appear in words.txt with expected values, if not, it will "
                                  "print out the options with correct value to stdout, which may look like "
@@ -27,7 +30,7 @@ lower_ids = {}
 upper_ids = {}
 input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='latin-1')
 for line in input_stream:
-    fields = line.split()
+    fields = re.split(tab_or_space, line)
     assert(len(fields) == 2)
     sym = fields[0]
     if sym in special_symbols:

--- a/scripts/rnnlm/get_unigram_probs.py
+++ b/scripts/rnnlm/get_unigram_probs.py
@@ -74,7 +74,7 @@ def get_all_data_sources_except_dev(text_dir):
 #                    value is a tuple (repeated_times_per_epoch, weight)
 def read_data_weights(weights_file, data_sources):
     data_weights = {}
-    with open(weights_file, 'r', encoding="utf-8") as f:
+    with open(weights_file, 'r', encoding="latin-1") as f:
         for line in f:
             try:
                 fields = line.split()
@@ -99,7 +99,7 @@ def read_data_weights(weights_file, data_sources):
 # return the vocab, which is a dict mapping the word to a integer id.
 def read_vocab(vocab_file):
     vocab = {}
-    with open(vocab_file, 'r', encoding="utf-8") as f:
+    with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert len(fields) == 2
@@ -128,10 +128,11 @@ def get_counts(data_sources, data_weights, vocab):
         if weight == 0.0:
             continue
 
-        with open(counts_file, 'r', encoding="utf-8") as f:
+        with open(counts_file, 'r', encoding="latin-1") as f:
             for line in f:
                 fields = line.split()
-                assert len(fields) == 2
+                if len(fields) != 2: print("Warning, should be 2 cols:", fields, file=sys.stderr);
+                assert(len(fields) == 2)
                 word = fields[0]
                 count = fields[1]
                 if word not in vocab:

--- a/scripts/rnnlm/get_unigram_probs.py
+++ b/scripts/rnnlm/get_unigram_probs.py
@@ -7,6 +7,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script gets the unigram probabilities of words.",
                                  epilog="E.g. " + sys.argv[0] + " --vocab-file=data/rnnlm/vocab/words.txt "
                                         "--data-weights-file=exp/rnnlm/data_weights.txt data/rnnlm/data "
@@ -77,7 +80,7 @@ def read_data_weights(weights_file, data_sources):
     with open(weights_file, 'r', encoding="latin-1") as f:
         for line in f:
             try:
-                fields = line.split()
+                fields = re.split(tab_or_space, line)
                 assert len(fields) == 3
                 if fields[0] in data_weights:
                     raise Exception("duplicated data source({0}) specified in "
@@ -101,7 +104,7 @@ def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert len(fields) == 2
             if fields[0] in vocab:
                 sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
@@ -130,8 +133,8 @@ def get_counts(data_sources, data_weights, vocab):
 
         with open(counts_file, 'r', encoding="latin-1") as f:
             for line in f:
-                fields = line.split()
-                if len(fields) != 2: print("Warning, should be 2 cols:", fields, file=sys.stderr);
+                fields = re.split(tab_or_space, line)
+                if len(fields) != 2: print("Warning, should be 2 cols:", fields, line, file=sys.stderr);
                 assert(len(fields) == 2)
                 word = fields[0]
                 count = fields[1]

--- a/scripts/rnnlm/get_vocab.py
+++ b/scripts/rnnlm/get_vocab.py
@@ -8,6 +8,9 @@ import argparse
 import sys
 sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script get a vocab from unigram counts "
                                  "of words produced by get_unigram_counts.sh",
                                  epilog="E.g. " + sys.argv[0] + " data/rnnlm/data > data/rnnlm/vocab/words.txt",
@@ -28,7 +31,7 @@ def add_counts(word_counts, counts_file):
     with open(counts_file, 'r', encoding="latin-1") as f:
         for line in f:
             line = line.strip()
-            word_and_count = line.split()
+            word_and_count = re.split(tab_or_space, line)
             assert len(word_and_count) == 2
             if word_and_count[0] in word_counts:
                 word_counts[word_and_count[0]] += int(word_and_count[1])

--- a/scripts/rnnlm/get_vocab.py
+++ b/scripts/rnnlm/get_vocab.py
@@ -6,7 +6,7 @@
 import os
 import argparse
 import sys
-sys.stdout = open(1, 'w', encoding='utf-8', closefd=False)
+sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
 parser = argparse.ArgumentParser(description="This script get a vocab from unigram counts "
                                  "of words produced by get_unigram_counts.sh",
@@ -25,7 +25,7 @@ special_symbols = ['<s>', '<brk>', '<eps>']
 # Add the count for every word in counts_file
 # the result is written into word_counts
 def add_counts(word_counts, counts_file):
-    with open(counts_file, 'r', encoding="utf-8") as f:
+    with open(counts_file, 'r', encoding="latin-1") as f:
         for line in f:
             line = line.strip()
             word_and_count = line.split()

--- a/scripts/rnnlm/get_word_features.py
+++ b/scripts/rnnlm/get_word_features.py
@@ -9,6 +9,9 @@ import sys
 import math
 from collections import defaultdict
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script turns the words into the sparse feature representation, "
                                              "using features from rnnlm/choose_features.py.",
                                  epilog="E.g. " + sys.argv[0] + " --unigram-probs=exp/rnnlm/unigram_probs.txt "
@@ -40,7 +43,7 @@ def read_vocab(vocab_file):
     vocab = {}
     with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert len(fields) == 2
             if fields[0] in vocab:
                 sys.exit(sys.argv[0] + ": duplicated word({0}) in vocab: {1}"
@@ -61,7 +64,7 @@ def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
     with open(unigram_probs_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert len(fields) == 2
             idx = int(fields[0])
             if idx >= len(unigram_probs):
@@ -102,7 +105,7 @@ def read_features(features_file):
 
     with open(features_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert(len(fields) in [3, 4, 5])
 
             feat_id = int(fields[0])

--- a/scripts/rnnlm/get_word_features.py
+++ b/scripts/rnnlm/get_word_features.py
@@ -38,7 +38,7 @@ args = parser.parse_args()
 # return the vocab, which is a dict mapping the word to a integer id.
 def read_vocab(vocab_file):
     vocab = {}
-    with open(vocab_file, 'r', encoding="utf-8") as f:
+    with open(vocab_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert len(fields) == 2
@@ -59,7 +59,7 @@ def read_vocab(vocab_file):
 # return a list of unigram_probs, indexed by word id
 def read_unigram_probs(unigram_probs_file):
     unigram_probs = []
-    with open(unigram_probs_file, 'r', encoding="utf-8") as f:
+    with open(unigram_probs_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert len(fields) == 2
@@ -100,7 +100,7 @@ def read_features(features_file):
     feats['min_ngram_order'] = 10000
     feats['max_ngram_order'] = -1
 
-    with open(features_file, 'r', encoding="utf-8") as f:
+    with open(features_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert(len(fields) in [3, 4, 5])

--- a/scripts/rnnlm/prepare_split_data.py
+++ b/scripts/rnnlm/prepare_split_data.py
@@ -8,6 +8,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script prepares files containing integerized text, "
                                  "for consumption by nnet3-get-egs.",
                                  epilog="E.g. " + sys.argv[0] + " --vocab-file=data/rnnlm/vocab/words.txt "
@@ -66,7 +69,7 @@ def read_data_weights(weights_file, data_sources):
     with open(weights_file, 'r', encoding="latin-1") as f:
         for line in f:
             try:
-                fields = line.split()
+                fields = re.split(tab_or_space, line)
                 assert len(fields) == 3
                 if fields[0] in data_weights:
                     raise Exception("duplicated data source({0}) specified in "

--- a/scripts/rnnlm/prepare_split_data.py
+++ b/scripts/rnnlm/prepare_split_data.py
@@ -63,7 +63,7 @@ def get_all_data_sources_except_dev(text_dir):
 #                    value is a tuple (repeated_times_per_epoch, weight)
 def read_data_weights(weights_file, data_sources):
     data_weights = {}
-    with open(weights_file, 'r', encoding="utf-8") as f:
+    with open(weights_file, 'r', encoding="latin-1") as f:
         for line in f:
             try:
                 fields = line.split()
@@ -94,7 +94,7 @@ def distribute_to_outputs(source_filename, weight, output_filehandles):
     num_outputs = len(output_filehandles)
     n = 0
     try:
-        f = open(source_filename, 'r', encoding="utf-8")
+        f = open(source_filename, 'r', encoding="latin-1")
     except Exception as e:
         sys.exit(sys.argv[0] + ": failed to open file {0} for reading: {1} ".format(
             source_filename, str(e)))
@@ -121,7 +121,7 @@ if not os.path.exists(args.split_dir + "/info"):
     os.makedirs(args.split_dir +  "/info")
 
 # set up the 'num_splits' file, which contains an integer.
-with open("{0}/info/num_splits".format(args.split_dir), 'w', encoding="utf-8") as f:
+with open("{0}/info/num_splits".format(args.split_dir), 'w', encoding="latin-1") as f:
     print(args.num_splits, file=f)
 
 # e.g. set temp_files = [ 'foo/1.tmp', 'foo/2.tmp', ..., 'foo/5.tmp' ]
@@ -133,7 +133,7 @@ temp_files = [ "{0}/{1}.tmp".format(args.split_dir, n) for n in range(1, args.nu
 temp_filehandles = []
 for fname in temp_files:
     try:
-        temp_filehandles.append(open(fname, 'w', encoding="utf-8"))
+        temp_filehandles.append(open(fname, 'w', encoding="latin-1"))
     except Exception as e:
         sys.exit(sys.argv[0] + ": failed to open file: " + str(e) +
                  ".. if this is a max-open-filehandles limitation, you may "

--- a/scripts/rnnlm/show_word_features.py
+++ b/scripts/rnnlm/show_word_features.py
@@ -8,6 +8,9 @@ import argparse
 import sys
 sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="This script turns the word features to a human readable format.",
                                  epilog="E.g. " + sys.argv[0] + "exp/rnnlm/word_feats.txt exp/rnnlm/features.txt "
                                         "> exp/rnnlm/word_feats.str.txt",
@@ -29,7 +32,7 @@ def read_feature_type_and_key(features_file):
 
     with open(features_file, 'r', encoding="latin-1") as f:
         for line in f:
-            fields = line.split()
+            fields = re.split(tab_or_space, line)
             assert(len(fields) in [2, 3, 4])
 
             feat_id = int(fields[0])
@@ -46,7 +49,7 @@ feat_type_and_key = read_feature_type_and_key(args.features_file)
 num_word_feats = 0
 with open(args.word_features_file, 'r', encoding="latin-1") as f:
     for line in f:
-        fields = line.split()
+        fields = re.split(tab_or_space, line)
         assert len(fields) % 2 == 1
 
         print(int(fields[0]), end='\t')

--- a/scripts/rnnlm/show_word_features.py
+++ b/scripts/rnnlm/show_word_features.py
@@ -6,7 +6,7 @@
 import os
 import argparse
 import sys
-sys.stdout = open(1, 'w', encoding='utf-8', closefd=False)
+sys.stdout = open(1, 'w', encoding='latin-1', closefd=False)
 
 parser = argparse.ArgumentParser(description="This script turns the word features to a human readable format.",
                                  epilog="E.g. " + sys.argv[0] + "exp/rnnlm/word_feats.txt exp/rnnlm/features.txt "
@@ -27,7 +27,7 @@ args = parser.parse_args()
 def read_feature_type_and_key(features_file):
     feat_types = {}
 
-    with open(features_file, 'r', encoding="utf-8") as f:
+    with open(features_file, 'r', encoding="latin-1") as f:
         for line in f:
             fields = line.split()
             assert(len(fields) in [2, 3, 4])
@@ -44,7 +44,7 @@ def read_feature_type_and_key(features_file):
 feat_type_and_key = read_feature_type_and_key(args.features_file)
 
 num_word_feats = 0
-with open(args.word_features_file, 'r', encoding="utf-8") as f:
+with open(args.word_features_file, 'r', encoding="latin-1") as f:
     for line in f:
         fields = line.split()
         assert len(fields) % 2 == 1

--- a/scripts/rnnlm/train_rnnlm.sh
+++ b/scripts/rnnlm/train_rnnlm.sh
@@ -188,12 +188,16 @@ while [ $x -lt $num_iters ]; do
         else dest_number=$[x+1]; fi
         # in the normal case $repeated data will be just one copy.
         repeated_data=$(for n in $(seq $num_repeats); do echo -n $dir/text/$split.txt ''; done)
-        
+
         rnnlm_l2_factor=$(perl -e "print (1.0/$this_num_jobs);")
         embedding_l2_regularize=$(perl -e "print ($embedding_l2/$this_num_jobs);")
 
+        # allocate queue-slots for threads doing sampling,
+        num_threads_=$[$num_egs_threads*2/3]
+        [ -f $dir/sampling.lm ] && queue_thread_opt="--num-threads $num_threads_" || queue_thread_opt=
+
         # Run the training job or jobs.
-        $cmd $queue_gpu_opt $dir/log/train.$x.$n.log \
+        $cmd $queue_gpu_opt $queue_thread_opt $dir/log/train.$x.$n.log \
            rnnlm-train \
              --rnnlm.max-param-change=$rnnlm_max_change \
              --rnnlm.l2_regularize_factor=$rnnlm_l2_factor \

--- a/scripts/rnnlm/validate_features.py
+++ b/scripts/rnnlm/validate_features.py
@@ -7,6 +7,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="Validates features file, produced by rnnlm/choose_features.py.",
                                  epilog="E.g. " + sys.argv[0] + " exp/rnnlm/features.txt",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -30,7 +33,7 @@ with open(args.features_file, 'r', encoding="latin-1") as f:
     final_feats = {}
     word_feats = {}
     for line in f:
-        fields = line.split()
+        fields = re.split(tab_or_space, line)
         assert(len(fields) in [3, 4, 5])
 
         assert idx == int(fields[0])

--- a/scripts/rnnlm/validate_features.py
+++ b/scripts/rnnlm/validate_features.py
@@ -21,7 +21,7 @@ EOS_SYMBOL = '</s>'
 if not os.path.isfile(args.features_file):
     sys.exit(sys.argv[0] + ": Expected file {0} to exist".format(args.features_file))
 
-with open(args.features_file, 'r', encoding="utf-8") as f:
+with open(args.features_file, 'r', encoding="latin-1") as f:
     has_unigram = False
     has_length = False
     idx = 0

--- a/scripts/rnnlm/validate_text_dir.py
+++ b/scripts/rnnlm/validate_text_dir.py
@@ -37,7 +37,7 @@ num_text_files = 0
 
 
 def check_text_file(text_file):
-    with open(text_file, 'r', encoding="utf-8") as f:
+    with open(text_file, 'r', encoding="latin-1") as f:
         found_nonempty_line = False
         lineno = 0
         if args.allow_internal_eos == 'true':
@@ -73,7 +73,7 @@ def check_text_file(text_file):
     # with some kind of utterance-id
     first_field_set = set()
     other_fields_set = set()
-    with open(text_file, 'r', encoding="utf-8") as f:
+    with open(text_file, 'r', encoding="latin-1") as f:
         for line in f:
             array = line.split()
             if len(array) > 0:

--- a/scripts/rnnlm/validate_text_dir.py
+++ b/scripts/rnnlm/validate_text_dir.py
@@ -7,6 +7,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="Validates data directory containing text "
                                  "files from one or more data sources, including dev.txt.",
                                  epilog="E.g. " + sys.argv[0] + " data/rnnlm/data",
@@ -51,7 +54,7 @@ def check_text_file(text_file):
             lineno += 1
             if args.spot_check == 'true' and lineno > 10:
                 break
-            words = line.split()
+            words = re.split(tab_or_space, line)
             if len(words) != 0:
                 found_nonempty_line = True
                 for word in words:
@@ -75,7 +78,7 @@ def check_text_file(text_file):
     other_fields_set = set()
     with open(text_file, 'r', encoding="latin-1") as f:
         for line in f:
-            array = line.split()
+            array = re.split(tab_or_space, line)
             if len(array) > 0:
                 first_word = array[0]
                 if first_word in first_field_set or first_word in other_fields_set:

--- a/scripts/rnnlm/validate_word_features.py
+++ b/scripts/rnnlm/validate_word_features.py
@@ -25,7 +25,7 @@ constant_feat_value = None
 unigram_feat_id = -1
 length_feat_id = -1
 max_feat_id = -1
-with open(args.features_file, 'r', encoding="utf-8") as f:
+with open(args.features_file, 'r', encoding="latin-1") as f:
     for line in f:
         fields = line.split()
         assert(len(fields) in [3, 4, 5])
@@ -49,7 +49,7 @@ with open(args.features_file, 'r', encoding="utf-8") as f:
         if feat_id > max_feat_id:
             max_feat_id = feat_id
 
-with open(args.word_features_file, 'r', encoding="utf-8") as f:
+with open(args.word_features_file, 'r', encoding="latin-1") as f:
     for line in f:
         fields = line.split()
         assert len(fields) > 0 and len(fields) % 2 == 1

--- a/scripts/rnnlm/validate_word_features.py
+++ b/scripts/rnnlm/validate_word_features.py
@@ -7,6 +7,9 @@ import os
 import argparse
 import sys
 
+import re
+tab_or_space = re.compile('[ \t]')
+
 parser = argparse.ArgumentParser(description="Validates word features file, produced by rnnlm/get_word_features.py.",
                                  epilog="E.g. " + sys.argv[0] + " --features-file=exp/rnnlm/features.txt "
                                         "exp/rnnlm/word_feats.txt",
@@ -27,7 +30,7 @@ length_feat_id = -1
 max_feat_id = -1
 with open(args.features_file, 'r', encoding="latin-1") as f:
     for line in f:
-        fields = line.split()
+        fields = re.split(tab_or_space, line)
         assert(len(fields) in [3, 4, 5])
 
         feat_id = int(fields[0])
@@ -51,7 +54,7 @@ with open(args.features_file, 'r', encoding="latin-1") as f:
 
 with open(args.word_features_file, 'r', encoding="latin-1") as f:
     for line in f:
-        fields = line.split()
+        fields = re.split(tab_or_space, line)
         assert len(fields) > 0 and len(fields) % 2 == 1
         word_id = int(fields[0])
 


### PR DESCRIPTION
- helps if the words in 'words.txt' contain special UTF whitespaces,
  which otherwise lead to having >2 columns,
- it will make the code a little more robust to 'dirty' dataprep,