### PR TITLE
Simplify installation and document the use of Intel MKL

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -809,8 +809,8 @@ threaded_atlas=false
 mkl_threading=sequential
 android=false
 
-MATHLIB='ATLAS'
-ATLASROOT=`rel2abs ../tools/ATLAS_headers/`
+MATHLIB=MKL
+MKLROOT=/opt/intel/mkl
 FSTROOT=`rel2abs ../tools/openfst`
 CUBROOT=`rel2abs ../tools/cub`
 

--- a/src/doc/build_setup.dox
+++ b/src/doc/build_setup.dox
@@ -32,12 +32,12 @@
 
  The build process for Windows is separate from the build process for
  UNIX-like systems, and is described in windows/INSTALL (tested some time ago with
- Windows 7 and Microsoft Visual Studio 10.0).  We use scripts to
+ Windows 7 and Microsoft Visual Studio 2013).  We use scripts to
  create the Visual Studio 10.0 solution file.  There are two options for
- the math library on Windows: either you can use Cygwin to compile ATLAS, or you
- can use the Intel MKL library.  Detailed instructions are provided.  However, note
+ the math library on Windows: either Intel MKL, or use Cygwin to compile ATLAS.
+ Detailed instructions are provided.  However, note
  that the Windows setup is becoming out of date and is not regularly tested,
- and not all the code currently compiles on it.
+ and not all the may compile.
 
  \section build_setup_configure How our configure script works (for UNIX variants)
 
@@ -143,6 +143,6 @@ preprocessor variables, setting compile options, linking with libraries, and so 
 
 We have compiled Kaldi on Windows, Cygwin, various flavors of Linux (including
 Ubuntu, CentOS, Debian, Red Hat and SUSE), and Darwin. We recommend you use g++ version
-4.4 or above, although other compilers such as llvm and Intel's icc are also known to work.
+4.7 or above, although other compilers such as llvm and Intel's icc are also known to work.
 
 */

