### PR TITLE
Failed assertion only if divide by priors is set to True.

### DIFF
--- a/src/nnet2bin/nnet-am-compute.cc
+++ b/src/nnet2bin/nnet-am-compute.cc
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
     int64 num_done = 0, num_frames = 0;
 
     Vector<BaseFloat> inv_priors(am_nnet.Priors());
-    KALDI_ASSERT(inv_priors.Dim() == am_nnet.NumPdfs() &&
+    KALDI_ASSERT(!divide_by_priors || inv_priors.Dim() == am_nnet.NumPdfs() &&
                  "Priors in neural network not set up.");
     inv_priors.ApplyPow(-1.0);
 


### PR DESCRIPTION
Nnet-am-compute crashes if the Nnet was truncated in following pipeline
nnet-am-copy --truncate=15 final.mdl - | nnet-am-compute --divide-by-priors=false - ark:feats.scp ark:-

The pipeline returns the output of a hidden component (Component 14).