### PR TITLE
Allow for a special case in the segments file

### DIFF
--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -165,7 +165,7 @@ if [ -f $data/wav.scp ]; then
     check_sorted_and_uniq $data/segments
     # We have a segments file -> interpret wav file as "recording-ids" not utterance-ids.
     ! cat $data/segments | \
-      awk '{if (NF != 4 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
+      awk '{if (NF != 4 || ($4 != -1 && $4 <= $3)) { print "Bad line in segments file", $0; exit(1); }}' && \
       echo "$0: badly formatted segments file" && exit 1;
 
     segments_len=`cat $data/segments | wc -l`


### PR DESCRIPTION
Previously, `validate_data_dir.sh` did not allow the `segments` file to contain lines with `end-time=-1`, for example:
`AR042_33-2 AR042_33 0.5 -1`
However, lines like this are valid; citing `extract-segments.cc`: 
> And \<end-time\> of -1 means the segment runs till the end of the WAV file.