### PR TITLE
add python symlink to .gitignore in cases python2 doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ GSYMS
 /tools/cub-1.8.0.zip
 /tools/cub-1.8.0/
 /tools/cub
+/tools/python/


### PR DESCRIPTION
Compiled on MacOs Mojave with brew installed dependencies.  
python2 binary/link doesn't exist so the extra/check_dependencies.sh creates a symlink for python2 in tools/python/.

This location is not ignored in .gitignore so it causes git to assume directory is dirty.