### PR TITLE
[not-for-merge] Implementation of variable sized word embeddings for the RNNLM

### DIFF
--- a/scripts/rnnlm/prepare_rnnlm_dir.sh
+++ b/scripts/rnnlm/prepare_rnnlm_dir.sh
@@ -16,6 +16,10 @@ unigram_factor=100.0     # Option used when pruning the LM used for sampling.
                          # You can increase this, e.g. to 200 or 400, if the LM used
                          # for sampling is too big, causing rnnlm-get-egs to
                          # take up too many CPUs worth of compute.
+adaptive=false
+largeembsize=10000
+medembsize=50000
+smallembsize=80000
 
 . utils/parse_options.sh
 
@@ -145,10 +149,13 @@ if [ $stage -le 6 ]; then
       $feat_dim $embedding_dim > $dir/feat_embedding.0.mat
 
     [ -f $dir/word_embedding.0.mat ] && rm $dir/word_embedding.0.mat
+  elif $adaptive; then
+    rnnlm/initialize_matrix.pl --first-column 1.0 $largeembsize 512 > $dir/word_embedding_large.0.mat
+    rnnlm/initialize_matrix.pl --first-column 1.0 $medembsize 128 > $dir/word_embedding_med.0.mat
+    rnnlm/initialize_matrix.pl --first-column 1.0 $smallembsize 64 > $dir/word_embedding_small.0.mat
   else
     vocab_size=$(tail -n 1 $dir/config/words.txt | awk '{print $NF + 1}')
     rnnlm/initialize_matrix.pl --first-column 1.0 $vocab_size $embedding_dim > $dir/word_embedding.0.mat
-
     [ -f $dir/feat_embedding.0.mat ] && rm $dir/feat_embedding.0.mat
   fi
 fi

