### PR TITLE
Implement --one-based:

### DIFF
--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -46,7 +46,7 @@ $job_id = 0;
 $utt2spk_file = "";
 $one_based = 0;
 
-for ($x = 1; $x <= 2 && @ARGV > 0; $x++) {
+for ($x = 1; $x <= 3 && @ARGV > 0; $x++) {
     if ($ARGV[0] eq "-j") {
         shift @ARGV;
         $num_jobs = shift @ARGV;

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -44,6 +44,7 @@ use warnings; #sed replacement for -w perl parameter
 $num_jobs = 0;
 $job_id = 0;
 $utt2spk_file = "";
+$one_based = 0;
 
 for ($x = 1; $x <= 2 && @ARGV > 0; $x++) {
     if ($ARGV[0] eq "-j") {
@@ -58,11 +59,18 @@ for ($x = 1; $x <= 2 && @ARGV > 0; $x++) {
         $utt2spk_file=$1;
         shift;
     }
+    if ($ARGV[0] eq '--one-based') {
+        $one_based = 1;
+        shift @ARGV;
+    }
 }
+
+$one_based
+    and $job_id--;
 
 if(($num_jobs == 0 && @ARGV < 2) || ($num_jobs > 0 && (@ARGV < 1 || @ARGV > 2))) {
     die "Usage: split_scp.pl [--utt2spk=<utt2spk_file>] in.scp out1.scp out2.scp ... \n" .
-        " or: split_scp.pl -j num-jobs job-id [--utt2spk=<utt2spk_file>] in.scp [out.scp]\n" .
+        " or: split_scp.pl -j num-jobs job-id [--one-based] [--utt2spk=<utt2spk_file>] in.scp [out.scp]\n" .
         " ... where 0 <= job-id < num-jobs.";
 }
 


### PR DESCRIPTION
[This is my second attempt at it. I've closed #3162.]

If you now call the code with --one-based, your "jobs id" will start
from one instead of zero.

    # This sets the 2nd output to "output_file"
    split_scp.pl -j 2 1 inscp_file output_file

    # This sets the 1st output to "output_file"
    split_scp.pl --one-based -j 2 1 inscp_file output_file


I apologize for the time this super-small patch took. I found the code
confusing and had to sit and write tests to make sure I understand how
the code works and what this patch will do. Then work got in the way. :/

I have separated this completely from any other change I want to do
of clean ups. Once this is merged, I would like to start introducing
small changes that make the code more readable and more secure.

(Specifically, there are several security issues with this code that
my original PR fixed, but I will provide them separately in a clean
PR.)

Thank you for the patience and help in understanding this.