### PR TITLE
Remove duplicate test mode option from class GeneralDropoutComponent

### DIFF
--- a/src/nnet3/nnet-general-component.h
+++ b/src/nnet3/nnet-general-component.h
@@ -910,8 +910,6 @@ class GeneralDropoutComponent: public RandomComponent {
 
   bool continuous_;
 
-  bool test_mode_;
-
   const GeneralDropoutComponent &operator
   = (const GeneralDropoutComponent &other); // Disallow.
 };


### PR DESCRIPTION
The duplicate member `GeneralDropoutComponent::test_mode_` shadows `RandomComponent::test_mode_` and makes `SetDropoutProportion` not work. This PR removes the former from `GeneralDropoutComponent`.