### PR TITLE
[RM chain script] refactoring RM chain script

### DIFF
--- a/egs/rm/s5/RESULTS
+++ b/egs/rm/s5/RESULTS
@@ -235,7 +235,7 @@ for x in exp/nnet2_online_wsj/nnet_ms_a_smbr_0.00005/1/decode_*; do grep WER $x/
 %WER 2.71 [ 340 / 12533, 58 ins, 59 del, 223 sub ] exp/chain/tdnn_5n/decode/wer_4_0.0
 # Its topology of chain model is from mini_librispeech's.
 # It uses a new configs convention for chain model after kaldi 5.2.
-%WER 1.37 [ 172 / 12533, 16 ins, 32 del, 124 sub ] exp/chain/tdnn_5o/decode/wer_3_1.0
+%WER 1.32 [ 166 / 12533, 19 ins, 31 del, 116 sub ] exp/chain/tdnn_5o/decode/wer_4_0.0
 ### WSJ->RM Transfer learning using chain model ###
 %WER 1.68 [ 210 / 12533, 25 ins, 33 del, 152 sub ] exp/chain/tdnn_wsj_rm_1a/decode/wer_2_0.0
  

--- a/egs/rm/s5/RESULTS
+++ b/egs/rm/s5/RESULTS
@@ -233,10 +233,9 @@ for x in exp/nnet2_online_wsj/nnet_ms_a_smbr_0.00005/1/decode_*; do grep WER $x/
 # current best chain result with TDNN (check local/chain/run_tdnn_5g.sh)
 %WER 2.86 [ 358 / 12533, 46 ins, 61 del, 251 sub ] exp/chain/tdnn_5g/decode/wer_5_0.0
 %WER 2.71 [ 340 / 12533, 58 ins, 59 del, 223 sub ] exp/chain/tdnn_5n/decode/wer_4_0.0
-# This is a modified version of run_tdnn_5n.sh. It uses
-# a new configs convention for chain model after kaldi 5.2.
-%WER 1.52 [ 191 / 12533, 14 ins, 39 del, 138 sub ] exp/chain/tdnn_5o/decode/wer_4_0.5
-
+# Its topology of chain model is from mini_librispeech's.
+# It uses a new configs convention for chain model after kaldi 5.2.
+%WER 1.37 [ 172 / 12533, 16 ins, 32 del, 124 sub ] exp/chain/tdnn_5o/decode/wer_3_1.0
 ### WSJ->RM Transfer learning using chain model ###
 %WER 1.68 [ 210 / 12533, 25 ins, 33 del, 152 sub ] exp/chain/tdnn_wsj_rm_1a/decode/wer_2_0.0
  

--- a/egs/rm/s5/conf/mfcc_hires.conf
+++ b/egs/rm/s5/conf/mfcc_hires.conf
@@ -1,0 +1,8 @@
+# config for high-resolution MFCC features, intended for neural network training
+# Note: we keep all cepstra, so it has the same info as filterbank features,
+# but MFCC is more easily compressible (because less correlated) which is why 
+# we prefer this method.
+--use-energy=false   # use average of log energy, not energy.
+--low-freq=20     # low cutoff frequency for mel bins... this is high-bandwidth data, so
+                  # there might be some information at the low end.
+--high-freq=-400 # high cutoff frequently, relative to Nyquist of 8000 (=7600) 

--- a/egs/rm/s5/local/chain/tuning/run_tdnn_5o.sh
+++ b/egs/rm/s5/local/chain/tuning/run_tdnn_5o.sh
@@ -2,7 +2,6 @@
 
 # this script is a modified version of run_tdnn_5n.sh. It uses
 # a new configs convention for chain model after kaldi 5.2.
-# 
 
 
 

--- a/egs/rm/s5/local/chain/tuning/run_tdnn_5o.sh
+++ b/egs/rm/s5/local/chain/tuning/run_tdnn_5o.sh
@@ -15,7 +15,7 @@ xent_regularize=0.1
 dir=exp/chain/tdnn_5o
 
 # training options
-num_epochs=14
+num_epochs=13
 initial_effective_lrate=0.005
 final_effective_lrate=0.0005
 max_param_change=2.0

--- a/egs/rm/s5/local/online/run_nnet2_common.sh
+++ b/egs/rm/s5/local/online/run_nnet2_common.sh
@@ -8,7 +8,7 @@ stage=1
 nnet_affix=_online
 extractor=exp/nnet2${nnet_affix}/extractor
 ivector_dim=50
