### PR TITLE
Minor updates to WSJ-e2e recipes

### DIFF
--- a/egs/wsj/s5/local/chain/e2e/run_tdnn_flatstart.sh
+++ b/egs/wsj/s5/local/chain/e2e/run_tdnn_flatstart.sh
@@ -13,23 +13,23 @@
 # of phone_lm.fst (in stage 1 below)
 
 # local/chain/compare_wer.sh exp/chain/e2e_tdnn_1a
-# System                e2e_tdnn_1a
-#WER dev93 (tgpr)                9.70
-#WER dev93 (tg)                  9.05
-#WER dev93 (big-dict,tgpr)       7.20
-#WER dev93 (big-dict,fg)         6.36
-#WER eval92 (tgpr)               5.88
-#WER eval92 (tg)                 5.32
-#WER eval92 (big-dict,tgpr)      3.67
-#WER eval92 (big-dict,fg)        3.05
-# Final train prob        -0.0741
-# Final valid prob        -0.0951
+# System                   e2e_tdnn_1a
+#WER dev93 (tgpr)                9.63
+#WER dev93 (tg)                  9.07
+#WER dev93 (big-dict,tgpr)       7.41
+#WER dev93 (big-dict,fg)         6.55
+#WER eval92 (tgpr)               5.90
+#WER eval92 (tg)                 5.17
+#WER eval92 (big-dict,tgpr)      3.56
+#WER eval92 (big-dict,fg)        2.85
+# Final train prob        -0.0726
+# Final valid prob        -0.0884
 # Final train prob (xent)
 # Final valid prob (xent)
-# Num-params                 5562234
+# Num-params                 3740934
 
 # steps/info/chain_dir_info.pl exp/chain/e2e_tdnn_1a
-# exp/chain/e2e_tdnn_1a: num-iters=68 nj=2..5 num-params=5.6M dim=40->84 combine=-0.094->-0.094 logprob:train/valid[44,67,final]=(-0.083,-0.073,-0.072/-0.097,-0.095,-0.095)
+# exp/chain/e2e_tdnn_1a: num-iters=102 nj=2..5 num-params=3.7M dim=40->84 combine=-0.117->-0.116 (over 3) logprob:train/valid[67,101,final]=(-0.080,-0.073,-0.073/-0.090,-0.089,-0.088)
 
 set -e
 
@@ -37,7 +37,7 @@ set -e
 stage=0
 train_stage=-10
 get_egs_stage=-10
-affix=1a_dim450
+affix=1a
 
 # training options
 num_epochs=4
@@ -85,10 +85,18 @@ if [ $stage -le 0 ]; then
 fi
 
 if [ $stage -le 1 ]; then
+  echo "$0: Estimating a phone language model for the denominator graph..."
+  mkdir -p $treedir/log
+  $train_cmd $treedir/log/make_phone_lm.log \
+             cat data/$train_set/text \| \
+             steps/nnet3/chain/e2e/text_to_phones.py --between-silprob 0.1 \
+             data/lang_nosp \| \
+             utils/sym2int.pl -f 2- data/lang_nosp/phones.txt \| \
+             chain-est-phone-lm --num-extra-lm-states=2000 \
+             ark:- $treedir/phone_lm.fst
   steps/nnet3/chain/e2e/prepare_e2e.sh --nj 30 --cmd "$train_cmd" \
                                        --shared-phones true \
                                        data/$train_set $lang $treedir
-  cp exp/chain/e2e_base/phone_lm.fst $treedir/
 fi
 
 if [ $stage -le 2 ]; then

--- a/egs/wsj/s5/local/chain/e2e/run_tdnn_lstm_flatstart.sh
+++ b/egs/wsj/s5/local/chain/e2e/run_tdnn_lstm_flatstart.sh
@@ -92,11 +92,18 @@ if [ $stage -le 0 ]; then
 fi
 
 if [ $stage -le 1 ]; then
+  echo "$0: Estimating a phone language model for the denominator graph..."
+  mkdir -p $treedir/log
+  $train_cmd $treedir/log/make_phone_lm.log \
+             cat data/$train_set/text \| \
+             steps/nnet3/chain/e2e/text_to_phones.py data/lang_nosp \| \
+             utils/sym2int.pl -f 2- data/lang_nosp/phones.txt \| \
+             chain-est-phone-lm --num-extra-lm-states=2000 \
+             ark:- $treedir/phone_lm.fst
   steps/nnet3/chain/e2e/prepare_e2e.sh --nj 30 --cmd "$train_cmd" \
                                        --type biphone \
                                        --shared-phones true \
                                        data/$train_set $lang $treedir
-  cp exp/chain/e2e_base/char_lm.fst $treedir/phone_lm.fst
 fi
 
 if [ $stage -le 2 ]; then

--- a/egs/wsj/s5/local/e2e/run_end2end_char.sh
+++ b/egs/wsj/s5/local/e2e/run_end2end_char.sh
@@ -85,8 +85,8 @@ else
 
     # 12 in the following command means the allowed lengths are spaced
     # by 12% change in length.
-    python utils/data/perturb_speed_to_allowed_lengths.py 12 data/${trainset} \
-           data/${trainset}_spe2e_hires
+    utils/data/perturb_speed_to_allowed_lengths.py 12 data/${trainset} \
+                                                   data/${trainset}_spe2e_hires
     cat data/${trainset}_spe2e_hires/utt2dur | \
       awk '{print $1 " " substr($1,5)}' >data/${trainset}_spe2e_hires/utt2uniq
     utils/fix_data_dir.sh data/${trainset}_spe2e_hires