--- a/src/doc/matrixwrap.dox
+++ b/src/doc/matrixwrap.dox
@@ -22,93 +22,155 @@ namespace kaldi {
 
 /** \page matrixwrap External matrix libraries
 
-  Here we describe how our \ref matrix "matrix library" makes use of 
+  Here we describe how our \ref matrix "matrix library" makes use of
   external libraries.
 
   \section matrixwrap_summary Overview
- 
-  The matrix code in Kaldi is mostly a wrapper on top of the
-  linear-algebra libraries BLAS and LAPACK.  The code has been designed to be as flexible
-  as possible in terms of what libraries it can use.  Currently it supports four options:
+
+  The matrix code in Kaldi is mostly a wrapper on top of the linear-algebra
+  libraries BLAS and LAPACK.  The code has been designed to be as flexible as
+  possible in terms of what libraries it can use.  Currently it supports four
+  options:
+    -  Intel MKL, which provides both BLAS and LAPACK (the default)
+    -  OpenBLAS, which provides BLAS and LAPACK
     -  ATLAS, which is an implementation of BLAS plus a subset of LAPACK (with a different interface)
     -  Some implementation of BLAS plus CLAPACK (note: this has not been tested recently).
-    -  Intel's MKL, which provides both BLAS and LAPACK
-    -  OpenBLAS, which provides BLAS and LAPACK
 
-  The code has to "know" which of these four options is being used, because although in principle
-  BLAS and LAPACK are standardized, there are some differences in the interfaces.
-  The Kaldi code requires exactly one
-  of the three strings HAVE_ATLAS, HAVE_CLAPACK, HAVE_OPENBLAS or HAVE_MKL to be defined 
-  (e.g. using -DHAVE_ATLAS as an option to the compiler).  It must then be 
-  linked with the appropriate libraries.  The code that deals most directly
-  with including the external libraries and setting up the appropriate
-  typedef's and defines, is in \ref kaldi-blas.h.   However, the rest of
-  the matrix code is not completely insulated from these issues because the ATLAS
-  and CLAPACK versions of higher-level routines are called differently (so
-  we have a lot of "#ifdef HAVE_ATLAS" directives and the like).  Additionally, some routines
-  are not even available in ATLAS so we have had to implement them ourselves.
+  The code has to "know" which of these four options is being used, because
+  although in principle BLAS and LAPACK are standardized, there are some
+  differences in the interfaces.  The Kaldi code requires exactly one of the
+  three macros \c HAVE_ATLAS, \c HAVE_CLAPACK, \c HAVE_OPENBLAS or \c HAVE_MKL
+  to be defined (normally using \c -DHAVE_ATLAS as an option to the compiler).
+  It must then be linked with the appropriate libraries.  The code that deals
+  most directly with including the external libraries and setting up the
+  appropriate typedef's and defines, is in \ref kaldi-blas.h.  However, the rest
+  of the matrix code is not completely insulated from these issues because the
+  ATLAS and CLAPACK versions of higher-level routines are called differently (so
+  we have a lot of "#ifdef HAVE_ATLAS" directives and the like).  Additionally,
+  some routines are not even available in ATLAS so we have had to implement them
+  ourselves.
 
-  The "configure" script in the "src" directory is responsible for setting up Kaldi to use the libraries.
-  It does this by creating the file "kaldi.mk" in the "src" directory, which gives appropriate flags
-  to the compiler.   If called with no arguments it will use any ATLAS installation it can find in "normal" places
-  in your system, but it is quite configurable.  See the script itself for usage.
+  The "configure" script in the "src" directory is responsible for setting up
+  Kaldi to use the libraries.  It does this by creating the file "kaldi.mk" in
+  the "src" directory, which gives appropriate flags to the compiler. If called
+  with no arguments it will use any Intel MKL installation it can find in
+  "normal" places in your system, but it is configurable. Run the script with
+  the \c \--help option for the complete option list.
 
- \section matrixwrap_blas Basic Linear Algebra Subroutines (BLAS)
+ \section matrixwrap_matalgebra Understanding BLAS and LAPACK
 
-   Because we refer a lot to BLAS in this section, we briefly explain what it is. 
-   BLAS is a set of subroutine declarations that correspond to low-level
-   matrix-vector operations.  There is Level 1 Blas (vector-vector), Level 2
-   (vector-matrix) and Level 3 (matrix-matrix).  They have names like daxpy (for
-   double-precision a*x plus y), and dgemm (for double general matrix-matrix
-   multiply).  BLAS has various actual implementations.  The "reference BLAS",
-   supplied I believe by Netlib (the folks who also brought us the most common version
-   of LAPACK), is one.  ATLAS is another one (but it also implements some functions
-   from LAPACK).
+  Because we refer a lot to BLAS (and more often CBLAS) and LAPACK (or, rarely,
+  CLAPACK) in this section, we briefly explain what it is.
 
- \section matrixwrap_lapack Linear Algebra PACKage (LAPACK)
+ \subsection matrixwrap_blas Basic Linear Algebra Subroutines (BLAS)
 
-   Lapack is a set of linear-algebra routines, originally written in Fortran.  It includes
-   higher-level routines than BLAS, such as matrix inversion, SVD, etc.  
-   Netlib has implemented this (this is the "normal" LAPACK).  LAPACK requires
-   BLAS.  It is possible to mix-and-match LAPACK and BLAS implementations 
-   (e.g. Netlib's LAPACK with ATLAS's BLAS).
- 
-  CLAPACK is a version of LAPACK that has been converted from Fortan to C automatically
-  using the f2c utility.  When we talk about using LAPACK, we are actually
-  talking about using CLAPACK.  Because CLAPACK has been converted to C using the
-  f2c utility, when we link against it we need to include the f2c library (e.g. -lf2c,
-  or -lg2c if using recent versions of gcc), otherwise we will get linking errors.
+  BLAS is a set of subroutine declarations that correspond to low-level
+  matrix-vector operations.  There is BLAS Level 1 (vector-vector), Level 2
+  (vector-matrix) and Level 3 (matrix-matrix). They have names like \c daxpy
+  (for \"<b>d</b>ouble-precision \b a \b x <b>p</b>lus \b y\"), and \c dgemm
+  (for "double-precision general matrix-matrix multiply"). BLAS has various
+  actual implementations. The <a href="http://www.netlib.org/blas/">reference
+  implementation of BLAS</a> originated back in 1979, and has been maintained
+  since by Netlib. The reference implementation lacks any optimization
+  whatsoever, and exists solely as a touchstone to validate the correctness of
+  other implementations. MKL, ATLAS and OpenBLAS provide optimized
+  implementations of BLAS.
 
+  CBLAS is just the C language interface to BLAS.
 
-  \section matrixwrap_atlas Automatically Tuned Linear Algebra Software (ATLAS) 
+ \subsection matrixwrap_lapack Linear Algebra PACKage (LAPACK)
+
+  LAPACK is a set of linear-algebra routines, originally written in Fortran.  It
+  includes higher-level routines than BLAS, such as matrix inversion, SVD, etc.
+  The <a href="https://github.com/Reference-LAPACK">reference implementation of
+  LAPACK</a> was implemented and has been maintained by Netlib.  LAPACK
+  internally uses BLAS. It is possible to mix-and-match LAPACK and BLAS
+  implementations (e.g. Netlib's LAPACK with ATLAS's BLAS).
+
+  CLAPACK is a version of LAPACK that has been converted from Fortan to C
+  automatically using the f2c utility. Because of this, the f2c library is
+  required during linking with the "original" CLAPACK (usually \c -lg2c or
+  \c -lf2c).
+
+  MKL provides complete C-callable interfaces for its own BLAS and LAPACK
+  implementations; no additional libraries are required.
+
+ \section matrixwrap_mkl Intel Math Kernel Library (MKL)
+
+  Intel MKL provides C-language interface to a high-performance implementation
+  of the BLAS and LAPACK routines, and is currently the preferred CBLAS/CLAPACK
+  provider for Kaldi. To use MKL with Kaldi use the \c -DHAVE_MKL compiler flag.
+
+  Previously MKL used to be a paid product. Starting 2017, Intel made MKL freely
+  available and allows royalty-freely runtime redistribution even for commercial
+  application (although, just like, for example, CUDA, it is still a
+  closed-source commercial product).
+
+  MKL provides a very highly optimized implementation of linear algebra
+  routines, and especially on Intel CPUs. In fact, the library contains multiple
+  code paths, which are selected at runtime depending on individual features of
+  the CPU it is being loaded on. Thus with MKL you will automatically benefit
+  from all features and instruction sets (such as AVX2 and AVX512) if they are
+  available on your CPU, without any additional configuration. These
+  instructions accelerate linear algebra operations on CPU significantly.  It is
+  usually a good idea to use a recent MKL version if your CPU is of a newer
+  architecture.
+
+  To simplify MKL setup on Linux, we provide a script
+  \c tools/extras/install_mkl.sh. We install only 64-bit binaries for MKL, but
+  once the \c install_mkl.sh script completes successfully once, the Intel
+  repositories are registered on your system, and you can both obtain new
+  versions and 32-bit libraries using your system's package manager.
+
+  For Mac and Windows, <a href="https://software.intel.com/mkl/choose-download">
+  download the installer from Intel's Web site</a> (registration may be
+  required).  Refer to the same page in case the above Linux script does not
+  support your Linux distribution. The Intel installers (Mac, Windows) let you
+  select the 32-bit and 64-bit packages separately. To run Kaldi training
+  recipes only the 64-bit version is required.
+
+  We have tested Kaldi extensively with 64-bit libraries under Linux and
+  Windows.
+
+  The <a href="http://software.intel.com/articles/intel-mkl-link-line-advisor/">
+  MKL Link Line Advisor</a> is an interactive Web tool that allows configuring
+  the compiler flags for various systems and compilers, in case our "configure"
+  script does not cover it.
+  \n \b NOTE: Do not use the the multithreaded mode for
+  Kaldi training (select "sequential" as the threading option). Our script and
+  binary setups are designed to run multiple processes on a single machine,
+  presumably maxing out its CPU, and an attempt to multi-thread linear algebra
+  computations will only adversely impact the performance.
+
+  \section matrixwrap_atlas Automatically Tuned Linear Algebra Software (ATLAS)
 
   ATLAS is a well known implementation of BLAS plus a subset of LAPACK.  The
   general idea of ATLAS is to tune to the particular processor setup, so the
   compilation process is quite complex and can take a while.  For this reason,
-  it can be quite tricky to compile ATLAS.  On UNIX-based systems, you can't even do it unless you 
+  it can be quite tricky to compile ATLAS.  On UNIX-based systems, you can't even do it unless you
   are root or are friendly with your system administrator, because to compile
   it you need to turn off CPU throttling; and on Windows, ATLAS does not compile
   "natively", only in Cygwin.  Sometimes it can be a better bet to find libraries that
   have been compiled by someone else for your particular platform, but we can't offer
-  much advice on how to do this.  ATLAS generally performs better 
+  much advice on how to do this.  ATLAS generally performs better
   than the "reference BLAS" available from Netlib.   ATLAS only includes
   a few LAPACK routines.  These include matrix inversion and Cholesky factorization,
   but not SVD.  For this reason we have implemented a couple more of the LAPACK
-  routines (SVD and eigenvalue decomposition); see 
+  routines (SVD and eigenvalue decomposition); see
   the next section.
-  
+
   ATLAS conforms to the BLAS interface, but its interface for the subset of
-  LAPACK routines that it provides is not the same as Netlib's (it's more
-  C-like and less FORTRAN-ish).  For this reason, there are quite a number of #ifdef's in our code
-  to switch between the calling styles, depending whether we are
+  LAPACK routines that it provides is not the same as Netlib's (it's more C-like
+  and less FORTRAN-ish).  For this reason, there are quite a number of \#ifdef's
+  in our code to switch between the calling styles, depending whether we are
   linking with ATLAS or CLAPACK.
-  
+
   \subsection matrixwrap_atlas_install_windows Installing ATLAS (on Windows)
 
   For instructions on how to install ATLAS on Windows (and note that these
   instructions require Cygwin), see the file windows/INSTALL.atlas
   in our source distribution.  Note that our Windows setup is not being
-  actvely maintained at the moment and we don't anticipate that it will work
+  actively maintained at the moment and we don't anticipate that it will work
   very cleanly.
 
   \subsection matrixwrap_atlas_install_linux Installing ATLAS (on Linux)
@@ -118,39 +180,31 @@ namespace kaldi {
   pre-built binaries available, they may not be the best binaries possible for your
   architecture so it is probably a better idea to compile from source.
   The easiest way to do this
-  is to cd from "src" to "../tools" and to run ./install_atlas.sh.  
+  is to cd from "src" to "../tools" and to run ./install_atlas.sh.
   If this does not work, the detailed installation
-  instructions can be found at: http://math-atlas.sourceforge.net/atlas_install/. 
-	
+  instructions can be found at: http://math-atlas.sourceforge.net/atlas_install/.
+
   One useful note is that before installing ATLAS you should turn off CPU
- throttling using "cpufreq-selector -g performance" (cpufreq-selector may be in
- sbin), if it is enabled (see the ATLAS install page).  You can first try running the 
- "install_atlas.sh" script before doing this, to see whether it works-- if CPU
+  throttling using "cpufreq-selector -g performance" (cpufreq-selector may be in
+  sbin), if it is enabled (see the ATLAS install page).  You can first try running the
+  "install_atlas.sh" script before doing this, to see whether it works-- if CPU
   throttling is enabled, the ATLAS installation scripts will die with an error.
-	
-	\section matrixwrap_mkl Intel Math Kernel Library (MKL)
-	Intel MKL also provides C-language interface to the BLAS and LAPACK routines,
-	and can be used with Kaldi by using the -DHAVE_MKL compiler flag. The linker
-	flags for MKL tend to be quite different depending on the OS, architecture, 
-	compiler, etc. used. We have tested Kaldi on 32-bit Windows and x86_64 (or EMT64) Linux.
-	Flags for other platforms can be obtained from:
-  http://software.intel.com/en-us/articles/intel-mkl-link-line-advisor/
 
   \section matrixwrap_openblas OpenBLAS
 
-    Kaldi now supports linking against the OpenBLAS library, which  is an implementation
+  Kaldi now supports linking against the OpenBLAS library, which  is an implementation
   of BLAS and parts of LAPACK.  OpenBLAS also automatically compiles Netlib's implementation of LAPACK,
-  so that it can explort LAPACK in its entirety.
+  so that it can export LAPACK in its entirety.
   OpenBLAS is a fork of the GotoBLAS project (an assembler-heavy implementation of BLAS) which is no longer being
   maintained.  In order to use GotoBLAS you can cd from "src" to "../tools", type
   "make openblas", then cd to "../src" and give the correct option to the "configure" script
   to use OpenBLAS (look at the comments at the top of the configure script to find this option).
   Thanks to Sola Aina for suggesting this and helping us to get this to work.
-  
+
   \section matrixwrap_jama Java Matrix Package (JAMA)
 
   JAMA is an implementation of linear-algebra routines for Java, written
-  in collaboration between NIST and MathWorks and put into the public domain 
+  in collaboration between NIST and MathWorks and put into the public domain
   (see math.nist.gov/javanumerics/jama).  We used some of this code to fill
   in a couple of holes in ATLAS-- specifically, if we're compiling with
  -DHAVE_ATLAS, we don't have the CLAPACK routines for SVD and eigenvalue
@@ -165,7 +219,7 @@ namespace kaldi {
   directory and see if it succeeds.  A lot of compilation issues will manifest themselves
   as linking errors.  In this section we give a summary of some of the more common
   linking errors (at least, those that relate specifically to the matrix library).
- 
+
    Depending on the compilation option (-DHAVE_CLAPACK, -DHAVE_LAPACK or -DHAVE_MKL),
   the code will be expecting to link with different things.  When debugging linking
   errors, bear in mind that the problem could be a mismatch between the compilation
@@ -182,7 +236,7 @@ namespace kaldi {
    s_cat, pow_dd, r_sign, pow_ri, pow_di, s_copy, s_cmp, d_sign
 
   \subsection matrix_err_clapack CLAPACK linking errors
-    
+
    You will get these errors if you compiled with -DHAVE_CLAPACK but did
    not provide the CLAPACK library.  The symbols you will be missing are:
 
@@ -195,15 +249,15 @@ namespace kaldi {
   but it supplies different symbols.   The native CLAPACK version of liblapack
   has symbols like those above (e.g. sgesvd_, sgetrf_), but the ATLAS version
   has symbols like clapack_sgetrf and also ones like ATL_sgetrf.
-  
+
   \subsection matrix_err_blas BLAS linking errors
-  
+
    You will get these errors if you failed to link against an implementation
    of BLAS.  These errors can also occur if libraries are linked in the wrong
    order.  CLAPACK requires BLAS, so you have to link BLAS after CLAPACK.
-   
+
    The symbols you will see if you failed to link with BLAS include:
-  
+
    cblas_sger, cblas_saxpy, cblas_dapy, cblas_ddot, cblas_sdot, cblas_sgemm, cblas_dgemm
 
    To fix these, link with a static library like libcblas.a, or do -lcblas (assuming
@@ -220,7 +274,7 @@ namespace kaldi {
   CLAPACK.  The cblaswrap library should be invoked before the cblas one.  If you
   are missing cblaswrap, you will see errors about symbols like:
 
-  f2c_sgemm, f2c_strsm, f2c_sswap, f2c_scopy, f2c_sspmv, f2c_sdot, f2c_sgemv 
+  f2c_sgemm, f2c_strsm, f2c_sswap, f2c_scopy, f2c_sspmv, f2c_sdot, f2c_sgemv
 
   and so on (there are a lot of these symbols).
 
@@ -235,15 +289,15 @@ namespace kaldi {
 
   \subsection matrix_err_atl_clapack Missing the ATLAS implementation of (parts of) CLAPACK
 
-  These errors can only occur if you compiled wiht the -DHAVE_ATLAS option.
+  These errors can only occur if you compiled with the -DHAVE_ATLAS option.
   Atlas's name for the CLAPACK routines are different from clapack's own (they
   have clapack_ prepended to indicate the origin, which can be quite confusing).
 
   If you have undefined references to the following symbols:
-  
+
    clapack_sgetrf, clapack_sgetri, clapack_dgetrf, clapack_dgetri
 
-  then it means you failed to link with an ATLAS library containing these symbols.  
+  then it means you failed to link with an ATLAS library containing these symbols.
   This may be variously called liblapack.a, libclapack.a or liblapack_atlas.a,
   but you can tell that it is the right one if it defines a symbol called ATL_cgetrf
   (type "nm <library-name> | grep ATL_cgetrf" to see).  You may be able to link
@@ -252,7 +306,6 @@ namespace kaldi {
   be CLAPACK or it could be ATLAS's version of CLAPACK, and as noted in section
   \ref matrix_err_f2c, they supply different symbols.  The only way to find
   out is to look inside it using "nm" or "strings".
-
 
 
 */

--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -135,8 +135,14 @@ printed=false
 # it if installed in an alternative location (this is unlikely).
 if [ ! -f /opt/intel/mkl/include/mkl.h ] &&
    ! echo '#include <mkl.h>' | $CXX -I /opt/intel/mkl/include -E - >&/dev/null; then
-  echo "$0: Intel MKL is not installed. Run extras/install_mkl.sh to intall it.
- ... You can also use other matrix algebra libraries; for information, see
+  if [[ $(uname) == Linux ]]; then
+    echo "$0: Intel MKL is not installed. Run extras/install_mkl.sh to install it."
+  else
+    echo "$0: Intel MKL is not installed. Download the installer package for your
+ ... system from: https://software.intel.com/mkl/choose-download."
+  fi
+ echo "\
+ ... You can also use other matrix algebra libraries. For information, see:
  ... http://kaldi-asr.org/doc/matrixwrap.html"
   printed=true
 fi
@@ -147,12 +153,13 @@ if [ -n "$debian_packages" ]; then
     # Guess package manager from user's distribution type. Use a subshell
     # because we are potentially importing a lot of dirt here.
     eval $(grep 2>/dev/null ^ID /etc/os-release) 2>/dev/null
-    for rune in $ID $ID_LIKE; do
+    for rune in ${ID-} ${ID_LIKE-}; do
+      # The case '(pattern)' syntax is necessary in subshell for bash 3.x.
       case $rune in
-        rhel|centos|redhat) echo "yum install $redhat_packages"; break;;
-        fedora) echo "dnx install $redhat_packages"; break;;
-        suse) echo "zypper install $opensuse_packages"; break;;
-        debian) echo "apt-get install $debian_packages"; break;;
+        (rhel|centos|redhat) echo "yum install $redhat_packages"; break;;
+        (fedora) echo "dnx install $redhat_packages"; break;;
+        (suse) echo "zypper install $opensuse_packages"; break;;
+        (debian) echo "apt-get install $debian_packages"; break;;
       esac
     done
   )

