### PR TITLE
remove extra comma produced by bsd seq in macos

### DIFF
--- a/egs/csj/s5/local/csj_make_trans/csj_autorun.sh
+++ b/egs/csj/s5/local/csj_make_trans/csj_autorun.sh
@@ -21,7 +21,7 @@ set -e # exit on error
 case "$csjv" in
     "merl" ) SDB=sdb/ ; WAV=WAV/ ; disc=CSJ2004 ;; # Set SDB directory and WAV directory respectively.
     "usb" ) SDB=MORPH/SDB/ ; WAV=WAV/ ; disc="core noncore" ;; # Set SDB directory and WAV directory respectively.
-    "dvd" ) num=dvd        ; SDB=           ; WAV=     ; disc=$num`seq -s " "$num 3 17` ;; # Set preserved format name to $num.
+    "dvd" ) num=dvd        ; SDB=           ; WAV=     ; disc=$num`seq -s " "$num 3 17| sed "s/ $num$//"` ;; # Set preserved format name to $num.
     *) echo "Input variable is usb or dvd only. $csjv is UNAVAILABLE VERSION." && exit 1;
 esac
 

--- a/egs/hub4_english/s5/local/data_prep/prepare_1996_csr_hub4_lm_corpus.sh
+++ b/egs/hub4_english/s5/local/data_prep/prepare_1996_csr_hub4_lm_corpus.sh
@@ -40,7 +40,7 @@ done | sort > $dir/filelist
 mkdir -p $dir/split$nj/
 
 if [ $stage -le 1 ]; then
-  eval utils/split_scp.pl $dir/filelist $dir/split$nj/filelist.{`seq -s, $nj`}
+  eval utils/split_scp.pl $dir/filelist $dir/split$nj/filelist.{`seq -s, $nj | sed 's/,$//'`}
   $cmd JOB=1:$nj $dir/log/process_text.JOB.log \
     local/data_prep/process_1996_csr_hub4_lm_filelist.py \
     $dir/split$nj/filelist.JOB $dir

--- a/egs/hub4_english/s5/local/data_prep/prepare_na_news_text_corpus.sh
+++ b/egs/hub4_english/s5/local/data_prep/prepare_na_news_text_corpus.sh
@@ -44,7 +44,7 @@ for x in $SOURCE_DIR/*/*/*; do
   mkdir -p $d/split$nj
 
   eval utils/split_scp.pl $d/articles.list \
-    $d/split$nj/articles.list.{`seq -s, $nj`}
+    $d/split$nj/articles.list.{`seq -s, $nj | sed 's/,$//'`}
 
   $cmd JOB=1:$nj $d/log/get_processed_text.JOB.log \
     local/data_prep/process_na_news_text.py $d/split$nj/articles.list.JOB \

--- a/egs/hub4_english/s5/local/data_prep/prepare_na_news_text_supplement.sh
+++ b/egs/hub4_english/s5/local/data_prep/prepare_na_news_text_supplement.sh
@@ -53,7 +53,7 @@ for x in $SOURCE_DIR/nyt/*/ $SOURCE_DIR/latwp/ $SOURCE_DIR/apws/*/; do
   mkdir -p $d/split$nj
 
   eval utils/split_scp.pl $d/articles.list \
-    $d/split$nj/articles.list.{`seq -s, $nj`}
+    $d/split$nj/articles.list.{`seq -s, $nj | sed 's/,$//'`}
 
   $cmd JOB=1:$nj $d/log/get_processed_text.JOB.log \
     local/data_prep/process_na_news_text.py $d/split$nj/articles.list.JOB \

--- a/egs/librispeech/s5/local/lm/train_lm.sh
+++ b/egs/librispeech/s5/local/lm/train_lm.sh
@@ -47,7 +47,7 @@ split_prefix=$tmp_dir/split
 if [ "$stage" -le 1 ]; then
   mkdir -p $tmp_dir
   echo "Splitting into $normjobs parts, to allow for parallel processing ..."
-  split_files=$(eval "echo $split_prefix-{$(seq -s',' $normjobs)}")
+  split_files=$(eval "echo $split_prefix-{$(seq -s',' $normjobs | sed 's/,$//')}")
   find $corpus_dir -mindepth 1 -maxdepth 1 -type d |\
     tee $tmp_dir/all_texts.txt |\
     utils/split_scp.pl - $split_files

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -72,7 +72,7 @@ if [ $stage -le 1 ]; then
   auto_lexicon_prefix="$g2p_dir/lexicon_autogen"
 
   mkdir -p $g2p_dir/log
-  auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj)}")
+  auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed "s/,$//")}")
   awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab |\
     sort | tee $g2p_dir/vocab_autogen.full |\
     utils/split_scp.pl - $auto_vocab_splits || exit 1

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -72,7 +72,7 @@ if [ $stage -le 1 ]; then
   auto_lexicon_prefix="$g2p_dir/lexicon_autogen"
 
   mkdir -p $g2p_dir/log
-  auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed "s/,$//")}")
+  auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}")
   awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab |\
     sort | tee $g2p_dir/vocab_autogen.full |\
     utils/split_scp.pl - $auto_vocab_splits || exit 1

--- a/egs/librispeech/s5/local/run_rnnlm.sh
+++ b/egs/librispeech/s5/local/run_rnnlm.sh
@@ -68,7 +68,7 @@ if [ $stage -le 2 ]; then
       rnnlm_cmd="$rnnlm_path"
       if type taskset >/dev/null 2>&1 ; then
           # HogWild works much faster if all threads are binded to the same phisical cpu
-          rnnlm_cmd="taskset -c $(seq -s, 0 $(( $num_threads - 1 )) ) $rnnlm_cmd"
+          rnnlm_cmd="taskset -c $(seq -s, 0 $(( $num_threads - 1 )) | sed 's/,$//') $rnnlm_cmd"
       fi
       $rnnlm_cmd -rnnlm $modeldir/rnnlm.tmp \
           -train $data_dir/librispeech-lm-norm.train.txt \


### PR DESCRIPTION
In macos, the bsd version "seq" produce extra comma in `$(seq -s',' $nj)`, which makes `$auto_vocab_splits` wrong.
remove extra comma. 
