### PR TITLE
[egs] Fix an issue that `egs/csj/s5/local/csj_data_prep.sh` always fails if target file (`$dir/lexicon.txt`) already exists.

### DIFF
--- a/egs/csj/s5/local/csj_data_prep.sh
+++ b/egs/csj/s5/local/csj_data_prep.sh
@@ -45,7 +45,9 @@ if [ ! -d $CSJ ]; then
 fi
 
 # CSJ dictionary file check
-[ ! -f $dir/lexicon.txt ] && cp $CSJ/lexicon/lexicon.txt $dir || exit 1;
+if [ ! -f $dir/lexicon.txt ]; then
+  cp $CSJ/lexicon/lexicon.txt $dir || exit 1;
+fi
 
 ### Config of using wav data that relates with acoustic model training ###
 if [ $mode -eq 3 ]


### PR DESCRIPTION
egs/csj has an issue that `s5/local/csj_data_prep.sh` always fails if target file (`$dir/lexicon.txt`) already exists.
It happens when execute `egs/csj/s5/run.sh` again after run.sh is finished.

This commit fixes this issue.