--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -10,48 +10,45 @@ debian_packages=
 opensuse_packages=
 
 function add_packages {
-  redhat_packages="$redhat_packages $1";
-  debian_packages="$debian_packages $2";
-  opensuse_packages="$opensuse_packages $3";
+  redhat_packages="$redhat_packages $1"
+  debian_packages="$debian_packages ${2:-$1}"
+  opensuse_packages="$opensuse_packages ${3:-$1}"
 }
 
-if ! which which >&/dev/null; then
-  echo "$0: which is not installed."
-  add_packages which debianutils which
-fi
+function have { type -t "$1" >/dev/null; }
 
-COMPILER_VER_INFO=$($CXX --version 2>/dev/null)
-case $COMPILER_VER_INFO in
+compiler_ver_info=$($CXX --version 2>/dev/null)
+case $compiler_ver_info in
   "")
-    echo "$0: $CXX is not installed."
+    echo "$0: Compiler '$CXX' is not installed."
     echo "$0: You need g++ >= 4.8.3, Apple Xcode >= 5.0 or clang >= 3.3."
-    add_packages gcc-c++ g++ gcc-c++
+    add_packages gcc-c++ g++
     status=1
     ;;
   "g++ "* )
-    GCC_VER=$($CXX -dumpversion)
-    GCC_VER_NUM=$(echo $GCC_VER | sed 's/\./ /g' | xargs printf "%d%02d%02d")
-    if [ $GCC_VER_NUM -lt 40803 ]; then
-        echo "$0: $CXX (g++-$GCC_VER) is not supported."
+    gcc_ver=$($CXX -dumpversion)
+    gcc_ver_num=$(echo $gcc_ver | sed 's/\./ /g' | xargs printf "%d%02d%02d")
+    if [ $gcc_ver_num -lt 40803 ]; then
+        echo "$0: Compiler '$CXX' (g++-$gcc_ver) is not supported."
         echo "$0: You need g++ >= 4.8.3, Apple clang >= 5.0 or LLVM clang >= 3.3."
         status=1
     fi
     ;;
   "Apple LLVM "* )
     # See https://gist.github.com/yamaya/2924292
