### PR TITLE
Add CUDA accelerated MFCC computation.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,16 +4,16 @@
 
 SHELL := /bin/bash
 
-SUBDIRS = base matrix util feat tree gmm transform \
+SUBDIRS = base matrix util feat cudafeat tree gmm transform \
           fstext hmm lm decoder lat kws cudamatrix nnet \
-          bin fstbin gmmbin fgmmbin featbin \
+          bin fstbin gmmbin fgmmbin featbin cudafeatbin \
           nnetbin latbin sgmm2 sgmm2bin nnet2 nnet3 rnnlm chain nnet3bin nnet2bin kwsbin \
           ivector ivectorbin online2 online2bin lmbin chainbin rnnlmbin \
 	  cudadecoder cudadecoderbin
 
-MEMTESTDIRS = base matrix util feat tree gmm transform \
+MEMTESTDIRS = base matrix util feat cudafeat tree gmm transform \
           fstext hmm lm decoder lat nnet kws chain \
-          bin fstbin gmmbin fgmmbin featbin \
+          bin fstbin gmmbin fgmmbin featbin cudafeatbin \
           nnetbin latbin sgmm2 nnet2 nnet3 rnnlm nnet2bin nnet3bin sgmm2bin kwsbin \
           ivector ivectorbin online2 online2bin lmbin
 
@@ -143,8 +143,8 @@ $(EXT_SUBDIRS) : checkversion kaldi.mk mklibdir ext_depend
 ### Dependency list ###
 # this is necessary for correct parallel compilation
 #1)The tools depend on all the libraries
-bin fstbin gmmbin fgmmbin sgmm2bin featbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin lmbin kwsbin online2bin rnnlmbin cudadecoderbin: \
- base matrix util feat tree gmm transform sgmm2 fstext hmm \
+bin fstbin gmmbin fgmmbin sgmm2bin featbin cudafeatbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin lmbin kwsbin online2bin rnnlmbin cudadecoderbin: \
+ base matrix util feat cudafeat tree gmm transform sgmm2 fstext hmm \
  lm decoder lat cudamatrix nnet nnet2 nnet3 ivector chain kws online2 rnnlm
 
 #2)The libraries have inter-dependencies
@@ -171,6 +171,7 @@ ivector: base util matrix transform tree gmm
 #3)Dependencies for optional parts of Kaldi
 onlinebin: base matrix util feat tree gmm transform sgmm2 fstext hmm lm decoder lat cudamatrix nnet nnet2 online
 # python-kaldi-decoding: base matrix util feat tree gmm transform sgmm2 fstext hmm decoder lat online
+cudafeat: base matrix util gmm transform tree feat cudamatrix
 online: decoder gmm transform feat matrix util base lat hmm tree
 online2: decoder gmm transform feat matrix util base lat hmm tree ivector cudamatrix nnet2 nnet3 chain
 kws: base util hmm tree matrix lat

--- a/src/cudafeat/Makefile
+++ b/src/cudafeat/Makefile
@@ -1,0 +1,29 @@
+
+
+all:
+
+include ../kaldi.mk
+
+TESTFILES = 
+
+OBJFILES =  
+
+ifeq ($(CUDA), true)
+  OBJFILES +=  feature-window-cuda.o feature-mfcc-cuda.o
+endif
+
+
+LIBNAME = kaldi-cudafeat
+
+ADDLIBS = ../feat/kaldi-feat.a ../util/kaldi-util.a ../matrix/kaldi-matrix.a \
+          ../base/kaldi-base.a ../cudamatrix/kaldi-cudamatrix.a \
+          ../gmm/kaldi-gmm.a 
+
+LDFLAGS += $(CUDA_LDFLAGS)
+LDLIBS += $(CUDA_LDLIBS)
+
+
+%.o : %.cu
+	$(CUDATKDIR)/bin/nvcc -c -g $< -o $@ $(CUDA_INCLUDE) $(CUDA_FLAGS) $(CUDA_ARCH) -I../ -I$(OPENFSTINC)
+
+include ../makefiles/default_rules.mk

