### PR TITLE
Simplifying AMI recipe

### DIFF
--- a/egs/ami/s5b/RESULTS_ihm
+++ b/egs/ami/s5b/RESULTS_ihm
@@ -88,6 +88,10 @@
 
 # local/chain/multi_condition/tuning/run_tdnn_lstm_1a.sh --mic ihm
 # cleanup + chain TDNN+LSTM model + IHM reverberated data
+# Old results:
 %WER 19.4 | 13098 94479 | 83.8 10.0 6.1 3.2 19.4 51.8 | -0.168 | exp/ihm/chain_cleaned_rvb/tdnn_lstm1i_sp_rvb_bi/decode_dev/ascore_10/dev_hires.ctm.filt.sys
 %WER 19.3 | 12643 89977 | 83.3 11.0 5.7 2.6 19.3 49.6 | -0.046 | exp/ihm/chain_cleaned_rvb/tdnn_lstm1i_sp_rvb_bi/decode_eval/ascore_10/eval_hires.ctm.filt.sys
 
+# New results after simplifying scripts to remove combining short segments etc.:
+%WER 19.4 | 12643 89979 | 83.1 10.9 6.0 2.5 19.4 50.7 | 0.010 | exp/ihm/chain_cleaned_rvb/tdnn_lstm1a_sp_rvb_bi/decode_eval/ascore_11/eval_hires.ctm.filt.sys
+%WER 19.4 | 13098 94484 | 83.7 10.2 6.1 3.1 19.4 52.0 | -0.119 | exp/ihm/chain_cleaned_rvb/tdnn_lstm1a_sp_rvb_bi/decode_dev/ascore_11/dev_hires.ctm.filt.sys

--- a/egs/ami/s5b/RESULTS_sdm
+++ b/egs/ami/s5b/RESULTS_sdm
@@ -96,6 +96,10 @@
 # local/chain/multi_condition/tuning/run_tdnn_lstm_1a.sh --mic sdm1 --use-ihm-ali true --train-set train_cleaned --gmm tri3_cleaned 
 # cleanup + chain TDNN+LSTM model, SDM original + IHM reverberated data, alignments from ihm data.
 # *** best system ***
+# Old results:
 %WER 34.0 | 14455 94497 | 69.8 17.7 12.5 3.8 34.0 63.9 | 0.675 | exp/sdm1/chain_cleaned_rvb/tdnn_lstm1i_sp_rvb_bi_ihmali/decode_dev/ascore_10/dev_hires_o4.ctm.filt.sys
 %WER 37.5 | 13261 89982 | 65.9 19.3 14.7 3.5 37.5 66.2 | 0.642 | exp/sdm1/chain_cleaned_rvb/tdnn_lstm1i_sp_rvb_bi_ihmali/decode_eval/ascore_10/eval_hires_o4.ctm.filt.sys
 
+# New results after simplifying scripts to remove combining short segments etc.:
+%WER 34.6 | 14604 94498 | 69.6 18.8 11.6 4.2 34.6 64.4 | 0.652 | exp/sdm1/chain_cleaned_rvb/tdnn_lstm1a_sp_rvb_bi_ihmali/decode_dev/ascore_11/dev_hires_o4.ctm.filt.sys
+%WER 37.6 | 13606 89636 | 66.1 21.0 12.9 3.7 37.6 65.1 | 0.613 | exp/sdm1/chain_cleaned_rvb/tdnn_lstm1a_sp_rvb_bi_ihmali/decode_eval/ascore_11/eval_hires_o4.ctm.filt.sys

--- a/egs/ami/s5b/local/nnet3/multi_condition/run_ivector_common.sh
+++ b/egs/ami/s5b/local/nnet3/multi_condition/run_ivector_common.sh
@@ -10,19 +10,17 @@ set -e -o pipefail
 stage=1
 mic=ihm
 nj=30
