### PR TITLE
fixed path error in download_and_untar

### DIFF
--- a/egs/mini_librispeech/s5/local/download_and_untar.sh
+++ b/egs/mini_librispeech/s5/local/download_and_untar.sh
@@ -77,6 +77,7 @@ if [ ! -f $data/$part.tar.gz ]; then
     echo "$0: error executing wget $full_url"
     exit 1;
   fi
+  cd -
 fi
 
 cd $data


### PR DESCRIPTION
Earlier there were 2 "cd" commands which would cause problems if path was relative, e.g. "../". Added a "cd -" to fix it.

This was raised in issue https://github.com/kaldi-asr/kaldi/issues/2688