--- a/src/cudafeat/feature-mfcc-cuda.cu
+++ b/src/cudafeat/feature-mfcc-cuda.cu
@@ -1,0 +1,541 @@
+// cudafeature/feature-mfcc-cuda.cu
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <nvToolsExt.h>
+#include <cub/cub.cuh>
+
+#include "cudafeat/feature-mfcc-cuda.h"
+#include "cudamatrix/cu-rand.h"
+
+// Each thread block processes a unique frame
+// threads in the same threadblock collaborate to
+// compute the frame together.
+__global__ void apply_lifter_and_floor_energy(
+    int num_frames, int num_cols, float cepstral_lifter, bool use_energy,
+    float energy_floor, float *log_energy, float *lifter_coeffs,
+    float *features, int32_t ldf) {
+  int thread_id = threadIdx.x;
+  int frame = blockIdx.x;
+
+  float *feats = features + frame * ldf;
+
+  // apply lifter coefficients
+  if (cepstral_lifter != 0.0f) {
+    for (int c = thread_id; c < num_cols; c += CU1DBLOCK) {
+      float lift = lifter_coeffs[c];
+      float f = feats[c];
+      feats[c] = f * lift;
+    }
+  }
+
+  // Thread 0 for each frame will apply energy
+  if (use_energy && thread_id == 0) {
+    float energy = log_energy[frame];
+    float log_energy_floor = log(energy_floor);
+
+    if (energy_floor > 0.0f && energy < log_energy_floor) {
+      energy = log_energy_floor;
+    }
+    feats[0] = energy;
+  }
+}
+
+// Each threadblock computes a different row of the matrix.
+// Threads in the same block compute the row collaboratively.
+// This kernel must be called out of place (A_in!=A_out).
+__global__ void power_spectrum_kernel(int row_length, float *A_in, int32_t ldi,
+                                      float *A_out, int32_t ldo) {
+  int thread_id = threadIdx.x;
+  int block_id = blockIdx.x;
+  float *Ar = A_in + block_id * ldi;
+  float *Aw = A_out + block_id * ldo;
+
+  int half_length = row_length / 2;
+  for (int idx = thread_id; idx < half_length; idx += CU1DBLOCK) {
+    // ignore special case
+    if (idx == 0) continue;
+
+    float2 val = reinterpret_cast<float2 *>(Ar)[idx];
+    float ret = val.x * val.x + val.y * val.y;
+    Aw[idx] = ret;
+  }
+
+  // handle special case
+  if (threadIdx.x == 0) {
+    float real = Ar[0];
+    // cufft puts this at the end, this is different than kaldi does with its
+    // own
+    // internal implementation
+    float im = Ar[row_length];
+
+    Aw[0] = real * real;
+    Aw[half_length] = im * im;
+  }
+}
+
+// Expects to be called with 32x8 sized thread block.
+__global__ void mel_banks_compute_kernel(int32_t num_frames, float energy_floor,
+                                         int32 *offsets, int32 *sizes,
+                                         float **vecs, const float *feats,
+                                         int32_t ldf, float *mels,
+                                         int32_t ldm) {
+  // Specialize WarpReduce for type float
+  typedef cub::WarpReduce<float> WarpReduce;
+  // Allocate WarpReduce shared memory for 8 warps
+  __shared__ typename WarpReduce::TempStorage temp_storage[8];
+
+  // warp will work together to compute sum
+  int tid = threadIdx.x;
+  int wid = threadIdx.y;
+  // blocks in the x dimension take different bins
+  int bin = blockIdx.x;
+  // frame is a combination of blocks in the y dimension and threads in the y
+  // dimension
+  int frame = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if (frame >= num_frames) return;
+
+  int offset = offsets[bin];
+  int size = sizes[bin];
+  const float *v = vecs[bin];
+  const float *w = feats + frame * ldf + offset;
+
+  // perfom local sum
+  float sum = 0;
+  for (int idx = tid; idx < size; idx += 32) {
+    sum += v[idx] * w[idx];
+  }
+
+  // Sum in cub
+  sum = WarpReduce(temp_storage[wid]).Sum(sum);
+  if (tid == 0) {
+    // avoid log of zero
+    if (sum < energy_floor) sum = energy_floor;
+    float val = logf(sum);
+    mels[frame * ldm + bin] = val;
+  }
+}
+
+__global__ void process_window_kernel(
+    int frame_length, float dither, float energy_floor, bool remove_dc_offset,
+    float preemph_coeff, bool need_raw_log_energy, float *log_energy_pre_window,
+    const float *windowing, float *tmp_windows, int32_t ldt, float *windows,
+    int32_t ldw) {
+  // Specialize WarpReduce for type float
+  typedef cub::BlockReduce<float, CU1DBLOCK> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  int thread_id = threadIdx.x;
+  int row = blockIdx.x;
+  float *tmp_window = tmp_windows + row * ldt;
+  float *window = windows + row * ldw;
+
+  __shared__ float ssum;
+
+  float sum = 0;
+  float wdot = 0;
+
+  for (int idx = thread_id; idx < frame_length; idx += CU1DBLOCK) {
+    // tmp_window contains optional dither.  Apply that on read.
+    float wval = window[idx];
+    if (dither != 0.0f) {
+      wval += tmp_window[idx] * dither;
+    }
+    // compute local sum for removing dc offset
+    sum += wval;
+    // compute dot product for log energy
+    wdot += wval * wval;
+
+    float windowing_mul = 1;
+    if (remove_dc_offset == false && preemph_coeff == 0.0f) {
+      // we are done here so set windowing multiplication on write.
+      windowing_mul = windowing[idx];
+    }
+
+    // write dithered output
+    window[idx] = wval * windowing_mul;
+  }
+  __syncthreads();
+  if (remove_dc_offset) {
+    // we will recompute this below
+    wdot = 0.0f;
+    // use cub to reduce
+    sum = BlockReduce(temp_storage).Sum(sum);
+
+    // broadcast sum to entire block
+    if (thread_id == 0) ssum = sum;
+    __syncthreads();
+
+    sum = -ssum / frame_length;
+    for (int idx = thread_id; idx < frame_length; idx += CU1DBLOCK) {
+      float windowing_mul = 1;
+      float *out = window;
+      if (preemph_coeff == 0.0f) {
+        // we are done here so apply windowing
+        windowing_mul = windowing[idx];
+      } else {
+        // write to temp window as we will copy back into window
+        // when doing pre-emphasis
+        out = tmp_window;
+      }
+      // updated window value
+      float wval = window[idx] + sum;
+
+      // compute new dot product with dc offset removed
+      wdot += wval * wval;
+
+      assert(windowing_mul == 1);
+      // write output
+      out[idx] = wval * windowing_mul;
+    }
+  }
+  __syncthreads();
+
+  // if pointer is not NULL we will set energy to either
+  // the computed energy or 0 depending on need_raw_log_energy
+  if (log_energy_pre_window != NULL) {
+    float energy = 0.0f;
+
+    if (need_raw_log_energy) {
+      // must sync to use retemp_storage
+      if (remove_dc_offset) __syncthreads();
+      // use cub to reduce
+      wdot = BlockReduce(temp_storage).Sum(wdot);
+
+      energy = max(wdot, energy_floor);
+    }
+
+    if (thread_id == 0) {
+      log_energy_pre_window[row] = log(energy);
+    }
+  }
+
+  // TODO this could be more efficient using shared memory instead of
+  // tmp_window.
+  if (preemph_coeff != 0.0f) {
+    // wait for tmp_window to be computed
+    __threadfence();
+    __syncthreads();
+    // starting thread idx at 0 to keep writes aligned.
+    // unaligned reads are less painful then unaligned writes
+    for (int idx = thread_id; idx < frame_length; idx += CU1DBLOCK) {
+      float wval = tmp_window[idx];
+      float prev_window = wval;
+      if (idx > 0) {
+        prev_window = tmp_window[idx - 1];
+      }
+      // use __fmul_rn to match CPU
+      // window[idx] = (wval - preemph_coeff*prev_window) * windowing[idx];
+      window[idx] =
+          (wval - __fmul_rn(preemph_coeff, prev_window)) * windowing[idx];
+    }
+  }
+}
+
+__device__ inline int32 FirstSampleOfFrame(int32 frame, int32 frame_shift,
+                                           int32 window_size, bool snip_edges) {
+  if (snip_edges) {
+    return frame * frame_shift;
+  } else {
+    int32 midpoint_of_frame = frame_shift * frame + frame_shift / 2,
+          beginning_of_frame = midpoint_of_frame - window_size / 2;
+    return beginning_of_frame;
+  }
+}
+
+__global__ void extract_window_kernel(
+    int32 frame_shift, int32 frame_length, int32 frame_length_padded,
+    int32 window_size, bool snip_edges, int32_t sample_offset,
+    const BaseFloat __restrict__ *wave, int32 wave_dim,
+    BaseFloat *__restrict__ windows, int32_t wlda) {
+  int frame = blockIdx.x;
+  int tidx = threadIdx.x;
+
+  int32 start_sample =
+      FirstSampleOfFrame(frame, frame_shift, window_size, snip_edges);
+
+  // wave_start and wave_end are start and end indexes into 'wave', for the
+  // piece of wave that we're trying to extract.
+  int32 wave_start = int32(start_sample - sample_offset),
+        wave_end = wave_start + frame_length;
+
+  BaseFloat *window = windows + frame * wlda;
+  if (wave_start >= 0 && wave_end <= wave_dim) {
+    // the normal case-- no edge effects to consider.
+    for (int i = tidx; i < frame_length; i += blockDim.x) {
+      window[i] = wave[wave_start + i];
+    }
+  } else {
+    // Deal with any end effects by reflection, if needed.  This code will only
+    // be reached for about two frames per utterance, so we don't concern
+    // ourselves excessively with efficiency.
+    for (int s = tidx; s < frame_length; s += blockDim.x) {
+      int32 s_in_wave = s + wave_start;
+      while (s_in_wave < 0 || s_in_wave >= wave_dim) {
+        // reflect around the beginning or end of the wave.
+        // e.g. -1 -> 0, -2 -> 1.
+        // dim -> dim - 1, dim + 1 -> dim - 2.
+        // the code supports repeated reflections, although this
+        // would only be needed in pathological cases.
+        if (s_in_wave < 0)
+          s_in_wave = -s_in_wave - 1;
+        else
+          s_in_wave = 2 * wave_dim - 1 - s_in_wave;
+      }
+      window[s] = wave[s_in_wave];
+    }
+  }
+
+  if (frame_length_padded > frame_length) {
+    for (int i = frame_length + tidx; i < frame_length_padded;
+         i += blockDim.x) {
+      window[i] = 0.0f;
+    }
+  }
+}
+
+// For each frame
+//   compute logf(dot(signal_frame, signal_frame))
+__global__ void dot_log_kernel(int32_t num_frames, int32_t frame_length,
+                               float *signal_frame, int32_t lds,
+                               float *signal_log_energy) {
+  // Specialize WarpReduce for type float
+  typedef cub::BlockReduce<float, CU1DBLOCK> BlockReduce;
+  // Allocate WarpReduce shared memory for 8 warps
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  int32_t frame = blockIdx.x;
+  int32_t tid = threadIdx.x;
+
+  float *in = signal_frame + frame * lds;
+  float sum = 0;
+
+  // preform local dot product
+  for (int32_t i = tid; i < frame_length; i += blockDim.x) {
+    float val = in[i];
+    sum += val * val;
+  }
+
+  // reduce using cub
+  sum = BlockReduce(temp_storage).Sum(sum);
+
+  if (threadIdx.x == 0) {
+    signal_log_energy[frame] = logf(sum);
+  }
+}
+
+namespace kaldi {
+
+CudaMfcc::CudaMfcc(const MfccOptions &opts)
+    : MfccComputer(opts),
+      cu_lifter_coeffs_(lifter_coeffs_),
+      cu_dct_matrix_(dct_matrix_),
+      window_function_(opts.frame_opts) {
+  const MelBanks *mel_banks = GetMelBanks(1.0);
+  const std::vector<std::pair<int32, Vector<BaseFloat>>> &bins =
+      mel_banks->GetBins();
+  int size = bins.size();
+  bin_size_ = size;
+  std::vector<int32> offsets(size), sizes(size);
+  std::vector<float *> vecs(size);
+  cu_vecs_ = new CuVector<float>[size];
+  for (int i = 0; i < bins.size(); i++) {
+    cu_vecs_[i].Resize(bins[i].second.Dim(), kUndefined);
+    cu_vecs_[i].CopyFromVec(bins[i].second);
+    vecs[i] = cu_vecs_[i].Data();
+    sizes[i] = cu_vecs_[i].Dim();
+    offsets[i] = bins[i].first;
+  }
+  offsets_ = static_cast<int32 *>(
+      CuDevice::Instantiate().Malloc(size * sizeof(int32)));
+  sizes_ = static_cast<int32 *>(
+      CuDevice::Instantiate().Malloc(size * sizeof(int32)));
+  vecs_ = static_cast<float **>(
+      CuDevice::Instantiate().Malloc(size * sizeof(float *)));
+
+  CU_SAFE_CALL(cudaMemcpyAsync(vecs_, &vecs[0], size * sizeof(float *),
+                               cudaMemcpyHostToDevice, cudaStreamPerThread));
+  CU_SAFE_CALL(cudaMemcpyAsync(offsets_, &offsets[0], size * sizeof(int32),
+                               cudaMemcpyHostToDevice, cudaStreamPerThread));
+  CU_SAFE_CALL(cudaMemcpyAsync(sizes_, &sizes[0], size * sizeof(int32),
+                               cudaMemcpyHostToDevice, cudaStreamPerThread));
+  CU_SAFE_CALL(cudaStreamSynchronize(cudaStreamPerThread));
+
+  frame_length_ = opts.frame_opts.WindowSize();
+  padded_length_ = opts.frame_opts.PaddedWindowSize();
+  fft_length_ = padded_length_ / 2;  // + 1;
+  fft_size_ = 800;
+
+  // place holders to get strides for cufft.  these will be resized correctly
+  // later.  The +2 for cufft/fftw requirements of an extra element at the end.
+  // turning off stride because cufft seems buggy with a stride
+  cu_windows_.Resize(fft_size_, padded_length_, kUndefined,
+                     kStrideEqualNumCols);
+  tmp_window_.Resize(fft_size_, padded_length_ + 2, kUndefined,
+                     kStrideEqualNumCols);
+
+  stride_ = cu_windows_.Stride();
+  tmp_stride_ = tmp_window_.Stride();
+
+  cufftPlanMany(&plan_, 1, &padded_length_, NULL, 1, stride_, NULL, 1,
+                tmp_stride_ / 2, CUFFT_R2C, fft_size_);
+  cufftSetStream(plan_, cudaStreamPerThread);
+}
+
+// ExtractWindow extracts a windowed frame of waveform with a power-of-two,
+// padded size.  It does mean subtraction, pre-emphasis and dithering as
+// requested.
+void CudaMfcc::ExtractWindows(int32_t num_frames, int64 sample_offset,
+                              const CuVectorBase<BaseFloat> &wave,
+                              const FrameExtractionOptions &opts) {
+  KALDI_ASSERT(sample_offset >= 0 && wave.Dim() != 0);
+  int32 frame_length = opts.WindowSize(),
+        frame_length_padded = opts.PaddedWindowSize();
+  int64 num_samples = sample_offset + wave.Dim();
+
+  extract_window_kernel<<<num_frames, CU1DBLOCK>>>(
+      opts.WindowShift(), frame_length, frame_length_padded, opts.WindowSize(),
+      opts.snip_edges, sample_offset, wave.Data(), wave.Dim(),
+      cu_windows_.Data(), cu_windows_.Stride());
+  CU_SAFE_CALL(cudaGetLastError());
+}
+
+void CudaMfcc::ProcessWindows(int num_frames,
+                              const FrameExtractionOptions &opts,
+                              CuVectorBase<BaseFloat> *log_energy_pre_window) {
+  if (num_frames == 0) return;
+
+  int fft_num_frames = cu_windows_.NumRows();
+  KALDI_ASSERT(fft_num_frames % fft_size_ == 0);
+
+  process_window_kernel<<<num_frames, CU1DBLOCK>>>(
+      frame_length_, opts.dither, std::numeric_limits<float>::epsilon(),
+      opts.remove_dc_offset, opts.preemph_coeff, NeedRawLogEnergy(),
+      log_energy_pre_window->Data(), window_function_.cu_window.Data(),
+      tmp_window_.Data(), tmp_window_.Stride(), cu_windows_.Data(),
+      cu_windows_.Stride());
+
+  CU_SAFE_CALL(cudaGetLastError());
+}
+
+void CudaMfcc::ComputeFinalFeatures(int num_frames, BaseFloat vtln_wrap,
+                                    CuVector<BaseFloat> *cu_signal_log_energy,
+                                    CuMatrix<BaseFloat> *cu_features) {
+  Vector<float> tmp;
+  assert(opts_.htk_compat == false);
+
+  if (num_frames == 0) return;
+
+  if (opts_.use_energy && !opts_.raw_energy) {
+    dot_log_kernel<<<num_frames, CU1DBLOCK>>>(
+        num_frames, cu_windows_.NumCols(), cu_windows_.Data(),
+        cu_windows_.Stride(), cu_signal_log_energy->Data());
+    CU_SAFE_CALL(cudaGetLastError());
+  }
+
+  // make sure a reallocation hasn't changed these
+  KALDI_ASSERT(cu_windows_.Stride() == stride_);
+  KALDI_ASSERT(tmp_window_.Stride() == tmp_stride_);
+
+  // Perform FFTs in batches of fft_size.  This reduces memory requirements
+  for (int idx = 0; idx < num_frames; idx += fft_size_) {
+    CUFFT_SAFE_CALL(cufftExecR2C(
+        plan_, cu_windows_.Data() + cu_windows_.Stride() * idx,
+        (cufftComplex *)(tmp_window_.Data() + tmp_window_.Stride() * idx)));
+  }
+
+  // Compute Power spectrum
+  CuMatrix<BaseFloat> power_spectrum(tmp_window_.NumRows(),
+                                     padded_length_ / 2 + 1, kUndefined);
+
+  power_spectrum_kernel<<<num_frames, CU1DBLOCK>>>(
+      padded_length_, tmp_window_.Data(), tmp_window_.Stride(),
+      power_spectrum.Data(), power_spectrum.Stride());
+  CU_SAFE_CALL(cudaGetLastError());
+
+  // mel banks
+  int num_bins = bin_size_;
+  cu_mel_energies_.Resize(num_frames, num_bins, kUndefined);
+  dim3 mel_threads(32, 8);
+  dim3 mel_blocks(num_bins, (num_frames + mel_threads.y - 1) / mel_threads.y);
+  mel_banks_compute_kernel<<<mel_blocks, mel_threads>>>(
+      num_frames, std::numeric_limits<float>::epsilon(), offsets_, sizes_,
+      vecs_, power_spectrum.Data(), power_spectrum.Stride(),
+      cu_mel_energies_.Data(), cu_mel_energies_.Stride());
+  CU_SAFE_CALL(cudaGetLastError());
+
+  // dct transform
+  cu_features->AddMatMat(1.0, cu_mel_energies_, kNoTrans, cu_dct_matrix_,
+                         kTrans, 0.0);
+
+  apply_lifter_and_floor_energy<<<num_frames, CU1DBLOCK>>>(
+      cu_features->NumRows(), cu_features->NumCols(), opts_.cepstral_lifter,
+      opts_.use_energy, opts_.energy_floor, cu_signal_log_energy->Data(),
+      cu_lifter_coeffs_.Data(), cu_features->Data(), cu_features->Stride());
+  CU_SAFE_CALL(cudaGetLastError());
+}
+
+void CudaMfcc::ComputeFeatures(const CuVectorBase<BaseFloat> &cu_wave,
+                               BaseFloat sample_freq, BaseFloat vtln_warp,
+                               CuMatrix<BaseFloat> *cu_features) {
+  nvtxRangePushA("CudaMfcc::ComputeFeatures");
+  const FrameExtractionOptions &frame_opts = GetFrameOptions();
+  int num_frames = NumFrames(cu_wave.Dim(), frame_opts, true);
+  // compute fft frames by rounding up to a multiple of fft_size_
+  int fft_num_frames = num_frames + (fft_size_ - num_frames % fft_size_);
+  int feature_dim = Dim();
+  bool use_raw_log_energy = NeedRawLogEnergy();
+
+  CuVector<BaseFloat> raw_log_energies;
+  raw_log_energies.Resize(num_frames, kUndefined);
+
+  cu_windows_.Resize(fft_num_frames, padded_length_, kUndefined,
+                     kStrideEqualNumCols);
+  cu_features->Resize(num_frames, feature_dim, kUndefined);
+  //+1 matches cufft/fftw requirements
+  tmp_window_.Resize(fft_num_frames, padded_length_ + 2, kUndefined,
+                     kStrideEqualNumCols);
+
+  if (frame_opts.dither != 0.0f) {
+    // Calling cu-rand directly
+    // CuRand class works on CuMatrixBase which must
+    // assume that the matrix is part of a larger matrix
+    // Doing this directly avoids unecessary memory copies
+    CURAND_SAFE_CALL(
+        curandGenerateNormal(GetCurandHandle(), tmp_window_.Data(),
+                             tmp_window_.NumRows() * tmp_window_.Stride(),
+                             0.0 /*mean*/, 1.0 /*stddev*/));
+  }
+
+  // Extract Windows
+  ExtractWindows(num_frames, 0, cu_wave, frame_opts);
+
+  // Process Windows
+  ProcessWindows(num_frames, frame_opts, &raw_log_energies);
+
+  // Compute Features
+  ComputeFinalFeatures(num_frames, 1.0, &raw_log_energies, cu_features);
+
+  nvtxRangePop();
+}
+CudaMfcc::~CudaMfcc() {
+  delete[] cu_vecs_;
+  CuDevice::Instantiate().Free(vecs_);
+  CuDevice::Instantiate().Free(offsets_);
+  CuDevice::Instantiate().Free(sizes_);
+  cufftDestroy(plan_);
+}
+}  // namespace kaldi

