### PR TITLE
Memory optimization for online feature extraction of long recordings

### DIFF
--- a/src/feat/feature-window.h
+++ b/src/feat/feature-window.h
@@ -62,7 +62,7 @@ struct FrameExtractionOptions {
       blackman_coeff(0.42),
       snip_edges(true),
       allow_downsample(false),
-      max_feature_vectors(-1) { }
+      max_feature_vectors(-1),
       allow_upsample(false) { }
 
   void Register(OptionsItf *opts) {

--- a/src/feat/feature-window.h
+++ b/src/feat/feature-window.h
@@ -44,6 +44,7 @@ struct FrameExtractionOptions {
   BaseFloat blackman_coeff;
   bool snip_edges;
   bool allow_downsample;
+  int max_feature_vectors;
   // May be "hamming", "rectangular", "povey", "hanning", "blackman"
   // "povey" is a window I made to be similar to Hamming but to go to zero at the
   // edges, it's pow((0.5 - 0.5*cos(n/N*2*pi)), 0.85)
@@ -59,7 +60,8 @@ struct FrameExtractionOptions {
       round_to_power_of_two(true),
       blackman_coeff(0.42),
       snip_edges(true),
-      allow_downsample(false) { }
+      allow_downsample(false),
+      max_feature_vectors(-1) { }
 
   void Register(OptionsItf *opts) {
     opts->Register("sample-frequency", &samp_freq,
@@ -90,6 +92,10 @@ struct FrameExtractionOptions {
     opts->Register("allow-downsample", &allow_downsample,
                    "If true, allow the input waveform to have a higher frequency than "
                    "the specified --sample-frequency (and we'll downsample).");
+    opts->Register("max-feature-vectors", &max_feature_vectors,
+                   "Memory optimization. If larger than 0, periodically remove feature "
+                   "vectors so that only this number of the latest feature vectors is "
+                   "retained.");
   }
   int32 WindowShift() const {
     return static_cast<int32>(samp_freq * 0.001 * frame_shift_ms);

--- a/src/feat/online-feature-test.cc
+++ b/src/feat/online-feature-test.cc
@@ -381,13 +381,15 @@ void TestRecyclingVector() {
   for (int i = 0; i != 100; ++i) {
     Vector <BaseFloat> data(1);
     data.Set(i);
-    full_vec.Store(new Vector<BaseFloat>(data));
-    shrinking_vec.Store(new Vector<BaseFloat>(data));
+    full_vec.PushBack(new Vector<BaseFloat>(data));
+    shrinking_vec.PushBack(new Vector<BaseFloat>(data));
   }
+  KALDI_ASSERT(full_vec.Size() == 100);
+  KALDI_ASSERT(shrinking_vec.Size() == 100);
 
   // full_vec should contain everything
   for (int i = 0; i != 100; ++i) {
-    Vector <BaseFloat> *data = full_vec.Retrieve(i);
+    Vector <BaseFloat> *data = full_vec.At(i);
     KALDI_ASSERT(data != nullptr);
     KALDI_ASSERT((*data)(0) == static_cast<BaseFloat>(i));
   }
@@ -396,7 +398,7 @@ void TestRecyclingVector() {
   int caught_exceptions = 0;
   for (int i = 0; i != 90; ++i) {
     try {
-      shrinking_vec.Retrieve(i);
+      shrinking_vec.At(i);
     } catch (const std::runtime_error &) {
       ++caught_exceptions;
     }
@@ -406,7 +408,7 @@ void TestRecyclingVector() {
 
   // shrinking_vec should contain the last 10 elements
   for (int i = 90; i != 100; ++i) {
-    Vector <BaseFloat> *data = shrinking_vec.Retrieve(i);
+    Vector <BaseFloat> *data = shrinking_vec.At(i);
     KALDI_ASSERT(data != nullptr);
     KALDI_ASSERT((*data)(0) == static_cast<BaseFloat>(i));
   }

--- a/src/feat/online-feature.cc
+++ b/src/feat/online-feature.cc
@@ -34,7 +34,9 @@ RecyclingVector::~RecyclingVector() {
 Vector<BaseFloat> *RecyclingVector::Retrieve(int index) const {
   if (index < first_available_index_) {
     KALDI_ERR << "Attempted to retrieve feature vector that was "
-                 "already removed by the RecyclingVector";
+                 "already removed by the RecyclingVector (index = " << index << "; "
+              << "first_available_index = " << first_available_index_ << "; "
+              << "size = " << Size() << ")";
   }
   // 'at' does size checking.
   return items_.at(index - first_available_index_);

--- a/src/feat/online-feature.cc
+++ b/src/feat/online-feature.cc
@@ -47,6 +47,9 @@ void RecyclingVector::Store(Vector<BaseFloat> *item) {
   // when this number is reached
   const int size_before_erase = items_.size();
   if (size_before_erase == 2 * items_to_hold_) {
+    for (int i = 0; i != items_to_hold_; ++i) {
+      delete items_[i];
+    }
     items_.erase(items_.begin(), items_.begin() + items_to_hold_);
     first_available_index_ += (size_before_erase - items_.size());
   }

--- a/src/feat/online-feature.h
+++ b/src/feat/online-feature.h
@@ -52,16 +52,20 @@ public:
   /// By default it does not remove any elements.
   RecyclingVector(int items_to_hold = -1);
 
-  Vector<BaseFloat> *Retrieve(int index) const;
+  /// The ownership is being retained by this collection - do not delete the item.
+  Vector<BaseFloat> *At(int index) const;
 
-  void Store(Vector<BaseFloat> *item);
+  /// The ownership of the item is passed to this collection - do not delete the item.
+  void PushBack(Vector<BaseFloat> *item);
 
+  /// This method returns the size as if no "recycling" had happened,
+  /// i.e. equivalent to the number of times the PushBack method has been called.
   int Size() const;
 
   ~RecyclingVector();
 
 private:
-  std::vector<Vector<BaseFloat>*> items_;
+  std::deque<Vector<BaseFloat>*> items_;
   int items_to_hold_;
   int first_available_index_;
 };

--- a/src/feat/online-feature.h
+++ b/src/feat/online-feature.h
@@ -49,6 +49,7 @@ namespace kaldi {
 /// cause the memory to eventually blow up when the features are not being removed.
 class RecyclingVector {
 public:
+  /// By default it does not remove any elements.
   RecyclingVector(int items_to_hold = -1);
 
   Vector<BaseFloat> *Retrieve(int index) const;


### PR DESCRIPTION
It introduces a configurable maximum size of the vector which keeps the MFCC/PLP/filterbank feature vectors - the last N elements are retained, but are accessible with the original indexing. By default it doesn't remove anything i.e. the behaviour doesn't change.