### PR TITLE
Fix None arg in pad segments

### DIFF
--- a/egs/wsj/s5/steps/segmentation/internal/sad_to_segments.py
+++ b/egs/wsj/s5/steps/segmentation/internal/sad_to_segments.py
@@ -162,6 +162,8 @@ class Segmentation(object):
         """Pads segments by duration 'segment_padding' on either sides, but
         ensures that the segments don't go beyond the neighboring segments
         or the duration of the utterance 'max_duration'."""
+        if max_duration == None:
+            max_duration = float("inf")
         for i, segment in enumerate(self.segments):
             assert segment[2] == 2, segment
             segment[0] -= segment_padding   # try adding padding on the left side


### PR DESCRIPTION
`pad_speech_segments` is called in https://github.com/kaldi-asr/kaldi/blob/fd545bbf6f1fbbc4b87612d0dbdbbe20bb80eab0/egs/wsj/s5/steps/segmentation/internal/sad_to_segments.py#L236-L238 where `max_duration` might get set to `None`.  This doesn't  fall back on the default value, and causes a type error at https://github.com/kaldi-asr/kaldi/blob/fd545bbf6f1fbbc4b87612d0dbdbbe20bb80eab0/egs/wsj/s5/steps/segmentation/internal/sad_to_segments.py#L186