-min_seg_len=1.55  # min length in seconds... we do this because chain training
-                  # will discard segments shorter than 1.5 seconds.  Must remain in sync with
-                  # the same option given to prepare_lores_feats.sh.
 train_set=train_cleaned   # you might set this to e.g. train_cleaned.
-gmm=tri3_cleaned  # This specifies a GMM-dir from the features of the type you're training the system on;
-                  # it should contain alignments for 'train_set'.
-
+norvb_datadir=data/ihm/train_cleaned_sp
 
 num_threads_ubm=32
 rvb_affix=_rvb
 nnet3_affix=_cleaned     # affix for exp/$mic/nnet3 directory to put iVector stuff in, so it
                          # becomes exp/$mic/nnet3_cleaned or whatever.
 num_data_reps=1
+sample_rate=16000
+
+max_jobs_run=10
 
 . ./cmd.sh
 . ./path.sh
@@ -30,10 +28,7 @@ num_data_reps=1
 
 nnet3_affix=${nnet3_affix}$rvb_affix
 
-gmmdir=exp/${mic}/${gmm}
-
-
-for f in data/${mic}/${train_set}/feats.scp ${gmmdir}/final.mdl; do
+for f in data/${mic}/${train_set}/feats.scp; do
   if [ ! -f $f ]; then
     echo "$0: expected file $f to exist"
     exit 1
@@ -73,36 +68,23 @@ if [ $stage -le 1 ]; then
 
   for datadir in ${train_set}_sp dev eval; do
     steps/make_mfcc.sh --nj $nj --mfcc-config conf/mfcc_hires.conf \
-      --cmd "$train_cmd" data/$mic/${datadir}_hires
+      --cmd "$train_cmd --max-jobs-run $max_jobs_run" data/$mic/${datadir}_hires
     steps/compute_cmvn_stats.sh data/$mic/${datadir}_hires
     utils/fix_data_dir.sh data/$mic/${datadir}_hires
   done
 fi
 
-if [ $stage -le 2 ]; then
-  echo "$0: combining short segments of speed-perturbed high-resolution MFCC training data"
-  # we have to combine short segments or we won't be able to train chain models
-  # on those segments.
-  utils/data/combine_short_segments.sh \
-     data/${mic}/${train_set}_sp_hires $min_seg_len data/${mic}/${train_set}_sp_hires_comb
-
-  # just copy over the CMVN to avoid having to recompute it.
-  cp data/${mic}/${train_set}_sp_hires/cmvn.scp data/${mic}/${train_set}_sp_hires_comb/
-  utils/fix_data_dir.sh data/${mic}/${train_set}_sp_hires_comb/
-fi
 
 if [ $stage -le 3 ]; then
   echo "$0: creating reverberated MFCC features"
 
-  datadir=data/ihm/train_cleaned_sp
-
-  mfccdir=${datadir}_rvb${num_data_reps}_hires/data
+  mfccdir=${norvb_datadir}${rvb_affix}${num_data_reps}_hires/data
   if [[ $(hostname -f) == *.clsp.jhu.edu ]] && [ ! -d $mfccdir/storage ]; then
     utils/create_split_dir.pl /export/b0{5,6,7,8}/$USER/kaldi-data/egs/ami-$mic-$(date +'%m_%d_%H_%M')/s5/$mfccdir/storage $mfccdir/storage
   fi
 
-  if [ ! -f ${datadir}_rvb${num_data_reps}_hires/feats.scp ]; then
-    if [ ! -d "RIRS_NOISES" ]; then
+  if [ ! -f ${norvb_datadir}${rvb_affix}${num_data_reps}_hires/feats.scp ]; then
+    if [ ! -d "RIRS_NOISES/" ]; then
       # Download the package that includes the real RIRs, simulated RIRs, isotropic noises and point-source noises
       wget --no-check-certificate http://www.openslr.org/resources/28/rirs_noises.zip
       unzip rirs_noises.zip