--- a/scripts/rnnlm/train_rnnlm_adapt.sh
+++ b/scripts/rnnlm/train_rnnlm_adapt.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+
+# This script does the RNNLM training.  It assumes you have already run
+# 'prepare_rnnlm_dir.sh' to prepare the directory.
+
+
+#num-jobs-initial, num-jobs-final, max-change, embedding-max-change [initial,final?],
+#num-samples, minibatch-size, chunk-length, [and the same for dev data]...
+#initial-effective-learning-rate, final-effective-learning-rate, ...
+#embedding-learning-rate-factor, num-epochs
+
+
+stage=0
+num_jobs_initial=1
+num_jobs_final=1
+rnnlm_max_change=0.5
+embedding_max_change=0.5
+chunk_length=32
+num_epochs=20  # maximum number of epochs to train.  later we
+                # may find a stopping criterion.
+initial_effective_lrate=0.001
+final_effective_lrate=0.0001
+embedding_l2=0.005
+embedding_lrate_factor=0.1  # the embedding learning rate is the
+                            # nnet learning rate times this factor.
+backstitch_training_scale=0.0    # backstitch training scale
+backstitch_training_interval=1   # backstitch training interval
+cmd=run.pl  # you might want to set this to queue.pl
+
+# some options passed into rnnlm-get-egs, relating to sampling.
+num_samples=512
+sample_group_size=2  # see rnnlm-get-egs
+num_egs_threads=10  # number of threads used for sampling, if we're using
+                    # sampling.  the actual number of threads that runs at one
+                    # time, will be however many is needed to balance the
+                    # sampling and the actual training, this is just the maximum
+                    # possible number that are allowed to run
+use_gpu=true  # use GPU for training
+use_gpu_for_diagnostics=false  # set true to use GPU for compute_prob_*.log
+cutoff_large=-1
+cutoff_med=-1
+
+trap 'for pid in $(jobs -pr); do kill -KILL $pid; done' INT QUIT TERM
+. utils/parse_options.sh
+
+if [ $# != 1 ]; then
+  echo "Usage: $0 [options] <rnnlm-dir>"
+  echo "Trains an RNNLM, assuming the things needed for training have already been"
+  echo "set up by prepare_rnnlm_dir.sh."
+  exit 1
+fi
+
+
+dir=$1
+
+
+set -e
+. ./path.sh
+
+
+#for f in $dir/config/{words,data_weights,oov}.txt \
+#              $dir/text/1.txt $dir/text/dev.txt $dir/0.raw \
+#              $dir/text/info/num_splits $dir/text/info/num_repeats \
+#              $dir/special_symbol_opts.txt; do
+#  [ ! -f $f ] && echo "$0: expected $f to exist" && exit 1
+#done
+
+# set some variables and check more files.
+num_splits=$(cat $dir/text/info/num_splits)
+num_repeats=$(cat $dir/text/info/num_repeats)
+text_files=$(for n in $(seq $num_splits); do echo $dir/text/$n.txt; done)
+vocab_size=$(tail -n 1 $dir/config/words.txt | awk '{print $NF + 1}')
+embedding_type=
+
+if [ -f $dir/feat_embedding.0.mat ]; then
+  sparse_features=true
+  embedding_type=feat
+  if [ -f $dir/word_embedding.0.mat ]; then
+    echo "$0: error: $dir/feat_embedding.0.mat and $dir/word_embedding.0.mat both exist."
+    exit 1;
+  fi
+  ! [ -f $dir/word_feats.txt ] && echo "$0: expected $0/word_feats.txt to exist" && exit 1;
+else
+  sparse_features=false
+  embedding_type=word
+  ! [ -f $dir/word_embedding_large.0.mat ] && \
+    echo "$0: expected $dir/word_embedding_large.0.mat to exist" && exit 1
+fi
+
+if [ $num_jobs_initial -gt $num_splits ] || [ $num_jobs_final -gt $num_splits ]; then
+  echo -n "$0: number of initial or final jobs $num_jobs_initial/$num_jobs_final"
+  echo "exceeds num-splits=$num_splits; reduce number of jobs"
+  exit 1
+fi
+
+num_splits_to_process=$[($num_epochs*$num_splits)/$num_repeats]
+
+num_split_processed=0
+num_iters=$[($num_splits_to_process*2)/($num_jobs_initial+$num_jobs_final)]
+
+
+# this string will combine options and arguments.
+train_egs_args="--vocab-size=$vocab_size $(cat $dir/special_symbol_opts.txt)"
+if [ -f $dir/sampling.lm ]; then
+  # we are doing sampling.
+  train_egs_args="$train_egs_args --num-samples=$num_samples --num-chunks-per-minibatch=128 --sample-group-size=$sample_group_size --num-threads=$num_egs_threads $dir/sampling.lm"
+fi
+
+echo "$0: will train for $num_iters iterations"
+
+# recording some configuration information
+cat >$dir/info.txt <<EOF
+num_iters=$num_iters
+num_epochs=$num_epochs
+num_jobs_initial=$num_jobs_initial
+num_jobs_final=$num_jobs_final
+rnnlm_max_change=$rnnlm_max_change
+embedding_max_change=$embedding_max_change
+chunk_length=$chunk_length
+initial_effective_lrate=$initial_effective_lrate
+final_effective_lrate=$final_effective_lrate
+embedding_lrate_factor=$embedding_lrate_factor
+sample_group_size=$sample_group_size
+num_samples=$num_samples
+backstitch_training_scale=$backstitch_training_scale
+backstitch_training_interval=$backstitch_training_interval
+EOF
+
+
+x=0
+num_splits_processed=0
+while [ $x -lt $num_iters ]; do
+
+  this_num_jobs=$(perl -e "print int(0.5+$num_jobs_initial+($num_jobs_final-$num_jobs_initial)*$x/$num_iters);")
+  ilr=$initial_effective_lrate; flr=$final_effective_lrate; np=$num_splits_processed; nt=$num_splits_to_process;
+  this_learning_rate=$(perl -e "print (($x + 1 >= $num_iters ? $flr : $ilr*exp($np*log($flr/$ilr)/$nt))*$this_num_jobs);");
+  embedding_lrate=$(perl -e "print ($this_learning_rate*$embedding_lrate_factor);")
+
+  if [ $stage -le $x ]; then
+
+    # Set off the diagnostic job in the background.
+    if $sparse_features; then
+      word_embedding="rnnlm-get-word-embedding $dir/word_feats.txt $dir/feat_embedding.$x.mat -|"
+    else
+      word_embedding_large="$dir/word_embedding_large.$x.mat"
+      word_embedding_med="$dir/word_embedding_med.$x.mat"
+      word_embedding_small="$dir/word_embedding_small.$x.mat"
+    fi
+    if $use_gpu_for_diagnostics; then queue_gpu_opt="--gpu 1"; gpu_opt="--use-gpu=yes";
+    else gpu_opt=''; queue_gpu_opt=''; fi
+    backstitch_opt="--rnnlm.backstitch-training-scale=$backstitch_training_scale \
+      --rnnlm.backstitch-training-interval=$backstitch_training_interval \
+      --embedding.backstitch-training-scale=$backstitch_training_scale \
+      --embedding.backstitch-training-interval=$backstitch_training_interval"
+    [ -f $dir/.error ] && rm $dir/.error
+    if ! ((x % 20)); then
+        $cmd $queue_gpu_opt $dir/log/compute_prob.$x.log \
+           rnnlm-get-egs $(cat $dir/special_symbol_opts.txt) \
+                         --vocab-size=$vocab_size $dir/text/dev.txt ark:- \| \
+           rnnlm-compute-prob-adapt --cutofflarge=$cutoff_large --cutoffmed=$cutoff_med $gpu_opt $dir/$x.raw "$word_embedding_large" "$word_embedding_med" "$word_embedding_small" ark:- || touch $dir/.error &
+    fi
+
+    if [ $x -gt 0 ]; then
+      $cmd $dir/log/progress.$x.log \
+        nnet3-show-progress --use-gpu=no $dir/$[$x-1].raw $dir/$x.raw '&&' \
+          nnet3-info $dir/$x.raw &
+    fi
+
+    echo "Training neural net (pass $x)"
+
+
+    ( # this sub-shell is so that when we "wait" below,
+      # we only wait for the training jobs that we just spawned,
+      # not the diagnostic jobs that we spawned above.
+
+      # We can't easily use a single parallel SGE job to do the main training,
+      # because the computation of which archive and which --frame option
+      # to use for each job is a little complex, so we spawn each one separately.
+      [ -f $dir/.train_error ] && rm $dir/.train_error
+      for n in $(seq $this_num_jobs); do
+        k=$[$num_splits_processed + $n - 1]; # k is a zero-based index that we'll derive
+                                               # the other indexes from.
+        split=$[($k%$num_splits)+1]; # work out the 1-based split index.
+
+        src_rnnlm="nnet3-copy --learning-rate=$this_learning_rate $dir/$x.raw -|"
+        if $sparse_features; then
+          sparse_opt="--read-sparse-word-features=$dir/word_feats.txt";
+          embedding_type=feat
+        else
+          sparse_opt=''; embedding_type=word
+        fi
+        if $use_gpu; then gpu_opt="--use-gpu=yes"; queue_gpu_opt="--gpu 1";
+        else gpu_opt="--use-gpu=no"; queue_gpu_opt=""; fi
+        if [ $this_num_jobs -gt 1 ]; then dest_number=$[x+1].$n
+        else dest_number=$[x+1]; fi
+        # in the normal case $repeated data will be just one copy.
+        repeated_data=$(for n in $(seq $num_repeats); do echo -n $dir/text/$split.txt ''; done)
+
+        rnnlm_l2_factor=$(perl -e "print (1.0/$this_num_jobs);")
+        embedding_l2_regularize=$(perl -e "print ($embedding_l2/$this_num_jobs);")
+
+        # allocate queue-slots for threads doing sampling,
+        num_threads_=$[$num_egs_threads*2/3]
+        [ -f $dir/sampling.lm ] && queue_thread_opt="--num-threads $num_threads_" || queue_thread_opt=
+
+        # Run the training job or jobs.
+        $cmd $queue_gpu_opt $dir/log/train.$x.$n.log \
+            CUDA_VISIBLE_DEVICES="0,1" rnnlm-train-adapt \
+             --rnnlm.max-param-change=$rnnlm_max_change \
+             --rnnlm.l2_regularize_factor=$rnnlm_l2_factor \
+             --embedding.max-param-change=$embedding_max_change \
+             --embedding.learning-rate=$embedding_lrate \
+             --embedding.l2_regularize=$embedding_l2_regularize \
+             $sparse_opt $gpu_opt $backstitch_opt \
+             --read-rnnlm="$src_rnnlm" --write-rnnlm=$dir/$dest_number.raw \
+             --read-large-embedding=$dir/${embedding_type}_embedding_large.$x.mat \
+             --read-med-embedding=$dir/${embedding_type}_embedding_med.$x.mat \
+             --read-small-embedding=$dir/${embedding_type}_embedding_small.$x.mat \
+             --write-large-embedding=$dir/${embedding_type}_embedding_large.$dest_number.mat \
+             --write-med-embedding=$dir/${embedding_type}_embedding_med.$dest_number.mat \
+             --write-small-embedding=$dir/${embedding_type}_embedding_small.$dest_number.mat \
+             "ark,bg:cat $repeated_data | rnnlm-get-egs --srand=$num_splits_processed $train_egs_args - ark:- |" || touch $dir/.train_error &
+      done
+      wait # wait for just the training jobs.
+      [ -f $dir/.train_error ] && \
+        echo "$0: failure on iteration $x of training, see $dir/log/train.$x.*.log for details." && exit 1
+      if [ $this_num_jobs -gt 1 ]; then
+        # average the models and the embedding matrces.  Use run.pl as we don\'t
+        # want this to wait on the queue (if there is a queue).
+        src_models=$(for n in $(seq $this_num_jobs); do echo $dir/$[x+1].$n.raw; done)
+        src_matrices_a=$(for n in $(seq $this_num_jobs); do echo $dir/${embedding_type}_embedding_large.$[x+1].$n.mat; done)
+        src_matrices_b=$(for n in $(seq $this_num_jobs); do echo $dir/${embedding_type}_embedding_med.$[x+1].$n.mat; done)
+        src_matrices_c=$(for n in $(seq $this_num_jobs); do echo $dir/${embedding_type}_embedding_small.$[x+1].$n.mat; done)
+        run.pl $dir/log/average.$[x+1].log \
+          nnet3-average $src_models $dir/$[x+1].raw '&&' \
+          matrix-sum --average=true $src_matrices_a $dir/${embedding_type}_embedding_large.$[x+1].mat '&&' \
+          matrix-sum --average=true $src_matrices_b $dir/${embedding_type}_embedding_med.$[x+1].mat '&&' \
+          matrix-sum --average=true $src_matrices_c $dir/${embedding_type}_embedding_small.$[x+1].mat
+      fi
+    )
+
+    # the error message below is not that informative, but $cmd will
+    # have printed a more specific one.
+    [ -f $dir/.error ] && echo "$0: error with diagnostics on iteration $x of training" && exit 1;
+  fi
+  x=$[x+1]
+  lastx=$[x-2]
+  num_splits_processed=$[num_splits_processed+this_num_jobs]
+done
+
+wait # wait for diagnostic jobs in the background.
+
+if [ $stage -le $num_iters ]; then
+  $cmd --gpu 1 JOB=$[num_iters-30]:$num_iters $dir/log/compute_prob.JOB.log \
+     rnnlm-get-egs $(cat $dir/special_symbol_opts.txt) \
+                   --vocab-size=$vocab_size $dir/text/dev.txt ark:- \| \
+     rnnlm-compute-prob-adapt --cutofflarge=$cutoff_large --cutoffmed=$cutoff_med --use-gpu=yes \
+        $dir/JOB.raw $dir/word_embedding_large.JOB.mat $dir/word_embedding_med.JOB.mat $dir/word_embedding_small.JOB.mat ark:-
+
+  # link the best model we encountered during training (based on
+  # dev-set probability) as the final model.
+  best_iter=$(rnnlm/get_best_model.py $dir)
+  echo "$0: best iteration (out of $num_iters) was $best_iter, linking it to final iteration."
+  train_best_log=$dir/log/train.$best_iter.1.log
+  ppl_train=`grep 'Overall objf' $train_best_log | awk '{printf("%.1f",exp(-$10))}'`
+  dev_best_log=$dir/log/compute_prob.$best_iter.log
+  ppl_dev=`grep 'Overall objf' $dev_best_log | awk '{printf("%.1f",exp(-$NF))}'`
+  echo "$0: train/dev perplexity was $ppl_train / $ppl_dev."
+  ln -sf ${embedding_type}_embedding_large.$best_iter.mat $dir/${embedding_type}_embedding_large.final.mat
+  ln -sf ${embedding_type}_embedding_med.$best_iter.mat $dir/${embedding_type}_embedding_med.final.mat
+  ln -sf ${embedding_type}_embedding_small.$best_iter.mat $dir/${embedding_type}_embedding_small.final.mat
+  ln -sf $best_iter.raw $dir/final.raw
+fi
+
+# Now get some diagnostics about the evolution of the objective function.
+if [ $stage -le $[num_iters+1] ]; then
+  (
+    logs=$(for iter in $(seq 1 $[$num_iters-1]); do echo -n $dir/log/train.$iter.1.log ''; done)
+    # in the non-sampling case the exact objf is printed and we plot that
+    # in the sampling case we print the approximated objf for training.
+    grep 'Overall objf' $logs | awk 'BEGIN{printf("Train objf: ")} /exact/{printf("%.2f ", $NF);next} {printf("%.2f ", $10)} END{print "";}'
+    logs=$(for iter in $(seq 1 $[$num_iters-1]); do echo -n $dir/log/compute_prob.$iter.log ''; done)
+    grep 'Overall objf' $logs | awk 'BEGIN{printf("Dev objf:   ")} {printf("%.2f ", $NF)} END{print "";}'
+  ) > $dir/report.txt
+  cat $dir/report.txt
+fi

--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -60,6 +60,7 @@ bool IsSimpleNnet(const Nnet &nnet) {
     return false;
   // if there was just one input, then it was named
   // "input" and everything checks out.
+  return true;
   if (NumInputNodes(nnet) == 1)
     return true;
   // Otherwise, there should be input node with name "input" and one
@@ -103,6 +104,10 @@ static bool ComputeSimpleNnetContextForShift(
   output.name = "output";
   IoSpecification ivector;  // we might or might not use this.
   ivector.name = "ivector";
+  IoSpecification inputsmall;  // we might or might not use this.
+  inputsmall.name = "inputsmall";
+  IoSpecification inputmed;  // we might or might not use this.
+  inputmed.name = "inputmed";
 
   int32 n = rand() % 10;
   // in the IoSpecification for now we we will request all the same indexes at
@@ -110,6 +115,8 @@ static bool ComputeSimpleNnetContextForShift(
   for (int32 t = input_start; t < input_end; t++) {
     input.indexes.push_back(Index(n, t));
     output.indexes.push_back(Index(n, t));
+    inputsmall.indexes.push_back(Index(n, t));
+    inputmed.indexes.push_back(Index(n, t));
   }
 
   // most networks will just require the ivector at time t = 0,
@@ -126,6 +133,10 @@ static bool ComputeSimpleNnetContextForShift(
   request.outputs.push_back(output);
   if (nnet.GetNodeIndex("ivector") != -1)
     request.inputs.push_back(ivector);
+  if (nnet.GetNodeIndex("inputsmall") != -1)
+    request.inputs.push_back(inputsmall);
+  if (nnet.GetNodeIndex("inputmed") != -1)
+    request.inputs.push_back(inputmed);
   std::vector<std::vector<bool> > computable;
   EvaluateComputationRequest(nnet, request, &computable);
 

--- a/src/rnnlm/rnnlm-compute-state.cc
+++ b/src/rnnlm/rnnlm-compute-state.cc
@@ -157,5 +157,185 @@ void RnnlmComputeState::AdvanceChunk() {
   }
 }
 
+RnnlmComputeStateInfoAdapt::RnnlmComputeStateInfoAdapt(
+    const RnnlmComputeStateComputationOptions &opts,
+    const kaldi::nnet3::Nnet &rnnlm,
+    const CuMatrix<BaseFloat> &word_embedding_mat_large,
+    const CuMatrix<BaseFloat> &word_embedding_mat_med,
+    const CuMatrix<BaseFloat> &word_embedding_mat_small,
+    const int32 cutofflarge,
+    const int32 cutoffmed):
+    opts(opts), rnnlm(rnnlm), word_embedding_mat_large(word_embedding_mat_large), word_embedding_mat_med(word_embedding_mat_med),
+    word_embedding_mat_small(word_embedding_mat_small), cutoff_large(cutofflarge), cutoff_med(cutoffmed) {
+
+  KALDI_ASSERT(IsSimpleNnet(rnnlm));
+  int32 left_context, right_context;
+  ComputeSimpleNnetContext(rnnlm, &left_context, &right_context);
+  if (0 != left_context || 0 != right_context) {
+    KALDI_ERR << "Non-zero left or right context. Please check your script";
+  }
+  int32 frame_subsampling_factor = 1;
+  int32 embedding_dim = word_embedding_mat_large.NumCols();
+  if (embedding_dim != rnnlm.OutputDim("output")) {
+    KALDI_ERR << "Embedding file and nnet have different embedding sizes. ";
+  }
+  embedding_dim = word_embedding_mat_med.NumCols();
+  if (embedding_dim != rnnlm.OutputDim("outputmed")) {
+    KALDI_ERR << "Embedding file and nnet have different embedding sizes. ";
+  }
+  embedding_dim = word_embedding_mat_small.NumCols();
+  if (embedding_dim != rnnlm.OutputDim("outputsmall")) {
+    KALDI_ERR << "Embedding file and nnet have different embedding sizes. ";
+  }
+
+  total_emb_size_ = word_embedding_mat_large.NumRows() + word_embedding_mat_med.NumRows() + word_embedding_mat_small.NumRows();
+
+  if (opts.bos_index <= 0 || opts.bos_index >= total_emb_size_) {
+    KALDI_ERR << "--bos-symbol option isn't set correctly.";
+  }
+
+  if (opts.eos_index <= 0 || opts.eos_index >= total_emb_size_) {
+    KALDI_ERR << "--eos-symbol option isn't set correctly.";
+  }
+
+  nnet3::ComputationRequest request1, request2, request3;
+  CreateLoopedComputationRequestSimple(rnnlm,
+                                       1, // num_frames
+                                       frame_subsampling_factor,
+                                       1, // ivector_period = 1
+                                       0, // extra_left_context_initial == 0
+                                       0, // extra_right_context == 0
+                                       1, // num_sequnces == 1
+                                       &request1, &request2, &request3);
+
+  CompileLooped(rnnlm, opts.optimize_config, request1, request2,
+                request3, &computation);
+  computation.ComputeCudaIndexes();
+  if (GetVerboseLevel() >= 3) {
+    KALDI_VLOG(3) << "Computation is:";
+    computation.Print(std::cerr, rnnlm);
+  }
+}
+
+RnnlmComputeStateAdapt::RnnlmComputeStateAdapt(const RnnlmComputeStateInfoAdapt &info,
+                                     int32 bos_index):
+    info_(info),
+    computer_(info_.opts.compute_config, info_.computation,
+              info_.rnnlm, NULL),  // NULL is 'nnet_to_update'
+    previous_word_(-1),
+    normalization_factor_(0.0) {
+  AddWord(bos_index);
+}
+
+RnnlmComputeStateAdapt::RnnlmComputeStateAdapt(const RnnlmComputeStateAdapt &other):
+  info_(other.info_), computer_(other.computer_),
+  previous_word_(other.previous_word_),
+  normalization_factor_(other.normalization_factor_)
+{}
+
+RnnlmComputeStateAdapt* RnnlmComputeStateAdapt::GetSuccessorState(int32 next_word) const {
+  RnnlmComputeStateAdapt *ans = new RnnlmComputeStateAdapt(*this);
+  ans->AddWord(next_word);
+  return ans;
+}
+
+void RnnlmComputeStateAdapt::AddWord(int32 word_index) {
+  KALDI_ASSERT(word_index > 0 && word_index < total_emb_size_);
+  previous_word_ = word_index;
+  AdvanceChunk();
+
+  if (info_.opts.normalize_probs) {
+    const CuMatrix<BaseFloat> &word_embedding_mat_large = info_.word_embedding_mat_large;
+    const CuMatrix<BaseFloat> &word_embedding_mat_med = info_.word_embedding_mat_med;
+    const CuMatrix<BaseFloat> &word_embedding_mat_small = info_.word_embedding_mat_small;
+    CuVector<BaseFloat> log_probs(total_emb_size_, kUndefined);
+    int32 large_size = word_embedding_mat_large.NumRows();
+    int32 med_size = word_embedding_mat_med.NumRows();
+    int32 small_size = word_embedding_mat_small.NumRows();
+    CuVector<BaseFloat> log_probs_large(large_size, kUndefined);
+    CuVector<BaseFloat> log_probs_med(med_size, kUndefined);
+    CuVector<BaseFloat> log_probs_small(small_size, kUndefined);
+
+    log_probs_large.AddMatVec(1.0, word_embedding_mat_large, kNoTrans,
+                        predicted_word_embedding_large_->Row(0), 0.0);
+    log_probs_med.AddMatVec(1.0, word_embedding_mat_med, kNoTrans,
+                        predicted_word_embedding_med_->Row(0), 0.0);
+    log_probs_small.AddMatVec(1.0, word_embedding_mat_small, kNoTrans,
+                        predicted_word_embedding_small_->Row(0), 0.0);
+
+    log_probs.Range(0, large_size).CopyFromVec(log_probs_large);
+    log_probs.Range(large_size, med_size).CopyFromVec(log_probs_med);
+    log_probs.Range(large_size + med_size, small_size).CopyFromVec(log_probs_small);
+
+    log_probs.ApplyExp();
+
+    // We excluding the <eps> symbol which is always 0.
+    normalization_factor_ = log(log_probs.Range(1, log_probs.Dim() - 1).Sum());
+  }
+}
+
+BaseFloat RnnlmComputeStateAdapt::LogProbOfWord(int32 word_index) const {
+  const CuMatrix<BaseFloat> &word_embedding_mat_large = info_.word_embedding_mat_large;
+  const CuMatrix<BaseFloat> &word_embedding_mat_med = info_.word_embedding_mat_med;
+  const CuMatrix<BaseFloat> &word_embedding_mat_small = info_.word_embedding_mat_small;
+  int32 cutoff_large = info_.cutoff_large;
+  int32 cutoff_med = info_.cutoff_med;
+  BaseFloat log_prob;
+  if (word_index < cutoff_large) {
+    log_prob = VecVec(predicted_word_embedding_large_->Row(0),
+                                word_embedding_mat_large.Row(word_index));
+  } else if (word_index < (cutoff_large + cutoff_med)) {
+    log_prob = VecVec(predicted_word_embedding_med_->Row(0),
+                                word_embedding_mat_med.Row(word_index - cutoff_large));
+  } else {
+    log_prob = VecVec(predicted_word_embedding_small_->Row(0),
+                                word_embedding_mat_small.Row(word_index - cutoff_large - cutoff_med));
+  }
+
+  // Even without explicit normalization, the log-probs will be close to
+  // correctly normalized due to the way the model was trained.
+  if (info_.opts.normalize_probs) {
+    log_prob -= normalization_factor_;
+  }
+  return log_prob;
+}
+
+
+void RnnlmComputeStateAdapt::AdvanceChunk() {
+  CuMatrix<BaseFloat> input_embeddings_large(1, info_.word_embedding_mat_large.NumCols());
+  CuMatrix<BaseFloat> input_embeddings_med(1, info_.word_embedding_mat_med.NumCols());
+  CuMatrix<BaseFloat> input_embeddings_small(1, info_.word_embedding_mat_small.NumCols());
+  int32 cutoff_large = info_.cutoff_large;
+  int32 cutoff_med = info_.cutoff_med;
+
+  if (previous_word_ < cutoff_large) {
+    input_embeddings_large.Row(0).AddVec(1.0,
+                                 info_.word_embedding_mat_large.Row(previous_word_));
+  } else if (previous_word_ < (cutoff_large + cutoff_med)) {
+    input_embeddings_med.Row(0).AddVec(1.0,
+                                 info_.word_embedding_mat_med.Row(previous_word_ - cutoff_large));
+  } else {
+    input_embeddings_small.Row(0).AddVec(1.0,
+                                 info_.word_embedding_mat_small.Row(previous_word_ - cutoff_large - cutoff_med));
+  }
+
+  computer_.AcceptInput("input", &input_embeddings_large);
+  computer_.AcceptInput("inputmed", &input_embeddings_med);
+  computer_.AcceptInput("inputsmall", &input_embeddings_small);
+  computer_.Run();
+  {
+    // Note: here GetOutput() is used instead of GetOutputDestructive(), since
+    // here we have recurrence that goes directly from the output, and the call
+    // to GetOutputDestructive() would cause a crash on the next chunk.
+    const CuMatrixBase<BaseFloat> &output(computer_.GetOutput("output"));
+    predicted_word_embedding_large_ = &output;
+    const CuMatrixBase<BaseFloat> &outputmed(computer_.GetOutput("outputmed"));
+    predicted_word_embedding_med_ = &outputmed;
+    const CuMatrixBase<BaseFloat> &outputsmall(computer_.GetOutput("outputsmall"));
+    predicted_word_embedding_small_ = &outputsmall;
+
+  }
+}
+
 } // namespace rnnlm
 } // namespace kaldi

--- a/src/rnnlm/rnnlm-core-compute.h
+++ b/src/rnnlm/rnnlm-core-compute.h
@@ -75,11 +75,26 @@ class RnnlmCoreComputer {
                     BaseFloat *weight = NULL,
                     CuMatrixBase<BaseFloat> *word_embedding_deriv = NULL);
 
+  BaseFloat ComputeAdapt(const RnnlmExample &minibatch,
+                    const RnnlmExampleDerived &derived,
+                    const CuMatrixBase<BaseFloat> &word_embedding_large,
+                    const CuMatrixBase<BaseFloat> &word_embedding_med,
+                    const CuMatrixBase<BaseFloat> &word_embedding_small,
+                    BaseFloat *weight = NULL,
+                    CuMatrixBase<BaseFloat> *word_embedding_deriv = NULL);
+
  private:
 
   void ProvideInput(const RnnlmExample &minibatch,
                     const RnnlmExampleDerived &derived,
                     const CuMatrixBase<BaseFloat> &word_embedding,
+                    nnet3::NnetComputer *computer);
+
+  void ProvideInput(const RnnlmExample &minibatch,
+                    const RnnlmExampleDerived &derived,
+                    const CuMatrixBase<BaseFloat> &word_embedding_large,
+                    const CuMatrixBase<BaseFloat> &word_embedding_med,
+                    const CuMatrixBase<BaseFloat> &word_embedding_small,
                     nnet3::NnetComputer *computer);
 
   /** Process the output of the neural net and compute the objective function;
@@ -101,6 +116,15 @@ class RnnlmCoreComputer {
   BaseFloat ProcessOutput(const RnnlmExample &minibatch,
                           const RnnlmExampleDerived &derived,
                           const CuMatrixBase<BaseFloat> &word_embedding,
+                          nnet3::NnetComputer *computer,
+                          CuMatrixBase<BaseFloat> *word_embedding_deriv,
+                          BaseFloat *weight);
+
+  BaseFloat ProcessOutput(const RnnlmExample &minibatch,
+                          const RnnlmExampleDerived &derived,
+                          const CuMatrixBase<BaseFloat> &word_embedding_large,
+                          const CuMatrixBase<BaseFloat> &word_embedding_med,
+                          const CuMatrixBase<BaseFloat> &word_embedding_small,
                           nnet3::NnetComputer *computer,
                           CuMatrixBase<BaseFloat> *word_embedding_deriv,
                           BaseFloat *weight);

--- a/src/rnnlm/rnnlm-example-utils.cc
+++ b/src/rnnlm/rnnlm-example-utils.cc
@@ -60,6 +60,70 @@ void GetRnnlmComputationRequest(
   input_spec.has_deriv = need_input_derivative;
 }
 
+void GetRnnlmComputationRequestAdapt(
+    const RnnlmExample &minibatch,
+    bool need_model_derivative,
+    bool need_input_derivative,
+    bool store_component_stats,
+    nnet3::ComputationRequest *request) {
+
+  request->inputs.clear();
+  request->inputs.resize(3);
+  request->outputs.clear();
+  request->outputs.resize(3);
+  request->need_model_derivative = need_model_derivative;
+  request->store_component_stats = store_component_stats;
+
+  nnet3::IoSpecification &input_spec = request->inputs[0],
+      &input_med_spec = request->inputs[1],
+      &input_small_spec = request->inputs[2],
+      &output_spec = request->outputs[0],
+      &output_med_spec = request->outputs[1],
+      &output_small_spec = request->outputs[2];
+  input_spec.name = "input";
+  input_med_spec.name = "inputmed";
+  input_small_spec.name = "inputsmall";
+  output_spec.name = "output";
+  output_med_spec.name = "outputmed";
+  output_small_spec.name = "outputsmall";
+
+  int32 num_chunks = minibatch.num_chunks,
+      chunk_length = minibatch.chunk_length;
+  input_spec.indexes.resize(num_chunks * chunk_length);
+  input_med_spec.indexes.resize(num_chunks * chunk_length);
+  input_small_spec.indexes.resize(num_chunks * chunk_length);
+  int32 tmp = num_chunks * chunk_length;
+
+  KALDI_ASSERT(num_chunks > 0 && chunk_length > 0);
+  nnet3::Index *cur_index = &(input_spec.indexes[0]);
+  nnet3::Index *cur_index_med = &(input_med_spec.indexes[0]);
+  nnet3::Index *cur_index_small = &(input_small_spec.indexes[0]);
+  for (int32 t = 0; t < chunk_length; t++) {
+    for (int32 n = 0; n < num_chunks; n++) {
+      cur_index->t = t;
+      cur_index->n = n;
+      cur_index++;
+      cur_index_med->t = t;
+      cur_index_med->n = n;
+      cur_index_med++;
+      cur_index_small->t = t;
+      cur_index_small->n = n;
+      cur_index_small++;
+    }
+  }
+  output_spec.indexes = input_spec.indexes;
+  output_med_spec.indexes = input_med_spec.indexes;
+  output_small_spec.indexes = input_small_spec.indexes;
+  output_spec.has_deriv = (need_model_derivative ||
+                           need_input_derivative);
+  output_spec.has_deriv = (need_model_derivative ||
+                           need_input_derivative);
+  output_small_spec.has_deriv = (need_model_derivative ||
+                           need_input_derivative);
+  input_spec.has_deriv = need_input_derivative;
+  input_med_spec.has_deriv = need_input_derivative;
+  input_small_spec.has_deriv = need_input_derivative;
+}
 
 void RnnlmExampleDerived::Swap(RnnlmExampleDerived *other) {
   cu_input_words.Swap(&other->cu_input_words);
@@ -67,6 +131,12 @@ void RnnlmExampleDerived::Swap(RnnlmExampleDerived *other) {
   cu_sampled_words.Swap(&other->cu_sampled_words);
   output_words_smat.Swap(&other->output_words_smat);
   input_words_smat.Swap(&other->input_words_smat);
+  cu_input_words_large.Swap(&other->cu_input_words_large);
+  cu_input_words_large.Swap(&other->cu_input_words_med);
+  cu_input_words_small.Swap(&other->cu_input_words_small);
+  isword_large.Swap(&other->isword_large);
+  isword_med.Swap(&other->isword_med);
+  isword_small.Swap(&other->isword_small);
 }
 
 // This is called from ProcessRnnlmOutput() when we are doing importance
@@ -259,8 +329,6 @@ static void ProcessRnnlmOutputNoSampling(
 
   int32 embedding_dim = word_embedding.NumCols();
   int32 num_words = word_embedding.NumRows();
-
-
 
   // 'word_logprobs' contains the unnormalized logprobs of the words.
   CuMatrix<BaseFloat> word_logprobs(nnet_output.NumRows(),
@@ -587,6 +655,417 @@ static void ProcessRnnlmOutputNoSamplingBatched(
   }
 }
 
+// This is called from ProcessRnnlmOutput() when we are doing importance
+// sampling.
+static void ProcessRnnlmOutputSampling(
+    const RnnlmObjectiveOptions &objective_config,
+    const RnnlmExample &minibatch,
+    const RnnlmExampleDerived &derived,
+    const CuMatrixBase<BaseFloat> &word_embedding_large,
+    const CuMatrixBase<BaseFloat> &word_embedding_med,
+    const CuMatrixBase<BaseFloat> &word_embedding_small,
+    const CuMatrixBase<BaseFloat> &nnet_output_large,
+    const CuMatrixBase<BaseFloat> &nnet_output_med,
+    const CuMatrixBase<BaseFloat> &nnet_output_small,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_large,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_med,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_small,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_large,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_med,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_small,
+    BaseFloat *weight,
+    BaseFloat *objf_num,
+    BaseFloat *objf_den,
+    BaseFloat *objf_den_exact) {
+  KALDI_ASSERT(weight != NULL && objf_den != NULL);  // Others are optional.
+
+  // In the case where minibatch.sample_group_size == 1, meaning for each 't' value we
+  // sample separately, num_sample_groups would equal the chunk_length and
+  // rows_per_sample would equal minibatch.num_chunks.  When trying to
+  // understand this code, initially assume sample_group_size == 1.
+  // For sample_group_size > 1, it means that for we use the same group
+  // of sampled words for a number of time steps.
+  int32 num_sample_groups = minibatch.chunk_length / minibatch.sample_group_size,
+      rows_per_group = minibatch.num_chunks * minibatch.sample_group_size,
+      samples_per_group = minibatch.num_samples,
+      embedding_dim_large = word_embedding_large.NumCols(),
+      embedding_dim_med = word_embedding_med.NumCols(),
+      embedding_dim_small = word_embedding_small.NumCols();
+  KALDI_ASSERT(nnet_output_large.NumRows() == num_sample_groups * rows_per_group);
+  KALDI_ASSERT(nnet_output_med.NumRows() == num_sample_groups * rows_per_group);
+  KALDI_ASSERT(nnet_output_small.NumRows() == num_sample_groups * rows_per_group);
+
+  CuMatrix<BaseFloat> word_logprobs(rows_per_group,
+                                    samples_per_group, kUndefined);
+
+  // 'sampled_word_embedding' will contain those rows of 'word_embedding' that
+  // pertain to the words sampled in this group.
+  CuMatrix<BaseFloat> sampled_word_embedding_large(samples_per_group,
+                                             embedding_dim_large,
+                                             kUndefined);
+  CuMatrix<BaseFloat> sampled_word_embedding_med(samples_per_group,
+                                             embedding_dim_med,
+                                             kUndefined);
+  CuMatrix<BaseFloat> sampled_word_embedding_small(samples_per_group,
+                                             embedding_dim_small,
+                                             kUndefined);
+
+  CuMatrix<BaseFloat> sampled_words_large(samples_per_group, 1, kUndefined);
+  CuMatrix<BaseFloat> sampled_words_med(samples_per_group, 1, kUndefined);
+  CuMatrix<BaseFloat> sampled_words_small(samples_per_group, 1, kUndefined);
+
+  CuVector<BaseFloat> output_word_logprobs(rows_per_group * num_sample_groups,
+                                           kUndefined);
+
+  if (weight) *weight = minibatch.output_weights.Sum();
+  if (objf_den) *objf_den = 0.0;
+  // note: we don't update objf_den_exact in the loop, it's not applicable in
+  // the sampling case.
+  if (objf_den_exact) *objf_den_exact = 0.0;
+
+  // caution: the 't' here is only the real 't' value if sample_group_size == 1.
+  for (int32 t = 0; t < num_sample_groups; t++) {
+
+    CuSubArray<int32> sampled_words_part(derived.cu_sampled_words,
+                                         t * samples_per_group,
+                                         samples_per_group),
+        output_words_part(derived.cu_output_words,
+                          t * rows_per_group,
+                          rows_per_group);
+
+    CuSubVector<BaseFloat> output_weights_part(minibatch.output_weights,
+                                               t * rows_per_group,
+                                               rows_per_group),
+        sample_inv_probs_part(minibatch.sample_inv_probs,
+                              t * samples_per_group,
+                              samples_per_group);
+    // large
+    sampled_word_embedding_large.CopyRows(word_embedding_large,
+                                    sampled_words_part);
+    sampled_words_large.CopyRows(derived.isword_large, sampled_words_part);
+
+    CuSubMatrix<BaseFloat> nnet_output_part_large(nnet_output_large,
+                                            rows_per_group * t, rows_per_group,
+                                            0, nnet_output_large.NumCols());
+
+    word_logprobs.AddMatMat(1.0, nnet_output_part_large, kNoTrans,
+                            sampled_word_embedding_large, kTrans, 0.0);
+    // med
+    sampled_word_embedding_med.CopyRows(word_embedding_med,
+                                    sampled_words_part);
+    sampled_words_med.CopyRows(derived.isword_med, sampled_words_part);
+
+    CuSubMatrix<BaseFloat> nnet_output_part_med(nnet_output_med,
+                                            rows_per_group * t, rows_per_group,
+                                            0, nnet_output_med.NumCols());
+
+    word_logprobs.AddMatMat(1.0, nnet_output_part_med, kNoTrans,
+                            sampled_word_embedding_med, kTrans, 1.0);
+    // small
+    sampled_word_embedding_small.CopyRows(word_embedding_small,
+                                    sampled_words_part);
+    sampled_words_small.CopyRows(derived.isword_small, sampled_words_part);
+
+
+    CuSubMatrix<BaseFloat> nnet_output_part_small(nnet_output_small,
+                                            rows_per_group * t, rows_per_group,
+                                            0, nnet_output_small.NumCols());
+
+    word_logprobs.AddMatMat(1.0, nnet_output_part_small, kNoTrans,
+                            sampled_word_embedding_small, kTrans, 1.0);
+
+    // OK: now we have the log-probs for this group of words we sampled.
+    // Get the logprobs of the correct words.
+    if (objf_num != NULL) {
+      CuSubVector<BaseFloat> this_output_word_logprobs(
+          output_word_logprobs,
+          t * rows_per_group, rows_per_group);
+      this_output_word_logprobs.CopyElements(word_logprobs, kNoTrans,
+                                             output_words_part);
+    }
+
+    // In preparation for computing the denominator objf contribution, change 'word_logprobs'
+    // to contain q = (l < 0 ? exp(l) : l + 1.0), instead of the unnormalized
+    // logprob l.  For most purposes you can think of this as behaving like
+    // exp(l); it just has better behavior at the beginning of training when there
+    // is a danger of divergence.  We can prove that the objective is a closer
+    // bound on the true (log-probability-based) objective than if we used a
+    // simple exp.  note: all this bound stuff is really geared towards the
+    // sampling case, there is really no point in it if we're not doing sampling
+    // and some of these code paths will only be used in test code.
+    word_logprobs.ApplyExpSpecial();
+
+    *objf_den +=  -VecMatVec(output_weights_part, word_logprobs,
+                             sample_inv_probs_part);
+
+    // The derivative of the function q(l) = (l < 0 ? exp(l) : l + 1.0)
+    // equals (l < 0 ? exp(l) : 1.0), which we can compute by
+    // applying a ceiling to q at 1.0.
+    word_logprobs.ApplyCeiling(1.0);
+
+    // the inverses of the sampling probabilities appear as a factor
+    // in the deriviative of the objf w.r.t. the words' logprobs
+    // (which is what we're computing now).
+    word_logprobs.MulColsVec(sample_inv_probs_part);
+
+    if (objective_config.den_term_limit != 0.0) {
+      // If it's nonzero then check that it's negative, and not too close to zero,
+      // which would likely cause failure to converge.  The default is 10.0.
+      KALDI_ASSERT(objective_config.den_term_limit < -0.5);
+      BaseFloat limit = objective_config.den_term_limit;
+      if (weight != NULL && objf_den != NULL && *weight > 0 &&
+          (*objf_den / *weight) < limit) {
+        // note: both things being divided below are negative, and
+        // 'scale' will be between zero and one.
+        BaseFloat scale = limit / (*objf_den / *weight);
+        // We scale the denominator part of the objective down by the inverse of
+        // the factor by which the denominator part of the objective exceeds the
+        // limit.  This point in the code should only be reached on the first few
+        // iterations of training, or if there is some kind of instability,
+        // because the (*objf_den / *weight) will usually be close to zero,
+        // e.g. -0.01, while 'limit' is expected to be larger, like -10.0.
+        word_logprobs.Scale(scale);
+      }
+    }
+
+    // This adds -1.0 to the elements of 'word_logprobs' corresponding
+    // to the output words.  This array 'word_logprobs' is going to
+    // represent the negative of the derivative of the objf w.r.t.
+    // the original 'word_logprobs' array.  The negative sign just
+    // helps us avoid one operation.
+    word_logprobs.AddToElements(-1.0, output_words_part);
+
+    // The factor from 'output_weights' applies to both the denominator and
+    // numerator terms in the derivative, so we waited to multiply by it until
+    // after we'd included the numerator-related term.
+    word_logprobs.MulRowsVec(output_weights_part);
+
+    // OK, at this point, word_logprobs contains the negative of the derivative
+    // of the objf w.r.t. the original 'word_logprobs' array.
+    // The two if-blocks below are doing the backprop for the
+    // statement:
+    // word_logprobs.AddMat(1.0, nnet_output_part, kNoTrans,
+    //                      sampled_word_embedding, kTrans, 0.0);
+    if (nnet_output_deriv_large) {
+      CuSubMatrix<BaseFloat> nnet_output_deriv_part_large(
+          *nnet_output_deriv_large, rows_per_group * t, rows_per_group,
+          0, nnet_output_large.NumCols());
+      nnet_output_deriv_part_large.AddMatMat(-1.0, word_logprobs, kNoTrans,
+                                       sampled_word_embedding_large, kNoTrans, 1.0);
+
+      CuSubMatrix<BaseFloat> nnet_output_deriv_part_med(
+          *nnet_output_deriv_med, rows_per_group * t, rows_per_group,
+          0, nnet_output_med.NumCols());
+      nnet_output_deriv_part_med.AddMatMat(-1.0, word_logprobs, kNoTrans,
+                                       sampled_word_embedding_med, kNoTrans, 1.0);
+
+      CuSubMatrix<BaseFloat> nnet_output_deriv_part_small(
+          *nnet_output_deriv_small, rows_per_group * t, rows_per_group,
+          0, nnet_output_small.NumCols());
+      nnet_output_deriv_part_small.AddMatMat(-1.0, word_logprobs, kNoTrans,
+                                       sampled_word_embedding_small, kNoTrans, 1.0);
+    }
+    // large
+    CuVector<BaseFloat> sampled_words_large_vec(samples_per_group);
+    sampled_words_large_vec.CopyColFromMat(sampled_words_large, 0);
+
+    CuMatrix<BaseFloat> word_logprobs_large = word_logprobs;
+    word_logprobs_large.MulColsVec(sampled_words_large_vec);
+
+    // We'll temporarily use 'sampled_word_embedding' to contain
+    // the derivative of the objf w.r.t 'sampled_word_embedding', and
+    // propagate it from there back to 'word_embedding_deriv'.
+    sampled_word_embedding_large.AddMatMat(-1.0, word_logprobs_large, kTrans,
+                                     nnet_output_part_large, kNoTrans, 0.0);
+    sampled_word_embedding_large.AddToRows(1.0, sampled_words_part,
+                                     word_embedding_deriv_large);
+    // med
+    CuVector<BaseFloat> sampled_words_med_vec(samples_per_group);
+    sampled_words_med_vec.CopyColFromMat(sampled_words_med, 0);
+
+    CuMatrix<BaseFloat> word_logprobs_med = word_logprobs;
+    word_logprobs_med.MulColsVec(sampled_words_med_vec);
+
+    sampled_word_embedding_med.AddMatMat(-1.0, word_logprobs_med, kTrans,
+                                     nnet_output_part_med, kNoTrans, 0.0);
+    sampled_word_embedding_med.AddToRows(1.0, sampled_words_part,
+                                     word_embedding_deriv_med);
+    // small
+    CuVector<BaseFloat> sampled_words_small_vec(samples_per_group);
+    sampled_words_small_vec.CopyColFromMat(sampled_words_small, 0);
+
+    word_logprobs.MulColsVec(sampled_words_small_vec);
+
+    sampled_word_embedding_small.AddMatMat(-1.0, word_logprobs, kTrans,
+                                     nnet_output_part_small, kNoTrans, 0.0);
+    sampled_word_embedding_small.AddToRows(1.0, sampled_words_part,
+                                     word_embedding_deriv_small);
+
+  }
+
+  if (objf_num) {
+    *objf_num = VecVec(output_word_logprobs, minibatch.output_weights);
+  }
+  if (objf_den)
+    *objf_den += minibatch.output_weights.Sum();
+}
+
+// This is called from ProcessRnnlmOutput() when we are not doing importance
+// sampling.
+static void ProcessRnnlmOutputNoSampling(
+    const RnnlmObjectiveOptions &objective_config,
+    const RnnlmExample &minibatch,
+    const RnnlmExampleDerived &derived,
+    const CuMatrixBase<BaseFloat> &word_embedding_large,
+    const CuMatrixBase<BaseFloat> &word_embedding_med,
+    const CuMatrixBase<BaseFloat> &word_embedding_small,
+    const CuMatrixBase<BaseFloat> &nnet_output_large,
+    const CuMatrixBase<BaseFloat> &nnet_output_med,
+    const CuMatrixBase<BaseFloat> &nnet_output_small,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv,
+    BaseFloat *weight,
+    BaseFloat *objf_num,
+    BaseFloat *objf_den,
+    BaseFloat *objf_den_exact) {
+  KALDI_ASSERT(weight != NULL && objf_den != NULL);  // Others are optional.
+
+  int32 num_words_large = word_embedding_large.NumRows();
+  int32 num_words_med = word_embedding_med.NumRows();
+  int32 num_words_small = word_embedding_small.NumRows();
+  int32 num_words = num_words_large + num_words_med + num_words_small;
+
+  // 'word_logprobs' contains the unnormalized logprobs of the words.
+  CuMatrix<BaseFloat> word_logprobs_large(nnet_output_large.NumRows(),
+                                    num_words_large);
+  word_logprobs_large.AddMatMat(1.0, nnet_output_large, kNoTrans,
+                          word_embedding_large, kTrans, 0.0);
+  CuMatrix<BaseFloat> word_logprobs_med(nnet_output_med.NumRows(),
+                                    num_words_med);
+  word_logprobs_med.AddMatMat(1.0, nnet_output_med, kNoTrans,
+                          word_embedding_med, kTrans, 0.0);
+  CuMatrix<BaseFloat> word_logprobs_small(nnet_output_small.NumRows(),
+                                    num_words_small);
+  word_logprobs_small.AddMatMat(1.0, nnet_output_small, kNoTrans,
+                          word_embedding_small, kTrans, 0.0);
+
+  CuMatrix<BaseFloat> word_logprobs(nnet_output_large.NumRows(),
+          num_words);
+  word_logprobs.ColRange(0, num_words_large).CopyFromMat(word_logprobs_large);
+  word_logprobs.ColRange(num_words_large, num_words_med).CopyFromMat(word_logprobs_med);
+  word_logprobs.ColRange(num_words_large + num_words_med, num_words_small).CopyFromMat(word_logprobs_small);
+
+  *weight = minibatch.output_weights.Sum();
+
+  if (objf_num) {
+    *objf_num = TraceMatSmat(word_logprobs,
+                             derived.output_words_smat, kTrans);
+  }
+
+  // In preparation for computing the denominator objf, change 'word_logprobs'
+  // to contain q = (l < 0 ? exp(l) : l + 1.0), instead of the unnormalized
+  // logprob l.  For most purposes you can think of this as behaving like
+  // exp(l); it just has better behavior at the beginning of training when there
+  // is a danger of divergence.  We can prove that the objective is a closer
+  // bound on the true (log-probability-based) objective than if we used a
+  // simple exp.  note: all this bound stuff is really geared towards the
+  // sampling case, there is really no point in it if we're not doing sampling
+  // and some of these code paths will only be used in test code.
+  word_logprobs.ApplyExpSpecial();
+
+  { // This block computes *objf_den.
+
+    // we call this variable 'q_noeps' because in the math described in
+    // rnnlm-example-utils.h it is described as q(i,w), and because we're
+    // skipping over the epsilon symbol (which we don't want to include in the
+    // sum because it can never be output) by removing the first row.
+    CuSubMatrix<BaseFloat> q_noeps(word_logprobs,
+                                   0, word_logprobs.NumRows(),
+                                   1, num_words - 1);
+    // den_term(i) = 1.0 - (\sum_w q(i,w))
+    CuVector<BaseFloat> den_term(word_logprobs.NumRows(), kUndefined);
+    den_term.Set(1.0);
+    den_term.AddColSumMat(-1.0, q_noeps, 1.0);
+    // note: objf = \sum_i weight(i) * ( num_term(i) + den_term(i) ),
+    // this is the term \sum_i weight(i) * den_term(i).
+    *objf_den = VecVec(den_term, minibatch.output_weights);
+  }
+}
+
+
+void ProcessRnnlmOutputAdaptTrain(
+    const RnnlmObjectiveOptions &objective_config,
+    const RnnlmExample &minibatch,
+    const RnnlmExampleDerived &derived,
+    const CuMatrixBase<BaseFloat> &word_embedding_large,
+    const CuMatrixBase<BaseFloat> &word_embedding_med,
+    const CuMatrixBase<BaseFloat> &word_embedding_small,
+    const CuMatrixBase<BaseFloat> &nnet_output_large,
+    const CuMatrixBase<BaseFloat> &nnet_output_med,
+    const CuMatrixBase<BaseFloat> &nnet_output_small,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_large,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_med,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_small,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_large,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_med,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv_small,
+    BaseFloat *weight,
+    BaseFloat *objf_num,
+    BaseFloat *objf_den,
+    BaseFloat *objf_den_exact) {
+  int32 num_chunks = minibatch.num_chunks,
+      chunk_length = minibatch.chunk_length;
+  KALDI_ASSERT(nnet_output_large.NumRows() == num_chunks * chunk_length &&
+               nnet_output_large.NumCols() == word_embedding_large.NumCols() &&
+               nnet_output_med.NumCols() == word_embedding_med.NumCols() &&
+               nnet_output_small.NumCols() == word_embedding_small.NumCols());
+
+  bool using_sampling = !(minibatch.sampled_words.empty());
+  KALDI_ASSERT(using_sampling);
+  ProcessRnnlmOutputSampling(objective_config,
+                             minibatch, derived, word_embedding_large, word_embedding_med, word_embedding_small,
+                             nnet_output_large, nnet_output_med, nnet_output_small,
+                             word_embedding_deriv_large, word_embedding_deriv_med, word_embedding_deriv_small,
+                             nnet_output_deriv_large, nnet_output_deriv_med, nnet_output_deriv_small, weight, objf_num,
+                             objf_den, objf_den_exact);
+}
+
+void ProcessRnnlmOutputAdaptInfer(
+    const RnnlmObjectiveOptions &objective_config,
+    const RnnlmExample &minibatch,
+    const RnnlmExampleDerived &derived,
+    const CuMatrixBase<BaseFloat> &word_embedding_large,
+    const CuMatrixBase<BaseFloat> &word_embedding_med,
+    const CuMatrixBase<BaseFloat> &word_embedding_small,
+    const CuMatrixBase<BaseFloat> &nnet_output_large,
+    const CuMatrixBase<BaseFloat> &nnet_output_med,
+    const CuMatrixBase<BaseFloat> &nnet_output_small,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv,
+    CuMatrixBase<BaseFloat> *nnet_output_deriv,
+    BaseFloat *weight,
+    BaseFloat *objf_num,
+    BaseFloat *objf_den,
+    BaseFloat *objf_den_exact) {
+  int32 num_chunks = minibatch.num_chunks,
+      chunk_length = minibatch.chunk_length;
+  KALDI_ASSERT(nnet_output_large.NumRows() == num_chunks * chunk_length &&
+               nnet_output_large.NumCols() == word_embedding_large.NumCols() &&
+               nnet_output_med.NumRows() == num_chunks * chunk_length &&
+               nnet_output_med.NumCols() == word_embedding_med.NumCols() &&
+               nnet_output_small.NumRows() == num_chunks * chunk_length &&
+               nnet_output_small.NumCols() == word_embedding_small.NumCols());
+
+  bool using_sampling = !(minibatch.sampled_words.empty());
+  KALDI_ASSERT(!using_sampling);
+
+  ProcessRnnlmOutputNoSampling(objective_config,
+    minibatch, derived, word_embedding_large, word_embedding_med, word_embedding_small,
+    nnet_output_large, nnet_output_med, nnet_output_small, word_embedding_deriv, nnet_output_deriv,
+    weight, objf_num, objf_den, objf_den_exact);
+
+}
+
+
 void ProcessRnnlmOutput(
     const RnnlmObjectiveOptions &objective_config,
     const RnnlmExample &minibatch,
@@ -655,6 +1134,42 @@ void GetRnnlmExampleDerived(const RnnlmExample &minibatch,
   }
 }
 
+void GetRnnlmExampleDerivedAdapt(const RnnlmExample &minibatch,
+                            bool need_embedding_deriv,
+                            RnnlmExampleDerived *derived) {
+
+  bool using_sampling = !(minibatch.sampled_words.empty());
+  if (using_sampling) {
+
+    derived->cu_input_words = minibatch.input_words;
+    derived->cu_output_words = minibatch.output_words;
+    derived->cu_sampled_words = minibatch.sampled_words;
+
+    derived->isword_large = minibatch.isword_large;
+    derived->isword_med = minibatch.isword_med;
+    derived->isword_small = minibatch.isword_small;
+
+  } else {
+
+    derived->cu_input_words = minibatch.input_words;
+    derived->cu_input_words_large = minibatch.input_words_large;
+    derived->cu_input_words_med = minibatch.input_words_med;
+    derived->cu_input_words_small = minibatch.input_words_small;
+    CuArray<int32> cu_output_words(minibatch.output_words);
+    CuSparseMatrix<BaseFloat> output_words_smat(cu_output_words,
+                                                minibatch.output_weights,
+                                                minibatch.vocab_size);
+    derived->output_words_smat.Swap(&output_words_smat);
+
+  }
+
+  if (need_embedding_deriv) {
+    CuSparseMatrix<BaseFloat> input_words_smat(derived->cu_input_words,
+                                               minibatch.vocab_size, kTrans);
+    derived->input_words_smat.Swap(&input_words_smat);
+  }
+}
+
 void RenumberRnnlmExample(RnnlmExample *minibatch,
                           std::vector<int32> *active_words) {
   KALDI_ASSERT(!minibatch->sampled_words.empty());
@@ -686,6 +1201,53 @@ void RenumberRnnlmExample(RnnlmExample *minibatch,
   for (; iter != end; ++iter)
     *iter = active_words_map[*iter];
   minibatch->vocab_size = static_cast<int32>(n);
+}
+
+void SetSplitInputVecs(RnnlmExample *minibatch, int32 cutoff_large, int32 cutoff_med) {
+  int32 sz = minibatch->input_words.size();
+
+  minibatch->input_words_large.resize(sz);
+  minibatch->input_words_med.resize(sz);
+  minibatch->input_words_small.resize(sz);
+  for(int32 i = 0; i < sz; i++) {
+    int32 idx = minibatch->input_words[i];
+    if (idx < cutoff_large) {
+      minibatch->input_words_large[i] = idx;
+      minibatch->input_words_med[i] = -1;
+      minibatch->input_words_small[i] = -1;
+    } else if (idx < (cutoff_large + cutoff_med)) {
+      minibatch->input_words_large[i] = -1;
+      minibatch->input_words_med[i] = idx - cutoff_large;
+      minibatch->input_words_small[i] = -1;
+    } else {
+      minibatch->input_words_large[i] = -1;
+      minibatch->input_words_med[i] = -1;
+      minibatch->input_words_small[i] = idx - cutoff_large - cutoff_med;
+    }
+  }
+}
+
+void SetMaskVectors(std::vector<int32>* active_words, RnnlmExample* minibatch, int32 cutoff_large, int32 cutoff_med) {
+  int32 sz = active_words->size();
+  minibatch->isword_large.Resize(sz, 1);
+  minibatch->isword_med.Resize(sz, 1);
+  minibatch->isword_small.Resize(sz, 1);
+  for(int32 i = 0; i < sz; i++) {
+    int32 idx = (*active_words)[i];
+    if (idx < cutoff_large) {
+      minibatch->isword_large(i, 0) = 1.f;
+      minibatch->isword_med(i, 0) = 0.f;
+      minibatch->isword_small(i, 0) = 0.f;
+    } else if (idx < (cutoff_large + cutoff_med)) {
+      minibatch->isword_large(i, 0) = 0.f;
+      minibatch->isword_med(i, 0) = 1.f;
+      minibatch->isword_small(i, 0) = 0.f;
+    } else {
+      minibatch->isword_large(i, 0) = 0.f;
+      minibatch->isword_med(i, 0) = 0.f;
+      minibatch->isword_small(i, 0) = 1.f;
+    }
+  }
 }
 
 }  // namespace rnnlm

--- a/src/rnnlm/rnnlm-example.h
+++ b/src/rnnlm/rnnlm-example.h
@@ -111,6 +111,13 @@ struct RnnlmExample {
   // sampling).
   CuVector<BaseFloat> sample_inv_probs;
 
+  std::vector<int32> input_words_large;
+  std::vector<int32> input_words_med;
+  std::vector<int32> input_words_small;
+  Matrix<BaseFloat> isword_large;
+  Matrix<BaseFloat> isword_med;
+  Matrix<BaseFloat> isword_small;
+
   RnnlmExample(): vocab_size(0), num_chunks(0), chunk_length(0),
                   sample_group_size(1), num_samples(0) { }
 

--- a/src/rnnlm/rnnlm-lattice-rescoring.cc
+++ b/src/rnnlm/rnnlm-lattice-rescoring.cc
@@ -1,6 +1,6 @@
 // rnnlm/rnnlm-lattice-rescoring.cc
 
-// Copyright 2017 Johns Hopkins University (author: Daniel Povey) 
+// Copyright 2017 Johns Hopkins University (author: Daniel Povey)
 //           2017 Yiming Wang
 //           2017 Hainan Xu
 //
@@ -32,7 +32,7 @@ KaldiRnnlmDeterministicFst::~KaldiRnnlmDeterministicFst() {
   int32 size = state_to_rnnlm_state_.size();
   for (int32 i = 0; i < size; i++)
     delete state_to_rnnlm_state_[i];
-  
+
   state_to_rnnlm_state_.resize(0);
   state_to_wseq_.resize(0);
   wseq_to_state_.clear();
@@ -44,7 +44,7 @@ void KaldiRnnlmDeterministicFst::Clear() {
   int32 size = state_to_rnnlm_state_.size();
   for (int32 i = 1; i < size; i++)
     delete state_to_rnnlm_state_[i];
-  
+
   state_to_rnnlm_state_.resize(1);
   state_to_wseq_.resize(1);
   wseq_to_state_.clear();
@@ -104,6 +104,94 @@ bool KaldiRnnlmDeterministicFst::GetArc(StateId s, Label ilabel,
   // If the pair was just inserted, then also add it to state_to_* structures.
   if (result.second == true) {
     RnnlmComputeState *rnnlm2 = rnnlm->GetSuccessorState(ilabel);
+    state_to_wseq_.push_back(word_seq);
+    state_to_rnnlm_state_.push_back(rnnlm2);
+  }
+
+  // Creates the arc.
+  oarc->ilabel = ilabel;
+  oarc->olabel = ilabel;
+  oarc->nextstate = result.first->second;
+  oarc->weight = Weight(-logprob);
+  return true;
+}
+
+KaldiRnnlmDeterministicFstAdapt::~KaldiRnnlmDeterministicFstAdapt() {
+  int32 size = state_to_rnnlm_state_.size();
+  for (int32 i = 0; i < size; i++)
+    delete state_to_rnnlm_state_[i];
+
+  state_to_rnnlm_state_.resize(0);
+  state_to_wseq_.resize(0);
+  wseq_to_state_.clear();
+}
+
+void KaldiRnnlmDeterministicFstAdapt::Clear() {
+  // This function is similar to the destructor but we retain the 0-th entries
+  // in each map which corresponds to the <bos> state.
+  int32 size = state_to_rnnlm_state_.size();
+  for (int32 i = 1; i < size; i++)
+    delete state_to_rnnlm_state_[i];
+
+  state_to_rnnlm_state_.resize(1);
+  state_to_wseq_.resize(1);
+  wseq_to_state_.clear();
+  wseq_to_state_[state_to_wseq_[0]] = 0;
+}
+
+KaldiRnnlmDeterministicFstAdapt::KaldiRnnlmDeterministicFstAdapt(int32 max_ngram_order,
+    const RnnlmComputeStateInfo &info) {
+  max_ngram_order_ = max_ngram_order;
+  bos_index_ = info.opts.bos_index;
+  eos_index_ = info.opts.eos_index;
+
+  std::vector<Label> bos_seq;
+  bos_seq.push_back(bos_index_);
+  state_to_wseq_.push_back(bos_seq);
+  RnnlmComputeStateAdapt *decodable_rnnlm = new RnnlmComputeStateAdapt(info, bos_index_);
+  wseq_to_state_[bos_seq] = 0;
+  start_state_ = 0;
+
+  state_to_rnnlm_state_.push_back(decodable_rnnlm);
+}
+
+fst::StdArc::Weight KaldiRnnlmDeterministicFstAdapt::Final(StateId s) {
+  /// At this point, we have created the state.
+  KALDI_ASSERT(static_cast<size_t>(s) < state_to_wseq_.size());
+
+  RnnlmComputeStateAdapt* rnn = state_to_rnnlm_state_[s];
+  return Weight(-rnn->LogProbOfWord(eos_index_));
+}
+
+bool KaldiRnnlmDeterministicFstAdapt::GetArc(StateId s, Label ilabel,
+                                        fst::StdArc *oarc) {
+  /// At this point, we have created the state.
+  KALDI_ASSERT(static_cast<size_t>(s) < state_to_wseq_.size());
+
+  std::vector<Label> word_seq = state_to_wseq_[s];
+  const RnnlmComputeStateAdapt* rnnlm = state_to_rnnlm_state_[s];
+
+  BaseFloat logprob = rnnlm->LogProbOfWord(ilabel);
+
+  word_seq.push_back(ilabel);
+  if (max_ngram_order_ > 0) {
+    while (word_seq.size() >= max_ngram_order_) {
+      /// History state has at most <max_ngram_order_> - 1 words in the state.
+      word_seq.erase(word_seq.begin(), word_seq.begin() + 1);
+    }
+  }
+
+  std::pair<const std::vector<Label>, StateId> wseq_state_pair(
+      word_seq, static_cast<Label>(state_to_wseq_.size()));
+
+  // Attemps to insert the current <wseq_state_pair>. If the pair already exists
+  // then it returns false.
+  typedef MapType::iterator IterType;
+  std::pair<IterType, bool> result = wseq_to_state_.insert(wseq_state_pair);
+
+  // If the pair was just inserted, then also add it to state_to_* structures.
+  if (result.second == true) {
+    RnnlmComputeStateAdapt *rnnlm2 = rnnlm->GetSuccessorState(ilabel);
     state_to_wseq_.push_back(word_seq);
     state_to_rnnlm_state_.push_back(rnnlm2);
   }

--- a/src/rnnlm/rnnlm-lattice-rescoring.h
+++ b/src/rnnlm/rnnlm-lattice-rescoring.h
@@ -1,6 +1,6 @@
 // rnnlm/rnnlm-lattice-rescoring.h
 //
-// Copyright 2017 Johns Hopkins University (author: Daniel Povey) 
+// Copyright 2017 Johns Hopkins University (author: Daniel Povey)
 //           2017 Yiming Wang
 //           2017 Hainan Xu
 //
@@ -73,6 +73,49 @@ class KaldiRnnlmDeterministicFst
   // Mapping from state-id to RNNLM states.
   // The pointers are owned in this class
   std::vector<RnnlmComputeState*> state_to_rnnlm_state_;
+
+};
+
+class KaldiRnnlmDeterministicFstAdapt
+    : public fst::DeterministicOnDemandFst<fst::StdArc> {
+ public:
+  typedef fst::StdArc::Weight Weight;
+  typedef fst::StdArc::StateId StateId;
+  typedef fst::StdArc::Label Label;
+
+  // Does not take ownership.
+  KaldiRnnlmDeterministicFstAdapt(int32 max_ngram_order,
+      const RnnlmComputeStateInfoAdapt &info);
+  ~KaldiRnnlmDeterministicFstAdapt();
+
+  void Clear();
+
+  // We cannot use "const" because the pure virtual function in the interface is
+  // not const.
+  virtual StateId Start() { return start_state_; }
+
+  // We cannot use "const" because the pure virtual function in the interface is
+  // not const.
+  virtual Weight Final(StateId s);
+
+  virtual bool GetArc(StateId s, Label ilabel, fst::StdArc* oarc);
+
+ private:
+  typedef unordered_map
+      <std::vector<Label>, StateId, VectorHasher<Label> > MapType;
+  StateId start_state_;
+  int32 max_ngram_order_;
+  int32 bos_index_;
+  int32 eos_index_;
+
+  MapType wseq_to_state_;
+
+  // Mapping from state-id to history sequence>
+  std::vector<std::vector<Label> > state_to_wseq_;
+
+  // Mapping from state-id to RNNLM states.
+  // The pointers are owned in this class
+  std::vector<RnnlmComputeStateAdapt*> state_to_rnnlm_state_;
 
 };
 

--- a/src/rnnlm/rnnlm-training.cc
+++ b/src/rnnlm/rnnlm-training.cc
@@ -19,6 +19,7 @@
 
 #include "rnnlm/rnnlm-training.h"
 #include "nnet3/nnet-utils.h"
+#include "cudamatrix/cu-rand.h"
 
 namespace kaldi {
 namespace rnnlm {
@@ -285,6 +286,245 @@ RnnlmTrainer::~RnnlmTrainer() {
             << " minibatches.\n";
 }
 
+
+
+RnnlmTrainerAdapt::RnnlmTrainerAdapt(bool train_embedding,
+                           const RnnlmCoreTrainerOptions &core_config,
+                           const RnnlmEmbeddingTrainerOptions &embedding_config,
+                           const RnnlmObjectiveOptions &objective_config,
+                           CuMatrix<BaseFloat> *embedding_mat_large,
+                           CuMatrix<BaseFloat> *embedding_mat_med,
+                           CuMatrix<BaseFloat> *embedding_mat_small,
+                           nnet3::Nnet *rnnlm,
+                           int32 cutofflarge,
+                           int32 cutoffmed):
+    train_embedding_(train_embedding),
+    core_config_(core_config),
+    embedding_config_(embedding_config),
+    objective_config_(objective_config),
+    rnnlm_(rnnlm),
+    core_trainer_(NULL),
+    embedding_mat_large_(embedding_mat_large),
+    embedding_mat_med_(embedding_mat_med),
+    embedding_mat_small_(embedding_mat_small),
+    embedding_trainer_large_(NULL),
+    embedding_trainer_med_(NULL),
+    embedding_trainer_small_(NULL),
+    num_minibatches_processed_(0),
+    cutoff_large(cutofflarge),
+    cutoff_med(cutoffmed),
+    srand_seed_(RandInt(0, 100000)) {
+
+  core_trainer_ = new RnnlmCoreTrainerAdapt(core_config_, objective_config_, rnnlm_);
+
+  KALDI_ASSERT (train_embedding);
+  embedding_trainer_large_ = new RnnlmEmbeddingTrainer(embedding_config,
+                                                 embedding_mat_large_);
+  embedding_trainer_med_ = new RnnlmEmbeddingTrainer(embedding_config,
+                                                 embedding_mat_med_);
+  embedding_trainer_small_ = new RnnlmEmbeddingTrainer(embedding_config,
+                                                 embedding_mat_small_);
+
+}
+
+
+void RnnlmTrainerAdapt::Train(RnnlmExample *minibatch) {
+  // check the minibatch for sanity.
+  if (minibatch->vocab_size != VocabSize())
+      KALDI_ERR << "Vocabulary size mismatch: expected "
+                << VocabSize() << ", got "
+                << minibatch->vocab_size;
+
+  current_minibatch_.Swap(minibatch);
+  num_minibatches_processed_++;
+  RnnlmExampleDerived derived;
+  CuArray<int32> active_words_cuda;
+  CuSparseMatrix<BaseFloat> active_word_features;
+  CuSparseMatrix<BaseFloat> active_word_features_trans;
+
+  std::vector<int32> active_words_cpu;
+  if (!current_minibatch_.sampled_words.empty()) {
+    RenumberRnnlmExample(&current_minibatch_, &active_words_cpu);
+    active_words_cuda.CopyFromVec(active_words_cpu);
+
+  }
+  SetMaskVectors(&active_words_cpu, &current_minibatch_, cutoff_large, cutoff_med);
+
+  GetRnnlmExampleDerivedAdapt(current_minibatch_, train_embedding_,
+                              &derived);
+
+  int32 sz = active_words_cpu.size();
+  std::vector<int32> active_words_large(sz);
+  std::vector<int32> active_words_med(sz);
+  std::vector<int32> active_words_small(sz);
+  std::vector<int32> active_words_large_filt;
+  std::vector<int32> active_words_med_filt;
+  std::vector<int32> active_words_small_filt;
+  std::vector<int32> large_embed_active;
+  std::vector<int32> med_embed_active;
+  std::vector<int32> small_embed_active;
+  for(int32 i = 0; i < sz; i++) {
+    int32 idx = active_words_cpu[i];
+    if (idx < cutoff_large) {
+      large_embed_active.push_back(i);
+      active_words_large_filt.push_back(idx);
+      active_words_large[i] = idx;
+      active_words_med[i] = -1;
+      active_words_small[i] = -1;
+    } else if (idx < (cutoff_med + cutoff_large)) {
+      med_embed_active.push_back(i);
+      active_words_med_filt.push_back(idx - cutoff_large);
+      active_words_large[i] = -1;
+      active_words_med[i] = idx - cutoff_large;
+      active_words_small[i] = -1;
+    } else {
+      small_embed_active.push_back(i);
+      active_words_small_filt.push_back(idx - cutoff_large - cutoff_med);
+      active_words_large[i] = -1;
+      active_words_med[i] = -1;
+      active_words_small[i] = idx - cutoff_large - cutoff_med;
+    }
+  }
+  active_words_large_ = active_words_large;
+  active_words_med_ = active_words_med;
+  active_words_small_ = active_words_small;
+  large_embed_active_ = large_embed_active;
+  med_embed_active_ = med_embed_active;
+  small_embed_active_ = small_embed_active;
+  active_words_large_filt_ = active_words_large_filt;
+  active_words_med_filt_ = active_words_med_filt;
+  active_words_small_filt_ = active_words_small_filt;
+
+  derived_.Swap(&derived);
+  active_words_.Swap(&active_words_cuda);
+  active_word_features_.Swap(&active_word_features);
+  active_word_features_trans_.Swap(&active_word_features_trans);
+
+  TrainInternal();
+
+  if (num_minibatches_processed_ == 1)
+    core_trainer_->ConsolidateMemory();
+}
+
+
+void RnnlmTrainerAdapt::GetWordEmbedding(CuMatrix<BaseFloat> *word_embedding_storage_large,
+                                    CuMatrix<BaseFloat> *word_embedding_storage_med,
+                                    CuMatrix<BaseFloat> *word_embedding_storage_small,
+                                    CuMatrix<BaseFloat> **word_embedding_large,
+                                    CuMatrix<BaseFloat> **word_embedding_med,
+                                    CuMatrix<BaseFloat> **word_embedding_small) {
+  RnnlmExample &minibatch = current_minibatch_;
+  bool sampling = !minibatch.sampled_words.empty();
+
+  KALDI_ASSERT(word_feature_mat_ == NULL);
+   // There is no sparse word-feature matrix.
+  KALDI_ASSERT (sampling);
+
+  word_embedding_storage_large->Resize(active_words_.Dim(),
+                                 embedding_mat_large_->NumCols(),
+                                   kUndefined);
+  word_embedding_storage_large->CopyRows(*embedding_mat_large_, active_words_large_);
+
+  word_embedding_storage_med->Resize(active_words_.Dim(),
+                                 embedding_mat_med_->NumCols(),
+                                   kUndefined);
+  word_embedding_storage_med->CopyRows(*embedding_mat_med_, active_words_med_);
+
+  word_embedding_storage_small->Resize(active_words_.Dim(),
+                                 embedding_mat_small_->NumCols(),
+                                   kUndefined);
+  word_embedding_storage_small->CopyRows(*embedding_mat_small_, active_words_small_);
+
+  *word_embedding_large = word_embedding_storage_large;
+  *word_embedding_med = word_embedding_storage_med;
+  *word_embedding_small = word_embedding_storage_small;
+}
+
+
+
+void RnnlmTrainerAdapt::TrainWordEmbedding(
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_large,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_med,
+    CuMatrixBase<BaseFloat> *word_embedding_deriv_small) {
+  RnnlmExample &minibatch = current_minibatch_;
+  bool sampling = !minibatch.sampled_words.empty();
+
+  KALDI_ASSERT (word_feature_mat_ == NULL);
+  KALDI_ASSERT (sampling);
+  int32 sz = large_embed_active_.Dim();
+
+  CuMatrix<BaseFloat> word_emb_deriv_large_filtered(sz, word_embedding_deriv_large->NumCols());
+  word_emb_deriv_large_filtered.CopyRows(*word_embedding_deriv_large, large_embed_active_);
+
+  embedding_trainer_large_->Train(active_words_large_filt_,
+                            &word_emb_deriv_large_filtered);
+
+
+  sz = med_embed_active_.Dim();
+
+  CuMatrix<BaseFloat> word_emb_deriv_med_filtered(sz, word_embedding_deriv_med->NumCols());
+  word_emb_deriv_med_filtered.CopyRows(*word_embedding_deriv_med, med_embed_active_);
+
+  embedding_trainer_med_->Train(active_words_med_filt_,
+                            &word_emb_deriv_med_filtered);
+
+  sz = small_embed_active_.Dim();
+  CuMatrix<BaseFloat> word_emb_deriv_small_filtered(sz, word_embedding_deriv_small->NumCols());
+    word_emb_deriv_small_filtered.CopyRows(*word_embedding_deriv_small, small_embed_active_);
+
+  embedding_trainer_small_->Train(active_words_small_filt_,
+                            &word_emb_deriv_small_filtered);
+
+}
+
+
+void RnnlmTrainerAdapt::TrainInternal() {
+  CuMatrix<BaseFloat> word_embedding_storage_large;
+  CuMatrix<BaseFloat> *word_embedding_large;
+  CuMatrix<BaseFloat> word_embedding_storage_med;
+  CuMatrix<BaseFloat> *word_embedding_med;
+  CuMatrix<BaseFloat> word_embedding_storage_small;
+  CuMatrix<BaseFloat> *word_embedding_small;
+  GetWordEmbedding(&word_embedding_storage_large, &word_embedding_storage_med, &word_embedding_storage_small, 
+    &word_embedding_large, &word_embedding_med, &word_embedding_small);
+
+  CuMatrix<BaseFloat> word_embedding_deriv_large;
+  CuMatrix<BaseFloat> word_embedding_deriv_med;
+  CuMatrix<BaseFloat> word_embedding_deriv_small;
+
+  word_embedding_deriv_large.Resize(word_embedding_large->NumRows(),
+                                word_embedding_large->NumCols());
+  word_embedding_deriv_med.Resize(word_embedding_med->NumRows(),
+                                word_embedding_med->NumCols());                                
+  word_embedding_deriv_small.Resize(word_embedding_small->NumRows(),
+                                word_embedding_small->NumCols());
+
+
+  core_trainer_->Train(current_minibatch_, derived_, *word_embedding_large, *word_embedding_med, *word_embedding_small,
+                       &word_embedding_deriv_large, &word_embedding_deriv_med, &word_embedding_deriv_small);
+  KALDI_ASSERT (train_embedding_);
+  TrainWordEmbedding(&word_embedding_deriv_large, &word_embedding_deriv_med, &word_embedding_deriv_small);
+}
+
+int32 RnnlmTrainerAdapt::VocabSize() {
+  return embedding_mat_large_->NumRows() + embedding_mat_med_->NumRows() + embedding_mat_small_->NumRows();
+}
+
+RnnlmTrainerAdapt::~RnnlmTrainerAdapt() {
+  // Note: the following delete statements may cause some diagnostics to be
+  // issued, from the destructors of those classes.
+  if (core_trainer_)
+    delete core_trainer_;
+  if (embedding_trainer_large_)
+    delete embedding_trainer_large_;
+    if (embedding_trainer_med_)
+    delete embedding_trainer_med_;
+  if (embedding_trainer_small_)
+    delete embedding_trainer_small_;
+
+  KALDI_LOG << "Trained on " << num_minibatches_processed_
+            << " minibatches.\n";
+}
 
 
 }  // namespace rnnlm

--- a/src/rnnlm/rnnlm-training.h
+++ b/src/rnnlm/rnnlm-training.h
@@ -189,6 +189,180 @@ class RnnlmTrainer {
 };
 
 
+class RnnlmTrainerAdapt {
+ public:
+  /**
+     Constructor
+      @param [in] train_embedding  True if the user wants us to
+                             train the embedding matrix
+      @param [in] core_config  Options for training the core
+                              RNNLM
+      @param [in] embedding_config  Options for training the
+                              embedding matrix (only relevant
+                              if train_embedding is true).
+      @param [in] objective_config  Options relating to the objective
+                              function used for training.
+      @param [in] word_feature_mat Either NULL, or a pointer to a sparse
+                             word-feature matrix of dimension vocab-size by
+                             feature-dim, where vocab-size is the
+                             highest-numbered word plus one.
+      @param [in,out] embedding_mat  Pointer to the embedding
+                             matrix; this is trained if train_embedding is true,
+                             and in either case this class retains the pointer
+                             to 'embedding_mat' during its livetime.
+                             If word_feature_mat is NULL, this
+                             is the word-embedding matrix of dimension
+                             vocab-size by embedding-dim; otherwise it is the
+                             feature-embedding matrix of dimension feature-dim by
+                             by embedding-dim, and we have to multiply it by
+                             word_feature_mat to get the word embedding matrix.
+      @param [in,out] rnnlm  The RNNLM to be trained.  The class will retain
+                             this pointer and modify the neural net in-place.
+  */
+  RnnlmTrainerAdapt(bool train_embedding,
+               const RnnlmCoreTrainerOptions &core_config,
+               const RnnlmEmbeddingTrainerOptions &embedding_config,
+               const RnnlmObjectiveOptions &objective_config,
+               CuMatrix<BaseFloat> *embedding_mat_large,
+               CuMatrix<BaseFloat> *embedding_mat_med,
+               CuMatrix<BaseFloat> *embedding_mat_small,
+               nnet3::Nnet *rnnlm,
+               int32 cutofflarge,
+               int32 cutoffmed);
+
+
+
+  // Train on one example.  The example is provided as a pointer because we
+  // acquire it destructively, via Swap().
+  void Train(RnnlmExample *minibatch);
+
+
+  // The destructor writes out any files that we need to write out.
+  ~RnnlmTrainerAdapt();
+
+  int32 NumMinibatchesProcessed() { return num_minibatches_processed_; }
+
+  // Contains indices of embed matrix that belong to small / large.
+  CuArray<int32> large_embed_active_;
+  CuArray<int32> med_embed_active_;
+  CuArray<int32> small_embed_active_;
+  CuArray<int32> active_words_large_filt_;
+  CuArray<int32> active_words_med_filt_;
+  CuArray<int32> active_words_small_filt_;
+  int32 cutoff_large;
+  int32 cutoff_med;
+
+ private:
+
+  int32 VocabSize();
+
+  /// This function contains the actual training code, it's called from Train();
+  /// it trains on minibatch_previous_.
+  void TrainInternal();
+
+  /// This function works out the word-embedding matrix for the minibatch we're
+  /// training on (previous_minibatch_).  The word-embedding matrix for this
+  /// minibatch is a matrix of dimension current_minibatch_.vocab_size by
+  /// embedding_mat_.NumRows().  This function sets '*word_embedding' to be a
+  /// pointer to the embedding matrix, which will either be '&embedding_mat_'
+  /// (in the case where there is no sampling and no sparse feature
+  /// representation), or 'word_embedding_storage' otherwise.  In the latter
+  /// case, 'word_embedding_storage' will be resized and written to
+  /// appropriately.
+  void GetWordEmbedding(CuMatrix<BaseFloat> *word_embedding_storage_large,
+                        CuMatrix<BaseFloat> *word_embedding_storage_med,
+                        CuMatrix<BaseFloat> *word_embedding_storage_small,
+                        CuMatrix<BaseFloat> **word_embedding_large,
+                        CuMatrix<BaseFloat> **word_embedding_med,
+                        CuMatrix<BaseFloat> **word_embedding_small);
+
+
+  /// This function trains the word-embedding matrix for the minibatch we're
+  /// training on (in previous_minibatch_).  'embedding_deriv' is the derivative
+  /// w.r.t. the word-embedding for this minibatch (of dimension
+  /// previus_minibatch_.vocab_size by embedding_mat_.NumCols()).
+  /// You can think of it as the backprop for the function 'GetWordEmbedding()'.
+  ///   @param [in] word_embedding_deriv   The derivative w.r.t. the embeddings of
+  ///                       just the words used in this minibatch
+  ///                       (i.e. the minibatch-level word-embedding matrix,
+  ///                       possibly using a subset of words).  This is an input
+  ///                       but this function consumes it destructively.
+  void TrainWordEmbedding(CuMatrixBase<BaseFloat> *word_embedding_deriv_large,
+                          CuMatrixBase<BaseFloat> *word_embedding_deriv_med,
+                          CuMatrixBase<BaseFloat> *word_embedding_deriv_small);
+
+  bool train_embedding_;  // true if we are training the embedding.
+  const RnnlmCoreTrainerOptions &core_config_;
+  const RnnlmEmbeddingTrainerOptions &embedding_config_;
+  const RnnlmObjectiveOptions &objective_config_;
+
+  // The neural net we are training (not owned here)
+  nnet3::Nnet *rnnlm_;
+
+  // Pointer to the object that trains 'rnnlm_' (owned here).
+  RnnlmCoreTrainerAdapt *core_trainer_;
+
+  // The (word or feature) embedding matrix; it's the word embedding matrix if
+  // word_feature_mat_.NumRows() == 0, else it's the feature embedding matrix.
+  // The dimension is (num-words or num-features) by embedding-dim.
+  // It's owned outside this class.
+  CuMatrix<BaseFloat> *embedding_mat_large_;
+  CuMatrix<BaseFloat> *embedding_mat_med_;
+  CuMatrix<BaseFloat> *embedding_mat_small_;
+
+  // Pointer to the object that trains 'embedding_mat_', or NULL if we are not
+  // training it.  Owned here.
+  RnnlmEmbeddingTrainer *embedding_trainer_large_;
+  RnnlmEmbeddingTrainer *embedding_trainer_med_;
+  RnnlmEmbeddingTrainer *embedding_trainer_small_;
+
+  // If the --read-sparse-word-features options is provided, then
+  // word_feature_mat_ will contain the matrix of sparse word features, of
+  // dimension num-words by num-features.  In this case, the word embedding
+  // matrix is the product of this matrix times 'embedding_mat_'.
+  // It's owned outside this class.
+  const CuSparseMatrix<BaseFloat> *word_feature_mat_;
+
+  // This is the transpose of word_feature_mat_, which is needed only if we
+  // train on egs without sampling.  This is only computed once, if and when
+  // it's needed.
+  CuSparseMatrix<BaseFloat> word_feature_mat_transpose_;
+
+  int32 num_minibatches_processed_;
+
+  RnnlmExample current_minibatch_;
+
+  // The variables derived_ and active_words_ corresponds to group as current_minibatch_.
+  RnnlmExampleDerived derived_;
+  // Only if we are doing subsampling (depends on the eg), active_words_
+  // contains the list of active words for the minibatch 'current_minibatch_';
+  // it is a CUDA version of the 'active_words' output by
+  // RenumberRnnlmExample().  Otherwise it is empty.
+  CuArray<int32> active_words_;
+  CuArray<int32> active_words_large_;
+  CuArray<int32> active_words_med_;
+  CuArray<int32> active_words_small_;
+
+
+  // Only if we are doing subsampling AND we have sparse word features
+  // (i.e. word_feature_mat_ is nonempty), active_word_features_ contains
+  // just the rows of word_feature_mat_ which correspond to active_words_.
+  // This is a derived quantity computed by the background thread.
+  CuSparseMatrix<BaseFloat> active_word_features_;
+  // Only if we are doing subsampling AND we have sparse word features,
+  // active_word_features_trans_ is the transpose of active_word_features_;
+  // This is a derived quantity computed by the background thread.
+  CuSparseMatrix<BaseFloat> active_word_features_trans_;
+
+  // This value is used in backstitch training when we need to ensure
+  // consistent dropout masks.  It's set to a value derived from rand()
+  // when the class is initialized.
+  int32 srand_seed_;
+
+  KALDI_DISALLOW_COPY_AND_ASSIGN(RnnlmTrainerAdapt);
+};
+
+
 } // namespace rnnlm
 } // namespace kaldi
 

