### PR TITLE
Chain tdnn arg typos

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain/train.py
+++ b/egs/wsj/s5/steps/nnet3/chain/train.py
@@ -578,7 +578,7 @@ def train(args, run_opts):
                                      "{0}/final.mdl".format(args.dir))
             chain_lib.compute_train_cv_probabilities(
                 dir=args.dir, iter=num_iters, egs_dir=egs_dir,
-                l2_regularize=l2_regularize, xent_regularize=xent_regularize,
+                l2_regularize=args.l2_regularize, xent_regularize=args.xent_regularize,
                 leaky_hmm_coefficient=args.leaky_hmm_coefficient,
                 run_opts=run_opts,
                 use_multitask_egs=use_multitask_egs)


### PR DESCRIPTION
Hi! A little bug fix for you.

== Fix ==
Updated reference `l2_regularize` -> `args.l2_regularize` as well as `xent_regularize` -> `args.xent_regularize`

== Repro ==
Train a chain tdnn model with option `--trainer.optimization.do-final-combination false`

== Expected ==
final.mdl is linked to the last iteration

== Actual ==
Python fatal error:

Traceback (most recent call last):
  File "steps/nnet3/chain/train.py", line 622, in main
    train(args, run_opts)
  File "steps/nnet3/chain/train.py", line 581, in train
    l2_regularize=l2_regularize, xent_regularize=xent_regularize,
NameError: global name 'l2_regularize' is not defined