### PR TITLE
[src] Make sure expf() speed probe times sensibly

### DIFF
--- a/src/probe/README.slow_expf
+++ b/src/probe/README.slow_expf
@@ -1,5 +1,6 @@
-On some machines, expf() turns out to be very slow: much slower than its double precision counterpart exp().
-Probably this is concerned with the version of glibc.
+On some machines, expf() turns out to be very slow: much slower than its double
+precision counterpart exp().  Probably this is concerned with the version of
+glibc.
 
 Here are a couple of examples:
 
@@ -21,5 +22,7 @@ configuration$ ./exp-test
 exp() time: 0.0028439
 expf() time: 0.00713329
 
-If slow behaviour is detected, then KALDI_NO_EXPF macro will be used, and the Exp() wrapper in base/kaldi-math.h will use exp() even for single precision floats.
-The behaviour of expf() is considered to be slow if it is slower than exp() by at least 10%.
+If slow behaviour is detected, then KALDI_NO_EXPF macro will be used, and the
+Exp() wrapper in base/kaldi-math.h will use exp() even for single precision
+floats.  The behaviour of expf() is considered to be slow if it is slower than
+exp() by at least 10%.


### PR DESCRIPTION
I was getting random slow expf() detection even in different runs of configure without any changes in command line or switches. In addition to the CPU governor failing to bump up the clock quickly enough, the probe as currently written times the loops in microsecond or sub-microsecond range on a fast CPU.

Here I make sure that (1) the CPU clock is hot and (2) the test runs for 20 to 60 ms, to make the timing at the very least non-random.

Personally, I doubt the test is valid and the problem exists at all. Any sensible compiler will emit a hardware exponentiation instruction anyway. `-O0` is not the way to test performance of anything. But at the very least, in this form we won't get *random* false positives : )

No positives detected with
```
for cc in g++-6 g++-7 g++-8 clang++-5.0 clang++-6.0 clang++-7; do
  ${cc} -std=c++11 -I.. -isystem /home/kkm/work/kaldi2/tools/openfst/include -O0 exp-test.cc -o exp-test &&
    sleep 1 &&
    echo "${cc}: $(taskset 1 ./exp-test)"
done
```
(or with `-march=native`).