### PR TITLE
[src] Fix sample rounding errors in extract-segments

### DIFF
--- a/src/featbin/extract-segments.cc
+++ b/src/featbin/extract-segments.cc
@@ -70,18 +70,18 @@ int main(int argc, char *argv[]) {
 
     RandomAccessTableReader<WaveHolder> reader(wav_rspecifier);
     TableWriter<WaveHolder> writer(wav_wspecifier);
-    Input ki(segments_rxfilename);  // no binary argment: never binary.
+    Input ki(segments_rxfilename);  // No binary argment: never binary.
 
     int32 num_lines = 0, num_success = 0;
 
     std::string line;
-    /* read each line from segments file */
+    // Read each line from the segments file.
     while (std::getline(ki.Stream(), line)) {
       num_lines++;
       std::vector<std::string> split_line;
-      // Split the line by space or tab and check the number of fields in each
-      // line. There must be 4 fields--segment name , reacording wav file name,
-      // start time, end time; 5th field (channel info) is optional.
+      // Split the line into whitespace-separated fields and verify their
+      // number. There must be 4 or 5 fields: segment name, reacording ID, start
+      // time, end time, and the optional channel number.
       SplitStringToVector(line, " \t\r", true, &split_line);
       if (split_line.size() != 4 && split_line.size() != 5) {
         KALDI_WARN << "Invalid line in segments file: " << line;
@@ -92,8 +92,8 @@ int main(int argc, char *argv[]) {
           start_str = split_line[2],
           end_str = split_line[3];
 
-      // Convert the start time and endtime to real from string. Segment is
-      // ignored if start or end time cannot be converted to real.
+      // Parse the start and end times as float values. Segment is ignored if
+      // any of end times is malformed.
       double start, end;
       if (!ConvertStringToReal(start_str, &start)) {
         KALDI_WARN << "Invalid line in segments file [bad start]: " << line;
@@ -103,24 +103,24 @@ int main(int argc, char *argv[]) {
         KALDI_WARN << "Invalid line in segments file [bad end]: " << line;
         continue;
       }
-      // start time must not be negative; start time must not be greater than
-      // end time, except if end time is -1
-      if (start < 0 || (end != -1.0 && end <= 0) || ((start >= end) && (end > 0))) {
-        KALDI_WARN << "Invalid line in segments file [empty or invalid segment]: "
-                   << line;
+      // Start time must be non-negative and not greater than the end time,
+      // except if the end time is -1.
+      if (start < 0 || (end != -1.0 && end <= 0) ||
+          ((start >= end) && (end > 0))) {
+        KALDI_WARN << ("Invalid line in segments file "
+                       "[empty or invalid segment]: ") << line;
         continue;
       }
-      int32 channel = -1;  // means channel info is unspecified.
-      // if each line has 5 elements then 5th element must be channel identifier
+      int32 channel = -1;  // -1 means channel is unspecified.
+      // If the line has 5 elements, then the 5th element is the channel number.
       if (split_line.size() == 5) {
         if (!ConvertStringToInteger(split_line[4], &channel) || channel < 0) {
           KALDI_WARN << "Invalid line in segments file [bad channel]: " << line;
           continue;
         }
       }
-      /* check whether a segment start time and end time exists in recording
-       * if fails , skips the segment.
-       */
+
+      // Check whether the recording ID is in wav.scp; if not, skip the segment.
       if (!reader.HasKey(recording)) {
         KALDI_WARN << "Could not find recording " << recording
                    << ", skipping segment " << segment;
@@ -129,74 +129,70 @@ int main(int argc, char *argv[]) {
 
       const WaveData &wave = reader.Value(recording);
       const Matrix<BaseFloat> &wave_data = wave.Data();
-      BaseFloat samp_freq = wave.SampFreq();  // read sampling fequency
-      int32 num_samp = wave_data.NumCols(),  // number of samples in recording
-        num_chan = wave_data.NumRows();  // number of channels in recording
+      BaseFloat samp_freq = wave.SampFreq();  // Sampling fequency.
+      int32 num_samp = wave_data.NumCols(),  // Number of samples in recording.
+        num_chan = wave_data.NumRows();  // Number of channels in recording.
+      BaseFloat file_length = num_samp / samp_freq;  // In seconds.
 
-      // Convert starting time of the segment to corresponding sample number.
-      // If end time is -1 then use the whole file starting from start time.
-      int32 start_samp = start * samp_freq,
-          end_samp = (end != -1)? (end * samp_freq) : num_samp;
-      KALDI_ASSERT(start_samp >= 0 && end_samp > 0 && "Invalid start or end.");
-
-      // start sample must be less than total number of samples,
-      // otherwise skip the segment
-      if (start_samp < 0 || start_samp >= num_samp) {
-        KALDI_WARN << "Start sample out of range " << start_samp << " [length:] "
-                   << num_samp << ", skipping segment " << segment;
+      // Start must be within the wave data, otherwise skip the segment.
+      if (start < 0 || start > file_length) {
+        KALDI_WARN << "Segment start is out of file data range [0, "
+                   << file_length << "s]; skipping segment '" << line << "'";
         continue;
       }
-      /* end sample must be less than total number samples
-       * otherwise skip the segment
-       */
-      if (end_samp > num_samp) {
-        if ((end_samp >=
-             num_samp + static_cast<int32>(max_overshoot * samp_freq))) {
-          KALDI_WARN << "End sample too far out of range " << end_samp
-                     << " [length:] " << num_samp << ", skipping segment "
-                     << segment;
-          continue;
-        }
-        end_samp = num_samp;  // for small differences, just truncate.
+
+      // End must be less than the file length adjusted for possible overshoot;
+      // otherwise skip the segment. end == -1 passes the check.
+      if (end > file_length + max_overshoot) {
+        KALDI_WARN << "Segment end is too far out of file data range [0,"
+                   << file_length << "s]; skipping segment '" << line << "'";
+        continue;
       }
-      // Skip if segment size is less than minimum segment length (default 0.1s)
-      if (end_samp <=
-          start_samp + static_cast<int32>(min_segment_length * samp_freq)) {
+
+      // Otherwise ensure the end is not beyond the end of data, and default
+      // end == -1 to the end of file data.
+      if (end < 0 || end > file_length) end = file_length;
+
+      // Skip if segment size is less than the minimum allowed.
+      if (end - start < min_segment_length) {
         KALDI_WARN << "Segment " << segment << " too short, skipping it.";
         continue;
       }
-      /* check whether the wav file has more than one channel
-       * if yes, specify the channel info in segments file
-       * otherwise skips the segment
-       */
+
+      // Check that the channel is specified in the segments file for a multi-
+      // channel file, and that the channel actually exists in the wave data.
       if (channel == -1) {
         if (num_chan == 1) channel = 0;
         else {
-          KALDI_ERR << "If your data has multiple channels, you must specify the"
-              " channel in the segments file.  Processing segment " << segment;
+          KALDI_ERR << ("Your data has multiple channels. You must "
+                        "specify the channel in the segments file. "
+                        "Skipping segment ") << segment;
         }
       } else {
         if (channel >= num_chan) {
           KALDI_WARN << "Invalid channel " << channel << " >= " << num_chan
-                     << ", processing segment " << segment;
+                     << ". Skipping segment " << segment;
           continue;
         }
       }
-      /*
-       * This function  return a portion of a wav data from the orignial wav data matrix
-       */
-      SubMatrix<BaseFloat> segment_matrix(wave_data, channel, 1, start_samp, end_samp-start_samp);
+
+      // Convert endpoints of the segment to sample numbers. Note that the
+      // conversion requires a proper rounding.
+      int32 start_samp = static_cast<int32>(start * samp_freq + 0.5f),
+          end_samp = static_cast<int32>(end * samp_freq + 0.5f);
+
+      // Get the range of data from the orignial wave_data matrix.
+      SubMatrix<BaseFloat> segment_matrix(wave_data, channel, 1,
+                                          start_samp, end_samp - start_samp);
       WaveData segment_wave(samp_freq, segment_matrix);
-      writer.Write(segment, segment_wave); // write segment in wave format.
+      writer.Write(segment, segment_wave);  // Write the range in wave format.
       num_success++;
     }
     KALDI_LOG << "Successfully processed " << num_success << " lines out of "
               << num_lines << " in the segments file. ";
-    /* prints number of segments processed */
     return 0;
   } catch(const std::exception &e) {
     std::cerr << e.what();
     return -1;
   }
 }
-


### PR DESCRIPTION
With a segments file constructed from exact wave file durations
some segments came out one sample short. The reason is the
multiplication of the float sample frequency and double audio
time point is inexact. For example, float 8000.0 multiplied
by double 2.03 yields 16239.99999999999, one LSB short of the
correct sample number 16240.

Also changed all endpoint calculations so that they performed
in seconds, not sample numbers, as this does not require a
conversion in nearly every comparison, and report positions in
diagnostic messages also in seconds, not sample numbers.