### PR TITLE
[egs] updating results in voxceleb recipe

### DIFF
--- a/egs/voxceleb/v1/run.sh
+++ b/egs/voxceleb/v1/run.sh
@@ -123,7 +123,7 @@ if [ $stage -le 7 ]; then
   echo "EER: $eer%"
   echo "minDCF(p-target=0.01): $mindcf1"
   echo "minDCF(p-target=0.001): $mindcf2"
-  # EER: 5.419%
-  # minDCF(p-target=0.01): 0.4701
-  # minDCF(p-target=0.001): 0.5981
+  # EER: 5.329%
+  # minDCF(p-target=0.01): 0.4933
+  # minDCF(p-target=0.001): 0.6168
 fi

--- a/egs/voxceleb/v2/run.sh
+++ b/egs/voxceleb/v2/run.sh
@@ -205,12 +205,12 @@ if [ $stage -le 12 ]; then
   echo "EER: $eer%"
   echo "minDCF(p-target=0.01): $mindcf1"
   echo "minDCF(p-target=0.001): $mindcf2"
-  # EER: 3.224%
-  # minDCF(p-target=0.01): 0.3492
-  # minDCF(p-target=0.001): 0.5452
+  # EER: 3.128%
+  # minDCF(p-target=0.01): 0.3258
+  # minDCF(p-target=0.001): 0.5003
   #
   # For reference, here's the ivector system from ../v1:
-  # EER: 5.419%
-  # minDCF(p-target=0.01): 0.4701
-  # minDCF(p-target=0.001): 0.5981
+  # EER: 5.329%
+  # minDCF(p-target=0.01): 0.4933
+  # minDCF(p-target=0.001): 0.6168
 fi


### PR DESCRIPTION
Updating the voxceleb recipe results after applying @weichcai's bug fix in https://github.com/kaldi-asr/kaldi/pull/2475 .

I reran the v1 and v2 recipes from scratch. The i-vector results get a little worse, and the x-vector results get a little better. Probably just noise since the evaluation dataset is small. 