-    CLANG_VER=$(echo $COMPILER_VER_INFO | grep version | sed "s/.*version \([0-9\.]*\).*/\1/")
-    CLANG_VER_NUM=$(echo $COMPILER_VER_INFO | grep version | sed "s/.*clang-\([0-9]*\).*/\1/")
-    if [ $CLANG_VER_NUM -lt 500 ]; then
-        echo "$0: $CXX (Apple clang-$CLANG_VER) is not supported."
+    clang_ver=$(echo $compiler_ver_info | grep version | sed "s/.*version \([0-9\.]*\).*/\1/")
+    clang_ver_num=$(echo $compiler_ver_info | grep version | sed "s/.*clang-\([0-9]*\).*/\1/")
+    if [ $clang_ver_num -lt 500 ]; then
+        echo "$0: Compiler '$CXX' (Apple clang-$clang_ver) is not supported."
         echo "$0: You need g++ >= 4.8.3, Apple clang >= 5.0 or LLVM clang >= 3.3."
         status=1
     fi
     ;;
   "clang "* )
-    CLANG_VER=$(echo $COMPILER_VER_INFO | grep version | sed "s/.*version \([0-9\.]*\).*/\1/")
-    CLANG_VER_NUM=$(echo $CLANG_VER | sed 's/\./ /g' | xargs printf "%d%02d")
-    if [ $CLANG_VER_NUM -lt 303 ]; then
-        echo "$0: $CXX (LLVM clang-$CLANG_VER) is not supported."
+    clang_ver=$(echo $compiler_ver_info | grep version | sed "s/.*version \([0-9\.]*\).*/\1/")
+    clang_ver_num=$(echo $clang_ver | sed 's/\./ /g' | xargs printf "%d%02d")
+    if [ $clang_ver_num -lt 303 ]; then
+        echo "$0: Compiler '$CXX' (LLVM clang-$clang_ver) is not supported."
         echo "$0: You need g++ >= 4.8.3, Apple clang >= 5.0 or LLVM clang >= 3.3."
         status=1
     fi
