### PR TITLE
Add device options to enable tensor core math mode.

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -110,6 +110,13 @@ void CuDevice::Initialize() {
     // Initialize CUBLAS.
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
+    
+    if(device_options_.use_tensor_cores_) {
+      //Enable tensor cores in CUBLAS
+      //Note if the device does not support tensor cores this will fall back to normal math mode
+      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, CUBLAS_TENSOR_OP_MATH));
+    }
+
     // Initialize the cuSPARSE library
     CUSPARSE_SAFE_CALL(cusparseCreate(&cusparse_handle_));
     CUSPARSE_SAFE_CALL(cusparseSetStream(cusparse_handle_, cudaStreamPerThread));
@@ -525,6 +532,8 @@ CuDevice::~CuDevice() {
 // Each thread has its own copy of the CuDevice object.
 // Note: this was declared "static".
 thread_local CuDevice CuDevice::this_thread_device_;
+  
+CuDevice::CuDeviceOptions_t CuDevice::device_options_;
 
 // define and initialize the static members of the CuDevice object.
 int32 CuDevice::device_id_ = -1;

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -111,10 +111,11 @@ void CuDevice::Initialize() {
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
     
-    if(device_options_.use_tensor_cores_) {
-      //Enable tensor cores in CUBLAS
-      //Note if the device does not support tensor cores this will fall back to normal math mode
-      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, CUBLAS_TENSOR_OP_MATH));
+    if (device_options_.use_tensor_cores_) {
+      // Enable tensor cores in CUBLAS
+      // Note if the device does not support tensor cores this will fall back to normal math mode
+      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+            CUBLAS_TENSOR_OP_MATH));
     }
 
     // Initialize the cuSPARSE library
