### PR TITLE
fixed: Tedlium R3 failed in run_ivector_common.sh

### DIFF
--- a/egs/tedlium/s5_r3/local/chain/tuning/run_tdnn_1b.sh
+++ b/egs/tedlium/s5_r3/local/chain/tuning/run_tdnn_1b.sh
@@ -77,7 +77,6 @@ fi
 
 local/nnet3/run_ivector_common.sh --stage $stage \
                                   --nj $nj \
-                                  --min-seg-len $min_seg_len \
                                   --train-set $train_set \
                                   --gmm $gmm \
                                   --num-threads-ubm $num_threads_ubm \


### PR DESCRIPTION
> Tedlium R3 failes in run_ivector_common.sh... Following is the error:
> local/chain/run_tdnnf.sh
> local/nnet3/run_ivector_common.sh: invalid option --min-seg-len

Delete line 80 containing the option. It's not required here.