### PR TITLE
[build] Add cub library for cuda projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ GSYMS
 /tools/mmseg-1.3.0.tar.gz
 /tools/mmseg-1.3.0/
 /kaldiwin_vs*
+/tools/cub-1.8.0.zip
+/tools/cub-1.8.0/
+/tools/cub

--- a/src/configure
+++ b/src/configure
@@ -863,6 +863,7 @@ android=false
 MATHLIB='ATLAS'
 ATLASROOT=`rel2abs ../tools/ATLAS_headers/`
 FSTROOT=`rel2abs ../tools/openfst`
+CUBROOT=`rel2abs ../tools/cub`
 
 # Save the command line to include in kaldi.mk
 cmd_line="$0 $@"
@@ -954,6 +955,9 @@ do
     shift ;;
   --fst-root=*)
     FSTROOT=`read_dirname $1`;
+    shift ;;
+  --cub-root=*)
+    CUBROOT=`read_dirname $1`;
     shift ;;
   --clapack-root=*)
     CLAPACKROOT=`read_dirname $1`;
@@ -1091,6 +1095,13 @@ if $double_precision; then
   echo "DOUBLE_PRECISION = 1" >> kaldi.mk
 else
   echo "DOUBLE_PRECISION = 0" >> kaldi.mk
+fi
+$use_cuda && echo "Checking cub library in $CUBROOT ..."
+if [[ $use_cuda && ! -f $CUBROOT/cub/cub.cuh ]]; then
+  failure "Could not find file $CUBROOT/cub/cub.cuh:
+  you may not have installed cub. See ../tools/INSTALL"
+else
+  echo "CUBROOT = $CUBROOT" >> kaldi.mk
 fi
 echo "Checking OpenFst library in $FSTROOT ..."
 if [ ! -f $FSTROOT/include/fst/fst.h  ]; then

--- a/src/makefiles/cuda_32bit.mk
+++ b/src/makefiles/cuda_32bit.mk
@@ -5,10 +5,11 @@ ifndef CUDATKDIR
 $(error CUDATKDIR not defined.)
 endif
 
-CUDA_INCLUDE= -I$(CUDATKDIR)/include
-CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 32 -DHAVE_CUDA \
+CUDA_INCLUDE= -I$(CUDATKDIR)/include -I$(CUBROOT)
+CUDA_FLAGS = -Xcompiler "-fPIC -pthread -isystem $(OPENFSTINC)" --verbose --machine 32 -DHAVE_CUDA \
              -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
-             -DCUDA_API_PER_THREAD_DEFAULT_STREAM
+             -std=c++11 -DCUDA_API_PER_THREAD_DEFAULT_STREAM
+
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include
-LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath=$(CUDATKDIR)/lib
-LDLIBS += -lcublas -lcusparse -lcudart -lcurand #LDLIBS : The libs are loaded later than static libs in implicit rule
+CUDA_LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath,$(CUDATKDIR)/lib
+CUDA_LDLIBS += -lcuda -lcublas -lcusparse -lcudart -lcurand -lnvToolsExt #LDLIBS : The libs are loaded later than static libs in implicit rule

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -5,10 +5,11 @@ ifndef CUDATKDIR
 $(error CUDATKDIR not defined.)
 endif
 
-CUDA_INCLUDE= -I$(CUDATKDIR)/include
-CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA \
+CUDA_INCLUDE= -I$(CUDATKDIR)/include -I$(CUBROOT)
+CUDA_FLAGS = -Xcompiler "-fPIC -pthread -isystem $(OPENFSTINC)" --verbose --machine 64 -DHAVE_CUDA \
              -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