--- a/src/rnnlmbin/rnnlm-compute-prob-adapt.cc
+++ b/src/rnnlmbin/rnnlm-compute-prob-adapt.cc
@@ -1,0 +1,144 @@
+// rnnlmbin/rnnlm-compute-prob.cc
+
+// Copyright 2015-2017  Johns Hopkins University (author: Daniel Povey)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "rnnlm/rnnlm-core-training.h"
+#include "rnnlm/rnnlm-example-utils.h"
+#include "rnnlm/rnnlm-core-compute.h"
+#include "nnet3/nnet-utils.h"
+
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::rnnlm;
+    typedef kaldi::int32 int32;
+    typedef kaldi::int64 int64;
+
+    const char *usage =
+        "This program computes the probability per word of the provided training\n"
+        "data in 'egs' format as prepared by rnnlm-get-egs.  The interface is similar\n"
+        "to rnnlm-train, except that it doesn't train, and doesn't write the model;\n"
+        "it just prints the average probability to the standard output (in addition\n"
+        "to printing various diagnostics to the standard error).\n"
+        "\n"
+        "Usage:\n"
+        " rnnlm-compute-prob [options] <rnnlm> <word-embedding-matrix> <egs-rspecifier>\n"
+        "e.g.:\n"
+        " rnnlm-get-egs ... ark:- | \\\n"
+        " rnnlm-compute-prob 0.raw 0.word_embedding ark:-\n"
+        "(note: use rnnlm-get-word-embedding to get the word embedding matrix if\n"
+        "you are using sparse word features.)\n";
+
+    std::string use_gpu = "no";
+    bool batchnorm_test_mode = true, dropout_test_mode = true;
+    int32 cutoff_large = -1;
+    int32 cutoff_med = -1;
+
+    ParseOptions po(usage);
+    po.Register("use-gpu", &use_gpu,
+                "yes|no|optional|wait, only has effect if compiled with CUDA");
+    po.Register("batchnorm-test-mode", &batchnorm_test_mode,
+                "If true, set test-mode to true on any BatchNormComponents.");
+    po.Register("dropout-test-mode", &dropout_test_mode,
+                "If true, set test-mode to true on any DropoutComponents and "
+                "DropoutMaskComponents.");
+    po.Register("cutofflarge", &cutoff_large, "set cutoff index for adaptive emb");
+    po.Register("cutoffmed", &cutoff_med, "set cutoff index for adaptive emb");
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 5) {
+      po.PrintUsage();
+      exit(1);
+    }
+    KALDI_ASSERT(cutoff_large != -1);
+    KALDI_ASSERT(cutoff_med != -1);
+
+    std::string rnnlm_rxfilename = po.GetArg(1),
+        word_embedding_large_rxfilename = po.GetArg(2),
+        word_embedding_med_rxfilename = po.GetArg(3),
+        word_embedding_small_rxfilename = po.GetArg(4),
+        egs_rspecifier = po.GetArg(5);
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().SelectGpuId(use_gpu);
+    CuDevice::Instantiate().AllowMultithreading();
+#endif
+
+    kaldi::nnet3::Nnet rnnlm;
+    ReadKaldiObject(rnnlm_rxfilename, &rnnlm);
+
+    if (!IsSimpleNnet(rnnlm))
+      KALDI_ERR << "Input RNNLM in " << rnnlm_rxfilename
+                << " is not the type of neural net we were looking for; "
+          "failed IsSimpleNnet().";
+    if (batchnorm_test_mode)
+      SetBatchnormTestMode(true, &rnnlm);
+    if (dropout_test_mode)
+      SetDropoutTestMode(true, &rnnlm);
+
+    CuMatrix<BaseFloat> word_embedding_mat_large;
+    ReadKaldiObject(word_embedding_large_rxfilename, &word_embedding_mat_large);
+    CuMatrix<BaseFloat> word_embedding_mat_med;
+    ReadKaldiObject(word_embedding_med_rxfilename, &word_embedding_mat_med);
+    CuMatrix<BaseFloat> word_embedding_mat_small;
+    ReadKaldiObject(word_embedding_small_rxfilename, &word_embedding_mat_small);
+
+    SequentialRnnlmExampleReader example_reader(egs_rspecifier);
+
+    double tot_weight = 0.0, tot_objf = 0.0;
+    {
+      RnnlmCoreComputer computer(rnnlm);
+
+      int32 num_minibatches = 0;
+
+      for (; !example_reader.Done(); example_reader.Next()) {
+        RnnlmExample &minibatch = example_reader.Value();
+        RnnlmExampleDerived derived;
+        bool need_embedding_deriv = false;
+        SetSplitInputVecs(&minibatch, cutoff_large, cutoff_med);
+        GetRnnlmExampleDerivedAdapt(minibatch, need_embedding_deriv, &derived);
+        // compute for this minibatch.
+        BaseFloat weight,
+            objf = computer.ComputeAdapt(minibatch, derived, word_embedding_mat_large, word_embedding_mat_med, word_embedding_mat_small,
+                                    &weight, NULL);
+        tot_weight += weight;
+        tot_objf += objf;
+        num_minibatches++;
+      }
+      if (num_minibatches == 0)
+        KALDI_ERR << "Processed no data.";
+      // The destructor of 'computer' prints diagnostics so we don't need to
+      // print any diagnostic messages.
+    }
+
+
+    std::cout << (tot_objf / tot_weight) << std::endl;
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().PrintProfile();
+#endif
+    return 0;
+  } catch(const std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return -1;
+  }
+}