@@ -61,53 +58,55 @@ case $COMPILER_VER_INFO in
     ;;
 esac
 
-if ! echo "#include <zlib.h>" | $CXX -E - >&/dev/null; then
+# Cannot check this without a compiler.
+if have "$CXX" && ! echo "#include <zlib.h>" | $CXX -E - >&/dev/null; then
   echo "$0: zlib is not installed."
-  add_packages zlib-devel zlib1g-dev zlib-devel
+  add_packages zlib-devel zlib1g-dev
 fi
 
 for f in make automake autoconf patch grep bzip2 gzip unzip wget git sox; do
-  if ! which $f >&/dev/null; then
+  if ! have $f; then
     echo "$0: $f is not installed."
-    add_packages $f $f $f
+    add_packages $f
   fi
 done
 
-if ! which libtoolize >&/dev/null && ! which glibtoolize >&/dev/null; then
+if ! have libtoolize && ! have glibtoolize; then
   echo "$0: neither libtoolize nor glibtoolize is installed"
-  add_packages libtool libtool libtool
+  add_packages libtool
 fi
 
-if ! which svn >&/dev/null; then
+if ! have svn; then
   echo "$0: subversion is not installed"
-  add_packages subversion subversion subversion
+  add_packages subversion
 fi
 
-if ! which awk >&/dev/null; then
+if ! have awk; then
   echo "$0: awk is not installed"
-  add_packages gawk gawk gawk
+  add_packages gawk
 fi
 
 pythonok=true
-if ! which python2.7 >&/dev/null; then
+if ! have python2.7; then
   echo "$0: python2.7 is not installed"
-  add_packages python2.7 python2.7
+  add_packages python2.7
   pythonok=false
 fi
 
-if ! which python3 >&/dev/null; then
+if ! have python3; then
   echo "$0: python3 is not installed"
