### PR TITLE
Cleanup split_scp.pl

### DIFF
--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -89,31 +89,40 @@ my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
 if ( $utt2spk_file ) { # We have the --utt2spk option...
     open( my $utt_fh, "<", $utt2spk_file )
         || die "Failed to open utt2spk file $utt2spk_file";
+
     while (<$utt_fh>) {
         my @A = split;
         @A == 2 || die "Bad line $_ in utt2spk file $utt2spk_file";
         my ( $u, $s ) = @A;
         $utt2spk{$u} = $s;
     }
+
     close $utt_fh;
+
     open( my $in_fh, "<", $inscp ) || die "Opening input scp file $inscp";
+
     my @spkrs = ();
     while (<$in_fh>) {
         my @A = split;
         if ( @A == 0 ) { die "Empty or space-only line in scp file $inscp"; }
+
         my $u = $A[0];
         my $s = $utt2spk{$u};
+
         if ( !defined $s ) {
             die "No such utterance $u in utt2spk file $utt2spk_file";
         }
+
         if ( !defined $spk_count{$s} ) {
             push @spkrs, $s;
             $spk_count{$s} = 0;
             $spk_data{$s}  = []; # ref to new empty array.
         }
+
         $spk_count{$s}++;
         push @{ $spk_data{$s} }, $_;
     }
+
     close $in_fh;
 
     # Now split as equally as possible ..
@@ -126,9 +135,11 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
             "Refusing to split data because number of speakers $numspks is less "
             . "than the number of output .scp files $numscps";
     }
+
     for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
         $scparray[$scpidx] = []; # [] is array reference.
     }
+
     for ( my $spkidx = 0; $spkidx < $numspks; $spkidx++ ) {
         my $scpidx = int( ( $spkidx * $numscps ) / $numspks );
         my $spk = $spkrs[$spkidx];
@@ -152,11 +163,13 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
             # First try to reassign ending spk of this scp.
             if ( $scpidx < $numscps - 1 ) {
                 my $sz = @{ $scparray[$scpidx] };
+
                 if ( $sz > 0 ) {
                     my $spk   = $scparray[$scpidx]->[ $sz - 1 ];
                     my $count = $spk_count{$spk};
                     my $nutt1 = $scpcount[$scpidx];
                     my $nutt2 = $scpcount[ $scpidx + 1 ];
+
                     if (
                         abs( ( $nutt2 + $count ) - ( $nutt1 - $count ) )
                         < abs( $nutt2 - $nutt1 ) )
@@ -170,11 +183,13 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
                     }
                 }
             }
+
             if ( $scpidx > 0 && @{ $scparray[$scpidx] } > 0 ) {
                 my $spk   = $scparray[$scpidx]->[0];
                 my $count = $spk_count{$spk};
                 my $nutt1 = $scpcount[ $scpidx - 1 ];
                 my $nutt2 = $scpcount[$scpidx];
+
                 if (
                     abs( ( $nutt2 - $count ) - ( $nutt1 + $count ) )
                     < abs( $nutt2 - $nutt1 ) )
@@ -192,9 +207,11 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
 
     # Now print out the files...
     for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
+
         my $scpfn = $OUTPUTS[$scpidx];
         open( my $fh, ">", $scpfn )
             || die "Could not open scp file $scpfn for writing.";
+
         my $count = 0;
         if ( @{ $scparray[$scpidx] } == 0 ) {
             print STDERR
@@ -205,10 +222,12 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
                 print F @{ $spk_data{$spk} };
                 $count += $spk_count{$spk};
             }
+
             if ( $count != $scpcount[$scpidx] ) {
                 die "Count mismatch [code error]";
             }
         }
+
         close($fh);
     }
 } else {
@@ -229,9 +248,11 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
         print STDERR "split_scp.pl: error: empty input scp file $inscp , ";
         $error = 1;
     }
+
     my $linesperscp = int( $numlines / $numscps ); # the "whole part"..
     $linesperscp >= 1
         || die "You are splitting into too many pieces! [reduce \$nj]";
+
     my $remainder = $numlines - ( $linesperscp * $numscps );
     ( $remainder >= 0 && $remainder < $numlines )
         || die "bad remainder $remainder";
@@ -240,8 +261,10 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     my $n = 0;
     for ( my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++ ) {
         my $scpfile = $OUTPUTS[$scpidx];
+
         open( my $output_fh, ">", $scpfile )
             || die "Opening output scp file $scpfile";
+
         for (
             my $k = 0;
             $k < $linesperscp + ( $scpidx < $remainder ? 1 : 0 );
@@ -250,8 +273,10 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
         {
             print $output_fh $F[ $n++ ];
         }
+
         close($output_fh) || die "Closing scp file $scpfile";
     }
+
     $n == $numlines || die "split_scp.pl: code error., $n != $numlines";
 }
 

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -92,6 +92,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
         my ($u,$s) = @A;
         $utt2spk{$u} = $s;
     }
