### PR TITLE
Minor path fix for egs/csj/s5/local/csj_make_trans/csj_autorun.sh

### DIFF
--- a/egs/csj/s5/local/csj_make_trans/csj_autorun.sh
+++ b/egs/csj/s5/local/csj_make_trans/csj_autorun.sh
@@ -61,7 +61,7 @@ if [ ! -e $outd/.done_make_trans ];then
                 mkdir -p $outd/$vol/$id
 
                 case "$csjv" in
-                    "usb" ) TPATH="$resource/${SDB}$vol" ; WPATH="$resource/$WAV" ;;
+                    "usb" ) TPATH="$resource/${SDB}$vol" ; WPATH="$resource/${WAV}$vol" ;;
                     "dvd" ) TPATH="$resource/$vol/$id"   ; WPATH="$resource/$vol/$id" ;;
                     "merl" ) TPATH="$resource/$vol/$SDB" ; WPATH="$resource/$vol/$WAV" ;;
                 esac


### PR DESCRIPTION
Previously, if you have the USB version of CSJ.  Setting modes 2 and 3 for local/csj_data_prep.sh will not make a difference.  This is because the left and right mono channel versions of the dialogue files are not found in the incorrect path.