### PR TITLE
Adding constructors with arguments to decoder classes.

### DIFF
--- a/src/decoder/lattice-faster-decoder.h
+++ b/src/decoder/lattice-faster-decoder.h
@@ -62,6 +62,16 @@ struct LatticeFasterDecoderConfig {
                                 beam_delta(0.5),
                                 hash_ratio(2.0),
                                 prune_scale(0.1) { }
+
+  LatticeFasterDecoderConfig(BaseFloat beam, BaseFloat latbeam,
+      int32 max_active=std::numeric_limits<int32>::max(), int32 min_active=200,
+      int32 prune_interval=25, bool determinize_lattice=true, BaseFloat beam_delta=0.5,
+      BaseFloat hash_ratio=2.0, BaseFloat prune_scale=0.1):
+      beam(beam), lattice_beam(latbeam), max_active(max_active), min_active(min_active),
+      prune_interval(prune_interval), determinize_lattice(determinize_lattice),
+      beam_delta(beam_delta), hash_ratio(hash_ratio), prune_scale(prune_scale) { }
+
+
   void Register(OptionsItf *opts) {
     det_opts.Register(opts);
     opts->Register("beam", &beam, "Decoding beam.  Larger->slower, more accurate.");

--- a/src/nnet3/decodable-simple-looped.h
+++ b/src/nnet3/decodable-simple-looped.h
@@ -58,6 +58,14 @@ struct NnetSimpleLoopedComputationOptions {
       acoustic_scale(0.1),
       debug_computation(false) { }
 
+  NnetSimpleLoopedComputationOptions(BaseFloat am_scale, int32 frames_per_chunk,
+      int32 frame_subsample_factor, int32 extra_left_context_initial = 0,
+      bool debug_computation = false):
+      acoustic_scale(am_scale), frames_per_chunk(frames_per_chunk),
+      frame_subsampling_factor(frame_subsample_factor),
+      extra_left_context_initial(extra_left_context_initial),
+      debug_computation(debug_computation) { }
+
   void Check() const {
     KALDI_ASSERT(extra_left_context_initial >= 0 &&
                  frame_subsampling_factor > 0 && frames_per_chunk > 0 &&

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -423,6 +423,11 @@ struct OnlineSilenceWeightingConfig {
   OnlineSilenceWeightingConfig():
       silence_weight(1.0), max_state_duration(-1) { }
 
+  OnlineSilenceWeightingConfig(std::string sil_phones, BaseFloat sil_weight=1.0,
+      BaseFloat max_state_duration=-1):
+      silence_phones_str(sil_phones), silence_weight(sil_weight),
+      max_state_duration(max_state_duration) { }
+
   void Register(OptionsItf *opts) {
     opts->Register("silence-phones", &silence_phones_str, "(RE weighting in "
                    "iVector estimation for online decoding) List of integer ids of "

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -91,6 +91,23 @@ struct OnlineNnet2FeaturePipelineConfig {
   OnlineNnet2FeaturePipelineConfig():
       feature_type("mfcc"), add_pitch(false) { }
 
+  OnlineNnet2FeaturePipelineConfig(
+      std::string feature_config, std::string feature_type, std::string ivector_config,
+      OnlineSilenceWeightingConfig& sil_config, std::string pitch_config = "",
+      bool add_pitch = false):
+      feature_type(feature_type), ivector_extraction_config(ivector_config),
+      silence_weighting_config(sil_config), online_pitch_config(pitch_config),
+      add_pitch(add_pitch) {
+    if (feature_type == "mfcc") {
+      mfcc_config = feature_config;
+    } else if (feature_type == "fbank") {
+      fbank_config = feature_config;
+    } else if (feature_type == "plp") {
+      plp_config = feature_config;
+    } else {
+      KALDI_ERR << "Unknown feature type " << feature_type;
+    }
+  }
 
   void Register(OptionsItf *opts) {
     opts->Register("feature-type", &feature_type,


### PR DESCRIPTION
This is a very small PR which adds constructors with arguments to the standard classes used for decoding.

I know the kaldi PR philosophy seems to be if it's not used in any recipe to not merge it, but this is something basically everybody who uses kaldi for in some sort of production setting (where your decode settings are fixed and you don't want to pass them from the command line all the time) has to add. I thought it might make sense to add this to the master branch...

If you want I can also add a new binary `online2-nnet3-chain-decode` with reasonable defaults with which one can go straight from a WAV to a ctm, while only inputting a model folder path. So the help string would roughly look like
```Does online decoding on wavfile.
<model-dir> requires final.mdl, HCLG.fst, words.txt, align_lexicon.int and mfcc.conf
Usage: nnet3-decode <model-dir> <wav-path> <out-ctm>
```

Just so the new constructors are used somewhere...