--- a/src/cudafeat/feature-mfcc-cuda.h
+++ b/src/cudafeat/feature-mfcc-cuda.h
@@ -1,0 +1,71 @@
+// cudafeat/feature-mfcc-cuda.h
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_CUDAFEAT_FEATURE_MFCC_CUDA_H_
+#define KALDI_CUDAFEAT_FEATURE_MFCC_CUDA_H_
+
+#include <cufft.h>
+#include "cudafeat/feature-window-cuda.h"
+#include "cudamatrix/cu-matrix.h"
+#include "cudamatrix/cu-vector.h"
+#include "feat/feature-mfcc.h"
+
+namespace kaldi {
+// This class implements MFCC computation in CUDA.
+// It takes input from device memory and outputs to
+// device memory.  It also does no synchronization.
+class CudaMfcc : public MfccComputer {
+ public:
+  void ComputeFeatures(const CuVectorBase<BaseFloat> &cu_wave,
+                       BaseFloat sample_freq, BaseFloat vtln_warp,
+                       CuMatrix<BaseFloat> *cu_features);
+
+  CudaMfcc(const MfccOptions &opts);
+  ~CudaMfcc();
+
+ private:
+  void ExtractWindows(int32 num_frames, int64 sample_offset,
+                      const CuVectorBase<BaseFloat> &wave,
+                      const FrameExtractionOptions &opts);
+
+  void ProcessWindows(int num_frames, const FrameExtractionOptions &opts,
+                      CuVectorBase<BaseFloat> *log_energy_pre_window);
+
+  void ComputeFinalFeatures(int num_frames, BaseFloat vtln_wrap,
+                            CuVector<BaseFloat> *cu_signal_log_energy,
+                            CuMatrix<BaseFloat> *cu_features);
+
+  CuMatrix<BaseFloat> cu_windows_;
+  CuMatrix<float> tmp_window_, cu_mel_energies_;
+  CuMatrix<float> cu_dct_matrix_;
+  CuVector<float> cu_lifter_coeffs_;
+
+  int frame_length_, padded_length_, fft_length_, fft_size_;
+  cufftHandle plan_;
+  CudaFeatureWindowFunction window_function_;
+
+  int bin_size_;
+  int32 *offsets_, *sizes_;
+  CuVector<float> *cu_vecs_;
+  float **vecs_;
+
+  // for sanity checking cufft
+  int32_t stride_, tmp_stride_;
+};
+}
+
+#endif