@@ -123,60 +105,29 @@ if [ $stage -le 3 ]; then
       --isotropic-noise-addition-probability 1 \
       --num-replications ${num_data_reps} \
       --max-noises-per-minute 1 \
-      --source-sampling-rate 16000 \
-      ${datadir} ${datadir}_rvb${num_data_reps}
+      --source-sampling-rate $sample_rate \
+      ${norvb_datadir} ${norvb_datadir}${rvb_affix}${num_data_reps}
 
-    utils/copy_data_dir.sh ${datadir}_rvb${num_data_reps} ${datadir}_rvb${num_data_reps}_hires
-    utils/data/perturb_data_dir_volume.sh ${datadir}_rvb${num_data_reps}_hires
+    utils/copy_data_dir.sh ${norvb_datadir}${rvb_affix}${num_data_reps} ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
+    utils/data/perturb_data_dir_volume.sh ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
 
     steps/make_mfcc.sh --nj $nj --mfcc-config conf/mfcc_hires.conf \
-      --cmd "$train_cmd" ${datadir}_rvb${num_data_reps}_hires
-    steps/compute_cmvn_stats.sh ${datadir}_rvb${num_data_reps}_hires
-    utils/fix_data_dir.sh ${datadir}_rvb${num_data_reps}_hires  
-
-    utils/data/combine_short_segments.sh \
-      ${datadir}_rvb${num_data_reps}_hires $min_seg_len ${datadir}_rvb${num_data_reps}_hires_comb
-
-    # just copy over the CMVN to avoid having to recompute it.
-    cp ${datadir}_rvb${num_data_reps}_hires/cmvn.scp ${datadir}_rvb${num_data_reps}_hires_comb/
-    utils/fix_data_dir.sh ${datadir}_rvb${num_data_reps}_hires_comb/
+      --cmd "$train_cmd --max-jobs-run $max_jobs_run" ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
+    steps/compute_cmvn_stats.sh ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
+    utils/fix_data_dir.sh ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
   fi
 
-  utils/combine_data.sh data/${mic}/${train_set}_sp_rvb_hires data/${mic}/${train_set}_sp_hires ${datadir}_rvb${num_data_reps}_hires
-  utils/combine_data.sh data/${mic}/${train_set}_sp_rvb_hires_comb data/${mic}/${train_set}_sp_hires_comb ${datadir}_rvb${num_data_reps}_hires_comb
+  utils/combine_data.sh data/${mic}/${train_set}_sp${rvb_affix}_hires data/${mic}/${train_set}_sp_hires ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
 fi
 
-
 if [ $stage -le 4 ]; then
-  echo "$0: selecting segments of hires training data that were also present in the"
-  echo " ... original training data."
+  utils/combine_data.sh data/${mic}/${train_set}_sp${rvb_affix}_hires data/${mic}/${train_set}_sp_hires ${norvb_datadir}${rvb_affix}${num_data_reps}_hires
 
