### PR TITLE
fixing memory bug in kaldi::~LatticeFasterDecoderTpl(),

### DIFF
--- a/src/decoder/lattice-faster-decoder.cc
+++ b/src/decoder/lattice-faster-decoder.cc
@@ -49,7 +49,7 @@ template <typename FST, typename Token>
 LatticeFasterDecoderTpl<FST, Token>::~LatticeFasterDecoderTpl() {
   DeleteElems(toks_.Clear());
   ClearActiveTokens();
-  if (delete_fst_) delete &(fst_);
+  if (delete_fst_) delete fst_;
 }
 
 template <typename FST, typename Token>


### PR DESCRIPTION
- found it when running 'latgen-faster-mapped-parallel',
- core-dumps from the line: decoder/lattice-faster-decoder.cc:52
-- the line is doing 'delete &(FST*)', i.e. deleting the pointer to FST, instead of deleting the FST itslef,
-- bug was probably introduced by refactoring commit d0c68a60 from 2018-09-01,
-- after the change the code runs fine... (the unit tests for src/decoder are missing)