### PR TITLE
Add missing packages in extras/check_dependencies.sh

### DIFF
--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -25,6 +25,7 @@ case $COMPILER_VER_INFO in
   "")
     echo "$0: $CXX is not installed."
     echo "$0: You need g++ >= 4.8.3, Apple Xcode >= 5.0 or clang >= 3.3."
+    add_packages gcc-c++ g++ gcc-c++
     status=1
     ;;
   "g++ "* )
@@ -90,13 +91,13 @@ fi
 pythonok=true
 if ! which python2.7 >&/dev/null; then
   echo "$0: python2.7 is not installed"
-  add_packages python2.7
+  add_packages python2.7 python2.7
   pythonok=false
 fi
 
 if ! which python3 >&/dev/null; then
   echo "$0: python3 is not installed"
-  add_packages python3
+  add_packages python3 python3
   pythonok=false
 fi
 


### PR DESCRIPTION
Recently I was installing Kaldi on a bare-bones ubuntu and noticed some missing info in dependency suggestions.