--- a/src/cudafeat/feature-window-cuda.cu
+++ b/src/cudafeat/feature-window-cuda.cu
@@ -1,0 +1,37 @@
+// cudafeat/feature-window-cuda.cu
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nvToolsExt.h>
+#include "cudafeat/feature-window-cuda.h"
+#include "matrix/matrix-functions.h"
+
+namespace kaldi {
+
+CudaFeatureWindowFunction::CudaFeatureWindowFunction(
+    const FrameExtractionOptions &opts) {
+  nvtxRangePushA("CudaFeatureWindowFunction::CudaFeatureWindowFunction");
+  int32 frame_length = opts.WindowSize();
+
+  // Create CPU feature window
+  FeatureWindowFunction feature_window(opts);
+
+  // Copy into GPU memory
+  cu_window.Resize(frame_length, kUndefined);
+  cu_window.CopyFromVec(feature_window.window);
+  nvtxRangePop();
+}
+}  // namespace kaldi

--- a/src/cudafeat/feature-window-cuda.h
+++ b/src/cudafeat/feature-window-cuda.h
@@ -1,0 +1,38 @@
+// cudafeat/feature-window-cuda.h
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_CUDAFEAT_FEATURE_WINDOW_CUDA_H_
+#define KALDI_CUDAFEAT_FEATURE_WINDOW_CUDA_H_
+
+#include "cudamatrix/cu-matrix.h"
+#include "cudamatrix/cu-vector.h"
+#include "feat/feature-window.h"
+
+namespace kaldi {
+
+// This struct stores a feature window on the device.
+// Behind the scense it just computes a feature window on
+// the host and then copies it into device memory.
+struct CudaFeatureWindowFunction {
+  CudaFeatureWindowFunction() {}
+  explicit CudaFeatureWindowFunction(const FrameExtractionOptions &opts);
+  CuVector<float> cu_window;
+};
+
+}  // namespace kaldi
+
+#endif  // KALDI_CUDAFEAT_FEATURE_WINDOW_CUDA_H_

