### PR TITLE
fix unset bash variable in make_mfcc.sh

### DIFF
--- a/egs/wsj/s5/steps/make_mfcc.sh
+++ b/egs/wsj/s5/steps/make_mfcc.sh
@@ -75,6 +75,8 @@ if [ -f $data/spk2warp ]; then
 elif [ -f $data/utt2warp ]; then
   echo "$0 [info]: using VTLN warp factors from $data/utt2warp"
   vtln_opts="--vtln-map=ark:$data/utt2warp"
+else
+  vtln_opts=""
 fi
 
 for n in $(seq $nj); do


### PR DESCRIPTION
This fixes `steps/make_mfcc.sh: line 106: vtln_opts: unbound variable` if run the script with `set -eu` checking for unset variables.