### PR TITLE
deterministic results for make_rttm

### DIFF
--- a/egs/callhome_diarization/v1/diarization/make_rttm.py
+++ b/egs/callhome_diarization/v1/diarization/make_rttm.py
@@ -80,7 +80,7 @@ def main():
 
   # Cut up overlapping segments so they are contiguous
   contiguous_segs = []
-  for reco in reco2segs:
+  for reco in sorted(reco2segs):
     segs = reco2segs[reco].strip().split()
     new_segs = ""
     for i in range(1, len(segs)-1):


### PR DESCRIPTION
Hi,

This PR fixes make_rttm so for the same content if input files the output file is always the same which is currently not the case.
Currently, the lines of rttm are randomly permuted according to utterance-ids.

for Python3.5.2 (and for older versions) the order of iterating over keys of dictionaries is not guaranteed and indeed is often "random".
See https://docs.python.org/3.6/whatsnew/3.6.html#new-dict-implementation
