### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+    WARNING: THE KALDI ISSUE TRACKER IS **ONLY** USED FOR KALDI DEVELOPMENT!
+
+    If you have a question about using Kaldi, please use the kald-help discussion group:
+
+    https://groups.google.com/forum/#!forum/kaldi-help
+
+    Instructions for joining are available at: http://kaldi-asr.org/forums.html
+-->

--- a/.github/ISSUE_TEMPLATE/feature-proposal-discussion.md
+++ b/.github/ISSUE_TEMPLATE/feature-proposal-discussion.md
@@ -1,0 +1,18 @@
+---
+name: Feature proposal or discussion
+about: Suggest an idea for Kaldi
+title: ''
+labels: discussion
+assignees: ''
+
+---
+
+<!--
+    WARNING: THE KALDI ISSUE TRACKER IS **ONLY** USED FOR KALDI DEVELOPMENT!
+
+    If you have a question about using Kaldi, please use the kald-help discussion group:
+
+    https://groups.google.com/forum/#!forum/kaldi-help
+
+    Instructions for joining are available at: http://kaldi-asr.org/forums.html
+-->


### PR DESCRIPTION
Add two issue templates, with comments directing the user to the kaldi-help group if they have a Kaldi question.

I think it would be a better use for the tracker, and also that keeping Q/A in one easily searchable place would be be beneficial. I am seeing too many questions here, and always linger before closing them. Maybe this will keep us more manageable.

On the topic of manageability, I want to create project boards for codename Kaldi10, and for the current development and fixes. Is it ok?