### PR TITLE
Fix 'sausage-time' issue which occurs with disabled MBR decoding.

### DIFF
--- a/src/lat/sausages.cc
+++ b/src/lat/sausages.cc
@@ -53,7 +53,17 @@ void MinimumBayesRisk::MbrDecode() {
       }
       // build the outputs (time, confidences),
       if (R_[q] != 0 || opts_.print_silence) {
-        one_best_times_.push_back(times_[q][0]);
+        // see which 'item' from the sausage-bin should we select,
+        // (not necessarily the 1st one when MBR decoding disabled)
+        int32 s = 0;
+        for (int32 j=0; j<gamma_[q].size(); j++) {
+          if (gamma_[q][j].first == R_[q]) {
+            s = j;
+            break;
+          }
+        }
+        one_best_times_.push_back(times_[q][s]);
+        // post-process the times,
         size_t i = one_best_times_.size();
         if (i > 1 && one_best_times_[i-2].second > one_best_times_[i-1].first) {
           // It's quite possible for this to happen, but it seems like it would
@@ -76,8 +86,12 @@ void MinimumBayesRisk::MbrDecode() {
           one_best_times_[i-1].second = right;
         }
         BaseFloat confidence = 0.0;
-        for (int32 j = 0; j < gamma_[q].size(); j++)
-          if (gamma_[q][j].first == R_[q]) confidence = gamma_[q][j].second;
+        for (int32 j = 0; j < gamma_[q].size(); j++) {
+          if (gamma_[q][j].first == R_[q]) {
+            confidence = gamma_[q][j].second;
+            break;
+          }
+        }
         one_best_confidences_.push_back(confidence);
       }
     }


### PR DESCRIPTION
- the issue was introduced in #2972 and was addressed in #2993

In case of '--decode-mbr=false', the reference word sequence 'R_' is 'frozen'.
And the times in ctm output were sometimes taken from another word in the same bin
(it was taken always from the 1st word in the same bin with best score gamma_).

Now, the times are taken from the 'times_[q][s]', where 's' 
is looked-up to be corresponding to the word in 'R_[q]'.

I am looking forward to see the more accurate time-boundaries thanks to #2972.
The difference is there, but I did not listen to the data yet ;)