### PR TITLE
[scripts] prepare_rnn_lm.sh now treats features.txt as optional

### DIFF
--- a/scripts/rnnlm/prepare_rnnlm_dir.sh
+++ b/scripts/rnnlm/prepare_rnnlm_dir.sh
@@ -53,9 +53,13 @@ if [ $stage -le 1 ]; then
     echo "$0: copying config directory"
     mkdir -p $dir/config
     # copy expected things from $config_dir to $dir/config.
-    for f in words.txt features.txt data_weights.txt oov.txt xconfig; do
+    for f in words.txt data_weights.txt oov.txt xconfig; do
       cp $config_dir/$f $dir/config
     done
+    # features.txt is optional, check separately
+    if [ -f $config_dir/features.txt ]; then
+      cp $config_dir/features.txt $dir/config
+    fi
   fi
 
   rnnlm/get_special_symbol_opts.py < $dir/config/words.txt > $dir/special_symbol_opts.txt


### PR DESCRIPTION
validate_config_dir.sh says config/features.txt is optional, yet prepare_rnn_lm.sh dies on copying, if it doesn't find this file. This PR makes prepare_rnn_lm.sh check whether the features.txt file is present, before copying, thus, not killing the prepare script prematurely.