### PR TITLE
Removing has_key() because breaks in Python3 (c.f. issue #2570)

### DIFF
--- a/egs/voxforge/gst_demo/run-live.py
+++ b/egs/voxforge/gst_demo/run-live.py
@@ -68,7 +68,7 @@ class DemoApp(object):
           self.asr.set_property("acoustic-scale", 0.0769)
         else:
           print >> sys.stderr, "Couldn't create the onlinegmmfasterdecoder element. "
-          if os.environ.has_key("GST_PLUGIN_PATH"):
+          if "GST_PLUGIN_PATH" in os.environ:
             print >> sys.stderr, "Have you compiled the Kaldi GStreamer plugin?"
           else:
             print >> sys.stderr, "You probably need to set the GST_PLUGIN_PATH envoronment variable"

--- a/egs/wsj/s5/steps/libs/nnet3/report/log_parse.py
+++ b/egs/wsj/s5/steps/libs/nnet3/report/log_parse.py
@@ -85,7 +85,7 @@ def fill_nonlin_stats_table_with_regex_result(groups, gate_index, stats_table):
 
     if len(groups) <= 9:
         try:
-            if stats_table[component_name]['stats'].has_key(iteration):
+            if iteration in stats_table[component_name]['stats']:
                 stats_table[component_name]['stats'][iteration].extend(
                         [value_mean,  value_stddev,
                          deriv_mean,  deriv_stddev,
@@ -117,7 +117,7 @@ def fill_nonlin_stats_table_with_regex_result(groups, gate_index, stats_table):
         oderiv_50th = float(oderiv_percentiles_split[6])
         oderiv_95th = float(oderiv_percentiles_split[9])
         try:
-            if stats_table[component_name]['stats'].has_key(iteration):
+            if iteration in stats_table[component_name]['stats']:
                 stats_table[component_name]['stats'][iteration].extend(
                         [value_mean,  value_stddev,
                          deriv_mean,  deriv_stddev,

--- a/egs/wsj/s5/steps/libs/nnet3/xconfig/parser.py
+++ b/egs/wsj/s5/steps/libs/nnet3/xconfig/parser.py
@@ -88,7 +88,7 @@ def xconfig_line_to_object(config_line, prev_layers = None):
         if x is None:
             return None
         (first_token, key_to_value) = x
-        if not config_to_layer.has_key(first_token):
+        if not first_token in config_to_layer:
             raise RuntimeError("No such layer type '{0}'".format(first_token))
         return config_to_layer[first_token](first_token, key_to_value, prev_layers)
     except Exception:

--- a/egs/wsj/s5/steps/nnet2/make_multisplice_configs.py
+++ b/egs/wsj/s5/steps/nnet2/make_multisplice_configs.py
@@ -90,7 +90,7 @@ def create_config_files(output_dir, params):
   for i in xrange(1, params.num_hidden_layers): #just run till num_hidden_layers-1 since we do not add splice before the final affine transform
     lines=[]
     context_len = 1
-    if contexts.has_key(i):
+    if i in contexts:
         # Adding the splice component as a context is provided
         lines.append("SpliceComponent input-dim=%d context=%s " % (pnorm_output_dim, contexts[i]))
         context_len = len(contexts[i].split(":"))

--- a/egs/wsj/s5/steps/nnet3/dot/nnet3_to_dot.py
+++ b/egs/wsj/s5/steps/nnet3/dot/nnet3_to_dot.py
@@ -122,9 +122,9 @@ def ProcessAppendDescriptor(segment, parent_node_name, affix, edge_attributes = 
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1} [tailport=s]'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -142,9 +142,9 @@ def ProcessRoundDescriptor(segment, parent_node_name, affix, edge_attributes = N
     label = 'Round ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             style  = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
@@ -164,9 +164,9 @@ def ProcessOffsetDescriptor(segment, parent_node_name, affix, edge_attributes = 
     label = 'Offset ({0})'.format(segment['arguments'][1])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             style  = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
@@ -204,9 +204,9 @@ def ProcessSumDescriptor(segment, parent_node_name, affix, edge_attributes = Non
 
     attr_string = ''
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             attr_string += " label={0} ".format(edge_attributes['label'])
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             attr_string += ' style={0} '.format(edge_attributes['style'])
 
     dot_string = '{0} -> {1}'.format(GetDotNodeName(desc_name)['node'], GetDotNodeName(parent_node_name)['node'])
@@ -221,9 +221,9 @@ def ProcessReplaceIndexDescriptor(segment, parent_node_name, affix, edge_attribu
     label = 'ReplaceIndex({0}, {1})'.format(segment['arguments'][1], segment['arguments'][2])
     style = None
     if edge_attributes is not None:
-        if edge_attributes.has_key('label'):
+        if 'label' in edge_attributes:
             label = "{0} {1}".format(edge_attributes['label'], label)
-        if edge_attributes.has_key('style'):
+        if 'style' in edge_attributes:
             style  = 'style={0}'.format(edge_attributes['style'])
 
     attr_string = 'label="{0}"'.format(label)
@@ -324,7 +324,7 @@ def Nnet3ComponentToDot(component_config, component_attributes = None):
     attributes_to_print = set(component_attributes).intersection(component_config.keys())
     # process the known fields
     for key in attributes_to_print:
-        if component_config.has_key(key):
+        if key in component_config:
             label += '{0} = {1}\\n'.format(key, component_config[key])
 
     attr_string = ''

--- a/egs/wsj/s5/steps/nnet3/xconfig_to_configs.py
+++ b/egs/wsj/s5/steps/nnet3/xconfig_to_configs.py
@@ -296,10 +296,10 @@ def check_model_contexts(config_dir, nnet_edits=None, existing_model=None):
                 if key in ['left-context', 'right-context']:
                     contexts[file_name][key] = value
 
-    if contexts.has_key('init'):
-        assert(contexts.has_key('ref'))
-        if (contexts['init'].has_key('left-context') and
-            contexts['ref'].has_key('left-context')):
+    if 'init' in contexts:
+        assert('ref' in contexts)
+        if ('left-context' in contexts['init'] and
+            'left-context' in contexts['ref']):
             if ((contexts['init']['left-context']
                  > contexts['ref']['left-context'])
                 or (contexts['init']['right-context']


### PR DESCRIPTION
The `Dict.has_key(Key)` method has been removed and replaced with `Key in Dict`, which is compatible with Python 2 and 3.