### PR TITLE
[src] Disable unget warning in PeekToken

### DIFF
--- a/src/base/io-funcs.cc
+++ b/src/base/io-funcs.cc
@@ -179,11 +179,8 @@ int PeekToken(std::istream &is, bool binary) {
   int ans = is.peek();
   if (read_bracket) {
     if (!is.unget()) {
-      KALDI_WARN << "Error ungetting '<' in PeekToken";
-      // Clear the bad bit.  It seems to be possible for this code to be
-      // reached, and the C++ standard is very vague on whether even a single
-      // call to unget() should succeed; see
-      // http://www.cplusplus.com/reference/istream/istream/unget/
+      // Clear the bad bit. This code can be (and is in fact) reached, since the
+      // C++ standard does not guarantee that a call to unget() must succeed.
       is.clear();
     }
   }

--- a/src/base/io-funcs.h
+++ b/src/base/io-funcs.h
@@ -203,13 +203,18 @@ void WriteToken(std::ostream &os, bool binary, const std::string & token);
 /// value of the stream.
 int Peek(std::istream &is, bool binary);
 
-/// ReadToken gets the next token and puts it in str (exception on failure).
+/// ReadToken gets the next token and puts it in str (exception on failure). If
+/// PeekToken() had been previously called, it is possible that the stream had
+/// failed to unget the starting '<' character. In this case ReadToken() returns
+/// the token string without the leading '<'. You must be prepared to handle
+/// this case. ExpectToken() handles this internally, and is not affected.
 void ReadToken(std::istream &is, bool binary, std::string *token);
 
 /// PeekToken will return the first character of the next token, or -1 if end of
 /// file.  It's the same as Peek(), except if the first character is '<' it will
-/// skip over it and will return the next character.  It will unget the '<' so
-/// the stream is where it was before you did PeekToken().
+/// skip over it and will return the next character. It will attempt to unget
+/// the '<' so the stream is where it was before you did PeekToken(), however,
+/// this is not guaranteed (see ReadToken()).
 int PeekToken(std::istream &is, bool binary);
 
 /// ExpectToken tries to read in the given token, and throws an exception

--- a/src/hmm/hmm-topology.cc
+++ b/src/hmm/hmm-topology.cc
@@ -69,7 +69,7 @@ void HmmTopology::Read(std::istream &is, bool binary) {
         ReadToken(is, binary, &token);
         while (token != "</TopologyEntry>") {
           if (token != "<State>")
-            KALDI_ERR << "Expected </TopologyEntry> or <State>, got instead "<<token;
+            KALDI_ERR << "Expected </TopologyEntry> or <State>, got instead " << token;
           int32 state;
           ReadBasicType(is, binary, &state);
           if (state != static_cast<int32>(this_entry.size()))
@@ -88,7 +88,8 @@ void HmmTopology::Read(std::istream &is, bool binary) {
             int32 self_loop_pdf_class = kNoPdf;
             ReadBasicType(is, binary, &forward_pdf_class);
             ReadToken(is, binary, &token);
-            KALDI_ASSERT(token == "<SelfLoopPdfClass>");
+            if (token != "<SelfLoopPdfClass>")
+              KALDI_ERR << "Expected <SelfLoopPdfClass>, got instead " << token;
             ReadBasicType(is, binary, &self_loop_pdf_class);
             this_entry.push_back(HmmState(forward_pdf_class, self_loop_pdf_class));
             ReadToken(is, binary, &token);
@@ -102,10 +103,10 @@ void HmmTopology::Read(std::istream &is, bool binary) {
             this_entry.back().transitions.push_back(std::make_pair(dst_state, trans_prob));
             ReadToken(is, binary, &token);
           }
-          if(token == "<Final>") // TODO: remove this clause after a while.
+          if (token == "<Final>")  // TODO: remove this clause after a while.
             KALDI_ERR << "You are trying to read old-format topology with new Kaldi.";
           if (token != "</State>")
-            KALDI_ERR << "Reading HmmTopology,  unexpected token "<<token;
+            KALDI_ERR << "Expected </State>, got instead " << token;
           ReadToken(is, binary, &token);
         }
         int32 my_index = entries_.size();


### PR DESCRIPTION
Documented the behavior better.

Tangentially, fixed a misuse of KALDI_ASSERT where KALDI_ERR should have been used in hmm-topology.cc.