### PR TITLE
[src] Fix wrong assertion failure in fstmakecontextsym

### DIFF
--- a/src/fstext/context-fst.cc
+++ b/src/fstext/context-fst.cc
@@ -345,7 +345,7 @@ SymbolTable *CreateILabelInfoSymbolTable(const vector<vector<int32> > &info,
                                          const SymbolTable &phones_symtab,
                                          std::string separator,
                                          std::string initial_disambig) {  // e.g. separator = "/", initial-disambig="#-1"
-  KALDI_ASSERT(!info.empty() && !info[0].empty());
+  KALDI_ASSERT(!info.empty() && info[0].empty());
   SymbolTable *ans = new SymbolTable("ilabel-info-symtab");
   int64 s = ans->AddSymbol(phones_symtab.Find(static_cast<int64>(0)));
   assert(s == 0);


### PR DESCRIPTION
The very first item in ilabel_info data is supposed to be an empty
vector which encodes epsilon value, according to the current docs
(doc/tree_externals.html#tree_ilabel), but the assertion has been
inverted as of its introduction at a3a547cd9.