-  add_packages python3 python3
+  add_packages python3
   pythonok=false
 fi
 
 (
 #Use a subshell so that sourcing env.sh does not have an influence on the rest of the script
 [ -f ./env.sh ] && . ./env.sh
-if $pythonok && ! which python2 >&/dev/null; then
+if $pythonok && ! have python2; then
   mkdir -p $PWD/python
-  echo "$0: python2.7 is installed, but the python2 binary does not exist. Creating a symlink and adding this to tools/env.sh"
-  ln -s $(which python2.7) $PWD/python/python2
+  echo "$0: python2.7 is installed, but the python2 binary does not exist." \
+       "Creating a symlink and adding this to tools/env.sh"
+  ln -s $(command -v python2.7) $PWD/python/python2
   echo "export PATH=$PWD/python:\${PATH}" >> env.sh
 fi
 
@@ -115,13 +114,15 @@ if [[ -f $PWD/python/.use_default_python && -f $PWD/python/python ]]; then
   rm $PWD/python/python
 fi
 
-if $pythonok && which python >&/dev/null && [[ ! -f $PWD/python/.use_default_python ]]; then
-  version=`python 2>&1 --version | awk '{print $2}' `
+if $pythonok && have python && [[ ! -f $PWD/python/.use_default_python ]]; then
+  version=$(python 2>&1 --version | awk '{print $2}')
   if [[ $version != "2.7"* ]] ; then
-    echo "$0: WARNING python 2.7 is not the default python. We fixed this by adding a correct symlink more prominently on the path."
-    echo "$0: If you really want to use python $version as default, add an empty file $PWD/python/.use_default_python and run this script again."
+    echo "$0: WARNING python 2.7 is not the default python. We fixed this by" \
+         "adding a correct symlink more prominently on the path."
+    echo " ... If you really want to use python $version as default, add an" \
+         "empty file $PWD/python/.use_default_python and run this script again."
     mkdir -p $PWD/python
-    ln -s $(which python2.7) $PWD/python/python
+    ln -s $(command -v python2.7) $PWD/python/python
     echo "export PATH=$PWD/python:\${PATH}" >> env.sh
   fi
 fi
@@ -129,66 +130,54 @@ fi
 
 printed=false
 
-if which apt-get >&/dev/null && ! which zypper >/dev/null; then
-  # if we're using apt-get [but we're not OpenSuse, which uses zypper as the
-  # primary installer, but sometimes installs apt-get for some compatibility
-  # reason without it really working]...
-  if [ ! -z "$debian_packages" ]; then
-    echo "$0: we recommend that you run (our best guess):"
-    echo " sudo apt-get install $debian_packages"
-    printed=true
-    status=1
-  fi
-  if ! dpkg -l | grep -E 'libatlas3gf|libatlas3-base' >/dev/null; then
-    echo "You should probably do: "
-    echo " sudo apt-get install libatlas3-base"
-    printed=true
-  fi
-elif which yum >&/dev/null; then
-  if [ ! -z "$redhat_packages" ]; then
-    echo "$0: we recommend that you run (our best guess):"
-    echo " sudo yum install $redhat_packages"
-    printed=true
-    status=1
-  fi
-  if ! rpm -qa|  grep atlas >/dev/null; then
-    echo "You should probably do something like: "
-    echo "sudo yum install atlas.x86_64"
-    printed=true
-  fi
-elif which zypper >&/dev/null; then
-  if [ ! -z "$opensuse_packages" ]; then
-    echo "$0: we recommend that you run (our best guess):"
-    echo " sudo zypper install $opensuse_packages"
-    printed=true
-    status=1
-  fi
-  if ! zypper search -i | grep -E 'libatlas3|libatlas3-devel' >/dev/null; then
-    echo "You should probably do: "
-    echo "sudo zypper install libatlas3-devel"
-    printed=true
-  fi
+# MKL. We do not know if compiler exists at this point, so double-check
+# the well-known mkl.h file location. The compiler test would still find
+# it if installed in an alternative location (this is unlikely).
+if [ ! -f /opt/intel/mkl/include/mkl.h ] &&
+   ! echo '#include <mkl.h>' | $CXX -I /opt/intel/mkl/include -E - >&/dev/null; then
+  echo "$0: Intel MKL is not installed. Run extras/install_mkl.sh to intall it.
+ ... You can also use other matrix algebra libraries; for information, see
+ ... http://kaldi-asr.org/doc/matrixwrap.html"
+  printed=true
 fi
 
-if [ ! -z "$debian_packages" ]; then
-  # If the list of packages to be installed is nonempty,
-  # we'll exit with error status.  Check this outside of
-  # checking for yum or apt-get, as we want it to exit with
-  # error even if we're not on Debian or red hat.
+# Report missing programs and libraries.
+if [ -n "$debian_packages" ]; then
+  install_pkg_command=$(
+    # Guess package manager from user's distribution type. Use a subshell
+    # because we are potentially importing a lot of dirt here.
+    eval $(grep 2>/dev/null ^ID /etc/os-release) 2>/dev/null
+    for rune in $ID $ID_LIKE; do
+      case $rune in
+        rhel|centos|redhat) echo "yum install $redhat_packages"; break;;
+        fedora) echo "dnx install $redhat_packages"; break;;
+        suse) echo "zypper install $opensuse_packages"; break;;
+        debian) echo "apt-get install $debian_packages"; break;;
+      esac
+    done
+  )
+
+  # Print the suggestion to install missing packages.
+  if [ -n "$install_pkg_command" ]; then
+    echo "$0: Some prerequisites are missing; install them using the command:"
+    echo "  sudo" $install_pkg_command
+  else
+    echo "$0: The following prerequisites are missing; install them first:"
+    echo "  " $debian_packages
+  fi
   status=1
 fi
-
 
 if [ $(pwd | wc -w) -gt 1 ]; then
   echo "*** $0: Warning: Kaldi scripts will fail if the directory name contains a space."
   echo "***  (it's OK if you just want to compile a few tools -> disable this check)."
-  status=1;
+  status=1
 fi
 
-if which grep >&/dev/null && pwd | grep -E 'JOB|LMWT' >/dev/null; then
+if pwd | grep -E 'JOB|LMWT' >/dev/null; then
   echo "*** $0: Kaldi scripts will fail if the directory name contains"
   echo "***  either of the strings 'JOB' or 'LMWT'."
-  status=1;
+  status=1
 fi
 
 if ! $printed && [ $status -eq 0 ]; then