@@ -101,17 +101,6 @@ else
 fi
 
 if [ $stage -le 5 ]; then
-  echo "$0: estimating character language model for the denominator graph"
-  mkdir -p exp/chain/e2e_base/log
-  $train_cmd exp/chain/e2e_base/log/make_char_lm.log \
-  cat data/$trainset/text \| \
-    steps/nnet3/chain/e2e/text_to_phones.py data/lang_char \| \
-    utils/sym2int.pl -f 2- data/lang_char/phones.txt \| \
-    chain-est-phone-lm --num-extra-lm-states=2000 \
-                       ark:- exp/chain/e2e_base/char_lm.fst
-fi
-
-if [ $stage -le 6 ]; then
   echo "$0: calling the flat-start chain recipe..."
   local/chain/e2e/run_tdnn_lstm_flatstart.sh
 fi

--- a/egs/wsj/s5/local/e2e/run_end2end_phone.sh
+++ b/egs/wsj/s5/local/e2e/run_end2end_phone.sh
@@ -70,8 +70,8 @@ if [ $stage -le 2 ]; then
 
   # 12 in the following command means the allowed lengths are spaced
   # by 12% change in length.
-  python utils/data/perturb_speed_to_allowed_lengths.py 12 data/${trainset} \
-         data/${trainset}_spe2e_hires
+  utils/data/perturb_speed_to_allowed_lengths.py 12 data/${trainset} \
+                                                 data/${trainset}_spe2e_hires
   cat data/${trainset}_spe2e_hires/utt2dur | \
     awk '{print $1 " " substr($1,5)}' >data/${trainset}_spe2e_hires/utt2uniq
   utils/fix_data_dir.sh data/${trainset}_spe2e_hires
@@ -85,17 +85,6 @@ if [ $stage -le 3 ]; then
 fi
 
 if [ $stage -le 4 ]; then
-  echo "$0: estimating phone language model for the denominator graph"
-  mkdir -p exp/chain/e2e_base/log
-  $train_cmd exp/chain/e2e_base/log/make_phone_lm.log \
-  cat data/$trainset/text \| \
-    steps/nnet3/chain/e2e/text_to_phones.py data/lang_nosp \| \
-    utils/sym2int.pl -f 2- data/lang_nosp/phones.txt \| \
-    chain-est-phone-lm --num-extra-lm-states=2000 \
-                       ark:- exp/chain/e2e_base/phone_lm.fst
-fi
-
-if [ $stage -le 5 ]; then
   echo "$0: calling the flat-start chain recipe..."
   local/chain/e2e/run_tdnn_flatstart.sh
 fi

--- a/egs/wsj/s5/utils/data/extract_wav_segments_data_dir.sh
+++ b/egs/wsj/s5/utils/data/extract_wav_segments_data_dir.sh
@@ -7,13 +7,19 @@
 # wav segments (according to the 'segments' file)
 # so that the resulting data directory does not have a 'segments' file anymore.
 
-. utils/parse_options.sh
+nj=4
+cmd=run.pl
+
+. ./utils/parse_options.sh
 . ./path.sh
 
 if [ $# != 2 ]; then
   echo "Usage: $0 <srcdir> <destdir>"
-  echo " This script copies data directory <srcdir> to <destdir> and gets"
-  echo "rid of the 'segments' file by extracting the wav segments."
+  echo " This script copies data directory <srcdir> to <destdir> and removes"
+  echo " the 'segments' file by extracting the wav segments."
+  echo "Options: "
+  echo "  --nj <nj>                                        # number of parallel jobs"
+  echo "  --cmd (utils/run.pl|utils/queue.pl <queue opts>) # how to run jobs."
   exit 1;
 fi
 
@@ -22,17 +28,32 @@ export LC_ALL=C
 
 srcdir=$1
 dir=$2
-
+logdir=$dir/log
 
 if ! mkdir -p $dir/data; then
   echo "$0: failed to create directory $dir/data"
   exit 1
 fi
+mkdir -p $logdir
 
-set -e -o pipefail
+set -eu -o pipefail
 utils/copy_data_dir.sh $srcdir $dir
 
-extract-segments scp:$srcdir/wav.scp $srcdir/segments \
-                 ark,scp:$dir/data/wav_segments.ark,$dir/data/wav_segments.scp
+split_segments=""
+for n in $(seq $nj); do
+  split_segments="$split_segments $logdir/segments.$n"
+done
+
+utils/split_scp.pl $srcdir/segments $split_segments
+
+$cmd JOB=1:$nj $logdir/extract_wav_segments.JOB.log \
+     extract-segments scp,p:$srcdir/wav.scp $logdir/segments.JOB \
+     ark,scp:$dir/data/wav_segments.JOB.ark,$dir/data/wav_segments.JOB.scp
+
+# concatenate the .scp files together.
+for n in $(seq $nj); do
+  cat $dir/data/wav_segments.$n.scp
+done > $dir/data/wav_segments.scp
+
 cat $dir/data/wav_segments.scp | awk '{ print $1 " wav-copy " $2 " - |" }' >$dir/wav.scp
-rm $dir/reco2file_and_channel || true
+rm $dir/{segments,reco2file_and_channel} 2>/dev/null || true


### PR DESCRIPTION
- Moved the denominator-LM making stage from run_e2e.sh to the main chain script.
- Updated `extract_wav_segments_data_dir.sh` to be parallel
- Updated the results for the phone-based WSJ recipe (using the latest generic numerator codes)

