### PR TITLE
[egs] bug fix in egs/sitw/v2/run.sh

### DIFF
--- a/egs/sitw/v2/run.sh
+++ b/egs/sitw/v2/run.sh
@@ -208,11 +208,11 @@ if [ $stage -le 10 ]; then
   $train_cmd $nnet_dir/xvectors_train_combined_200k/log/lda.log \
     ivector-compute-lda --total-covariance-factor=0.0 --dim=$lda_dim \
     "ark:ivector-subtract-global-mean scp:$nnet_dir/xvectors_train_combined_200k/xvector.scp ark:- |" \
-    ark:data/train/utt2spk $nnet_dir/xvectors_train_combined_200k/transform.mat || exit 1;
+    ark:data/train_combined_200k/utt2spk $nnet_dir/xvectors_train_combined_200k/transform.mat || exit 1;
 
   # Train the PLDA model.
   $train_cmd $nnet_dir/xvectors_train_combined_200k/log/plda.log \
-    ivector-compute-plda ark:data/train/spk2utt \
+    ivector-compute-plda ark:data/train_combined_200k/spk2utt \
     "ark:ivector-subtract-global-mean scp:$nnet_dir/xvectors_train_combined_200k/xvector.scp ark:- | transform-vec $nnet_dir/xvectors_train_combined_200k/transform.mat ark:- ark:- | ivector-normalize-length ark:-  ark:- |" \
     $nnet_dir/xvectors_train_combined_200k/plda || exit 1;
 fi
@@ -228,9 +228,9 @@ if [ $stage -le 11 ]; then
     "cat '$sitw_dev_trials_core' | cut -d\  --fields=1,2 |" $nnet_dir/scores/sitw_dev_core_scores || exit 1;
 
   # SITW Dev Core:
-  # EER: 3.35%
-  # minDCF(p-target=0.01): 0.3134
-  # minDCF(p-target=0.001): 0.5149
+  # EER: 3.08%
+  # minDCF(p-target=0.01): 0.3016
+  # minDCF(p-target=0.001): 0.4993
   echo "SITW Dev Core:"
   eer=$(paste $sitw_dev_trials_core $nnet_dir/scores/sitw_dev_core_scores | awk '{print $6, $3}' | compute-eer - 2>/dev/null)
   mindcf1=`sid/compute_min_dcf.py --p-target 0.01 $nnet_dir/scores/sitw_dev_core_scores $sitw_dev_trials_core 2> /dev/null`
@@ -251,9 +251,9 @@ if [ $stage -le 12 ]; then
     "cat '$sitw_eval_trials_core' | cut -d\  --fields=1,2 |" $nnet_dir/scores/sitw_eval_core_scores || exit 1;
 
   # SITW Eval Core:
-  # EER: 3.609%
-  # minDCF(p-target=0.01): 0.3599
-  # minDCF(p-target=0.001): 0.5388
+  # EER: 3.335%
+  # minDCF(p-target=0.01): 0.3412
+  # minDCF(p-target=0.001): 0.5106
   echo -e "\nSITW Eval Core:";
   eer=$(paste $sitw_eval_trials_core $nnet_dir/scores/sitw_eval_core_scores | awk '{print $6, $3}' | compute-eer - 2>/dev/null)
   mindcf1=`sid/compute_min_dcf.py --p-target 0.01 $nnet_dir/scores/sitw_eval_core_scores $sitw_eval_trials_core 2> /dev/null`


### PR DESCRIPTION
There was a bug in egs/sitw/v2/run.sh that was preventing the PLDA backend from being trained on augmented data (it was only getting trained on the "clean" version of the training data).

Results improve modestly after fixing the bug. 

@danpovey, this should be OK to merge. 