### PR TITLE
switched from bc to perl for overlap duration computation (issue #2954)

### DIFF
--- a/egs/callhome_diarization/v1/diarization/extract_ivectors.sh
+++ b/egs/callhome_diarization/v1/diarization/extract_ivectors.sh
@@ -92,7 +92,7 @@ if [ $stage -le 0 ]; then
   fi
   utils/data/get_uniform_subsegments.py \
       --max-segment-duration=$window \
-      --overlap-duration=$(echo "$window-$period" | bc) \
+      --overlap-duration=$(perl -e "print $window-$period") \
       --max-remaining-duration=$min_segment \
       --constant-duration=True \
       $segments > $dir/subsegments


### PR DESCRIPTION
The diarization extract_ivectors.sh script used 'bc' for simple arithmetic computation of the overlap duration. This has been switched to 'perl -e' as is preferred.