### PR TITLE
FIX: add missing semicolons in configure

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -418,6 +418,7 @@ function configure_cuda {
         9_2 | 9_*)
           MIN_UNSUPPORTED_GCC_VER="8.0"
           MIN_UNSUPPORTED_GCC_VER_NUM=80000;
+        ;;
         *)
           echo "Unsupported CUDA_VERSION (CUDA_VERSION=$CUDA_VERSION), please report it to Kaldi mailing list, together with 'nvcc -h' or 'ptxas -h' which lists allowed -gencode values..."; exit 1;
         ;;


### PR DESCRIPTION
The `configure` script in `src` directory fails due to missing semicolons. I try to fix this small issue. Hope it will help.