### PR TITLE
[scripts] fixing bug in steps/nnet3/train_raw_{dnn,rnn}.py

### DIFF
--- a/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_dnn.py
@@ -305,7 +305,7 @@ def train(args, run_opts):
 
     if args.stage <= -1:
         logger.info("Preparing the initial network.")
-        common_train_lib.prepare_initial_network(args.dir, run_opts, args.input_model)
+        common_train_lib.prepare_initial_network(args.dir, run_opts, args.srand, args.input_model)
 
     # set num_iters so that as close as possible, we process the data
     # $num_epochs times, i.e. $num_iters*$avg_num_jobs) ==

--- a/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
+++ b/egs/wsj/s5/steps/nnet3/train_raw_rnn.py
@@ -360,7 +360,7 @@ def train(args, run_opts):
 
     if args.stage <= -1:
         logger.info("Preparing the initial network.")
-        common_train_lib.prepare_initial_network(args.dir, run_opts, args.input_model)
+        common_train_lib.prepare_initial_network(args.dir, run_opts, args.srand, args.input_model)
 
     # set num_iters so that as close as possible, we process the data
     # $num_epochs times, i.e. $num_iters*$avg_num_jobs) ==


### PR DESCRIPTION
There was a bug introduced in https://github.com/kaldi-asr/kaldi/commit/60141df48253b86258c8f3afe5b1468aa3b2b59e

The signature of the function prepare_initial_network was changed to include an additional argument, args.input_model (see https://github.com/kaldi-asr/kaldi/commit/60141df48253b86258c8f3afe5b1468aa3b2b59e#diff-4cc3f2f1ae133bd10a19b3314abcd144R538). However, calls to this function in train_raw_{dnn,rnn}.py do not take into account the srand option, which previously relied on using the default value (see https://github.com/kaldi-asr/kaldi/commit/60141df48253b86258c8f3afe5b1468aa3b2b59e#diff-22db274a920334596dbcfc58f30a7bf1R308).