--- a/src/cudafeatbin/Makefile
+++ b/src/cudafeatbin/Makefile
@@ -6,7 +6,11 @@ include ../kaldi.mk
 LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
 
-BINFILES = compute-mfcc-feats-cuda
+BINFILES = 
+
+ifeq ($(CUDA), true)
+  BINFILES += compute-mfcc-feats-cuda
+endif
 
 OBJFILES =
 

--- a/src/cudafeatbin/Makefile
+++ b/src/cudafeatbin/Makefile
@@ -1,0 +1,21 @@
+
+all:
+EXTRA_CXXFLAGS = -Wno-sign-compare
+include ../kaldi.mk
+
+LDFLAGS += $(CUDA_LDFLAGS)
+LDLIBS += $(CUDA_LDLIBS)
+
+BINFILES = compute-mfcc-feats-cuda
+
+OBJFILES =
+
+TESTFILES =
+
+ADDLIBS = ../cudafeat/kaldi-cudafeat.a ../cudamatrix/kaldi-cudamatrix.a \
+					../hmm/kaldi-hmm.a ../feat/kaldi-feat.a \
+          ../transform/kaldi-transform.a ../gmm/kaldi-gmm.a \
+          ../tree/kaldi-tree.a ../util/kaldi-util.a ../matrix/kaldi-matrix.a \
+          ../base/kaldi-base.a 
+
+include ../makefiles/default_rules.mk

