### PR TITLE
Optimizations for batch nnet3.  The issue fixed here is that

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -796,9 +796,9 @@ void cuda_uncompress_uint8(dim3 Gr, dim3 Bl, BaseFloat *dest,
                           MatrixDim dim, const uint8_t *src,
                           int src_stride, float scale);
 
-//copies the sub matrix in src[range_start, range_end] to the matrix in dst
-//if src row is outside of the clamped range it will clamp to the specified
-//rows. src and dst cannot overlap.
+// copies the sub matrix in src[range_start, range_end] to the matrix in dst
+// if src row is outside of the clamped range it will clamp to the specified
+// rows. src and dst cannot overlap.
 void cudaF_mat_copy_range_clamped(
    int32_t row_start, int32_t row_end, int32_t num_cols,
    const float *src, int32_t lds, 
@@ -809,6 +809,16 @@ void cudaD_mat_copy_range_clamped(
    const double *src, int32_t lds, 
    int32_t clamp_low, int32_t clamp_high,
    double *dst, int32_t ldd);
+
+// for i=[0,num_mats) perform the matrix copy outputs[i] = inputs[i] where
+// the matrices are of size num_rows[i] x num_cols[i] and have a leading
+// dimension of ldo[i] for the output and ldi[i] for the input.
+void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *ldo);
+void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *ldo);
 
 // Launches a kernel that does nothing, explicitly using the legacy default stream;
 // this will synchronize all CUDA streams (except for non-blocking streams) on the

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -3675,6 +3675,49 @@ void _cuda_mat_copy_range_clamped(
   }
 }
 
+template <typename Real> 
+struct MatrixCopyDesc {
+  Real *input, *output;
+  int32_t ldi, ldo;
+  int32_t num_rows, num_cols;
+};
+
+template <typename Real>
+struct  BatchedMatrixCopyDesc {
+  //maximum size allowed in formal parameter list
+  static const int32_t MAX_BATCH_SIZE=128; 
+  MatrixCopyDesc<Real> batch[MAX_BATCH_SIZE];
+};
+
+// launched with a block size of 32x32 (32 rows, 32 cols per CTA)
+// grid dim x,y expands to fill out average in x/y across batches
+// grid dim.z is batch
+template<typename Real>
+__global__ 
+void _cuda_batch_copy_mats(BatchedMatrixCopyDesc<Real> batch_desc) {
+
+  int32_t rid = blockIdx.y * blockDim.y + threadIdx.y;
+  int32_t cid = blockIdx.x * blockDim.x + threadIdx.x;
+  int32_t bid = blockIdx.z;  // batch id 
+
+  // read copy parameters
+  MatrixCopyDesc<Real> desc = batch_desc.batch[bid];
+  int32_t num_rows = desc.num_rows;
+  int32_t num_cols = desc.num_cols;
+  Real *input = desc.input;
+  Real *output = desc.output;
+  int32_t ldi = desc.ldi;
+  int32_t ldo = desc.ldo;
+
+  // for each row of output in parallel
+  for (int32_t r = rid; r < num_rows; r += blockDim.y * gridDim.y) {
+    // for each of column of output in parallel
+    for (int32_t c = cid; c < num_cols; c+= blockDim.x * gridDim.x) {
+      output[r * ldo + c] = input[r * ldi + c];
+    }
+  }
+}
+
 __global__
 static void _noop_kernel() {
 }
