### PR TITLE
[egs] egs/voxceleb1/ data preparation fix

### DIFF
--- a/egs/voxceleb/v1/local/make_voxceleb1.pl
+++ b/egs/voxceleb/v1/local/make_voxceleb1.pl
@@ -15,10 +15,6 @@ if (@ARGV != 2) {
 my $out_test_dir = "$out_dir/voxceleb1_test";
 my $out_train_dir = "$out_dir/voxceleb1_train";
 
-if (! -e "$data_base/voxceleb1_test.txt") {
-  system("wget -O $data_base/voxceleb1_test.txt http://www.openslr.org/resources/49/voxceleb1_test.txt");
-}
-
 if (system("mkdir -p $out_test_dir") != 0) {
   die "Error making directory $out_test_dir";
 }
@@ -31,20 +27,35 @@ opendir my $dh, "$data_base/voxceleb1_wav" or die "Cannot open directory: $!";
 my @spkr_dirs = grep {-d "$data_base/voxceleb1_wav/$_" && ! /^\.{1,2}$/} readdir($dh);
 closedir $dh;
 
+if (! -e "$data_base/voxceleb1_test.txt") {
+  system("wget -O $data_base/voxceleb1_test.txt http://www.openslr.org/resources/49/voxceleb1_test.txt");
+}
+
+if (! -e "$data_base/vox1_meta.csv") {
+  system("wget -O $data_base/vox1_meta.csv http://www.openslr.org/resources/49/vox1_meta.csv");
+}
+
 open(TRIAL_IN, "<", "$data_base/voxceleb1_test.txt") or die "Could not open the verification trials file $data_base/voxceleb1_test.txt";
+open(META_IN, "<", "$data_base/vox1_meta.csv") or die "Could not open the meta data file $data_base/vox1_meta.csv";
 open(SPKR_TEST, ">", "$out_test_dir/utt2spk") or die "Could not open the output file $out_test_dir/utt2spk";
 open(WAV_TEST, ">", "$out_test_dir/wav.scp") or die "Could not open the output file $out_test_dir/wav.scp";
 open(SPKR_TRAIN, ">", "$out_train_dir/utt2spk") or die "Could not open the output file $out_train_dir/utt2spk";
 open(WAV_TRAIN, ">", "$out_train_dir/wav.scp") or die "Could not open the output file $out_train_dir/wav.scp";
 open(TRIAL_OUT, ">", "$out_test_dir/trials") or die "Could not open the output file $out_test_dir/trials";
 
+my %id2spkr = ();
+while (<META_IN>) {
+  chomp;
+  my ($vox_id, $spkr_id, $gender, $nation, $set) = split;
+  $id2spkr{$vox_id} = $spkr_id;
+}
+
 my $test_spkrs = ();
 while (<TRIAL_IN>) {
   chomp;
-  my ($tar_or_none, $path1, $path2) = split;
+  my ($tar_or_non, $path1, $path2) = split;
 
   # Create entry for left-hand side of trial
-  my $wav = "$data_base/voxceleb1_wav/$path1";
   my ($spkr_id, $filename) = split('/', $path1);
   my $rec_id = substr($filename, 0, 11);
   my $segment = substr($filename, 12, 7);
@@ -52,7 +63,6 @@ while (<TRIAL_IN>) {
   $test_spkrs{$spkr_id} = ();
 
   # Create entry for right-hand side of trial
-  my $wav = "$data_base/voxceleb1_wav/$path2";
   my ($spkr_id, $filename) = split('/', $path2);
   my $rec_id = substr($filename, 0, 11);
   my $segment = substr($filename, 12, 7);
@@ -60,7 +70,7 @@ while (<TRIAL_IN>) {
   $test_spkrs{$spkr_id} = ();
 
   my $target = "nontarget";
-  if ($tar_or_none eq "1") {
+  if ($tar_or_non eq "1") {
     $target = "target";
   }
   print TRIAL_OUT "$utt_id1 $utt_id2 $target\n";
@@ -68,6 +78,12 @@ while (<TRIAL_IN>) {
 
 foreach (@spkr_dirs) {
   my $spkr_id = $_;
+  my $new_spkr_id = $spkr_id;
+  # If we're using a newer version of VoxCeleb1, we need to "deanonymize"
+  # the speaker labels.
+  if (exists $id2spkr{$spkr_id}) {
+    $new_spkr_id = $id2spkr{$spkr_id};
+  }
   opendir my $dh, "$data_base/voxceleb1_wav/$spkr_id/" or die "Cannot open directory: $!";
   my @files = map{s/\.[^.]+$//;$_}grep {/\.wav$/} readdir($dh);
   closedir $dh;
@@ -75,14 +91,14 @@ foreach (@spkr_dirs) {
     my $filename = $_;
     my $rec_id = substr($filename, 0, 11);
     my $segment = substr($filename, 12, 7);
-    my $utt_id = "$spkr_id-$rec_id-$segment";
     my $wav = "$data_base/voxceleb1_wav/$spkr_id/$filename.wav";
-    if (exists $test_spkrs{$spkr_id}) {
+    my $utt_id = "$new_spkr_id-$rec_id-$segment";
+    if (exists $test_spkrs{$new_spkr_id}) {
       print WAV_TEST "$utt_id", " $wav", "\n";
-      print SPKR_TEST "$utt_id", " $spkr_id", "\n";
+      print SPKR_TEST "$utt_id", " $new_spkr_id", "\n";
     } else {
       print WAV_TRAIN "$utt_id", " $wav", "\n";
-      print SPKR_TRAIN "$utt_id", " $spkr_id", "\n";
+      print SPKR_TRAIN "$utt_id", " $new_spkr_id", "\n";
     }
   }
 }
@@ -93,6 +109,7 @@ close(SPKR_TRAIN) or die;
 close(WAV_TRAIN) or die;
 close(TRIAL_OUT) or die;
 close(TRIAL_IN) or die;
+close(META_IN) or die;
 
 if (system(
   "utils/utt2spk_to_spk2utt.pl $out_test_dir/utt2spk >$out_test_dir/spk2utt") != 0) {


### PR DESCRIPTION
This PR resolves issue https://github.com/kaldi-asr/kaldi/issues/2650.

The VoxCeleb1 corpus was updated to anonymize the celebrity names. This caused a mismatch between the new version of the corpus and the trials file we mirror here: http://www.openslr.org/resources/49/voxceleb1_test.txt. See http://kaldi-asr.org/forums.html?place=msg%2Fkaldi-help%2F8cB9Q7BJWxE%2F7PSw7fIlBAAJ for more details about this.

I've added a new meta data file to http://www.openslr.org/49/ which, in addition to providing gender and nationality info, also provides a mapping between the old and new speaker IDs.

The PR modifies updates local/make_voxceleb1.pl so that it downloads the meta data file, and creates a mapping from the new anonymous speaker IDs to the old speaker IDs. The script then checks to see if the speaker IDs are in the new format, and if so, replaces them with the old speaker IDs. As a result, the script continues to work with the old trials file in http://www.openslr.org/49/.