--- a/src/cudafeatbin/compute-mfcc-feats-cuda.cc
+++ b/src/cudafeatbin/compute-mfcc-feats-cuda.cc
@@ -1,0 +1,192 @@
+// cudafeatbin/compute-mfcc-feats-cuda.cc
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "cudafeat/feature-mfcc-cuda.h"
+#include "feat/wave-reader.h"
+#include "cudamatrix/cu-matrix.h"
+#include "cudamatrix/cu-vector.h"
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    const char *usage =
+        "Create MFCC feature files.\n"
+        "Usage:  compute-mfcc-feats [options...] <wav-rspecifier> <feats-wspecifier>\n";
+
+    // construct all the global objects
+    ParseOptions po(usage);
+    MfccOptions mfcc_opts;
+    bool subtract_mean = false;
+    BaseFloat vtln_warp = 1.0;
+    std::string vtln_map_rspecifier;
+    std::string utt2spk_rspecifier;
+    int32 channel = -1;
+    BaseFloat min_duration = 0.0;
+    // Define defaults for gobal options
+    std::string output_format = "kaldi";
+
+    // Register the MFCC option struct
+    mfcc_opts.Register(&po);
+
+    // Register the options
+    po.Register("output-format", &output_format, "Format of the output "
+                "files [kaldi, htk]");
+    po.Register("subtract-mean", &subtract_mean, "Subtract mean of each "
+                "feature file [CMS]; not recommended to do it this way. ");
+    po.Register("vtln-warp", &vtln_warp, "Vtln warp factor (only applicable "
+                "if vtln-map not specified)");
+    po.Register("vtln-map", &vtln_map_rspecifier, "Map from utterance or "
+                "speaker-id to vtln warp factor (rspecifier)");
+    po.Register("utt2spk", &utt2spk_rspecifier, "Utterance to speaker-id map "
+                "rspecifier (if doing VTLN and you have warps per speaker)");
+    po.Register("channel", &channel, "Channel to extract (-1 -> expect mono, "
+                "0 -> left, 1 -> right)");
+    po.Register("min-duration", &min_duration, "Minimum duration of segments "
+                "to process (in seconds).");
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 2) {
+      po.PrintUsage();
+      exit(1);
+    }
+    
+    g_cuda_allocator.SetOptions(g_allocator_options);
+    CuDevice::Instantiate().SelectGpuId("yes");
+    CuDevice::Instantiate().AllowMultithreading();
+
+
+    std::string wav_rspecifier = po.GetArg(1);
+
+    std::string output_wspecifier = po.GetArg(2);
+
+    CudaMfcc mfcc(mfcc_opts);
+
+    SequentialTableReader<WaveHolder> reader(wav_rspecifier);
+    BaseFloatMatrixWriter kaldi_writer;  // typedef to TableWriter<something>.
+    TableWriter<HtkMatrixHolder> htk_writer;
+
+    if (utt2spk_rspecifier != "")
+      KALDI_ASSERT(vtln_map_rspecifier != "" && "the utt2spk option is only "
+                   "needed if the vtln-map option is used.");
+    RandomAccessBaseFloatReaderMapped vtln_map_reader(vtln_map_rspecifier,
+                                                      utt2spk_rspecifier);
+    
+    if (output_format == "kaldi") {
+      if (!kaldi_writer.Open(output_wspecifier))
+        KALDI_ERR << "Could not initialize output with wspecifier "
+                  << output_wspecifier;
+    } else if (output_format == "htk") {
+      if (!htk_writer.Open(output_wspecifier))
+        KALDI_ERR << "Could not initialize output with wspecifier "
+                  << output_wspecifier;
+    } else {
+      KALDI_ERR << "Invalid output_format string " << output_format;
+    }
+
+    int32 num_utts = 0, num_success = 0;
+    for (; !reader.Done(); reader.Next()) {
+      num_utts++;
+      std::string utt = reader.Key();
+      const WaveData &wave_data = reader.Value();
+      if (wave_data.Duration() < min_duration) {
+        KALDI_WARN << "File: " << utt << " is too short ("
+                   << wave_data.Duration() << " sec): producing no output.";
+        continue;
+      }
+      int32 num_chan = wave_data.Data().NumRows(), this_chan = channel;
+      {  // This block works out the channel (0=left, 1=right...)
+        KALDI_ASSERT(num_chan > 0);  // should have been caught in
+        // reading code if no channels.
+        if (channel == -1) {
+          this_chan = 0;
+          if (num_chan != 1)
+            KALDI_WARN << "Channel not specified but you have data with "
+                       << num_chan  << " channels; defaulting to zero";
+        } else {
+          if (this_chan >= num_chan) {
+            KALDI_WARN << "File with id " << utt << " has "
+                       << num_chan << " channels but you specified channel "
+                       << channel << ", producing no output.";
+            continue;
+          }
+        }
+      }
+      BaseFloat vtln_warp_local;  // Work out VTLN warp factor.
+      if (vtln_map_rspecifier != "") {
+        if (!vtln_map_reader.HasKey(utt)) {
+          KALDI_WARN << "No vtln-map entry for utterance-id (or speaker-id) "
+                     << utt;
+          continue;
+        }
+        vtln_warp_local = vtln_map_reader.Value(utt);
+      } else {
+        vtln_warp_local = vtln_warp;
+      }
+
+      SubVector<BaseFloat> waveform(wave_data.Data(), this_chan);
+      Matrix<BaseFloat> features;
+      try {
+        CuVector<BaseFloat> cu_waveform(waveform);
+        CuMatrix<BaseFloat> cu_features;
+        mfcc.ComputeFeatures(cu_waveform, wave_data.SampFreq(), vtln_warp_local, &cu_features);
+        features.Resize(cu_features.NumRows(), cu_features.NumCols());
+        features.CopyFromMat(cu_features);
+      } catch (...) {
+        KALDI_WARN << "Failed to compute features for utterance "
+                   << utt;
+        continue;
+      }
+      if (subtract_mean) {
+        Vector<BaseFloat> mean(features.NumCols());
+        mean.AddRowSumMat(1.0, features);
+        mean.Scale(1.0 / features.NumRows());
+        for (int32 i = 0; i < features.NumRows(); i++)
+          features.Row(i).AddVec(-1.0, mean);
+      }
+      if (output_format == "kaldi") {
+        kaldi_writer.Write(utt, features);
+      } else {
+        std::pair<Matrix<BaseFloat>, HtkHeader> p;
+        p.first.Resize(features.NumRows(), features.NumCols());
+        p.first.CopyFromMat(features);
+        HtkHeader header = {
+          features.NumRows(),
+          100000,  // 10ms shift
+          static_cast<int16>(sizeof(float)*(features.NumCols())),
+          static_cast<uint16>( 006 | // MFCC
+          (mfcc_opts.use_energy ? 0100 : 020000)) // energy; otherwise c0
+        };
+        p.second = header;
+        htk_writer.Write(utt, p);
+      }
+      if (num_utts % 10 == 0)
+        KALDI_LOG << "Processed " << num_utts << " utterances";
+      KALDI_VLOG(2) << "Processed features for key " << utt;
+      num_success++;
+    }
+    KALDI_LOG << " Done " << num_success << " out of " << num_utts
+              << " utterances.";
+    return (num_success != 0 ? 0 : 1);
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}
+

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -43,6 +43,14 @@
   } \
 }
 