@@ -533,7 +534,7 @@ CuDevice::~CuDevice() {
 // Note: this was declared "static".
 thread_local CuDevice CuDevice::this_thread_device_;
   
-CuDevice::CuDeviceOptions_t CuDevice::device_options_;
+CuDevice::CuDeviceOptions CuDevice::device_options_;
 
 // define and initialize the static members of the CuDevice object.
 int32 CuDevice::device_id_ = -1;

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -111,7 +111,7 @@ void CuDevice::Initialize() {
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
     
-    if (device_options_.use_tensor_cores_) {
+    if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
       CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -184,8 +184,25 @@ class CuDevice {
   /// (i.e. from outside the class), call this only if Enabled() returns true.
   bool IsComputeExclusive();
 
+  //Register command line options for CUDA device.  
+  //This must be done before calling CuDevice::Initialize()
+  static void RegisterDeviceOptions(OptionsItf *po) {
+    CuDevice::device_options_.Register(po);  
+  }
   ~CuDevice();
  private:
+
+  struct CuDeviceOptions_t {
+    bool use_tensor_cores_; //Enable tensor cores
+    CuDeviceOptions_t () : use_tensor_cores_(false) {};
+    void Register(OptionsItf *po) {
+      po->Register("cuda-use-tensor-cores",&use_tensor_cores_, "Enable FP16 tensor math. "
+          "This is higher performance but less accuracy.");
+    }
+  };
+
+  static CuDeviceOptions_t device_options_;
+
   // Default constructor used to initialize this_thread_device_
   CuDevice();
   CuDevice(CuDevice&); // Disallow.

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -199,7 +199,7 @@ class CuDevice {
     bool use_tensor_cores_; // Enable tensor cores
     CuDeviceOptions () : use_tensor_cores_(false) {};
     void Register(OptionsItf *po) {
-      po->Register("cuda-use-tensor-cores",&use_tensor_cores_, 
+      po->Register("cuda-use-tensor-cores", &use_tensor_cores_, 
           "Enable FP16 tensor math. "
           "This is higher performance but less accuracy. "
           "This is only recommended for inference.");

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -184,8 +184,11 @@ class CuDevice {
   /// (i.e. from outside the class), call this only if Enabled() returns true.
   bool IsComputeExclusive();
 
-  //Register command line options for CUDA device.  
-  //This must be done before calling CuDevice::Initialize()
+  // Register command line options for CUDA device.  
+  // This must be done before calling CuDevice::Initialize()
+  // Example:
+  //  CuDevice::RegisterDeviceOptions(&po);
+  //  CuDevice::Initialize();
   static void RegisterDeviceOptions(OptionsItf *po) {
     CuDevice::device_options_.Register(po);  
   }

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -196,10 +196,10 @@ class CuDevice {
  private:
 
   struct CuDeviceOptions {
-    bool use_tensor_cores_; // Enable tensor cores
-    CuDeviceOptions () : use_tensor_cores_(false) {};
+    bool use_tensor_cores; // Enable tensor cores
+    CuDeviceOptions () : use_tensor_cores(false) {};
     void Register(OptionsItf *po) {
-      po->Register("cuda-use-tensor-cores", &use_tensor_cores_, 
+      po->Register("cuda-use-tensor-cores", &use_tensor_cores, 
           "Enable FP16 tensor math. "
           "This is higher performance but less accuracy. "
           "This is only recommended for inference.");

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -195,16 +195,18 @@ class CuDevice {
   ~CuDevice();
  private:
 
-  struct CuDeviceOptions_t {
-    bool use_tensor_cores_; //Enable tensor cores
-    CuDeviceOptions_t () : use_tensor_cores_(false) {};
+  struct CuDeviceOptions {
+    bool use_tensor_cores_; // Enable tensor cores
+    CuDeviceOptions () : use_tensor_cores_(false) {};
     void Register(OptionsItf *po) {
-      po->Register("cuda-use-tensor-cores",&use_tensor_cores_, "Enable FP16 tensor math. "
-          "This is higher performance but less accuracy.");
+      po->Register("cuda-use-tensor-cores",&use_tensor_cores_, 
+          "Enable FP16 tensor math. "
+          "This is higher performance but less accuracy. "
+          "This is only recommended for inference.");
     }
   };
 
-  static CuDeviceOptions_t device_options_;
+  static CuDeviceOptions device_options_;
 
   // Default constructor used to initialize this_thread_device_
   CuDevice();

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -188,6 +188,7 @@ class CuDevice {
   // This must be done before calling CuDevice::Initialize()
   // Example:
   //  CuDevice::RegisterDeviceOptions(&po);
+  //  po.Read(argc, argv);
   //  CuDevice::Initialize();
   static void RegisterDeviceOptions(OptionsItf *po) {
     CuDevice::device_options_.Register(po);  

--- a/src/nnet3bin/nnet3-compute-batch.cc
+++ b/src/nnet3bin/nnet3-compute-batch.cc
@@ -80,6 +80,10 @@ int main(int argc, char *argv[]) {
                 "priors stored with the model (in this case, "
                 "a .mdl file is expected as input).");
 
+#if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
+#endif
+
     po.Read(argc, argv);
 
     if (po.NumArgs() != 3) {
@@ -88,7 +92,6 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
-    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().AllowMultithreading();
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif

--- a/src/nnet3bin/nnet3-compute-batch.cc
+++ b/src/nnet3bin/nnet3-compute-batch.cc
@@ -88,6 +88,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().AllowMultithreading();
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif

--- a/src/nnet3bin/nnet3-compute.cc
+++ b/src/nnet3bin/nnet3-compute.cc
@@ -78,6 +78,10 @@ int main(int argc, char *argv[]) {
                 "priors stored with the model (in this case, "
                 "a .mdl file is expected as input).");
 
+#if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
+#endif
+
     po.Read(argc, argv);
 
     if (po.NumArgs() != 3) {
@@ -86,7 +90,6 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
-    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 

--- a/src/nnet3bin/nnet3-compute.cc
+++ b/src/nnet3bin/nnet3-compute.cc
@@ -86,6 +86,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 

--- a/src/nnet3bin/nnet3-latgen-faster-batch.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-batch.cc
@@ -108,6 +108,10 @@ int main(int argc, char *argv[]) {
     po.Register("use-gpu", &use_gpu,
                 "yes|no|optional|wait, only has effect if compiled with CUDA");
 
+#if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
+#endif
+    
     po.Read(argc, argv);
 
     if (po.NumArgs() != 4) {
@@ -116,7 +120,6 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
-    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().AllowMultithreading();
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif

--- a/src/nnet3bin/nnet3-latgen-faster-batch.cc
+++ b/src/nnet3bin/nnet3-latgen-faster-batch.cc
@@ -116,6 +116,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().AllowMultithreading();
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif

--- a/src/nnet3bin/nnet3-xvector-compute.cc
+++ b/src/nnet3bin/nnet3-xvector-compute.cc
@@ -121,6 +121,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 

--- a/src/nnet3bin/nnet3-xvector-compute.cc
+++ b/src/nnet3bin/nnet3-xvector-compute.cc
@@ -113,6 +113,10 @@ int main(int argc, char *argv[]) {
     po.Register("pad-input", &pad_input, "If true, duplicate the first and "
       "last frames of the input features as required to equal min-chunk-size.");
 
+#if HAVE_CUDA==1
+    CuDevice::RegisterDeviceOptions(&po);
+#endif
+
     po.Read(argc, argv);
 
     if (po.NumArgs() != 3) {
@@ -121,7 +125,6 @@ int main(int argc, char *argv[]) {
     }
 
 #if HAVE_CUDA==1
-    CuDevice::RegisterDeviceOptions(&po);
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 


### PR DESCRIPTION
This commit allows us to enable the tensor cores on Volta/Turing based GPUs.

When you do this 32bit gemms are performed in 16 bit math using tensor cores.  This reduces precision but increases speed significantly.  For inference the loss in precision does not effect results.  By default this option is set to false making this an opt-in.