### PR TITLE
Tensorflow version update

### DIFF
--- a/src/tfrnnlm/Makefile
+++ b/src/tfrnnlm/Makefile
@@ -20,7 +20,8 @@ EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/pro
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
-                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src
+                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src \
+                 -I${TENSORFLOW}/tensorflow/contrib/makefile/downloads/absl
 
 OBJFILES = tensorflow-rnnlm.o
 

--- a/src/tfrnnlm/Makefile
+++ b/src/tfrnnlm/Makefile
@@ -16,7 +16,8 @@ TENSORFLOW = ../../tools/tensorflow
 
 all:
 
-EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf/src \
+EXTRA_CXXFLAGS = -Wno-sign-compare \
+                 -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf_archive/src \
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
@@ -30,7 +31,7 @@ TESTFILES =
 LIBNAME = kaldi-tensorflow-rnnlm
 
 ADDLIBS = ../lm/kaldi-lm.a ../util/kaldi-util.a ../matrix/kaldi-matrix.a \
-          ../base/kaldi-base.a 
+          ../base/kaldi-base.a
 LDLIBS +=  -lz -ldl -fPIC -lrt
 LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc -ltensorflow_framework
 

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -14,7 +14,8 @@ TENSORFLOW = $(shell pwd)/../../tools/tensorflow
 
 all:
 
-EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf/src \
+EXTRA_CXXFLAGS = -Wno-sign-compare \
+                 -I$(TENSORFLOW)/bazel-tensorflow/external/protobuf_archive/src
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
@@ -31,7 +32,7 @@ TESTFILES =
 ADDLIBS = ../lat/kaldi-lat.a ../lm/kaldi-lm.a ../fstext/kaldi-fstext.a \
           ../hmm/kaldi-hmm.a ../tree/kaldi-tree.a ../util/kaldi-util.a \
           ../matrix/kaldi-matrix.a ../base/kaldi-base.a \
-          ../tfrnnlm/kaldi-tensorflow-rnnlm.a 
+          ../tfrnnlm/kaldi-tensorflow-rnnlm.a
 
 LDLIBS +=  -lz -ldl -fPIC -lrt
 LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc -ltensorflow_framework

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -37,6 +37,6 @@ ADDLIBS = ../lat/kaldi-lat.a ../lm/kaldi-lm.a ../fstext/kaldi-fstext.a \
 LDLIBS +=  -lz -ldl -fPIC -lrt
 LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc -ltensorflow_framework
 
-LDFLAGS += -Wl,-rpath,$(shell pwd)/../../tools/tensorflow/bazel-bin/tensorflow/
+LDFLAGS += -Wl,-rpath,$(TENSORFLOW)/bazel-bin/tensorflow/
 
 include ../makefiles/default_rules.mk

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -18,7 +18,8 @@ EXTRA_CXXFLAGS = -Wno-sign-compare -I$(TENSORFLOW)/bazel-tensorflow/external/pro
                  -I$(TENSORFLOW)/bazel-genfiles -I$(TENSORFLOW) \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/eigen \
                  -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/nsync/public \
-                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src
+                 -I$(TENSORFLOW)/tensorflow/contrib/makefile/downloads/protobuf/src \
+                 -I${TENSORFLOW}/tensorflow/contrib/makefile/downloads/absl
 include ../kaldi.mk
 
 BINFILES = lattice-lmrescore-tf-rnnlm lattice-lmrescore-tf-rnnlm-pruned

--- a/src/tfrnnlmbin/Makefile
+++ b/src/tfrnnlmbin/Makefile
@@ -36,6 +36,6 @@ ADDLIBS = ../lat/kaldi-lat.a ../lm/kaldi-lm.a ../fstext/kaldi-fstext.a \
 LDLIBS +=  -lz -ldl -fPIC -lrt
 LDLIBS += -L$(TENSORFLOW)/bazel-bin/tensorflow -ltensorflow_cc -ltensorflow_framework
 
-LDFLAGS += -Wl,-rpath=$(shell pwd)/../../tools/tensorflow/bazel-bin/tensorflow/
+LDFLAGS += -Wl,-rpath,$(shell pwd)/../../tools/tensorflow/bazel-bin/tensorflow/
 
 include ../makefiles/default_rules.mk

--- a/tools/extras/install_tensorflow_cc.sh
+++ b/tools/extras/install_tensorflow_cc.sh
@@ -25,7 +25,7 @@ else
 fi
 
 
-[ ! -f bazel.zip ] && wget https://github.com/bazelbuild/bazel/releases/download/0.5.4/bazel-0.5.4-dist.zip -O bazel.zip
+[ ! -f bazel.zip ] && wget https://github.com/bazelbuild/bazel/releases/download/0.15.0/bazel-0.15.0-dist.zip -O bazel.zip
 mkdir -p bazel
 cd bazel
 unzip ../bazel.zip
@@ -33,9 +33,9 @@ unzip ../bazel.zip
 cd ../
 
 # now bazel is built
-git clone https://github.com/tensorflow/tensorflow
+[ ! -d tensorflow ] && git clone https://github.com/tensorflow/tensorflow
 cd tensorflow
-git checkout r1.4
+git checkout r1.12
 ./configure
 
 tensorflow/contrib/makefile/download_dependencies.sh 

--- a/tools/extras/install_tensorflow_cc.sh
+++ b/tools/extras/install_tensorflow_cc.sh
@@ -35,10 +35,11 @@ cd ../
 # now bazel is built
 [ ! -d tensorflow ] && git clone https://github.com/tensorflow/tensorflow
 cd tensorflow
+git fetch --tags
 git checkout r1.12
 ./configure
 
-tensorflow/contrib/makefile/download_dependencies.sh 
+tensorflow/contrib/makefile/download_dependencies.sh
 bazel build -c opt //tensorflow:libtensorflow.so
 bazel build -c opt //tensorflow:libtensorflow_cc.so
 


### PR DESCRIPTION
Installing tensorflow for the tfrnnlm setup caused some issues for some users [https://groups.google.com/forum/#!searchin/kaldi-help/tfrnnlm%7Csort:date/kaldi-help/Zjjsq0dEiWo/oDNMDkeCAQAJ](https://groups.google.com/forum/#!searchin/kaldi-help/tfrnnlm%7Csort:date/kaldi-help/Zjjsq0dEiWo/oDNMDkeCAQAJ).

I verified that using a newer bazel version resolves the issue. Theoretically, the issue causing the problem described in the post linked above could be solved by using bazel 0.10 however tensorflow before version 1.7 has errors in the version checking code and does not recognize 0.10 as a newer bazel version than 0.5.4. 

Tensorflow should be backwards compatible according to their versioning system, so I decided to update the scripts to a newer version using:

tensorflow v1.12
bazel 0.15.0

I also corrected the `-rpath` option in the tfrnnlmbin Makefile to not rely on GNU specific syntax. However, there is still an issue compiling this on MacOS because of `-lrt` but this might be better suited for another PR.