### PR TITLE
Fix division-related type issue for Python3

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/train/common.py
+++ b/egs/wsj/s5/steps/libs/nnet3/train/common.py
@@ -581,8 +581,11 @@ def get_model_combine_iters(num_iters, num_epochs,
     # But if this value is > max_models_combine, then the models
     # are subsampled to get these many models to combine.
 
-    num_iters_combine_initial = min(approx_iters_per_epoch_final/2 + 1,
-                                    num_iters/2)
+    # Cast to integer for Python 3 compatibility.
+    # As approx_iters_per_epoch_final can be float,
+    # floor division operator (//) is not enough
+    num_iters_combine_initial = int(
+        min(approx_iters_per_epoch_final/2 + 1, num_iters/2))
 
     if num_iters_combine_initial > max_models_combine:
         subsample_model_factor = int(


### PR DESCRIPTION
In WSJ egs, [libs.nnet3.train.common:get_model_combine_iters](https://github.com/kaldi-asr/kaldi/blob/78f01276cb4fe759be827d0e199e6660cf24a62f/egs/wsj/s5/steps/libs/nnet3/train/common.py#L560-L585) with certain parameters fails on Python 3, as division operation returns float type instead of integer as in Python 2.

In Python 2, local variables `approx_iters_per_epoch_final` and `num_iters_combine_initial` are both integer, given that the provided arguments are integer, but in Python3 they are both float type.

This PR fixes this issue by casting `num_iters_combine_initial` into integer type.

Test script;
```
import libs.nnet3.train.common as nnet3_common


def test_get_model_combine_iters():
    num_iters = 175
    num_jobs_final = 8
    num_epochs = 4
    num_archives = 336
    max_models_combine = 20

    val = nnet3_common.get_model_combine_iters(
        num_iters, num_epochs, num_archives,
        max_models_combine, num_jobs_final,
    )
    print(val)


if __name__ == '__main__':
    test_get_model_combine_iters()
```

Before fix;

```
$ /usr/bin/python2 test_common.py
set([154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175])
```

```
$ /usr/bin/python3 test_common.py
Traceback (most recent call last):
  File "test_common.py", line 18, in <module>
    test_get_model_combine_iters()
  File "test_common.py", line 13, in test_get_model_combine_iters
    max_models_combine, num_jobs_final,
  File "/kaldi/egs/wsj/s5/steps/libs/nnet3/train/common.py", line 593, in get_model_combine_iters
    num_iters + 1, subsample_model_factor))
TypeError: 'float' object cannot be interpreted as an integer
```

After fix;

```
$ /usr/bin/python2 test_common.py
set([154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175])
```

```
$ /usr/bin/python3 test_common.py
{154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175}
```