### PR TITLE
use ‘bc’ command to process float math

### DIFF
--- a/egs/wsj/s5/utils/nnet/subset_data_tr_cv.sh
+++ b/egs/wsj/s5/utils/nnet/subset_data_tr_cv.sh
@@ -39,7 +39,7 @@ if [ -z "$cv_spk_list" ]; then
   # Select 'cv_spk_percent' speakers randomly,
   cat $src_data/spk2utt | awk '{ print $1; }' | utils/shuffle_list.pl --srand $seed >$tmp/speakers
   n_spk=$(wc -l <$tmp/speakers)
-  n_spk_cv=$(echo "($cv_spk_percent * $n_spk) / 100" | bc)
+  n_spk_cv=$(perl -e "print int($cv_spk_percent * $n_spk / 100); ")
   #
   head -n $n_spk_cv $tmp/speakers >$tmp/speakers_cv
   tail -n+$((n_spk_cv+1)) $tmp/speakers >$tmp/speakers_trn

--- a/egs/wsj/s5/utils/nnet/subset_data_tr_cv.sh
+++ b/egs/wsj/s5/utils/nnet/subset_data_tr_cv.sh
@@ -39,7 +39,7 @@ if [ -z "$cv_spk_list" ]; then
   # Select 'cv_spk_percent' speakers randomly,
   cat $src_data/spk2utt | awk '{ print $1; }' | utils/shuffle_list.pl --srand $seed >$tmp/speakers
   n_spk=$(wc -l <$tmp/speakers)
-  n_spk_cv=$((cv_spk_percent * n_spk / 100))
+  n_spk_cv=$(echo "($cv_spk_percent * $n_spk) / 100" | bc)
   #
   head -n $n_spk_cv $tmp/speakers >$tmp/speakers_cv
   tail -n+$((n_spk_cv+1)) $tmp/speakers >$tmp/speakers_trn


### PR DESCRIPTION
When use 'float or < 1' percent args, get error like this:
![image](https://user-images.githubusercontent.com/705582/40636999-f69e3888-6334-11e8-88a6-70e4711f4823.png)
Thus, use 'bc' instand.