--- a/src/rnnlmbin/rnnlm-train-adapt.cc
+++ b/src/rnnlmbin/rnnlm-train-adapt.cc
@@ -1,0 +1,204 @@
+// rnnlmbin/rnnlm-train.cc
+
+// Copyright 2015-2017  Johns Hopkins University (author: Daniel Povey)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "rnnlm/rnnlm-training.h"
+#include "rnnlm/rnnlm-example-utils.h"
+#include "nnet3/nnet-utils.h"
+#include "cudamatrix/cu-allocator.h"
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::rnnlm;
+    typedef kaldi::int32 int32;
+    typedef kaldi::int64 int64;
+
+
+    // rnnlm_rxfilename must be supplied, via --read-rnnlm option.
+    std::string rnnlm_rxfilename;
+    // For now, rnnlm_wxfilename must be supplied (later we could make it possible
+    // to train the embedding matrix without training the RNNLM itself, if there
+    // is a need).
+    std::string rnnlm_wxfilename;
+    // embedding_rxfilename must be supplied, via --read-embedding option.
+    std::string embedding_large_rxfilename;
+    std::string embedding_large_wxfilename;
+    std::string embedding_med_rxfilename;
+    std::string embedding_med_wxfilename;
+    std::string embedding_small_rxfilename;
+    std::string embedding_small_wxfilename;
+    std::string word_features_rxfilename;
+    // binary mode for writing output.
+    bool binary = true;
+
+    RnnlmCoreTrainerOptions core_config;
+    RnnlmEmbeddingTrainerOptions embedding_config;
+    RnnlmObjectiveOptions objective_config;
+
+    const char *usage =
+        "Train nnet3-based RNNLM language model (reads minibatches prepared\n"
+        "by rnnlm-get-egs).  Supports various modes depending which parameters\n"
+        "we are training.\n"
+        "Usage:\n"
+        " rnnlm-train [options] <egs-rspecifier>\n"
+        "e.g.:\n"
+        " rnnlm-get-egs ... ark:- | \\\n"
+        " rnnlm-train --read-rnnlm=foo/0.raw --write-rnnlm=foo/1.raw --read-embedding=foo/0.embedding \\\n"
+        "       --write-embedding=foo/1.embedding --read-sparse-word-features=foo/word_feats.txt ark:-\n"
+        "See also: rnnlm-get-egs\n";
+
+
+    std::string use_gpu = "yes";
+
+    ParseOptions po(usage);
+    po.Register("use-gpu", &use_gpu,
+                "yes|no|optional|wait, only has effect if compiled with CUDA");
+    po.Register("read-rnnlm", &rnnlm_rxfilename,
+                "Read RNNLM from this location (e.g. 0.raw).  Must be supplied.");
+    po.Register("write-rnnlm", &rnnlm_wxfilename,
+                "Write RNNLM to this location (e.g. 1.raw)."
+                "If not supplied, the core RNNLM is not trained "
+                "(but other parts of the model might be.");
+    po.Register("read-large-embedding", &embedding_large_rxfilename,
+                "Location to read dense (feature or word) embedding matrix, "
+                "of dimension (num-words or num-features) by (embedding-dim).");
+        po.Register("read-med-embedding", &embedding_med_rxfilename,
+                "Location to read dense (feature or word) embedding matrix, "
+                "of dimension (num-words or num-features) by (embedding-dim).");
+    po.Register("read-small-embedding", &embedding_small_rxfilename,
+                "Location to read dense (feature or word) embedding matrix, "
+                "of dimension (num-words or num-features) by (embedding-dim).");
+    po.Register("write-large-embedding", &embedding_large_wxfilename,
+                "Location to write embedding matrix (c.f. --read-embedding). "
+                "If not provided, the embedding will not be trained.");
+    po.Register("write-med-embedding", &embedding_med_wxfilename,
+                "Location to write embedding matrix (c.f. --read-embedding). "
+                "If not provided, the embedding will not be trained.");
+    po.Register("write-small-embedding", &embedding_small_wxfilename,
+                "Location to write embedding matrix (c.f. --read-embedding). "
+                "If not provided, the embedding will not be trained.");
+    po.Register("read-sparse-word-features", &word_features_rxfilename,
+                "Location to read sparse word-feature matrix, e.g. "
+                "word_feats.txt.  Format is lines like: '1  30 1.0 516 1.0':"
+                "starting with word-index, then a list of pairs "
+                "(feature-index, value) only including nonzero features. "
+                "This will usually be determined in an ad-hoc way based on "
+                "letters and other hand-built features; it's not trainable."
+                " If present, the embedding matrix read via --read-embedding "
+                "will be interpreted as a feature-embedding matrix.");
+    po.Register("binary", &binary,
+                "If true, write outputs in binary form.");
+
+    objective_config.Register(&po);
+    RegisterCuAllocatorOptions(&po);
+
+    // register the core RNNLM training options options with the prefix "rnnlm",
+    // so they will appear as --rnnlm.max-change and the like.  This is done
+    // with a prefix because later we may add a neural net to transform the word
+    // embedding, and it would have options that would have a name conflict with
+    // some of these options.
+    ParseOptions core_opts("rnnlm", &po);
+    core_config.Register(&core_opts);
+    // ... and register the embedding options with the prefix "embedding".
+    ParseOptions embedding_opts("embedding", &po);
+    embedding_config.Register(&embedding_opts);
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 1) {
+      po.PrintUsage();
+      exit(1);
+    }
+    if (rnnlm_rxfilename == "" ||
+        rnnlm_wxfilename == "" ||
+        embedding_large_rxfilename == "") {
+      KALDI_WARN << "--read-rnnlm, --write-rnnlm and --read-embedding "
+          "options are required.";
+      po.PrintUsage();
+      exit(1);
+    }
+
+    std::string examples_rspecifier = po.GetArg(1);
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().SelectGpuId(use_gpu);
+    CuDevice::Instantiate().AllowMultithreading();
+#endif
+
+    kaldi::nnet3::Nnet rnnlm;
+
+    ReadKaldiObject(rnnlm_rxfilename, &rnnlm);
+
+    if (!IsSimpleNnet(rnnlm))
+      KALDI_ERR << "Input RNNLM in " << rnnlm_rxfilename
+                << " is not the type of neural net we were looking for; "
+          "failed IsSimpleNnet().";
+
+    CuMatrix<BaseFloat> embedding_mat_large;
+    ReadKaldiObject(embedding_large_rxfilename, &embedding_mat_large);
+    CuMatrix<BaseFloat> embedding_mat_med;
+    ReadKaldiObject(embedding_med_rxfilename, &embedding_mat_med);
+    CuMatrix<BaseFloat> embedding_mat_small;
+    ReadKaldiObject(embedding_small_rxfilename, &embedding_mat_small);
+
+    {
+      bool train_embedding = true;
+
+      RnnlmTrainerAdapt trainer(
+          train_embedding, core_config, embedding_config, objective_config,
+          &embedding_mat_large, &embedding_mat_med, &embedding_mat_small, &rnnlm, 10000, 50000);
+
+      SequentialRnnlmExampleReader example_reader(examples_rspecifier);
+
+      for (; !example_reader.Done(); example_reader.Next()) {
+        trainer.Train(&(example_reader.Value()));
+      }
+
+      if (trainer.NumMinibatchesProcessed() == 0)
+        KALDI_ERR << "There was no data to train on.";
+      // The destructor of 'trainer' trains on the last minibatch
+      // and writes out anything we need to write out.
+    }
+
+    WriteKaldiObject(rnnlm, rnnlm_wxfilename, binary);
+    KALDI_LOG << "Wrote RNNLM to "
+              << PrintableWxfilename(rnnlm_wxfilename);
+
+    WriteKaldiObject(embedding_mat_large, embedding_large_wxfilename, binary);
+    KALDI_LOG << "Wrote embedding matrix to "
+              << PrintableWxfilename(embedding_large_wxfilename);
+        WriteKaldiObject(embedding_mat_med, embedding_med_wxfilename, binary);
+    KALDI_LOG << "Wrote embedding matrix to "
+              << PrintableWxfilename(embedding_med_wxfilename);
+    WriteKaldiObject(embedding_mat_small, embedding_small_wxfilename, binary);
+    KALDI_LOG << "Wrote embedding matrix to "
+              << PrintableWxfilename(embedding_small_wxfilename);
+
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().PrintProfile();
+#endif
+    return 0;
+  } catch(const std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return -1;
+  }
+}


### PR DESCRIPTION
This implements the core idea of [this paper](https://openreview.net/forum?id=ByxZX20qFQ). With it I can have a vocab size of 140 000 while the embeddings only take up 65MB (in RAM as well as on disk, unlike when using character level features). For comparison 140000 x 512 x 4 / 1e6 = 286MB. I get good WER results with this (haven't had time to do a proper comparison across different model and embedding sizes, but it's better than both word/character level embeddings (size 512) at a vocab size of 60 000).

I'm opening this so that those interested can try it out, and so others have an example of how to make changes to the RNNLM training code. I do not have time for cleaning this up or making it nicer (refactoring), so unless there are bugs I do not intend to work on this PR, hope that is alright.

The model has three inputs and outputs (`input`, `inputmed` and `inputsmall`, same style for the output). The variables for the different embeddings have to be set in `prepare_rnnlm_dir.sh`, `rnnlm-train-adapt` and `rnnlm-compute-prob-adapt`. 

The lines changed count is misleading, rather than introducing a lot of if else branches I just copied a lot of classes and modified them, the amount of actually new code added is not that high.