@@ -5484,4 +5527,134 @@ void cudaD_mat_copy_range_clamped(
 
   _cuda_mat_copy_range_clamped<double><<<blocks,threads>>>(row_start, row_end, num_cols,
       src, lds, clamp_low, clamp_high, dst, ldd);
+}
+
+void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *ldo) {
+
+  dim3 threads(32,32);
+  int32_t total_rows=0, total_cols=0;
+  
+  BatchedMatrixCopyDesc<float> batch_desc; 
+  const int32_t MAX_BATCH_SIZE=batch_desc.MAX_BATCH_SIZE;
+
+  int i;
+  for (i = 0; i < num_mats; i++) {
+    int b = i%MAX_BATCH_SIZE;
+    
+    // fill in desc
+    MatrixCopyDesc<float> &desc = batch_desc.batch[b];
+    desc.num_rows = num_rows[i];
+    desc.num_cols = num_cols[i];
+    desc.input = inputs[i];
+    desc.output = outputs[i];
+    desc.ldi = ldi[i];
+    desc.ldo = ldo[i];
+
+    total_rows+=desc.num_rows;
+    total_cols+=desc.num_cols;
+
+    if (b==MAX_BATCH_SIZE-1) {
+      // compute average number of rows/cols across batch
+      int32_t rows = ceilf(total_rows / (float)MAX_BATCH_SIZE);
+      int32_t cols = ceilf(total_cols / (float)MAX_BATCH_SIZE);
+      dim3 blocks((cols + 31) / 32,
+                  (rows + 31) / 32, 
+                  MAX_BATCH_SIZE);
+
+      // no memcpy needed here.  Memory will be passed down directly
+      // through paramter passing and live in constant memory
+      
+      // launch batch
+       _cuda_batch_copy_mats<<<blocks,threads>>>(batch_desc);
+
+       // reset total counters
+       total_rows=0;
+       total_cols=0;
+    }
+  }
+
+  int32_t remaining = i%MAX_BATCH_SIZE;
+
+  if (remaining > 0) {
+      // compute average number of rows/cols across batch
+      int32_t rows = ceilf(total_rows / (float)remaining);
+      int32_t cols = ceilf(total_cols / (float)remaining);
+      
+      dim3 blocks((cols + 31) / 32,
+                  (rows + 31) / 32, 
+                  remaining);
+
+      // no memcpy needed here.  Memory will be passed down directly
+      // through paramter passing and live in constant memory
+
+      // launch batch
+       _cuda_batch_copy_mats<<<blocks,threads>>>(batch_desc);
+  }
+}
+
+void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *ldo) {
+
+  dim3 threads(32,32);
+  int32_t total_rows=0, total_cols=0;
+  
+  BatchedMatrixCopyDesc<double> batch_desc; 
+  const int32_t MAX_BATCH_SIZE=batch_desc.MAX_BATCH_SIZE;
+
+  int i;
+  for (i = 0; i < num_mats; i++) {
+    int b = i%MAX_BATCH_SIZE;
+    
+    // fill in desc
+    MatrixCopyDesc<double> &desc = batch_desc.batch[b];
+    desc.num_rows = num_rows[i];
+    desc.num_cols = num_cols[i];
+    desc.input = inputs[i];
+    desc.output = outputs[i];
+    desc.ldi = ldi[i];
+    desc.ldo = ldo[i];
+
+    total_rows+=desc.num_rows;
+    total_cols+=desc.num_cols;
+
+    if (b==MAX_BATCH_SIZE-1) {
+      // compute average number of rows/cols across batch
+      int32_t rows = ceilf(total_rows / (float)MAX_BATCH_SIZE);
+      int32_t cols = ceilf(total_cols / (float)MAX_BATCH_SIZE);
+      dim3 blocks((cols + 31) / 32,
+                  (rows + 31) / 32, 
+                  MAX_BATCH_SIZE);
+
+      // no memcpy needed here.  Memory will be passed down directly
+      // through paramter passing and live in constant memory
+      
+      // launch batch
+       _cuda_batch_copy_mats<<<blocks,threads>>>(batch_desc);
+
+       // reset total counters
+       total_rows=0;
+       total_cols=0;
+    }
+  }
+
+  int32_t remaining = i%MAX_BATCH_SIZE;
+
+  if (remaining > 0) {
+      // compute average number of rows/cols across batch
+      int32_t rows = ceilf(total_rows / (float)remaining);
+      int32_t cols = ceilf(total_cols / (float)remaining);
+
+      dim3 blocks((cols + 31) / 32,
+                  (rows + 31) / 32, 
+                  remaining);
+      
+      // no memcpy needed here.  Memory will be passed down directly
+      // through paramter passing and live in constant memory
+
+      // launch batch
+       _cuda_batch_copy_mats<<<blocks,threads>>>(batch_desc);
+  }
 }

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -1578,6 +1578,20 @@ inline void cuda_mat_copy_range_clamped(
   cudaF_mat_copy_range_clamped(row_start, row_end, num_cols,
       src, lds, clamp_low, clamp_high, dst, ldd);
 }
