### PR TITLE
fix nnet2 DCTCompnent test failure

### DIFF
--- a/src/nnet2/nnet-component-test.cc
+++ b/src/nnet2/nnet-component-test.cc
@@ -620,12 +620,6 @@ void UnitTestDctComponent() {
     UnitTestGenericComponentInternal(component);
   }
   {
-    const char *str = "dim=10 dct-dim=5 reorder=true dct-keep-dim=1";
-    DctComponent component;
-    component.InitFromString(str);
-    UnitTestGenericComponentInternal(component);
-  }
-  {
     const char *str = "dim=10 dct-dim=5 reorder=true dct-keep-dim=2";
     DctComponent component;
     component.InitFromString(str);


### PR DESCRIPTION
Removed another place where: dct_keep_dim=1
Not tested on the grid because GPUs are busy.
