### PR TITLE
[scripts] Use correct compile-time regex syntax in split_scp.pl

### DIFF
--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -55,7 +55,7 @@ for ($x = 1; $x <= 3 && @ARGV > 0; $x++) {
             die "Invalid num-jobs and job-id: $num_jobs and $job_id";
         }
     }
-    if ($ARGV[0] =~ "--utt2spk=(.+)") {
+    if ($ARGV[0] =~ /--utt2spk=(.+)/) {
         $utt2spk_file=$1;
         shift;
     }


### PR DESCRIPTION
This is a single commit with two character change. A simple cleanup.

The commit message:

Regular expressions should be written with // to allow the language to do compile-time checks for the regexp pattern.

This is from `perldoc perlop`:

    If the right argument is an expression rather than a search pattern,
    substitution, or transliteration, it is interpreted as a search pattern at
    run time. Note that this means that its contents will be interpolated
    twice, so

        '\\' =~ q'\\';

    is not ok, as the regex engine will end up trying to compile the pattern
    "\", which it will consider a syntax error.