### PR TITLE
fixed DCTCompnent test failure

### DIFF
--- a/src/nnet2/nnet-component-test.cc
+++ b/src/nnet2/nnet-component-test.cc
@@ -605,7 +605,7 @@ void UnitTestSumGroupComponent() {
 
 
 void UnitTestDctComponent() {
-  int32 m = 1 + Rand() % 4, n = 1 + Rand() % 4,
+  int32 m = 3 + Rand() % 4, n = 3 + Rand() % 4,
   dct_dim = m, dim = m * n;
   bool reorder = (Rand() % 2 == 0);
   {


### PR DESCRIPTION
A bug "DCTCompnent test failure with CUDA enabled" is reported thanks to Justin Luitjens.

To make sure the tests in the `kaldi/src/nnet2` dir run:

```
$ make test
...
Running nnet-component-test ... 8s... SUCCESS nnet-component-test
Running nnet-precondition-test ... 0s... SUCCESS nnet-precondition-test
Running nnet-precondition-online-test ... 3s... SUCCESS nnet-precondition-online-test
Running nnet-example-functions-test ... 0s... SUCCESS nnet-example-functions-test
Running nnet-nnet-test ... 0s... SUCCESS nnet-nnet-test
Running am-nnet-test ... 0s... SUCCESS am-nnet-test
Running online-nnet2-decodable-test ... 0s... SUCCESS online-nnet2-decodable-test
Running nnet-compute-test ... 1s... SUCCESS nnet-compute-test
```