+#define CUFFT_SAFE_CALL(fun) \
+{ \
+  int32 ret; \
+  if ((ret = (fun)) != CUFFT_SUCCESS) { \
+    KALDI_ERR << "cublasResult " << ret << " returned from '" << #fun << "'"; \
+  } \
+}
+
 #define CUBLAS_SAFE_CALL(fun) \
 { \
   int32 ret; \

--- a/src/feat/feature-mfcc.h
+++ b/src/feat/feature-mfcc.h
@@ -129,6 +129,7 @@ class MfccComputer {
   // disallow assignment.
   MfccComputer &operator = (const MfccComputer &in);
 
+ protected:
   const MelBanks *GetMelBanks(BaseFloat vtln_warp);
 
   MfccOptions opts_;

--- a/src/feat/mel-computations.h
+++ b/src/feat/mel-computations.h
@@ -116,6 +116,10 @@ class MelBanks {
   // returns vector of central freq of each bin; needed by plp code.
   const Vector<BaseFloat> &GetCenterFreqs() const { return center_freqs_; }
 
+  const std::vector<std::pair<int32, Vector<BaseFloat> > >& GetBins() const {
+    return bins_;
+  }
+
   // Copy constructor
   MelBanks(const MelBanks &other);
  private:

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -14,4 +14,4 @@ CUDA_FLAGS = --machine 64 -DHAVE_CUDA \
              --verbose -Xcompiler "$(CXXFLAGS)"
 
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-CUDA_LDLIBS += -lcublas -lcusparse -lcudart -lcurand -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcublas -lcusparse -lcudart -lcurand -lcufft -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule


### PR DESCRIPTION
Creates a new directory 'cudafeat' for placing cuda feature extraction
components as they are developed.  Added a directory 'cudafeatbin' for
placing binaries that are cuda accelerated that mirror binaries
elsewhere.

This commit implements:
  feature-window-cuda.h/cu which implements a feature window on the device
    by copying it from a host feature window.
  feature-mfcc-cuda.h/cu which implements the cuda mfcc feature
    extractor.
  compute-mfcc-feats-cuda.cc which mirriors compute-mfcc-feats.cc

  There were also minor changes to other files.