### PR TITLE
Remove redundant for loop in ProcessNonemitting while push state into queue_

### DIFF
--- a/src/decoder/lattice-faster-decoder.cc
+++ b/src/decoder/lattice-faster-decoder.cc
@@ -68,6 +68,7 @@ void LatticeFasterDecoderTpl<FST, Token>::InitDecoding() {
   Token *start_tok = new Token(0.0, 0.0, NULL, NULL, NULL);
   active_toks_[0].toks = start_tok;
   toks_.Insert(start_state, start_tok);
+  queue_.push_back(start_state);
   num_toks_++;
   ProcessNonemitting(config_.beam);
 }
@@ -265,7 +266,7 @@ void LatticeFasterDecoderTpl<FST, Token>::PossiblyResizeHash(size_t num_toks) {
 template <typename FST, typename Token>
 inline Token* LatticeFasterDecoderTpl<FST, Token>::FindOrAddToken(
       StateId state, int32 frame_plus_one, BaseFloat tot_cost,
-      Token *backpointer, bool *changed) {
+      Token *backpointer) {
   // Returns the Token pointer.  Sets "changed" (if non-NULL) to true
   // if the token was newly created or the cost changed.
   KALDI_ASSERT(frame_plus_one < active_toks_.size());
@@ -281,11 +282,12 @@ inline Token* LatticeFasterDecoderTpl<FST, Token>::FindOrAddToken(
     toks = new_tok;
     num_toks_++;
     toks_.Insert(state, new_tok);
-    if (changed) *changed = true;
+    queue_.push_back(state);
     return new_tok;
   } else {
     Token *tok = e_found->val;  // There is an existing Token for this state.
     if (tok->tot_cost > tot_cost) {  // replace old token
+      queue_.push_back(state);
       tok->tot_cost = tot_cost;
       // SetBackpointer() just does tok->backpointer = backpointer in
       // the case where Token == BackpointerToken, else nothing.
@@ -297,9 +299,6 @@ inline Token* LatticeFasterDecoderTpl<FST, Token>::FindOrAddToken(
       // in case we visit a state for the second time
       // those forward links, that lead to this replaced token before:
       // they remain and will hopefully be pruned later (PruneForwardLinks...)
-      if (changed) *changed = true;
-    } else {
-      if (changed) *changed = false;
     }
     return tok;
   }
@@ -801,7 +800,7 @@ BaseFloat LatticeFasterDecoderTpl<FST, Token>::ProcessEmitting(
           // Note: the frame indexes into active_toks_ are one-based,
           // hence the + 1.
           Token *next_tok = FindOrAddToken(arc.nextstate,
-                                           frame + 1, tot_cost, tok, NULL);
+                                           frame + 1, tot_cost, tok);
           // NULL: no change indicator needed
 
           // Add ForwardLink from tok to next_tok (put on head of list tok->links)
@@ -843,19 +842,11 @@ void LatticeFasterDecoderTpl<FST, Token>::ProcessNonemitting(BaseFloat cutoff) {
   // but in the baseline code, turning this vector into a set to fix this
   // problem did not improve overall speed.
 
-  KALDI_ASSERT(queue_.empty());
-
   if (toks_.GetList() == NULL) {
     if (!warned_) {
       KALDI_WARN << "Error, no surviving tokens: frame is " << frame;
       warned_ = true;
     }
-  }
-
-  for (const Elem *e = toks_.GetList(); e != NULL;  e = e->tail) {
-    StateId state = e->key;
-    if (fst_->NumInputEpsilons(state) != 0)
-      queue_.push_back(state);
   }
 
   while (!queue_.empty()) {
@@ -883,15 +874,10 @@ void LatticeFasterDecoderTpl<FST, Token>::ProcessNonemitting(BaseFloat cutoff) {
           bool changed;
 
           Token *new_tok = FindOrAddToken(arc.nextstate, frame + 1, tot_cost,
-                                          tok, &changed);
+                                          tok);
 
           tok->links = new ForwardLinkT(new_tok, 0, arc.olabel,
                                         graph_cost, 0, tok->links);
-
-          // "changed" tells us whether the new token has a different
-          // cost from before, or is new [if so, add into queue].
-          if (changed && fst_->NumInputEpsilons(arc.nextstate) != 0)
-            queue_.push_back(arc.nextstate);
         }
       }
     } // for all arcs

--- a/src/decoder/lattice-faster-decoder.h
+++ b/src/decoder/lattice-faster-decoder.h
@@ -381,8 +381,7 @@ class LatticeFasterDecoderTpl {
   // If Token == StdToken, the 'backpointer' argument has no purpose (and will
   // hopefully be optimized out).
   inline Token *FindOrAddToken(StateId state, int32 frame_plus_one,
-                               BaseFloat tot_cost, Token *backpointer,
-                               bool *changed);
+                               BaseFloat tot_cost, Token *backpointer);
 
   // prunes outgoing links for all tokens in active_toks_[frame]
   // it's called by PruneActiveTokens


### PR DESCRIPTION
The for loop can be removed, new state can be push in queue_ when call FindOrAddToken func