-mfcc_config=conf/mfcc_hires.conf
+mfcc_config=conf/mfcc.conf
 use_ivector=true # If false, it skips training ivector extractor and
                  # ivector extraction stages.
 . ./cmd.sh
@@ -36,6 +36,7 @@ else
 fi
 
 train_set=train
+test_set=test
 if [ $stage -le 0 ]; then
   echo "$0: creating high-resolution MFCC features."
   mfccdir=data/${train_set}_hires/data
@@ -48,9 +49,10 @@ if [ $stage -le 0 ]; then
     steps/compute_cmvn_stats.sh data/${datadir}_hires
     utils/fix_data_dir.sh data/${datadir}_hires
   done
+  train_set=${train_set}_hires
+  test_set=${test_set}_hires
 fi
 
-train_set=${train_set}_hires
 if [ ! -f $extractor/final.ie ] && [ $ivector_dim -gt 0 ]; then
   if [ $stage -le 1 ]; then
     mkdir -p exp/nnet2${nnet_affix}
@@ -61,7 +63,7 @@ if [ ! -f $extractor/final.ie ] && [ $ivector_dim -gt 0 ]; then
   if [ $stage -le 2 ]; then
     # use a smaller iVector dim (50) than the default (100) because RM has a very
     # small amount of data.
-    steps/online/nnet2/train_ivector_extractor.sh --cmd "$train_cmd" --nj 40 \
+    steps/online/nnet2/train_ivector_extractor.sh --cmd "$train_cmd" --nj 10 \
       --ivector-dim $ivector_dim \
      data/${train_set} exp/nnet2${nnet_affix}/diag_ubm $extractor || exit 1;
   fi
@@ -76,5 +78,5 @@ if [ $stage -le 3 ] && [ $ivector_dim -gt 0 ]; then
     data/${train_set}_max2 $extractor exp/nnet2${nnet_affix}/ivectors || exit 1;
 
   steps/online/nnet2/extract_ivectors_online.sh --cmd "$train_cmd" --nj 10 \
-    data/test_hires $extractor exp/nnet2${nnet_affix}/ivectors_test || exit 1;
+    data/${test_set} $extractor exp/nnet2${nnet_affix}/ivectors_test || exit 1;
 fi

--- a/egs/rm/s5/local/online/run_nnet2_common.sh
+++ b/egs/rm/s5/local/online/run_nnet2_common.sh
@@ -8,7 +8,7 @@ stage=1
 nnet_affix=_online
 extractor=exp/nnet2${nnet_affix}/extractor
 ivector_dim=50
-mfcc_config=conf/mfcc.conf
+mfcc_config=conf/mfcc_hires.conf
 use_ivector=true # If false, it skips training ivector extractor and
                  # ivector extraction stages.
 . ./cmd.sh

--- a/egs/rm/s5/run.sh
+++ b/egs/rm/s5/run.sh
@@ -11,7 +11,6 @@ set -e # exit on error
 
 #local/rm_data_prep.sh /mnt/matylda2/data/RM
 
-
 local/rm_data_prep.sh /export/corpora5/LDC/LDC93S3A/rm_comp
 
 #local/rm_data_prep.sh /home/dpovey/data/LDC93S3A/rm_comp

--- a/egs/rm/s5/run.sh
+++ b/egs/rm/s5/run.sh
@@ -11,6 +11,7 @@ set -e # exit on error
 
 #local/rm_data_prep.sh /mnt/matylda2/data/RM
 
+
 local/rm_data_prep.sh /export/corpora5/LDC/LDC93S3A/rm_comp
 
 #local/rm_data_prep.sh /home/dpovey/data/LDC93S3A/rm_comp
@@ -251,4 +252,4 @@ local/run_sgmm2.sh
 # local/nnet/run_cnn2d.sh
 
 # chain recipe
-# local/chain/run_tdnn_5f.sh
+# local/chain/run_tdnn.sh


### PR DESCRIPTION
Following  #3237 , I proposes this pull request for refactoring. 

Mainly changed;
1) In chain process, 'local/chain/run_tdnn.sh' script in RM egs is no longer generating High-resolution features because It does not use it.  (It has lower performance than no use version.)
2) Now, It uses model topology from mini_librispeech's. It shows a higher performance than wsj's under the appropriate number of epochs. (Minimum WER is 1.37%)
3) The run.sh introduces the recent chain scripts. (pointed by symbolic link.)

It is confirmed that the successful outputs can be obtained from run.sh script.