-  # note, these data-dirs are temporary; we put them in a sub-directory
-  # of the place where we'll make the alignments.
-  temp_data_root=exp/$mic/nnet3${nnet3_affix}/tri5
-  mkdir -p $temp_data_root
-
-  utils/data/subset_data_dir.sh --utt-list data/${mic}/${train_set}/feats.scp \
-          data/${mic}/${train_set}_sp_hires $temp_data_root/${train_set}_hires
-
-  # note: essentially all the original segments should be in the hires data.
-  n1=$(wc -l <data/${mic}/${train_set}/feats.scp)
-  n2=$(wc -l <$temp_data_root/${train_set}_hires/feats.scp)
-  if [ $n1 != $n1 ]; then
-    echo "$0: warning: number of feats $n1 != $n2, if these are very different it could be bad."
-  fi
-
-  echo "$0: training a system on the hires data for its LDA+MLLT transform, in order to produce the diagonal GMM."
-  if [ -e exp/$mic/nnet3${nnet3_affix}/tri5/final.mdl ]; then
-    # we don't want to overwrite old stuff, ask the user to delete it.
-    echo "$0: exp/$mic/nnet3${nnet3_affix}/tri5/final.mdl already exists: "
-    echo " ... please delete and then rerun, or use a later --stage option."
-    exit 1;
-  fi
-  steps/train_lda_mllt.sh --cmd "$train_cmd" --num-iters 7 --mllt-iters "2 4 6" \
-     --splice-opts "--left-context=3 --right-context=3" \
-     3000 10000 $temp_data_root/${train_set}_hires data/lang \
-      $gmmdir exp/$mic/nnet3${nnet3_affix}/tri5
+  steps/online/nnet2/get_pca_transform.sh --cmd "$train_cmd" \
+    --splice-opts "--left-context=3 --right-context=3" \
+    --max-utts 30000 --subsample 2 \
+    data/${mic}/${train_set}_sp${rvb_affix}_hires \
+    exp/$mic/nnet3${nnet3_affix}/pca_transform
 fi
 
 
@@ -186,22 +137,21 @@ if [ $stage -le 5 ]; then
   mkdir -p exp/$mic/nnet3${nnet3_affix}/diag_ubm
   temp_data_root=exp/$mic/nnet3${nnet3_affix}/diag_ubm
 
-  # train a diagonal UBM using a subset of about a quarter of the data
-  # we don't use the _comb data for this as there is no need for compatibility with
-  # the alignments, and using the non-combined data is more efficient for I/O
+  # train a diagonal UBM using a subset of about a quarter of the data,
+  # and using the non-combined data is more efficient for I/O
   # (no messing about with piped commands).
-  num_utts_total=$(wc -l <data/$mic/${train_set}_sp_rvb_hires/utt2spk)
+  num_utts_total=$(wc -l <data/$mic/${train_set}_sp${rvb_affix}_hires/utt2spk)
   num_utts=$[$num_utts_total/4]
-  utils/data/subset_data_dir.sh data/$mic/${train_set}_sp_rvb_hires \
-      $num_utts ${temp_data_root}/${train_set}_sp_rvb_hires_subset
+  utils/data/subset_data_dir.sh data/$mic/${train_set}_sp${rvb_affix}_hires \
+      $num_utts ${temp_data_root}/${train_set}_sp${rvb_affix}_hires_subset
 
   echo "$0: training the diagonal UBM."
   # Use 512 Gaussians in the UBM.
   steps/online/nnet2/train_diag_ubm.sh --cmd "$train_cmd" --nj 30 \
     --num-frames 700000 \
     --num-threads $num_threads_ubm \
-    ${temp_data_root}/${train_set}_sp_rvb_hires_subset 512 \
-    exp/$mic/nnet3${nnet3_affix}/tri5 exp/$mic/nnet3${nnet3_affix}/diag_ubm
+    ${temp_data_root}/${train_set}_sp${rvb_affix}_hires_subset 512 \
+    exp/$mic/nnet3${nnet3_affix}/pca_transform exp/$mic/nnet3${nnet3_affix}/diag_ubm
 fi
 
 if [ $stage -le 6 ]; then
@@ -210,14 +160,14 @@ if [ $stage -le 6 ]; then
   # 100.
   echo "$0: training the iVector extractor"
   steps/online/nnet2/train_ivector_extractor.sh --cmd "$train_cmd" --nj 10 \
-    data/$mic/${train_set}_sp_rvb_hires exp/$mic/nnet3${nnet3_affix}/diag_ubm exp/$mic/nnet3${nnet3_affix}/extractor || exit 1;
+    data/$mic/${train_set}_sp${rvb_affix}_hires exp/$mic/nnet3${nnet3_affix}/diag_ubm exp/$mic/nnet3${nnet3_affix}/extractor || exit 1;
 fi
 
 if [ $stage -le 7 ]; then
   # note, we don't encode the 'max2' in the name of the ivectordir even though
   # that's the data we extract the ivectors from, as it's still going to be
   # valid for the non-'max2' data, the utterance list is the same.
