### PR TITLE
Shuffle utt2uniq list before getting validation set

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain/get_egs.sh
+++ b/egs/wsj/s5/steps/nnet3/chain/get_egs.sh
@@ -155,7 +155,8 @@ if [ -f $data/utt2uniq ]; then
   # Must hold out all augmented versions of the same utterance.
   echo "$0: File $data/utt2uniq exists, so ensuring the hold-out set" \
        "includes all perturbed versions of the same source utterance."
-  utils/utt2spk_to_spk2utt.pl $data/utt2uniq 2>/dev/null |
+  utils/utt2spk_to_spk2utt.pl $data/utt2uniq 2>/dev/null | \
+      utils/shuffle_list.pl 2>/dev/null | \
     awk -v max_utt=$num_utts_subset '{
         for (n=2;n<=NF;n++) print $n;
         printed += NF-1;


### PR DESCRIPTION
This is to fix an issue which was created in https://github.com/kaldi-asr/kaldi/pull/3141 where only the top utterances were selected while creating the validation set, if an utt2uniq file exists.