+
+inline void cuda_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *ldo) {
+  cudaF_batched_copy_mats(num_mats, num_rows, num_cols, inputs, ldi,
+      outputs, ldo);
+}
+
+inline void cuda_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
+    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *ldo) {
+  cudaD_batched_copy_mats(num_mats, num_rows, num_cols, inputs, ldi,
+      outputs, ldo);
+}
     
 
 } // namespace kaldi

--- a/src/nnet3/nnet-batch-compute.cc
+++ b/src/nnet3/nnet-batch-compute.cc
@@ -394,36 +394,104 @@ void NnetBatchComputer::FormatInputs(
       num_tasks = tasks.size();
   KALDI_ASSERT(num_tasks > 0 && num_tasks <= minibatch_size);
   
+  // destination matrix
   input->Resize(minibatch_size * num_input_frames, input_dim,
                 kUndefined);
+ 
+#if HAVE_CUDA == 1
+  if (CuDevice::Instantiate().Enabled()) {
 
-  for (int32 n = 0; n < num_tasks; n++) {
-    CuSubMatrix<BaseFloat> input_part(*input,
-                                    n * num_input_frames, num_input_frames,
-                                    0, input_dim);
-    input_part.CopyFromMat(tasks[n]->input);
-  }
-  
-  if (num_tasks < minibatch_size) {
-    // The following will make things easier to debug if something fails, but
-    // shouldn't be strictly necessary.
-    // the -1 means 'take all remaining rows'.
-    input->RowRange(num_tasks * num_input_frames,
-                    (minibatch_size - num_tasks) * num_input_frames).SetZero();
-  }
+    std::vector<BaseFloat*> inputs(num_tasks), outputs(num_tasks);
+    std::vector<int32_t> ldi(num_tasks), ldo(num_tasks);
+    std::vector<int32_t> num_rows(num_tasks), num_cols(num_tasks);
 
-  if (ivector_dim != 0) {
-    
-    ivector->Resize(minibatch_size, ivector_dim, kUndefined);
+    // compute matrix descriptions for each copy
     for (int32 n = 0; n < num_tasks; n++) {
-      ivector->Row(n).CopyFromVec(tasks[n]->ivector);
+      CuMatrix<BaseFloat> &input_mat = tasks[n]->input;
+      CuSubMatrix<BaseFloat> output_mat = input->RowRange(
+          n * num_input_frames, num_input_frames);
+
+      // create matrix batch description arrays
+      num_rows[n] = num_input_frames;
+      num_cols[n] = input_dim;
+      outputs[n] = output_mat.Data();
+      inputs[n] = input_mat.Data();
+      ldo[n] = output_mat.Stride();
+      ldi[n] = input_mat.Stride();
     }
 
+    // execute batched copy
+    cuda_batched_copy_mats(num_tasks, &num_rows[0], &num_cols[0], &inputs[0], &ldi[0], 
+        &outputs[0], &ldo[0]);
+
+  } else 
+#else
+  {
+    for (int32 n = 0; n < num_tasks; n++) {
+      CuSubMatrix<BaseFloat> input_part(*input,
+                                    n * num_input_frames, num_input_frames,
+                                    0, input_dim);
+      input_part.CopyFromMat(tasks[n]->input);
+    }
+  }
+#endif
+
+  if (GetVerboseLevel() >=2 ) {
     if (num_tasks < minibatch_size) {
       // The following will make things easier to debug if something fails, but
       // shouldn't be strictly necessary.
       // the -1 means 'take all remaining rows'.
-      ivector->RowRange(num_tasks, minibatch_size - num_tasks).SetZero();
+      input->RowRange(num_tasks * num_input_frames,
+                      (minibatch_size - num_tasks) * num_input_frames).SetZero();
+    }
+  }
+
+  if (ivector_dim != 0) {
+    ivector->Resize(minibatch_size, ivector_dim, kUndefined);
+
+#if HAVE_CUDA == 1
+    if (CuDevice::Instantiate().Enabled()) {
+     
+      // using the batched matrix copy routine for this.  This isn't
+      // extremely efficient but the kernel takes a minimal amount of 
+      // time so making a batched vector copy is not worth the effort.
+      std::vector<BaseFloat*> inputs(num_tasks), outputs(num_tasks);
+      std::vector<int32_t> ldi(num_tasks), ldo(num_tasks);
+      std::vector<int32_t> num_rows(num_tasks), num_cols(num_tasks);
+
+      // compute source pointers for each input
+      for (int32 n = 0; n < num_tasks; n++) {
+        CuVector<BaseFloat> &input_vec = tasks[n]->ivector;
+        CuSubVector<BaseFloat> output_vec = ivector->Row(n);
+        // create matrix batch description arrays
+        num_rows[n] = 1;
+        num_cols[n] = ivector_dim;
+        outputs[n] = output_vec.Data();
+        inputs[n] = input_vec.Data();
+        ldo[n] = 1;
+        ldi[n] = 1;
+      }
+
+      // execute batched copy
+      cuda_batched_copy_mats(num_tasks, &num_rows[0], &num_cols[0], &inputs[0], &ldi[0], 
+          &outputs[0], &ldo[0]);
+
+    } else 
+#else
+    {
+      for (int32 n = 0; n < num_tasks; n++) {
+        ivector->Row(n).CopyFromVec(tasks[n]->ivector);
+      }
+    }
+#endif
+
+    if (GetVerboseLevel() >= 2) {
+      if (num_tasks < minibatch_size) {
+        // The following will make things easier to debug if something fails, but
+        // shouldn't be strictly necessary.
+        // the -1 means 'take all remaining rows'.
+        ivector->RowRange(num_tasks, minibatch_size - num_tasks).SetZero();
+      }
     }
   }
 }
@@ -437,42 +505,96 @@ void NnetBatchComputer::FormatOutputs(
       num_tasks = tasks.size();
   bool did_output_to_gpu = false;
 
-  // Note: it may not be optimal to do so many individual calls to copy the
-  // output to CPU; we'd have to test that, as I'm not sure how much the latency
-  // of a GPU call is.  On the other hand, the downsides of one big call are
-  // that we'd have to make another copy in CPU memory; and also we might not be
-  // able to take advantage if not all frames of the output are used.
-
-  // Also, we should probably used pinned memory.
-
   // We don't bother zeroing frames of the output that are unused, but you could
-  // un-comment the commented lines of code below to do so.
-  for (int32 n = 0; n < num_tasks; n++) {
-    NnetInferenceTask *task = tasks[n];
+  // un-comment the commented lines of code below to do so and add equivalent
+  // calls to the cuda version.
 
-    int32 left_unused = task->num_initial_unused_output_frames,
-        used = task->num_used_output_frames;
-     // int32 right_unused = num_output_frames - used - left_unused;
+#if HAVE_CUDA == 1 
+  if (CuDevice::Instantiate().Enabled()) {
 
-    if (task->output_to_cpu) {
-      task->output_cpu.Resize(num_output_frames, output_dim,
-                              kUndefined);
-      // if (left_unused > 0)
-      //   task->output_cpu.RowRange(0, left_unused).SetZero();
-      task->output_cpu.RowRange(left_unused, used).CopyFromMat(
-          output.RowRange(n * num_output_frames + left_unused, used));
-      // if (right_unused > 0)
-      //   task->output_cpu.RowRange(0, left_unused + used, right_unused).SetZero();
-    } else {
-      did_output_to_gpu = true;
-      task->output.Resize(num_output_frames, output_dim,
-                          kUndefined);
-      // if (left_unused > 0)
-      //   task->output.RowRange(0, left_unused).SetZero();
-      task->output.RowRange(left_unused, used).CopyFromMat(
-          output.RowRange(n * num_output_frames + left_unused, used));
-      // if (right_unused > 0)
-      //   task->output.RowRange(0, left_unused + used, right_unused).SetZero();
+    std::vector<BaseFloat*> inputs(num_tasks), outputs(num_tasks);
+    std::vector<int32_t> ldi(num_tasks), ldo(num_tasks);
+    std::vector<int32_t> num_rows(num_tasks), num_cols(num_tasks);
+
+    int b=0;  // batch counter
+    for (int32 n = 0; n < num_tasks; n++) {
+      NnetInferenceTask *task = tasks[n];
+
+      int32 left_unused = task->num_initial_unused_output_frames,
+            used = task->num_used_output_frames;
+      // int32 right_unused = num_output_frames - used - left_unused;
+      
+      // TODO do we really expect different tasks to output CPU or GPU? 
+      // This adds a bit of code complexity.  Perhaps output_to_cpu should 
+      // be a property of the batch computer and not the tasks
+      if (task->output_to_cpu) {
+        task->output_cpu.Resize(num_output_frames, output_dim,
+            kUndefined);
+        // if (left_unused > 0)
+        //   task->output_cpu.RowRange(0, left_unused).SetZero();
+        task->output_cpu.RowRange(left_unused, used).CopyFromMat(
+            output.RowRange(n * num_output_frames + left_unused, used));
+        // if (right_unused > 0)
+        //   task->output_cpu.RowRange(
+        //   0, left_unused + used, right_unused).SetZero();
+
+      } else {
+        did_output_to_gpu = true;
+        task->output.Resize(num_output_frames, output_dim,
+            kUndefined);
+
+        CuSubMatrix<BaseFloat> output_mat = task->output.RowRange(
+            left_unused, used);
+        CuSubMatrix<BaseFloat> input_mat = output.RowRange(
+            n * num_output_frames + left_unused, used);
+       
+        // create matrix batch description arrays
+        num_rows[b] = output_mat.NumRows();
+        num_cols[b] = output_mat.NumCols();
+        outputs[b] = output_mat.Data();
+        inputs[b] = input_mat.Data();
+        ldo[b] = output_mat.Stride();
+        ldi[b] = input_mat.Stride();
+        b++; // increase batch count
+      }
+    }
+    
+    // execute batched copy
+    cuda_batched_copy_mats(b, &num_rows[0], &num_cols[0], &inputs[0], &ldi[0], 
+        &outputs[0], &ldo[0]);
+  
+  } else
+#endif
+  {
+    //TODO i don't think all of these paths are actually possible.  We should simplify this.  
+    //Is it possible to output_to_gpu with HAVE_CUDA == 0 or when the device is disabled?
+    for (int32 n = 0; n < num_tasks; n++) {
+      NnetInferenceTask *task = tasks[n];
+
+      int32 left_unused = task->num_initial_unused_output_frames,
+            used = task->num_used_output_frames;
+      // int32 right_unused = num_output_frames - used - left_unused;
+
+      if (task->output_to_cpu) {
+        task->output_cpu.Resize(num_output_frames, output_dim,
+            kUndefined);
+        // if (left_unused > 0)
+        //   task->output_cpu.RowRange(0, left_unused).SetZero();
+        task->output_cpu.RowRange(left_unused, used).CopyFromMat(
+            output.RowRange(n * num_output_frames + left_unused, used));
+        // if (right_unused > 0)
+        //   task->output_cpu.RowRange(0, left_unused + used, right_unused).SetZero();
+      } else {
+        did_output_to_gpu = true;
+        task->output.Resize(num_output_frames, output_dim,
+            kUndefined);
+        // if (left_unused > 0)
+        //   task->output.RowRange(0, left_unused).SetZero();
+        task->output.RowRange(left_unused, used).CopyFromMat(
+            output.RowRange(n * num_output_frames + left_unused, used));
+        // if (right_unused > 0)
+        //   task->output.RowRange(0, left_unused + used, right_unused).SetZero();
+      }
     }
   }
   // The output of this function will likely be consumed by another thread.


### PR DESCRIPTION
small cuda memory copies are inefficeint because each copy can
add multiple micro-seconds of latency.  The code as written
would copy a small matrices or vectors to and from the tasks one
after another.  To avoid this i've implemented a batched matrix
copy routine.  This takes arrays of matrix descriptions for the
input and output and batches the copies in a single kernel call.
This is used in both FormatInputs and FormatOutputs to reduce
launch latency overhead.

The kernel for the batched copy uses a trick to avoid a memory
copy of the host paramters.  The parameters are put into a struct
containing a static sized array.  These parameters are then marshalled
like normal cuda parameters.  This avoids additional launch latency
overhead.

There is still more work to do at the beginning and end of nnet3.
In particular we may want to batch the clamped memory copies and
the large number of D2D copies at the end.  I haven't fully tracked
those down and may return to them in the future.