+    close U;
     open(I, "<", $inscp) || die "Opening input scp file $inscp";
     my @spkrs = ();
     while(<I>) {
@@ -108,6 +109,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
         $spk_count{$s}++;
         push @{$spk_data{$s}}, $_;
     }
+    close I;
     # Now split as equally as possible ..
     # First allocate spks to files by allocating an approximately
     # equal number of speakers.
@@ -203,6 +205,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     while(<I>) {
         push @F, $_;
     }
+    close I;
     my $numlines = @F;
     if($numlines == 0) {
         print STDERR "split_scp.pl: error: empty input scp file $inscp , ";

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings; #sed replacement for -w perl parameter
+
 # Copyright 2010-2011 Microsoft Corporation
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +16,6 @@ use warnings; #sed replacement for -w perl parameter
 # MERCHANTABLITY OR NON-INFRINGEMENT.
 # See the Apache 2 License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 # This program splits up any kind of .scp or archive-type file.
 # If there is no utt2spk option it will work on any text  file and
@@ -42,41 +41,44 @@ use warnings; #sed replacement for -w perl parameter
 # [note: with this option, it assumes zero-based indexing of the split parts,
 # i.e. the second number must be 0 <= n < num-jobs.]
 
-my $num_jobs = 0;
-my $job_id = 0;
+my $num_jobs     = 0;
+my $job_id       = 0;
 my $utt2spk_file = "";
 
-for (my $x = 1; $x <= 2 && @ARGV > 0; $x++) {
-    if ($ARGV[0] eq "-j") {
+for ( my $x = 1; $x <= 2 && @ARGV > 0; $x++ ) {
+    if ( $ARGV[0] eq "-j" ) {
         shift @ARGV;
         $num_jobs = shift @ARGV;
-        $job_id = shift @ARGV;
-        if ($num_jobs <= 0 || $job_id < 0 || $job_id >= $num_jobs) {
+        $job_id   = shift @ARGV;
+        if ( $num_jobs <= 0 || $job_id < 0 || $job_id >= $num_jobs ) {
             die "Invalid num-jobs and job-id: $num_jobs and $job_id";
         }
     }
-    if ($ARGV[0] =~ "--utt2spk=(.+)") {
-        $utt2spk_file=$1;
+    if ( $ARGV[0] =~ "--utt2spk=(.+)" ) {
+        $utt2spk_file = $1;
         shift;
     }
 }
 
-if(($num_jobs == 0 && @ARGV < 2) || ($num_jobs > 0 && (@ARGV < 1 || @ARGV > 2))) {
-    die "Usage: split_scp.pl [--utt2spk=<utt2spk_file>] in.scp out1.scp out2.scp ... \n" .
-        " or: split_scp.pl -j num-jobs job-id [--utt2spk=<utt2spk_file>] in.scp [out.scp]\n" .
-        " ... where 0 <= job-id < num-jobs.";
+if (   ( $num_jobs == 0 && @ARGV < 2 )
+    || ( $num_jobs > 0 && ( @ARGV < 1 || @ARGV > 2 ) ) )
+{
+    die
+        "Usage: split_scp.pl [--utt2spk=<utt2spk_file>] in.scp out1.scp out2.scp ... \n"
+        . " or: split_scp.pl -j num-jobs job-id [--utt2spk=<utt2spk_file>] in.scp [out.scp]\n"
+        . " ... where 0 <= job-id < num-jobs.";
 }
 
 my $error = 0;
 my $inscp = shift @ARGV;
 my @OUTPUTS;
-if ($num_jobs == 0) { # without -j option
+if ( $num_jobs == 0 ) { # without -j option
     @OUTPUTS = @ARGV;
 } else {
-    for (my $j = 0; $j < $num_jobs; $j++) {
-        if ($j == $job_id) {
-            if (@ARGV > 0) { push @OUTPUTS, $ARGV[0]; }
-            else { push @OUTPUTS, "-"; }
+    for ( my $j = 0; $j < $num_jobs; $j++ ) {
+        if ( $j == $job_id ) {
+            if   ( @ARGV > 0 ) { push @OUTPUTS, $ARGV[0]; }
+            else               { push @OUTPUTS, "-"; }
         } else {
             push @OUTPUTS, "/dev/null";
         }
@@ -84,48 +86,53 @@ if ($num_jobs == 0) { # without -j option
 }
 
 my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
-if ($utt2spk_file ne "") {  # We have the --utt2spk option...
-    open( my $utt_fh, "<", $utt2spk_file) || die "Failed to open utt2spk file $utt2spk_file";
-    while(<$utt_fh>) {
+if ( $utt2spk_file ne "" ) { # We have the --utt2spk option...
+    open( my $utt_fh, "<", $utt2spk_file )
+        || die "Failed to open utt2spk file $utt2spk_file";
+    while (<$utt_fh>) {
         my @A = split;
         @A == 2 || die "Bad line $_ in utt2spk file $utt2spk_file";
-        my ($u,$s) = @A;
+        my ( $u, $s ) = @A;
         $utt2spk{$u} = $s;
     }
     close $utt_fh;
-    open( my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
+    open( my $in_fh, "<", $inscp ) || die "Opening input scp file $inscp";
     my @spkrs = ();
-    while(<$in_fh>) {
+    while (<$in_fh>) {
         my @A = split;
-        if(@A == 0) { die "Empty or space-only line in scp file $inscp"; }
+        if ( @A == 0 ) { die "Empty or space-only line in scp file $inscp"; }
         my $u = $A[0];
         my $s = $utt2spk{$u};
-        if(!defined $s) { die "No such utterance $u in utt2spk file $utt2spk_file"; }
-        if(!defined $spk_count{$s}) {
+        if ( !defined $s ) {
+            die "No such utterance $u in utt2spk file $utt2spk_file";
+        }
+        if ( !defined $spk_count{$s} ) {
             push @spkrs, $s;
             $spk_count{$s} = 0;
-            $spk_data{$s} = [];  # ref to new empty array.
+            $spk_data{$s}  = []; # ref to new empty array.
         }
         $spk_count{$s}++;
-        push @{$spk_data{$s}}, $_;
+        push @{ $spk_data{$s} }, $_;
     }
     close $in_fh;
+
     # Now split as equally as possible ..
     # First allocate spks to files by allocating an approximately
     # equal number of speakers.
-    my $numspks = @spkrs;  # number of speakers.
+    my $numspks = @spkrs;   # number of speakers.
     my $numscps = @OUTPUTS; # number of output files.
-    if ($numspks < $numscps) {
-      die "Refusing to split data because number of speakers $numspks is less " .
-          "than the number of output .scp files $numscps";
+    if ( $numspks < $numscps ) {
+        die
+            "Refusing to split data because number of speakers $numspks is less "
+            . "than the number of output .scp files $numscps";
     }
-    for(my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
+    for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
         $scparray[$scpidx] = []; # [] is array reference.
     }
-    for (my $spkidx = 0; $spkidx < $numspks; $spkidx++) {
-        my $scpidx = int(($spkidx*$numscps) / $numspks);
+    for ( my $spkidx = 0; $spkidx < $numspks; $spkidx++ ) {
+        my $scpidx = int( ( $spkidx * $numscps ) / $numspks );
         my $spk = $spkrs[$spkidx];
-        push @{$scparray[$scpidx]}, $spk;
+        push @{ $scparray[$scpidx] }, $spk;
         $scpcount[$scpidx] += $spk_count{$spk};
     }
 
@@ -138,94 +145,114 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     # shows this method is bound to converge.
 
     my $changed = 1;
-    while($changed) {
+    while ($changed) {
         $changed = 0;
-        for(my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
+        for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
+
             # First try to reassign ending spk of this scp.
-            if($scpidx < $numscps-1) {
-                my $sz = @{$scparray[$scpidx]};
-                if($sz > 0) {
-                    my $spk = $scparray[$scpidx]->[$sz-1];
+            if ( $scpidx < $numscps - 1 ) {
+                my $sz = @{ $scparray[$scpidx] };
+                if ( $sz > 0 ) {
+                    my $spk   = $scparray[$scpidx]->[ $sz - 1 ];
                     my $count = $spk_count{$spk};
                     my $nutt1 = $scpcount[$scpidx];
-                    my $nutt2 = $scpcount[$scpidx+1];
-                    if( abs( ($nutt2+$count) - ($nutt1-$count))
-                        < abs($nutt2 - $nutt1))  { # Would decrease
-                        # size-diff by reassigning spk...
-                        $scpcount[$scpidx+1] += $count;
+                    my $nutt2 = $scpcount[ $scpidx + 1 ];
+                    if (
+                        abs( ( $nutt2 + $count ) - ( $nutt1 - $count ) )
+                        < abs( $nutt2 - $nutt1 ) )
+                    { # Would decrease
+                         # size-diff by reassigning spk...
+                        $scpcount[ $scpidx + 1 ] += $count;
                         $scpcount[$scpidx] -= $count;
-                        pop @{$scparray[$scpidx]};
-                        unshift @{$scparray[$scpidx+1]}, $spk;
+                        pop @{ $scparray[$scpidx] };
+                        unshift @{ $scparray[ $scpidx + 1 ] }, $spk;
                         $changed = 1;
                     }
                 }
             }
-            if($scpidx > 0 && @{$scparray[$scpidx]} > 0) {
-                my $spk = $scparray[$scpidx]->[0];
+            if ( $scpidx > 0 && @{ $scparray[$scpidx] } > 0 ) {
+                my $spk   = $scparray[$scpidx]->[0];
                 my $count = $spk_count{$spk};
-                my $nutt1 = $scpcount[$scpidx-1];
+                my $nutt1 = $scpcount[ $scpidx - 1 ];
                 my $nutt2 = $scpcount[$scpidx];
-                if( abs( ($nutt2-$count) - ($nutt1+$count))
-                    < abs($nutt2 - $nutt1))  { # Would decrease
-                    # size-diff by reassigning spk...
-                    $scpcount[$scpidx-1] += $count;
+                if (
+                    abs( ( $nutt2 - $count ) - ( $nutt1 + $count ) )
+                    < abs( $nutt2 - $nutt1 ) )
+                { # Would decrease
+                     # size-diff by reassigning spk...
+                    $scpcount[ $scpidx - 1 ] += $count;
                     $scpcount[$scpidx] -= $count;
-                    shift @{$scparray[$scpidx]};
-                    push @{$scparray[$scpidx-1]}, $spk;
+                    shift @{ $scparray[$scpidx] };
+                    push @{ $scparray[ $scpidx - 1 ] }, $spk;
                     $changed = 1;
                 }
             }
         }
     }
+
     # Now print out the files...
-    for(my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
+    for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
         my $scpfn = $OUTPUTS[$scpidx];
-        open(my $fh, ">", $scpfn) || die "Could not open scp file $scpfn for writing.";
+        open( my $fh, ">", $scpfn )
+            || die "Could not open scp file $scpfn for writing.";
         my $count = 0;
-        if(@{$scparray[$scpidx]} == 0) {
-            print STDERR "Error: split_scp.pl producing empty .scp file $scpfn (too many splits and too few speakers?)\n";
+        if ( @{ $scparray[$scpidx] } == 0 ) {
+            print STDERR
+                "Error: split_scp.pl producing empty .scp file $scpfn (too many splits and too few speakers?)\n";
             $error = 1;
         } else {
-            foreach my $spk ( @{$scparray[$scpidx]} ) {
-                print F @{$spk_data{$spk}};
+            foreach my $spk ( @{ $scparray[$scpidx] } ) {
+                print F @{ $spk_data{$spk} };
                 $count += $spk_count{$spk};
             }
-            if($count != $scpcount[$scpidx]) { die "Count mismatch [code error]"; }
+            if ( $count != $scpcount[$scpidx] ) {
+                die "Count mismatch [code error]";
+            }
         }
         close($fh);
     }
 } else {
-   # This block is the "normal" case where there is no --utt2spk
-   # option and we just break into equal size chunks.
 
-    open( my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
+    # This block is the "normal" case where there is no --utt2spk
+    # option and we just break into equal size chunks.
 
-    my $numscps = @OUTPUTS;  # size of array.
-    my @F = ();
-    while(<$in_fh>) {
+    open( my $in_fh, "<", $inscp ) || die "Opening input scp file $inscp";
+
+    my $numscps = @OUTPUTS; # size of array.
+    my @F       = ();
+    while (<$in_fh>) {
         push @F, $_;
     }
     close $in_fh;
     my $numlines = @F;
-    if($numlines == 0) {
+    if ( $numlines == 0 ) {
         print STDERR "split_scp.pl: error: empty input scp file $inscp , ";
         $error = 1;
     }
-    my $linesperscp = int( $numlines / $numscps); # the "whole part"..
-    $linesperscp >= 1 || die "You are splitting into too many pieces! [reduce \$nj]";
-    my $remainder = $numlines - ($linesperscp * $numscps);
-    ($remainder >= 0 && $remainder < $numlines) || die "bad remainder $remainder";
+    my $linesperscp = int( $numlines / $numscps ); # the "whole part"..
+    $linesperscp >= 1
+        || die "You are splitting into too many pieces! [reduce \$nj]";
+    my $remainder = $numlines - ( $linesperscp * $numscps );
+    ( $remainder >= 0 && $remainder < $numlines )
+        || die "bad remainder $remainder";
+
     # [just doing int() rounds down].
     my $n = 0;
-    for(my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++) {
+    for ( my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++ ) {
         my $scpfile = $OUTPUTS[$scpidx];
-        open(my $output_fh, ">", $scpfile) || die "Opening output scp file $scpfile";
-        for(my $k = 0; $k < $linesperscp + ($scpidx < $remainder ? 1 : 0); $k++) {
-            print $output_fh $F[$n++];
+        open( my $output_fh, ">", $scpfile )
+            || die "Opening output scp file $scpfile";
+        for (
+            my $k = 0;
+            $k < $linesperscp + ( $scpidx < $remainder ? 1 : 0 );
+            $k++
+            )
+        {
+            print $output_fh $F[ $n++ ];
         }
         close($output_fh) || die "Closing scp file $scpfile";
     }
     $n == $numlines || die "split_scp.pl: code error., $n != $numlines";
 }
 
-exit ($error ? 1 : 0);
+exit( $error ? 1 : 0 );

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -85,17 +85,17 @@ if ($num_jobs == 0) { # without -j option
 
 my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
 if ($utt2spk_file ne "") {  # We have the --utt2spk option...
-    open(U, "<", $utt2spk_file) || die "Failed to open utt2spk file $utt2spk_file";
-    while(<U>) {
+    open( my $utt_fh, "<", $utt2spk_file) || die "Failed to open utt2spk file $utt2spk_file";
+    while(<$utt_fh>) {
         my @A = split;
         @A == 2 || die "Bad line $_ in utt2spk file $utt2spk_file";
         my ($u,$s) = @A;
         $utt2spk{$u} = $s;
     }
-    close U;
-    open(I, "<", $inscp) || die "Opening input scp file $inscp";
+    close $utt_fh;
+    open( my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
     my @spkrs = ();
-    while(<I>) {
+    while(<$in_fh>) {
         my @A = split;
         if(@A == 0) { die "Empty or space-only line in scp file $inscp"; }
         my $u = $A[0];
@@ -109,7 +109,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
         $spk_count{$s}++;
         push @{$spk_data{$s}}, $_;
     }
-    close I;
+    close $in_fh;
     # Now split as equally as possible ..
     # First allocate spks to files by allocating an approximately
     # equal number of speakers.
@@ -180,7 +180,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     # Now print out the files...
     for(my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
         my $scpfn = $OUTPUTS[$scpidx];
-        open(F, ">", $scpfn) || die "Could not open scp file $scpfn for writing.";
+        open(my $fh, ">", $scpfn) || die "Could not open scp file $scpfn for writing.";
         my $count = 0;
         if(@{$scparray[$scpidx]} == 0) {
             print STDERR "Error: split_scp.pl producing empty .scp file $scpfn (too many splits and too few speakers?)\n";
@@ -192,20 +192,20 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
             }
             if($count != $scpcount[$scpidx]) { die "Count mismatch [code error]"; }
         }
-        close(F);
+        close($fh);
     }
 } else {
    # This block is the "normal" case where there is no --utt2spk
    # option and we just break into equal size chunks.
 
-    open(I, "<", $inscp) || die "Opening input scp file $inscp";
+    open( my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
 
     my $numscps = @OUTPUTS;  # size of array.
     my @F = ();
-    while(<I>) {
+    while(<$in_fh>) {
         push @F, $_;
     }
-    close I;
+    close $in_fh;
     my $numlines = @F;
     if($numlines == 0) {
         print STDERR "split_scp.pl: error: empty input scp file $inscp , ";
@@ -219,11 +219,11 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     my $n = 0;
     for(my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++) {
         my $scpfile = $OUTPUTS[$scpidx];
-        open(O, ">", $scpfile) || die "Opening output scp file $scpfile";
+        open(my $output_fh, ">", $scpfile) || die "Opening output scp file $scpfile";
         for(my $k = 0; $k < $linesperscp + ($scpidx < $remainder ? 1 : 0); $k++) {
-            print O $F[$n++];
+            print $output_fh $F[$n++];
         }
-        close(O) || die "Closing scp file $scpfile";
+        close($output_fh) || die "Closing scp file $scpfile";
     }
     $n == $numlines || die "split_scp.pl: code error., $n != $numlines";
 }

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -41,27 +41,27 @@ use warnings; #sed replacement for -w perl parameter
 # [note: with this option, it assumes zero-based indexing of the split parts,
 # i.e. the second number must be 0 <= n < num-jobs.]
 
-my $num_jobs     = 0;
-my $job_id       = 0;
+my $num_jobs = 0;
+my $job_id   = 0;
 my $utt2spk_file;
 
-for ( my $x = 1; $x <= 2 && @ARGV > 0; $x++ ) {
-    if ( $ARGV[0] eq "-j" ) {
+for (my $x = 1; $x <= 2 && @ARGV > 0; $x++) {
+    if ($ARGV[0] eq "-j") {
         shift @ARGV;
         $num_jobs = shift @ARGV;
         $job_id   = shift @ARGV;
-        if ( $num_jobs <= 0 || $job_id < 0 || $job_id >= $num_jobs ) {
+        if ($num_jobs <= 0 || $job_id < 0 || $job_id >= $num_jobs) {
             die "Invalid num-jobs and job-id: $num_jobs and $job_id";
         }
     }
-    if ( $ARGV[0] =~ /--utt2spk=(.+)/ ) {
+    if ($ARGV[0] =~ /--utt2spk=(.+)/) {
         $utt2spk_file = $1;
         shift;
     }
 }
 
-if (   ( $num_jobs == 0 && @ARGV < 2 )
-    || ( $num_jobs > 0 && ( @ARGV < 1 || @ARGV > 2 ) ) )
+if (($num_jobs == 0 && @ARGV < 2)
+ || ($num_jobs > 0 && (@ARGV < 1 || @ARGV > 2)))
 {
     die
         "Usage: split_scp.pl [--utt2spk=<utt2spk_file>] in.scp out1.scp out2.scp ... \n"
@@ -72,48 +72,48 @@ if (   ( $num_jobs == 0 && @ARGV < 2 )
 my $error = 0;
 my $inscp = shift @ARGV;
 my @OUTPUTS;
-if ( $num_jobs == 0 ) { # without -j option
+if ($num_jobs == 0) { # without -j option
     @OUTPUTS = @ARGV;
 } else {
-    for ( my $j = 0; $j < $num_jobs; $j++ ) {
+    for (my $j = 0; $j < $num_jobs; $j++) {
         if ( $j == $job_id ) {
-            if   ( @ARGV > 0 ) { push @OUTPUTS, $ARGV[0]; }
-            else               { push @OUTPUTS, "-"; }
+            if   (@ARGV > 0) { push @OUTPUTS, $ARGV[0]; }
+            else             { push @OUTPUTS, "-"; }
         } else {
             push @OUTPUTS, "/dev/null";
         }
     }
 }
 
-my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
-if ( $utt2spk_file ) { # We have the --utt2spk option...
-    open( my $utt_fh, "<", $utt2spk_file )
+my (%utt2spk, %spk_count, %spk_data, @scparray, @scpcount);
+if ($utt2spk_file) { # We have the --utt2spk option...
+    open(my $utt_fh, "<", $utt2spk_file)
         || die "Failed to open utt2spk file $utt2spk_file";
 
     while (<$utt_fh>) {
         my @A = split;
         @A == 2 || die "Bad line $_ in utt2spk file $utt2spk_file";
-        my ( $u, $s ) = @A;
+        my ($u, $s) = @A;
         $utt2spk{$u} = $s;
     }
 
     close $utt_fh;
 
-    open( my $in_fh, "<", $inscp ) || die "Opening input scp file $inscp";
+    open(my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
 
     my @spkrs = ();
     while (<$in_fh>) {
         my @A = split;
-        if ( @A == 0 ) { die "Empty or space-only line in scp file $inscp"; }
+        if (@A == 0) { die "Empty or space-only line in scp file $inscp"; }
 
         my $u = $A[0];
         my $s = $utt2spk{$u};
 
-        if ( !defined $s ) {
+        if (!defined $s) {
             die "No such utterance $u in utt2spk file $utt2spk_file";
         }
 
-        if ( !defined $spk_count{$s} ) {
+        if (!defined $spk_count{$s}) {
             push @spkrs, $s;
             $spk_count{$s} = 0;
             $spk_data{$s}  = []; # ref to new empty array.
@@ -130,18 +130,18 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     # equal number of speakers.
     my $numspks = @spkrs;   # number of speakers.
     my $numscps = @OUTPUTS; # number of output files.
-    if ( $numspks < $numscps ) {
+    if ($numspks < $numscps) {
         die
             "Refusing to split data because number of speakers $numspks is less "
             . "than the number of output .scp files $numscps";
     }
 
-    for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
+    for (my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
         $scparray[$scpidx] = []; # [] is array reference.
     }
 
-    for ( my $spkidx = 0; $spkidx < $numspks; $spkidx++ ) {
-        my $scpidx = int( ( $spkidx * $numscps ) / $numspks );
+    for (my $spkidx = 0; $spkidx < $numspks; $spkidx++) {
+        my $scpidx = int(($spkidx * $numscps) / $numspks);
         my $spk = $spkrs[$spkidx];
         push @{ $scparray[$scpidx] }, $spk;
         $scpcount[$scpidx] += $spk_count{$spk};
@@ -158,21 +158,21 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     my $changed = 1;
     while ($changed) {
         $changed = 0;
-        for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
+        for (my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
 
             # First try to reassign ending spk of this scp.
-            if ( $scpidx < $numscps - 1 ) {
+            if ($scpidx < $numscps - 1) {
                 my $sz = @{ $scparray[$scpidx] };
 
-                if ( $sz > 0 ) {
+                if ($sz > 0) {
                     my $spk   = $scparray[$scpidx]->[ $sz - 1 ];
                     my $count = $spk_count{$spk};
                     my $nutt1 = $scpcount[$scpidx];
                     my $nutt2 = $scpcount[ $scpidx + 1 ];
 
                     if (
-                        abs( ( $nutt2 + $count ) - ( $nutt1 - $count ) )
-                        < abs( $nutt2 - $nutt1 ) )
+                        abs(($nutt2 + $count) - ($nutt1 - $count))
+                        < abs($nutt2 - $nutt1))
                     { # Would decrease
                          # size-diff by reassigning spk...
                         $scpcount[ $scpidx + 1 ] += $count;
@@ -184,15 +184,15 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
                 }
             }
 
-            if ( $scpidx > 0 && @{ $scparray[$scpidx] } > 0 ) {
+            if ($scpidx > 0 && @{ $scparray[$scpidx] } > 0) {
                 my $spk   = $scparray[$scpidx]->[0];
                 my $count = $spk_count{$spk};
                 my $nutt1 = $scpcount[ $scpidx - 1 ];
                 my $nutt2 = $scpcount[$scpidx];
 
                 if (
-                    abs( ( $nutt2 - $count ) - ( $nutt1 + $count ) )
-                    < abs( $nutt2 - $nutt1 ) )
+                    abs(($nutt2 - $count) - ($nutt1 + $count))
+                    < abs($nutt2 - $nutt1))
                 { # Would decrease
                      # size-diff by reassigning spk...
                     $scpcount[ $scpidx - 1 ] += $count;
@@ -206,24 +206,24 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     }
 
     # Now print out the files...
-    for ( my $scpidx = 0; $scpidx < $numscps; $scpidx++ ) {
+    for (my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
 
         my $scpfn = $OUTPUTS[$scpidx];
-        open( my $fh, ">", $scpfn )
+        open(my $fh, ">", $scpfn)
             || die "Could not open scp file $scpfn for writing.";
 
         my $count = 0;
-        if ( @{ $scparray[$scpidx] } == 0 ) {
+        if (@{ $scparray[$scpidx] } == 0) {
             print STDERR
                 "Error: split_scp.pl producing empty .scp file $scpfn (too many splits and too few speakers?)\n";
             $error = 1;
         } else {
-            foreach my $spk ( @{ $scparray[$scpidx] } ) {
+            foreach my $spk (@{ $scparray[$scpidx] }) {
                 print $fh @{ $spk_data{$spk} };
                 $count += $spk_count{$spk};
             }
 
-            if ( $count != $scpcount[$scpidx] ) {
+            if ($count != $scpcount[$scpidx]) {
                 die "Count mismatch [code error]";
             }
         }
@@ -235,7 +235,7 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     # This block is the "normal" case where there is no --utt2spk
     # option and we just break into equal size chunks.
 
-    open( my $in_fh, "<", $inscp ) || die "Opening input scp file $inscp";
+    open(my $in_fh, "<", $inscp) || die "Opening input scp file $inscp";
 
     my $numscps = @OUTPUTS; # size of array.
     my @F       = ();
@@ -244,32 +244,32 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     }
     close $in_fh;
     my $numlines = @F;
-    if ( $numlines == 0 ) {
+    if ($numlines == 0) {
         print STDERR "split_scp.pl: error: empty input scp file $inscp , ";
         $error = 1;
     }
 
-    my $linesperscp = int( $numlines / $numscps ); # the "whole part"..
+    my $linesperscp = int($numlines / $numscps); # the "whole part"..
     $linesperscp >= 1
         || die "You are splitting into too many pieces! [reduce \$nj]";
 
-    my $remainder = $numlines - ( $linesperscp * $numscps );
-    ( $remainder >= 0 && $remainder < $numlines )
+    my $remainder = $numlines - ($linesperscp * $numscps);
+    ($remainder >= 0 && $remainder < $numlines)
         || die "bad remainder $remainder";
 
     # [just doing int() rounds down].
     my $n = 0;
-    for ( my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++ ) {
+    for (my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++) {
         my $scpfile = $OUTPUTS[$scpidx];
 
-        open( my $output_fh, ">", $scpfile )
+        open(my $output_fh, ">", $scpfile)
             || die "Opening output scp file $scpfile";
 
         for (
             my $k = 0;
-            $k < $linesperscp + ( $scpidx < $remainder ? 1 : 0 );
+            $k < $linesperscp + ($scpidx < $remainder ? 1 : 0);
             $k++
-            )
+           )
         {
             print $output_fh $F[ $n++ ];
         }
@@ -280,4 +280,4 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
     $n == $numlines || die "split_scp.pl: code error., $n != $numlines";
 }
 
-exit( $error ? 1 : 0 );
+exit($error ? 1 : 0);

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -85,14 +85,14 @@ if ($num_jobs == 0) { # without -j option
 
 my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
 if ($utt2spk_file ne "") {  # We have the --utt2spk option...
-    open(U, "<$utt2spk_file") || die "Failed to open utt2spk file $utt2spk_file";
+    open(U, "<", $utt2spk_file) || die "Failed to open utt2spk file $utt2spk_file";
     while(<U>) {
         my @A = split;
         @A == 2 || die "Bad line $_ in utt2spk file $utt2spk_file";
         my ($u,$s) = @A;
         $utt2spk{$u} = $s;
     }
-    open(I, "<$inscp") || die "Opening input scp file $inscp";
+    open(I, "<", $inscp) || die "Opening input scp file $inscp";
     my @spkrs = ();
     while(<I>) {
         my @A = split;
@@ -178,7 +178,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     # Now print out the files...
     for(my $scpidx = 0; $scpidx < $numscps; $scpidx++) {
         my $scpfn = $OUTPUTS[$scpidx];
-        open(F, ">$scpfn") || die "Could not open scp file $scpfn for writing.";
+        open(F, ">", $scpfn) || die "Could not open scp file $scpfn for writing.";
         my $count = 0;
         if(@{$scparray[$scpidx]} == 0) {
             print STDERR "Error: split_scp.pl producing empty .scp file $scpfn (too many splits and too few speakers?)\n";
@@ -196,7 +196,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
    # This block is the "normal" case where there is no --utt2spk
    # option and we just break into equal size chunks.
 
-    open(I, "<$inscp") || die "Opening input scp file $inscp";
+    open(I, "<", $inscp) || die "Opening input scp file $inscp";
 
     my $numscps = @OUTPUTS;  # size of array.
     my @F = ();
@@ -216,7 +216,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
     my $n = 0;
     for(my $scpidx = 0; $scpidx < @OUTPUTS; $scpidx++) {
         my $scpfile = $OUTPUTS[$scpidx];
-        open(O, ">$scpfile") || die "Opening output scp file $scpfile";
+        open(O, ">", $scpfile) || die "Opening output scp file $scpfile";
         for(my $k = 0; $k < $linesperscp + ($scpidx < $remainder ? 1 : 0); $k++) {
             print O $F[$n++];
         }

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/env perl
+use strict;
 use warnings; #sed replacement for -w perl parameter
 # Copyright 2010-2011 Microsoft Corporation
 

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -54,7 +54,7 @@ for ( my $x = 1; $x <= 2 && @ARGV > 0; $x++ ) {
             die "Invalid num-jobs and job-id: $num_jobs and $job_id";
         }
     }
-    if ( $ARGV[0] =~ "--utt2spk=(.+)" ) {
+    if ( $ARGV[0] =~ /--utt2spk=(.+)/ ) {
         $utt2spk_file = $1;
         shift;
     }

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -219,7 +219,7 @@ if ( $utt2spk_file ) { # We have the --utt2spk option...
             $error = 1;
         } else {
             foreach my $spk ( @{ $scparray[$scpidx] } ) {
-                print F @{ $spk_data{$spk} };
+                print $fh @{ $spk_data{$spk} };
                 $count += $spk_count{$spk};
             }
 

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -43,7 +43,7 @@ use warnings; #sed replacement for -w perl parameter
 
 my $num_jobs     = 0;
 my $job_id       = 0;
-my $utt2spk_file = "";
+my $utt2spk_file;
 
 for ( my $x = 1; $x <= 2 && @ARGV > 0; $x++ ) {
     if ( $ARGV[0] eq "-j" ) {
@@ -86,7 +86,7 @@ if ( $num_jobs == 0 ) { # without -j option
 }
 
 my ( %utt2spk, %spk_count, %spk_data, @scparray, @scpcount );
-if ( $utt2spk_file ne "" ) { # We have the --utt2spk option...
+if ( $utt2spk_file ) { # We have the --utt2spk option...
     open( my $utt_fh, "<", $utt2spk_file )
         || die "Failed to open utt2spk file $utt2spk_file";
     while (<$utt_fh>) {


### PR DESCRIPTION
Hi,

I cleaned up this script because we were trying to use it at work and it was hard to follow.

[Each commit here is self-contained, so it is easier to review it per commit than the entire diff.]

While I added a lot of whitespaces, I did make several more significant changes:

* All variables are properly declared. This prevents typos, overwriting of data, etc. that is otherwise completely undetected. (And also cleaning up memory.) Then I was able to add `strict.pm`, which is a required pragma nowadays when developing in Perl.
* Fixed insecure filehandle usage: The code made it possible to overwrite files, exhaust resources, etc. I fixed that.
* Removing bareword filehandles: This is a general bad pattern of using globally-accessible non-cleanup'able filehandles. I changed all of those to proper variables, allowing them to be scoped, cleaned up properly, and more.
* Closed filehandles explicitly. Perl attempts to close filehandles implicitly but depending on Perl version, the errors are handled differently. The safest is to close it yourself.