### PR TITLE
[src] Clean test file for RNNLM example test

### DIFF
--- a/src/rnnlm/rnnlm-example-test.cc
+++ b/src/rnnlm/rnnlm-example-test.cc
@@ -305,6 +305,8 @@ int main() {
   SetVerboseLevel(4);
   CuDevice::Instantiate().PrintProfile();
 #endif
+
+  unlink("tmp.ark");
   return 0;
 }
 


### PR DESCRIPTION
I noticed that after running `make test` the file `tmp.ark` was left in `src/rnnlm`. I now let the test binary remove this file in the same style as other test binaries.