### PR TITLE
Fix to tedlium v3 run.sh (rnnlm rescoring)

### DIFF
--- a/egs/tedlium/s5_r3/run.sh
+++ b/egs/tedlium/s5_r3/run.sh
@@ -207,7 +207,7 @@ if [ $stage -le 19 ]; then
 
   for dset in dev test; do
     data_dir=data/${dset}_hires
-    decoding_dir=exp/chain_cleaned/tdnnf_1a
+    decoding_dir=exp/chain_cleaned/tdnnf_1a/decode_${dset}
     suffix=$(basename $rnnlm_dir)
     output_dir=${decoding_dir}_$suffix
 


### PR DESCRIPTION
Fix to the rnnlm rescoring part (stage 19)
The path to previously decoded directory is wrong