-             -DCUDA_API_PER_THREAD_DEFAULT_STREAM
+             -std=c++11 -DCUDA_API_PER_THREAD_DEFAULT_STREAM
+
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-CUDA_LDLIBS += -lcublas -lcusparse -lcudart -lcurand #LDLIBS : The libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcuda -lcublas -lcusparse -lcudart -lcurand -lnvToolsExt #LDLIBS : The libs are loaded later than static libs in implicit rule

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,6 +8,7 @@ CC = gcc         # used for sph2pipe
 # Note: OpenFst requires a relatively recent C++ compiler with C++11 support,
 # e.g. g++ >= 4.7, Apple clang >= 5.0 or LLVM clang >= 3.3.
 OPENFST_VERSION ?= 1.6.7
+CUB_VERSION ?= 1.8.0
 
 # Default features configured for OpenFST; can be overridden in the make command line.
 OPENFST_CONFIGURE ?= --enable-static --enable-shared --enable-far --enable-ngram-fsts
@@ -18,7 +19,7 @@ ifeq ("$(shell expr $(OPENFST_VER_NUM) \< 10600)","1")
             Supported versions: >= 1.6.0)
 endif
 
-all: check_required_programs sph2pipe sclite openfst
+all: check_required_programs sph2pipe sclite openfst cub
 	@echo -e "\n\n"
 	@echo "Warning: IRSTLM is not installed by default anymore. If you need IRSTLM"
 	@echo "Warning: use the script extras/install_irstlm.sh"
@@ -49,6 +50,9 @@ distclean:
 	rm -rf openfst-$(OPENFST_VERSION).tar.gz
 	rm -f openfst
 	rm -rf libsndfile-1.0.25{,.tar.gz} BeamformIt-3.51{,.tgz}
+	rm -f cub-$(CUB_VERSION).zip
+	rm -rf cub-$(CUB_VERSION)
+	rm -f cub
 
 
 .PHONY: openfst # so target will be made even though "openfst" exists.
@@ -119,7 +123,7 @@ sph2pipe_v2.5/sph2pipe: | sph2pipe_v2.5
 	$(CC) -o sph2pipe  *.c -lm
 
 sph2pipe_v2.5: sph2pipe_v2.5.tar.gz
-	tar xzf sph2pipe_v2.5.tar.gz
+	tar --no-same-owner -xzf sph2pipe_v2.5.tar.gz
 
 sph2pipe_v2.5.tar.gz:
 	wget -T 10 -t 3 http://www.openslr.org/resources/3/sph2pipe_v2.5.tar.gz || \
@@ -149,3 +153,11 @@ openblas_compiled:
 	cd OpenBLAS; sed 's:# FCOMMON_OPT = -frecursive:FCOMMON_OPT = -frecursive:' < Makefile.rule >tmp && mv tmp Makefile.rule
 	# $(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=1 NUM_THREADS=64 -C OpenBLAS all install
 	$(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=0 -C OpenBLAS all install
+
+
+.PHONY: cub
+cub:
+	wget -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip
+	unzip -o cub-$(CUB_VERSION).zip
+	rm -f cub
+	ln -s cub-$(CUB_VERSION) cub

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -158,6 +158,6 @@ openblas_compiled:
 .PHONY: cub
 cub:
 	wget -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip
-	unzip -o cub-$(CUB_VERSION).zip
+	unzip -oq cub-$(CUB_VERSION).zip
 	rm -f cub
 	ln -s cub-$(CUB_VERSION) cub

--- a/tools/extras/travis_script.sh
+++ b/tools/extras/travis_script.sh
@@ -69,6 +69,7 @@ echo "Building tools..." [Time: $(date)]
 runvx cd tools
 runvx make -j$MAXPAR openfst "$CCC" CXXFLAGS="$CF" \
       OPENFST_CONFIGURE="--disable-static --enable-shared --disable-bin --disable-dependency-tracking"
+runvx make -j$MAXPAR cub "$CCC" CXXFLAGS="$CF"
 cd ..
 
 runvx cd src


### PR DESCRIPTION
This adds the [NVIDIA CUB library](https://nvlabs.github.io/cub/) to the tools/dependencies group and makes it available to modules using cuda.

Future PRs are going to require features from this library. In an effort to make that patchset easier to review, we're breaking it up into smaller pieces.