### PR TITLE
[build] check for i686 as a valid prefix for Android triplets

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -991,7 +991,8 @@ if is_set $HOST; then
   IFS='-' read -ra PARTS <<< "$HOST"
   # The first field in the PARTS list is the target architecture.
   TARGET_ARCH="$PARTS"
-  if [[ "$TARGET_ARCH" != aarch64* && "$TARGET_ARCH" != arm* && "$TARGET_ARCH" != ppc64le && "$TARGET_ARCH" != x86* ]] ; then
+  if [[ "$TARGET_ARCH" != aarch64* && "$TARGET_ARCH" != arm* && "$TARGET_ARCH" != ppc64le && \
+        "$TARGET_ARCH" != x86* && "$TARGET_ARCH" != i686* ]] ; then
     # We currently only support building for x86[_64], arm*, aarch64* and ppc64le.
     # If TARGET_ARCH was read from the HOST variable, it must be one of these.
     failure "$TARGET_ARCH is not a supported architecture.


### PR DESCRIPTION
Add check for i686 as a valid prefix for Android triplets. Fixes #3208
    
Kaldi configure script for 32-bit x86 expects x86 cross-compile
toolchains to start with x86.
    
Android compilers, however,  have triplets like i686-linux-android-gcc
and i686-linux-android-ar, using i686 as a prefix.
    
Fixes #3208
