### PR TITLE
fixed a minor issue in tri4b decode

### DIFF
--- a/egs/commonvoice/s5/run.sh
+++ b/egs/commonvoice/s5/run.sh
@@ -146,8 +146,8 @@ if [ $stage -le 7 ]; then
     utils/mkgraph.sh data/lang_test exp/tri4b exp/tri4b/graph
     for testset in valid_dev; do
       steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
-        exp/tri4b/graph_nosp_tgsmall data/$testset \
-        exp/tri4b/decode_nosp_tgsmall_$testset
+        exp/tri4b/graph data/$testset \
+        exp/tri4b/decode_$testset
     done
   )&
 fi


### PR DESCRIPTION
stage 7, tri4b decode: wrong graph name was used in decode_fmllr.sh command: 
exp/tri4b/graph_nosp_tgsmall -> exp/tri4b/graph