### PR TITLE
[src] Fix Singleton implementation of CuDevice.

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -514,7 +514,6 @@ CuDevice::CuDevice():
     cusparse_handle_(NULL) {
 }
 
-
 CuDevice::~CuDevice() {
   if (cublas_handle_)
     CUBLAS_SAFE_CALL(cublasDestroy(cublas_handle_));

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -184,10 +184,10 @@ class CuDevice {
   /// (i.e. from outside the class), call this only if Enabled() returns true.
   bool IsComputeExclusive();
 
-  CuDevice();
-
   ~CuDevice();
  private:
+  // Default constructor used to initialize this_thread_device_
+  CuDevice();
   CuDevice(CuDevice&); // Disallow.
   CuDevice &operator=(CuDevice&);  // Disallow.
 


### PR DESCRIPTION
No longer publicly expose the default constructor.

That could allow someone to do something like this:

CuDevice device1;
CuDevice device2;

We're not sure what this would cause, but it probably wouldn't be good.