-  ivectordir=exp/$mic/nnet3${nnet3_affix}/ivectors_${train_set}_sp_rvb_hires_comb
+  ivectordir=exp/$mic/nnet3${nnet3_affix}/ivectors_${train_set}_sp${rvb_affix}_hires
   if [[ $(hostname -f) == *.clsp.jhu.edu ]] && [ ! -d $ivectordir/storage ]; then
     utils/create_split_dir.pl /export/b0{5,6,7,8}/$USER/kaldi-data/egs/ami-$mic-$(date +'%m_%d_%H_%M')/s5/$ivectordir/storage $ivectordir/storage
   fi
@@ -231,10 +181,10 @@ if [ $stage -le 7 ]; then
   # handle per-utterance decoding well (iVector starts at zero).
   temp_data_root=${ivectordir}
   utils/data/modify_speaker_info.sh --utts-per-spk-max 2 \
-    data/${mic}/${train_set}_sp_rvb_hires_comb ${temp_data_root}/${train_set}_sp_rvb_hires_comb_max2
+    data/${mic}/${train_set}_sp${rvb_affix}_hires ${temp_data_root}/${train_set}_sp${rvb_affix}_hires_max2
 
   steps/online/nnet2/extract_ivectors_online.sh --cmd "$train_cmd" --nj $nj \
-    ${temp_data_root}/${train_set}_sp_rvb_hires_comb_max2 \
+    ${temp_data_root}/${train_set}_sp${rvb_affix}_hires_max2 \
     exp/$mic/nnet3${nnet3_affix}/extractor $ivectordir
 
   # Also extract iVectors for the test data, but in this case we don't need the speed

--- a/egs/ami/s5b/local/nnet3/prepare_lores_feats.sh
+++ b/egs/ami/s5b/local/nnet3/prepare_lores_feats.sh
@@ -17,6 +17,7 @@ nj=30
 min_seg_len=1.55  # min length in seconds... we do this because chain training
                   # will discard segments shorter than 1.5 seconds.  Must remain in
                   # sync with the same option given to run_ivector_common.sh.
+                  # Set it to empty string to skip combining segments.
 use_ihm_ali=false # If true, we use alignments from the IHM data (which is better..
                   # don't set this to true if $mic is set to ihm.)
 train_set=train   # you might set this to e.g. train_cleaned.
@@ -69,15 +70,17 @@ if [ $stage -le 9 ]; then
   utils/fix_data_dir.sh data/${mic}/${train_set}${ihm_suffix}_sp
 fi
 
-if [ $stage -le 10 ]; then
-  echo "$0: combining short segments of 13-dimensional speed-perturbed ${maybe_ihm}MFCC data"
-  src=data/${mic}/${train_set}${ihm_suffix}_sp
-  dest=data/${mic}/${train_set}${ihm_suffix}_sp_comb
-  utils/data/combine_short_segments.sh $src $min_seg_len $dest
-  # re-use the CMVN stats from the source directory, since it seems to be slow to
-  # re-compute them after concatenating short segments.
-  cp $src/cmvn.scp $dest/
-  utils/fix_data_dir.sh $dest
+if [ ! -z "$min_seg_len" ]; then
+  if [ $stage -le 10 ]; then
+    echo "$0: combining short segments of 13-dimensional speed-perturbed ${maybe_ihm}MFCC data"
+    src=data/${mic}/${train_set}${ihm_suffix}_sp
+    dest=data/${mic}/${train_set}${ihm_suffix}_sp_comb
+    utils/data/combine_short_segments.sh $src $min_seg_len $dest
+    # re-use the CMVN stats from the source directory, since it seems to be slow to
+    # re-compute them after concatenating short segments.
+    cp $src/cmvn.scp $dest/
+    utils/fix_data_dir.sh $dest
+  fi
 fi
 
 

