### PR TITLE
Backup in/utils/data/conver_data_dir_tw_whole.sh if files exist.

### DIFF
--- a/egs/wsj/s5/utils/data/convert_data_dir_to_whole.sh
+++ b/egs/wsj/s5/utils/data/convert_data_dir_to_whole.sh
@@ -41,8 +41,9 @@ fi
 if [ -f $dir/cmvn.scp ]; then
   mv $dir/cmvn.scp $dir/.backup
 fi
-
-rm $dir/utt2spk || true
+if [ -f $dir/utt2spk ]; then
+  mv $dir/utt2spk $dir/.backup
+fi
 
 [ -f $data/stm ] && cp $data/stm $dir
 [ -f $data/glm ] && cp $data/glm $dir

--- a/egs/wsj/s5/utils/data/convert_data_dir_to_whole.sh
+++ b/egs/wsj/s5/utils/data/convert_data_dir_to_whole.sh
@@ -35,7 +35,12 @@ if [ -f $data/reco2file_and_channel ]; then
 fi
 
 mkdir -p $dir/.backup
-mv $dir/feats.scp $dir/cmvn.scp $dir/.backup
+if [ -f $dir/feats.scp ]; then
+  mv $dir/feats.scp $dir/.backup
+fi
+if [ -f $dir/cmvn.scp ]; then
+  mv $dir/cmvn.scp $dir/.backup
+fi
 
 rm $dir/utt2spk || true
 


### PR DESCRIPTION
It will warn when running the original script first time.
```
mv: cannot stat 'data/train_whole/feats.scp': No such file or directory
mv: cannot stat 'data/train_whole/cmvn.scp': No such file or directory
rm: cannot remove 'data/train_whole/utt2spk': No such file or directory
```