### PR TITLE
fix bug in utils/add_lex_disambig.pl

### DIFF
--- a/egs/wsj/s5/utils/add_lex_disambig.pl
+++ b/egs/wsj/s5/utils/add_lex_disambig.pl
@@ -122,6 +122,7 @@ foreach $l (@L) {
     if ($sil_probs) {
       shift @A; # Remove silprob
       shift @A; # Remove silprob
+      shift @A; # Remove silprob, there three numbers for sil_probs
     }
     while(@A > 0) {
         pop @A;  # Remove last phone


### PR DESCRIPTION
This PR mainly fixes a bug in utils/add_lex_disambig.pl. Notice that there are only two "shift @A"s when $sil_probs is true. However, there are actually three numbers for sil probs, as a result, the keys in $issubseq contain the last number of sil probs. This not a problem for position-dependent phones since no prons is the prefix of another and "defined $issubseq{$phnseq}" is always false. But when it comes to position-independent phones, it will cause problems and will miss some necessary disambiguation symbols. 