--- a/egs/ami/s5b/local/prepare_parallel_train_data.sh
+++ b/egs/ami/s5b/local/prepare_parallel_train_data.sh
@@ -6,6 +6,10 @@
 # utterance ids are different between the different mics
 
 
+train_set=train
+
+. utils/parse_options.sh
+
 if [ $# != 1 ]; then
   echo "Usage: $0 [sdm1|mdm8]"
   exit 1
@@ -18,12 +22,10 @@ if [ $mic == "ihm" ]; then
   exit 1;
 fi
 
-train_set=train
-
 . ./cmd.sh
 . ./path.sh
 
-for f in data/ihm/train/utt2spk data/$mic/train/utt2spk; do
+for f in data/ihm/${train_set}/utt2spk data/$mic/${train_set}/utt2spk; do
   if [ ! -f $f ]; then
     echo "$0: expected file $f to exist"
     exit 1
@@ -32,12 +34,12 @@ done
 
 set -e -o pipefail
 
-mkdir -p data/$mic/train_ihmdata
+mkdir -p data/$mic/${train_set}_ihmdata
 
 # the utterance-ids and speaker ids will be from the SDM or MDM data
-cp data/$mic/train/{spk2utt,text,utt2spk} data/$mic/train_ihmdata/
+cp data/$mic/${train_set}/{spk2utt,text,utt2spk} data/$mic/${train_set}_ihmdata/
 # the recording-ids will be from the IHM data.
-cp data/ihm/train/{wav.scp,reco2file_and_channel} data/$mic/train_ihmdata/
+cp data/ihm/${train_set}/{wav.scp,reco2file_and_channel} data/$mic/${train_set}_ihmdata/
 
 # map sdm/mdm segments to the ihm segments
 
@@ -47,18 +49,18 @@ mic_base_upcase=$(echo $mic | sed 's/[0-9]//g' | tr 'a-z' 'A-Z')
 # It has lines like:
 # AMI_EN2001a_H02_FEO065_0021133_0021442 AMI_EN2001a_SDM_FEO065_0021133_0021442
 
-tmpdir=data/$mic/train_ihmdata/
+tmpdir=data/$mic/${train_set}_ihmdata/
 
-awk '{print $1, $1}' <data/ihm/train/utt2spk | \
+awk '{print $1, $1}' <data/ihm/${train_set}/utt2spk | \
   sed -e "s/_H[0-9][0-9]_/_${mic_base_upcase}_/" | \
   awk '{print $2, $1}' >$tmpdir/ihmutt2utt
 
 # Map the 1st field of the segments file from the ihm data (the 1st field being
 # the utterance-id) to the corresponding SDM or MDM utterance-id.  The other
 # fields remain the same (e.g. we want the recording-ids from the IHM data).
-utils/apply_map.pl -f 1 $tmpdir/ihmutt2utt <data/ihm/train/segments >data/$mic/train_ihmdata/segments
+utils/apply_map.pl -f 1 $tmpdir/ihmutt2utt <data/ihm/${train_set}/segments >data/$mic/${train_set}_ihmdata/segments
 
-utils/fix_data_dir.sh data/$mic/train_ihmdata
+utils/fix_data_dir.sh data/$mic/${train_set}_ihmdata
 
 rm $tmpdir/ihmutt2utt
 


### PR DESCRIPTION
Simplying AMI recipe (only the one with data augmentation)
1. LDA transformation is replaced by PCA for i-vector training
2. An extra alignment stage is removed and alignments is obtained from the supervision lattice best path.
3. Short segments are not combined to get 1.5s long segments. Instead, multiple smaller chunk-widths are used in training.

WER results are almost the same.