### PR TITLE
Fix incorrect exception handling syntax

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/report/log_parse.py
+++ b/egs/wsj/s5/steps/libs/nnet3/report/log_parse.py
@@ -532,7 +532,7 @@ def generate_acc_logprob_report(exp_dir, key="accuracy", output="output"):
         try:
             report.append("%d\t%s\t%g\t%g\t%g" % (x[0], str(times[x[0]]),
                                                   x[1], x[2], x[2]-x[1]))
-        except KeyError, IndexError:
+        except (KeyError, IndexError):
             continue
 
     total_time = 0


### PR DESCRIPTION
Python > 3.4 throws an incorrect syntax error if multiple exceptions being caught are not declared as tuples.

```
Traceback (most recent call last):
  File "steps/nnet3/chain/train.py", line 22, in <module>
    import libs.nnet3.report.log_parse as nnet3_log_parse
  File "steps/libs/nnet3/report/__init__.py", line 6, in <module>
    from . import log_parse
  File "steps/libs/nnet3/report/log_parse.py", line 535
    except KeyError, IndexError:
                   ^
SyntaxError: invalid syntax
```