### PR TITLE
[egs][aishell2] fix: add missing online cmvn config

### DIFF
--- a/egs/aishell2/s5/conf/online_cmvn.conf
+++ b/egs/aishell2/s5/conf/online_cmvn.conf
@@ -1,0 +1,1 @@
+# configuration file for apply-cmvn-online


### PR DESCRIPTION
Just noticed the online cmvn config file was missing. "steps/online/nnet2/train_diag_ubm.sh" requires this file, otherwise the recipe will raise an error and exit.

Now add the dummy config file (the one used in our previous experiments) to fix this. No effects on final results. 

@naxingyu @underdogliu have a check.