--- a/tools/extras/install_mkl.sh
+++ b/tools/extras/install_mkl.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+
+# Intel MKL is now freely available even for commercial use. This script
+# attempts to install the MKL package automatically from Intel's repository.
+#
+# For manual repository setup instructions, see:
+#   https://software.intel.com/articles/installing-intel-free-libs-and-python-yum-repo
+#   https://software.intel.com/articles/installing-intel-free-libs-and-python-apt-repo
+#
+# For other package managers, or non-Linux platforms, see:
+#   https://software.intel.com/mkl/choose-download
+
+set -o pipefail
+
+default_package=intel-mkl-64bit-2019.2-057
+
+yum_repo='https://yum.repos.intel.com/mkl/setup/intel-mkl.repo'
+apt_repo='https://apt.repos.intel.com/mkl'
+intel_key_url='https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'
+
+Usage () {
+  cat >&2 <<EOF
+Usage: $0 [-s] [<MKL-package>]
+
+Checks if MKL is present on the system, and/or attempts to install it.
+
+If <MKL-package> is not provided, ${default_package} will be installed.
+
+Intel packages are installed under the /opt/intel directory. You should be root
+to install MKL into this directory; run this script using the sudo command.
+
+Options:
+  -s  - Skip check for MKL being already present.
+  -p <suse|redhat|debian|fedora> -- Force type of package management. Use only
+                                    if automatic detection fails, as instructed.
+  -h  - Show this message.
+
+Environment:
+  CC   The C compiler to use for MKL check. If not set, uses 'cc'.
+EOF
+  exit 2
+}
+
+Fatal () { echo "$0: $@"; exit 1; }
+
+Have () { type -t "$1" >/dev/null; }
+
+# Option values.
+skip_cc=
+distro=
+
+while getopts ":hksp:" opt; do
+  case ${opt} in
+    h) Usage ;;
+    s) skip_cc=yes ;;
+    p) case $OPTARG in
+         suse|redhat|debian|fedora) distro=$OPTARG ;;
+         *) Fatal "invalid value -p '${OPTARG}'. " \
+                  "Allowed: 'suse', 'redhat', 'debian' or 'fedora'."
+       esac ;;
+    \?) echo >&2 "$0: invalid option -${OPTARG}."; Usage ;;
+  esac
+done
+shift $((OPTIND-1))
+
+orig_arg_package=${1-''}
+package=${1:-$default_package}
+
+# Check that we are actually on Linux, otherwise give a helpful reference.
+[[ $(uname) == Linux ]] || Fatal "\
+This script can be used on Linux only, and your system is $(uname).
+
+Installer packages for Mac and Windows are available for download from Intel:
+https://software.intel.com/mkl/choose-download"
+
+# Test if MKL is already installed on the system.
+if [[ ! $skip_cc ]]; then
+  : ${CC:=cc}
+  Have "$CC" || Fatal "\
+C compiler $CC not found.
+
+You can skip the check for MKL presence by invoking this script with the '-s'
+option to this script, but you will need a functional compiler anyway, so we
+recommend that you install it first."
+
+  mkl_version=$($CC -E -I /opt/intel/mkl/include - <<< \
+                      '#include <mkl_version.h>
+           __INTEL_MKL__.__INTEL_MKL_MINOR__.__INTEL_MKL_UPDATE__' 2>/dev/null |
+                  tail -n 1 ) || mkl_version=
+  mkl_version=${mkl_version// /}
+
+  [[ $mkl_version ]] && Fatal "\
+MKL version $mkl_version is already installed.
+
+You can skip the check for MKL presence by invoking this script with the '-s'
+option and proceed with automated installation, but we highly discourage
+this. This script will register Intel repositories with your system, and it
+seems that they have been already registered, or MKL has been installed some
+other way.
+
+You should use your package manager to check which MKL package is already
+installed. Note that Intel packages register the latest installed version of
+the library as the default. If your installed version is older than
+$package, it makes sense to upgrade."
+fi
+
+# Try to determine which package manager the distro uses, unless overridden.
+if [[ ! $distro ]]; then
+  dist_vars=$(cat /etc/os-release 2>/dev/null)
+  eval "$dist_vars"
+  for rune in $CPE_NAME $ID $ID_LIKE; do
+    case "$rune" in
+      cpe:/o:fedoraproject:fedora:2[01]) distro=redhat; break;;  # Use yum.
+      rhel|centos) distro=redhat; break;;
+      redhat|suse|fedora|debian) distro=$rune; break;;
+    esac
+  done
+
+  # Certain old distributions do not have /etc/os-release. We are unlikely to
+  # encounter these in the wild, but just in case.
+  # NOTE: Do not try to guess Fedora specifically here! Fedora 20 and below
+  #       detect as redhat, and this is good, because they use yum by default.
+  [[ ! $distro && -f /etc/redhat-release ]] && distro=redhat
+  [[ ! $distro && -f /etc/SuSE-release ]]   && distro=suse
+  [[ ! $distro && -f /etc/debian_release ]] && distro=debian
+
+  [[ ! $distro ]] && Fatal "\
+Unable to determine package management style.
+
+Invoke this script with the option '-p <style>', where <style> can be:
+  redhat -- RedHat-like, uses yum and rpm for package management.
+  fedora -- Fedora 22+, also RedHat-like, but uses dnf instead of yum.
+  suse   -- SUSE-like, uses zypper and rpm.
+  debian -- Debian-like, uses apt and dpkg.
+
+We do not currently support other package management systems. Check the Intel's
+documentation at https://software.intel.com/mkl/choose-download for other
+install options."
+
+  echo >&2 "$0: Your system is using ${distro}-style package management."
+fi
+
+# Check for root.
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo >&2 "$0: You must be root to install MKL.
+
+Restart this script using the 'sudo' command, as:
+
+  sudo $0 -sp $distro $package
+
+We recommend adding the '-sp $distro' options to skip the MKL and distro
+detection, since this has already been done. This minimizes the number of
+programs invoked with the root privileges to keep your system safe from
+unexpected or erroneous changes. Also, if you are setting the CC environment
+variable, sudo might not allow it to propagate to the command that it invokes."
+
+  if [ -t 0 ]; then
+    echo; read -ep "Run the above sudo command now? [Y/n]:"
+    case $REPLY in
+      ''|[Yy]*) set -x; exec sudo "$0" -sp "$distro" "$package"
+    esac
+  fi
+  exit 0
+fi
+
+# The install variants, each in a finction to simplify error reporting.
+# Each one invokes a subshell with a 'set -x' to to show system-modifying
+# commands it runs. The subshells simply limit the scope of this diagnostics
+# and avoid creating noise (if we were using 'set +x', it would be printed).
+Install_redhat () {
+  # yum-utils contains yum-config-manager, in case the user does not have it.
+  ( set -x
+    yum -y install yum-utils &&
+    yum-config-manager --add-repo "$yum_repo" &&
+    yum -y install "$package" )
+}
+
+Install_fedora () {
+  ( set -x
+    dnf -y install 'dnf-command(config-manager)' &&
+    dnf config-manager --add-repo "$yum_repo" &&
+    dnf -y install "$package" )
+}
+
+Install_suse () {
+  # zypper bug until libzypp-17.6.4: '--gpg-auto-import-keys' is ignored.
+  # See https://github.com/openSUSE/zypper/issues/144#issuecomment-418685933
+  # We must disable gpg checks with '--no-gpg-checks'. I won't bend backwards
+  # as far as check the installed .so version...
+  ( set -x
+    zypper addrepo "$yum_repo" &&
+    zypper --gpg-auto-import-keys --no-gpg-checks \
+           --non-interactive install "$package" )
+}
+
+Install_debian () {
+  local keyring='/usr/share/keyrings/intel-sw-products.gpg' \
+        sources_d='/etc/apt/sources.list.d' \
+        trusted_d='/etc/apt/trusted.gpg.d' \
+        apt_maj= apt_min= apt_ver=
+
+  # apt before 1.2 does not understand the signed-by option, and always
+  # look for the keyring in their trusted.gpg.d directory. This is not
+  # considered a good security practice any more. If apt is old, add a link
+  # to the keyring file and remind the user to delete it when apt is upgraded.
+  IFS=' .' builtin read _ apt_maj apt_min _ < <(apt-get --version)
+  apt_ver=$(builtin printf '%03d%03d' $apt_maj $apt_min)
+
+  # Get alternative location of /etc/apt/sources.list.d, if so configured.
+  eval $(apt-config shell sources_d Dir::Etc::sourceparts/f \
+                          trusted_d Dir::Etc::trustedparts/f)
+
+  # apt is much more involved to configure than other package managers, as fas
+  # as third-party security keys go.
+  ( set -x;
+    apt-get update &&
+    apt-get install -y wget apt-transport-https ca-certificates gnupg &&
+    wget -qO- $intel_key_url | apt-key --keyring $keyring add - &&
+    echo "deb [signed-by=${keyring}] $apt_repo all main" \
+         > "$sources_d/intel-mkl.list" ) || return 1
+
+  if [[ $apt_ver < '001002' ]]; then
+    ( set -x; ln -s "$keyring" "${trusted_d}/" ) || return 1
+  fi
+
+  ( set +x
+    apt-get update &&
+    apt-get install -y "$package" ) || return 1
+
+  # Print the message after the large install, so the user may notice. I hope...
+  if [[ $apt_ver < '001002' ]]; then
+    echo >&2 "$0: Your apt-get version is earlier than 1.2.
+
+This version does not understand individual repositories signing keys, and
+trusts all keys in $trusted_d. We have created a link
+$trusted_d/$(basename $keyring) pointing to the file
+$keyring. If/when you upgrade your system to
+a higher version of apt, removing this link will help make it more secure.
+
+This is not considered a severe security issue, but separating keyrings is the
+current recommended security practice."
+  fi
+}
+
+# Register MKL .so libraries with the ld.so.
+ConfigLdSo() {
+  [ -d /etc/ld.so.conf.d ] || return 0
+  type -t ldconfig >/dev/null || return 0
+  echo >&2 "$0: Configuring ld runtime bindings"
+  ( set -x;
+    echo >/etc/ld.so.conf.d/intel-mkl.conf "\
+/opt/intel/lib/intel64
+/opt/intel/mkl/lib/intel64"
+    ldconfig )
+}
+
+# Invoke installation.
+if Install_${distro} && ConfigLdSo; then
+  echo >&2 "$0: MKL package $package was successfully installed"
+else
+  Fatal "MKL package $package installation FAILED.
+
+Please open an issue with us at https://github.com/kaldi-asr/kaldi/ if you
+believe this is a bug."
+fi


