### PR TITLE
[scripts] replace a non-initialized variable in write_fst_no_silence in make_lexicon_fst.py

### DIFF
--- a/egs/wsj/s5/utils/lang/make_lexicon_fst.py
+++ b/egs/wsj/s5/utils/lang/make_lexicon_fst.py
@@ -209,7 +209,7 @@ def write_fst_no_silence(lexicon, nonterminals=None, left_context_phones=None):
 
     if nonterminals is not None:
         next_state = write_nonterminal_arcs(
-            start_state, loop_state, next_state,
+            loop_state, loop_state, next_state,
             nonterminals, left_context_phones)
 
     print("{state}\t{final_cost}".format(


### PR DESCRIPTION
start_state is not initialized in that function, wa can replace it with loop_state (which is also the start state in this case)