### PR TITLE
Fixed a bug in linux_configure_redhat_fat when use_cuda=no

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -612,8 +612,8 @@ function linux_configure_redhat_fat {
   else
     cat makefiles/linux_atlas.mk >> kaldi.mk
   fi
-  echo "Successfully configured for red hat [dynamic libraries, fat] with ATLASLIBS =$ATLASLIBS"
   $use_cuda && configure_cuda
+  echo "Successfully configured for red hat [dynamic libraries, fat] with ATLASLIBS =$ATLASLIBS"
 }
 
 function linux_configure_atlas_static {


### PR DESCRIPTION
`linux_configure_redhat_fat` in `src/configure` always return 1 when `use_cuda=no`.
Therefore `./configure --use-cuda=no` always failed in CentOS.
This PR fixes this issue.