### PR DESCRIPTION
Ok, here are my changes so far. The only thing I did not do here is change the configure default to MKL. so this may possibly be a WIP.

I debugged the script on 20 different Docker images, ranging from deprecated systems to the latest stable branches: https://github.com/kkm000/install_mkl. The tests use the expect tool, since the script asks to run sudo, sudo asks for the password, etc.

Now, how do we handle that transition overall? Just change the default blindly to MKL and see what is the fallout? I wold at least post a heads-up to the kaldi-help list. The current default is ATLAS, which is not good at all. What I am thinking of doing is maybe add some detection code (MKL in the recent packaging is very easy to detect, so it's either it's either in the system (just compiles) or in a well known directory /opt/inte/mkl). Except I do not know where to look for it on a Mac. My co-worker has a Mac, I'll email him to bring it, but I do not know if he still has it, and I do not remember if he's coming back from vacation today.

Generally, regarding openblas detection, I think invoking a test compile is a better approach than poking around trying to find it it's in the system in a known location. If it is, a compile with  -l... will do the trick. If not, then it's likely missing. In any case, it's probably better to build OpenBLAS from source. At the very least, it might be better optimized for the user's system.

Running the reference CBLAS will probably be disastrously slow anyway.

So, in the end, I'm thinking we should, in the case the user did not ask for a specific math lib:
 * Check if MKL is there, and use it.
 * Check for OpenBlas in tools/. Then check for it in the system. What we can do about packaging, I dunno yet. rhel packages seem to package `<cblas.h>`, should work as is. debian packages use a known filename, I'll see if we can adapt it.
  * If OpenBLAS is found, print a note that MKL is better, and use OpenBLAS.
 * If not, print an error and ask to use the option to specify the library.

I. e., do not probe for neither the reference blas or ATLAS, because these are rather inferior options.

What do you think? Am I making sense?

Close #3078