### PR TITLE
Added treatment for `utt2lang` file

### DIFF
--- a/egs/wsj/s5/utils/perturb_data_dir_speed.sh
+++ b/egs/wsj/s5/utils/perturb_data_dir_speed.sh
@@ -102,6 +102,9 @@ fi
 if [ -f $srcdir/spk2gender ]; then
   utils/apply_map.pl -f 1 $destdir/spk_map <$srcdir/spk2gender >$destdir/spk2gender
 fi
+if [ -f $srcdir/utt2lang ]; then
+  utils/apply_map.pl -f 1 $destdir/utt_map <$srcdir/utt2lang >$destdir/utt2lang
+fi
 
 #prepare speed-perturbed utt2dur
 if [ ! -f $srcdir/utt2dur ]; then


### PR DESCRIPTION
utt2lang file was omitted during file speed perturbation. The addition will create an updated `utt2lang` file in the destination directory, if it existed originally.