### PR TITLE
Use a regular expression to tokenize lexicon.txt

### DIFF
--- a/egs/wsj/s5/utils/lang/make_lexicon_fst.py
+++ b/egs/wsj/s5/utils/lang/make_lexicon_fst.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import sys
 import math
+import re
 
 # The use of latin-1 encoding does not preclude reading utf-8.  latin-1
 # encoding means "treat words as sequences of bytes", and it is compatible
@@ -70,7 +71,8 @@ def read_lexiconp(filename):
     # See the comment near the top of this file, RE why we use latin-1.
     with open(filename, 'r', encoding='latin-1') as f:
         for line in f:
-            a = line.split()
+            whitespace = re.compile("[ \t]+")
+            a = whitespace.split(line.strip())
             if len(a) < 2:
                 print("{0}: error: found bad line '{1}' in lexicon file {2} ".format(
                     sys.argv[0], line.strip(), filename), file=sys.stderr)


### PR DESCRIPTION
Some UTF-8 characters (for example Š) are interpreted in latin-1 as containing whitespace. For example, Š consists of bytes c5 and a0 in UTF-8, but a0 corresponds to non-breaking space in latin-1. This means that words containing Š are not tokenized correctly when reading lexicon.txt.

This change ensures that lexicon.txt is tokenized using only space or tab characters.