### PR TITLE
Fix backwards-incompatibility of changes made in #2383

### DIFF
--- a/src/bin/add-self-loops.cc
+++ b/src/bin/add-self-loops.cc
@@ -97,13 +97,11 @@ int main(int argc, char *argv[]) {
     if (!fst)
       KALDI_ERR << "add-self-loops: error reading input FST.";
 
-    bool check_no_self_loops = true;
-
     // The work gets done here.
     AddSelfLoops(trans_model,
                  disambig_syms_in,
                  self_loop_scale,
-                 reorder, check_no_self_loops, fst);
+                 reorder, fst);
 
     if (! fst->Write(fst_out_filename) )
       KALDI_ERR << "add-self-loops: error writing FST to "

--- a/src/chain/chain-den-graph.cc
+++ b/src/chain/chain-den-graph.cc
@@ -349,11 +349,10 @@ void CreateDenominatorFst(const ContextDependency &ctx_dep,
                                     // value in test time.
   // 'reorder' must always be set to true for chain models.
   bool reorder = true;
-  bool check_no_self_loops = true;
 
   // add self-loops to the FST with transition-ids as its labels.
   AddSelfLoops(trans_model, disambig_syms_h, self_loop_scale, reorder,
-               check_no_self_loops, &transition_id_fst);
+               &transition_id_fst);
   // at this point transition_id_fst will have transition-ids as its ilabels and
   // context-dependent phones (indexes into ILabelInfo()) as its olabels.
   // Discard the context-dependent phones by projecting on the input, keeping

--- a/src/chain/chain-supervision.cc
+++ b/src/chain/chain-supervision.cc
@@ -344,11 +344,10 @@ bool ProtoSupervisionToSupervision(
 
   // You should always set reorder to true; for the current chain-model
   // topologies, it will affect results if you are inconsistent about this.
-  bool reorder = true,
-      check_no_self_loops = true;
+  bool reorder = true;
   // add self-loops to the FST with transition-ids as its labels.
   AddSelfLoops(trans_model, disambig_syms_h, self_loop_scale, reorder,
-               check_no_self_loops, &transition_id_fst);
+               &transition_id_fst);
 
   // at this point transition_id_fst will have transition-ids as its ilabels and
   // context-dependent phones (indexes into ILabelInfo()) as its olabels.
@@ -1063,8 +1062,8 @@ bool ConvertSupervisionToUnconstrained(
     // self-loop-free.
     bool check_no_self_loops = false;
     supervision->e2e_fsts.resize(1);
-    AddSelfLoops(trans_mdl, disambig_syms, self_loop_scale,
-                 reorder, check_no_self_loops, &(supervision->e2e_fsts[0]));
+    AddSelfLoopsChecking(trans_mdl, disambig_syms, self_loop_scale,
+                         reorder, check_no_self_loops, &(supervision->e2e_fsts[0]));
   }
 
   { // Convert transition-ids to pdf-ids+1 on the FST labels,

--- a/src/decoder/training-graph-compiler.cc
+++ b/src/decoder/training-graph-compiler.cc
@@ -133,12 +133,10 @@ bool TrainingGraphCompiler::CompileGraph(const fst::VectorFst<fst::StdArc> &word
   MinimizeEncoded(&trans2word_fst);
 
   std::vector<int32> disambig;
-  bool check_no_self_loops = true;
   AddSelfLoops(trans_model_,
                disambig,
                opts_.self_loop_scale,
                opts_.reorder,
-               check_no_self_loops,
                &trans2word_fst);
 
   delete H;
@@ -233,12 +231,10 @@ bool TrainingGraphCompiler::CompileGraphs(
     MinimizeEncoded(&trans2word_fst);
 
     std::vector<int32> disambig;
-    bool check_no_self_loops = true;
     AddSelfLoops(trans_model_,
                  disambig,
                  opts_.self_loop_scale,
                  opts_.reorder,
-                 check_no_self_loops,
                  &trans2word_fst);
 
     KALDI_ASSERT(trans2word_fst.Start() != kNoStateId);

--- a/src/hmm/hmm-utils.cc
+++ b/src/hmm/hmm-utils.cc
@@ -566,8 +566,16 @@ void AddSelfLoops(const TransitionModel &trans_model,
                   const std::vector<int32> &disambig_syms,
                   BaseFloat self_loop_scale,
                   bool reorder,
-                  bool check_no_self_loops,
                   fst::VectorFst<fst::StdArc> *fst) {
+  return AddSelfLoopsChecking(trans_model, disambig_syms, self_loop_scale, reorder, true, fst);
+}
+
+void AddSelfLoopsChecking(const TransitionModel &trans_model,
+                          const std::vector<int32> &disambig_syms,
+                          BaseFloat self_loop_scale,
+                          bool reorder,
+                          bool check_no_self_loops,
+                          fst::VectorFst<fst::StdArc> *fst) {
   KALDI_ASSERT(fst->Start() != fst::kNoStateId);
   if (reorder)
     AddSelfLoopsReorder(trans_model, disambig_syms, self_loop_scale,

--- a/src/hmm/hmm-utils.h
+++ b/src/hmm/hmm-utils.h
@@ -174,8 +174,27 @@ void AddSelfLoops(const TransitionModel &trans_model,
                   const std::vector<int32> &disambig_syms,  // used as a check only.
                   BaseFloat self_loop_scale,
                   bool reorder,
-                  bool check_no_self_loops,
                   fst::VectorFst<fst::StdArc> *fst);
+
+/**
+  * For context, see \ref hmm_graph_add_self_loops.  This is an extension of
+  * AddSelfLoops that introduces an optional check for existing self-loops using
+  * the check_no_self_loops argument.  See AddSelfLoops for the other arguments.
+  *
+  * @param check_no_self_loops [in]  If true, it will check that there are no
+  *                      self-loops in the original graph; you'll normally want
+  *                      this to be true.  If false, it will allow them, and
+  *                      will add self-loops after the original self-loop
+  *                      transitions, assuming reorder==true... this happens to
+  *                      be what we want when converting normal to unconstrained
+  *                      chain examples.
+  */
+void AddSelfLoopsChecking(const TransitionModel &trans_model,
+                          const std::vector<int32> &disambig_syms,  // used as a check only.
+                          BaseFloat self_loop_scale,
+                          bool reorder,
+                          bool check_no_self_loops,
+                          fst::VectorFst<fst::StdArc> *fst);
 
 /**
   * Adds transition-probs, with the supplied


### PR DESCRIPTION
This fixes the backwards-incompatible changes made to AddSelfLoops in #2383. Instead of changing the original function signature we introduce a new function that provides the new functionality, calling this new function from the old one and from all the places where the new arguments were used with non-default values.

This makes AddSelfLoops backwards-compatible - external calls won't have to be updated (unless they were updated since #2383).