### PR TITLE
[WIP] A* combine decoder

### DIFF
--- a/egs/mini_librispeech/s5/run.sh
+++ b/egs/mini_librispeech/s5/run.sh
@@ -199,6 +199,17 @@ if [ $stage -le 9 ]; then
   local/chain/run_tdnn.sh --stage 0
 fi
 
+if [ $stage -le 10 ]; then
+  for test in dev_clean_2; do
+    steps/decode_biglm_fast.sh --stage 1 --nj 38 --cmd "$decode_cmd" \
+    --online-ivector-dir exp/nnet3/ivectors_${test}_hires \
+    --beam 15.0 --lattice-beam 8.0
+    exp/chain/tree_sp/graph_tgsmall \
+    data/lang_test_tgsmall/G.fst data/lang_test_tglarge/G.fst \
+    data/${test}_hires \
+    exp/chain/tdnn1h_sp/decode_biglm2_${test}_diff_15_8_15_cutoff
+  done
+fi
 # local/grammar/simple_demo.sh
 
 # Don't finish until all background decoding jobs are finished.

--- a/egs/wsj/s5/steps/decode_biglm_fast.sh
+++ b/egs/wsj/s5/steps/decode_biglm_fast.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Copyright 2012  Johns Hopkins University (Author: Daniel Povey)
+# Apache 2.0
+
+# Begin configuration.
+nj=4
+cmd=run.pl
+maxactive=7000
+beam=15.0
+lattice_beam=8.0
+expand_beam=30.0
+acwt=1.0
+skip_scoring=false
+
+stage=0
+online_ivector_dir=
+post_decode_acwt=10.0
+extra_left_context=0
+extra_right_context=0
+extra_left_context_initial=0
+extra_right_context_final=0
+chunk_width=140,100,160
+use_gpu=no
+# End configuration.
+
+echo "$0 $@"  # Print the command line for logging
+
+[ -f ./path.sh ] && . ./path.sh; # source the path.
+. parse_options.sh || exit 1;
+
+if [ $# != 5 ]; then
+   echo "Usage: steps/decode_biglm_fast.sh [options] <graph-dir> <old-LM-fst> <new-LM-fst> <data-dir> <decode-dir>"
+   echo "... where <decode-dir> is assumed to be a sub-directory of the directory"
+   echo " where the model is."
+   echo "e.g.: steps/decode_si.sh exp/mono/graph_tgpr data/test_dev93 exp/mono/decode_dev93_tgpr"
+   echo ""
+   echo "This script works on CMN + (delta+delta-delta | LDA+MLLT) features; it works out"
+   echo "what type of features you used (assuming it's one of these two)"
+   echo ""
+   echo "main options (for others, see top of script file)"
+   echo "  --config <config-file>                           # config containing options"
+   echo "  --nj <nj>                                        # number of parallel jobs"
+   echo "  --cmd (utils/run.pl|utils/queue.pl <queue opts>) # how to run jobs."
+   exit 1;
+fi
+
+
+graphdir=$1
+oldlm_fst=$2
+newlm_fst=$3
+data=$4
+dir=$5
+
+srcdir=`dirname $dir`; # The model directory is one level up from decoding directory.
+sdata=$data/split$nj;
+splice_opts=`cat $srcdir/splice_opts 2>/dev/null`
+cmvn_opts=`cat $srcdir/cmvn_opts 2>/dev/null`
+delta_opts=`cat $srcdir/delta_opts 2>/dev/null`
+
+mkdir -p $dir/log
+[[ -d $sdata && $data/feats.scp -ot $sdata ]] || split_data.sh $data $nj || exit 1;
+echo $nj > $dir/num_jobs
+
+
+for f in $sdata/1/feats.scp $sdata/1/cmvn.scp $srcdir/final.mdl $graphdir/HCLG.fst $oldlm_fst $newlm_fst; do
+  [ ! -f $f ] && echo "decode_si.sh: no such file $f" && exit 1;
+done
+
+
+if [ -f $srcdir/final.mat ]; then feat_type=lda; else feat_type=delta; fi
+echo "decode_si.sh: feature type is $feat_type"
+
+feats="ark,s,cs:apply-cmvn $cmvn_opts --utt2spk=ark:$sdata/JOB/utt2spk scp:$sdata/JOB/cmvn.scp scp:$sdata/JOB/feats.scp ark:- |"
+
+posteriors="ark,scp:$sdata/JOB/posterior.ark,$sdata/JOB/posterior.scp"
+posteriors_scp="scp:$sdata/JOB/posterior.scp"
+
+if [ ! -z "$online_ivector_dir" ]; then
+  ivector_period=$(cat $online_ivector_dir/ivector_period) || exit 1;
+  ivector_opts="--online-ivectors=scp:$online_ivector_dir/ivector_online.scp --online-ivector-period=$ivector_period"
+fi
+
+if [ "$post_decode_acwt" == 1.0 ]; then
+  lat_wspecifier="ark:|gzip -c >$dir/lat.JOB.gz"
+else
+  lat_wspecifier="ark:|lattice-scale --acoustic-scale=$post_decode_acwt ark:- ark:- | gzip -c >$dir/lat.JOB.gz"
+fi
+
+frame_subsampling_opt=
+if [ -f $srcdir/frame_subsampling_factor ]; then
+  # e.g. for 'chain' systems
+  frame_subsampling_opt="--frame-subsampling-factor=$(cat $srcdir/frame_subsampling_factor)"
+fi
+
+frames_per_chunk=$(echo $chunk_width | cut -d, -f1)
+# generate log-likelihood
+if [ $stage -le 1 ]; then
+  $cmd JOB=1:$nj $dir/log/nnet_compute.JOB.log \
+    nnet3-compute $ivector_opts $frame_subsampling_opt \
+    --acoustic-scale=$acwt \
+    --extra-left-context=$extra_left_context \
+    --extra-right-context=$extra_right_context \
+    --extra-left-context-initial=$extra_left_context_initial \
+    --extra-right-context-final=$extra_right_context_final \
+    --frames-per-chunk=$frames_per_chunk \
+    --use-gpu=$use_gpu --use-priors=true \
+    $srcdir/final.mdl "$feats" "$posteriors"
+fi
+
+[ -f `dirname $oldlm_fst`/words.txt ] && ! cmp `dirname $oldlm_fst`/words.txt $graphdir/words.txt && \
+  echo "Warning: old LM words.txt does not match with that in $graphdir .. probably will not work.";
+[ -f `dirname $newlm_fst`/words.txt ] && ! cmp `dirname $oldlm_fst`/words.txt $graphdir/words.txt && \
+  echo "Warning: new LM words.txt does not match with that in $graphdir .. probably will not work.";
+
+# fstproject replaces the disambiguation symbol #0, which only appears on the
+# input side, with the <eps> that appears in the corresponding arcs on the output side.
+oldlm_cmd="fstproject --project_output=true $oldlm_fst | fstarcsort --sort_type=ilabel |"
+newlm_cmd="fstproject --project_output=true $newlm_fst | fstarcsort --sort_type=ilabel |"
+
+$cmd JOB=1:$nj $dir/log/decode.JOB.log \
+ latgen-biglm-faster-combine-mapped --max-active=$maxactive --beam=$beam \
+   --lattice-beam=$lattice_beam \
+   --acoustic-scale=$acwt --allow-partial=true --word-symbol-table=$graphdir/words.txt \
+  $srcdir/final.mdl $graphdir/HCLG.fst "$oldlm_cmd" "$newlm_cmd" "$posteriors_scp" \
+  "$lat_wspecifier" || exit 1;
+
+if ! $skip_scoring ; then
+  [ ! -x local/score.sh ] && \
+    echo "Not scoring because local/score.sh does not exist or not executable." && exit 1;
+  local/score.sh --cmd "$cmd" $data $graphdir $dir ||
+    { echo "$0: Scoring failed. (ignore by '--skip-scoring true')"; exit 1; }
+fi
+
+exit 0;

--- a/src/bin/Makefile
+++ b/src/bin/Makefile
@@ -22,7 +22,7 @@ BINFILES = align-equal align-equal-compiled acc-tree-stats \
         matrix-sum build-pfile-from-ali get-post-on-ali tree-info am-info \
         vector-sum matrix-sum-rows est-pca sum-lda-accs sum-mllt-accs \
         transform-vec align-text matrix-dim post-to-smat compile-graph \
-        compare-int-vector latgen-biglm-faster-combine-mapped
+        compare-int-vector latgen-biglm-faster-combine-mapped latgen-biglm-faster-mapped
 
 
 OBJFILES =

--- a/src/bin/Makefile
+++ b/src/bin/Makefile
@@ -22,7 +22,7 @@ BINFILES = align-equal align-equal-compiled acc-tree-stats \
         matrix-sum build-pfile-from-ali get-post-on-ali tree-info am-info \
         vector-sum matrix-sum-rows est-pca sum-lda-accs sum-mllt-accs \
         transform-vec align-text matrix-dim post-to-smat compile-graph \
-        compare-int-vector
+        compare-int-vector latgen-biglm-faster-combine-mapped
 
 
 OBJFILES =

--- a/src/bin/latgen-biglm-faster-combine-mapped.cc
+++ b/src/bin/latgen-biglm-faster-combine-mapped.cc
@@ -1,0 +1,281 @@
+// bin/latgen-biglm-faster-mapped .cc
+
+// Copyright      2019  Hang Lyu
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "tree/context-dep.h"
+#include "hmm/transition-model.h"
+#include "fstext/fstext-lib.h"
+#include "decoder/decodable-matrix.h"
+#include "base/timer.h"
+#include "decoder/lattice-biglm-faster-decoder-combine.h"
+
+
+namespace kaldi {
+// In the futher, it will be put into "decoder/decoder-wrappers"
+//
+// Takes care of output.  Returns true on success.
+bool DecodeUtterance(LatticeBiglmFasterDecoderCombine &decoder, // not const but is really an input.
+                     DecodableInterface &decodable, // not const but is really an input.
+                     const TransitionModel &trans_model,
+                     const fst::SymbolTable *word_syms,
+                     std::string utt,
+                     double acoustic_scale,
+                     bool determinize,
+                     bool allow_partial,
+                     Int32VectorWriter *alignment_writer,
+                     Int32VectorWriter *words_writer,
+                     CompactLatticeWriter *compact_lattice_writer,
+                     LatticeWriter *lattice_writer,
+                     double *like_ptr) {  // puts utterance's like in like_ptr on success.
+  using fst::VectorFst;
+
+  if (!decoder.Decode(&decodable)) {
+    KALDI_WARN << "Failed to decode file " << utt;
+    return false;
+  }
+  if (!decoder.ReachedFinal()) {
+    if (allow_partial) {
+      KALDI_WARN << "Outputting partial output for utterance " << utt
+                 << " since no final-state reached\n";
+    } else {
+      KALDI_WARN << "Not producing output for utterance " << utt
+                 << " since no final-state reached and "
+                 << "--allow-partial=false.\n";
+      return false;
+    }
+  }
+
+  double likelihood;
+  LatticeWeight weight;
+  int32 num_frames;
+  { // First do some stuff with word-level traceback...
+    VectorFst<LatticeArc> decoded;
+    decoder.GetBestPath(&decoded);
+    if (decoded.NumStates() == 0)
+      // Shouldn't really reach this point as already checked success.
+      KALDI_ERR << "Failed to get traceback for utterance " << utt;
+
+    std::vector<int32> alignment;
+    std::vector<int32> words;
+    GetLinearSymbolSequence(decoded, &alignment, &words, &weight);
+    num_frames = alignment.size();
+    if (words_writer->IsOpen())
+      words_writer->Write(utt, words);
+    if (alignment_writer->IsOpen())
+      alignment_writer->Write(utt, alignment);
+    if (word_syms != NULL) {
+      std::cerr << utt << ' ';
+      for (size_t i = 0; i < words.size(); i++) {
+        std::string s = word_syms->Find(words[i]);
+        if (s == "")
+          KALDI_ERR << "Word-id " << words[i] <<" not in symbol table.";
+        std::cerr << s << ' ';
+      }
+      std::cerr << '\n';
+    }
+    likelihood = -(weight.Value1() + weight.Value2());
+  }
+
+  // Get lattice, and do determinization if requested.
+  Lattice lat;
+  decoder.GetRawLattice(&lat);
+  if (lat.NumStates() == 0)
+    KALDI_ERR << "Unexpected problem getting lattice for utterance " << utt;
+  fst::Connect(&lat);
+  if (determinize) {
+    CompactLattice clat;
+    if (!DeterminizeLatticePhonePrunedWrapper(
+            trans_model,
+            &lat,
+            decoder.GetOptions().lattice_beam,
+            &clat,
+            decoder.GetOptions().det_opts))
+      KALDI_WARN << "Determinization finished earlier than the beam for "
+                 << "utterance " << utt;
+    // We'll write the lattice without acoustic scaling.
+    if (acoustic_scale != 0.0)
+      fst::ScaleLattice(fst::AcousticLatticeScale(1.0 / acoustic_scale), &clat);
+    compact_lattice_writer->Write(utt, clat);
+  } else {
+    Lattice fst;
+    decoder.GetRawLattice(&fst);
+    if (fst.NumStates() == 0)
+      KALDI_ERR << "Unexpected problem getting lattice for utterance "
+                << utt;
+    fst::Connect(&fst); // Will get rid of this later... shouldn't have any
+    // disconnected states there, but we seem to.
+    if (acoustic_scale != 0.0) // We'll write the lattice without acoustic scaling
+      fst::ScaleLattice(fst::AcousticLatticeScale(1.0 / acoustic_scale), &fst); 
+    lattice_writer->Write(utt, fst);
+  }
+  KALDI_LOG << "Log-like per frame for utterance " << utt << " is "
+            << (likelihood / num_frames) << " over "
+            << num_frames << " frames.";
+  KALDI_VLOG(2) << "Cost for utterance " << utt << " is "
+                << weight.Value1() << " + " << weight.Value2();
+  *like_ptr = likelihood;
+  return true;
+}
+
+}
+
+
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    typedef kaldi::int32 int32;
+    using fst::SymbolTable;
+    using fst::VectorFst;
+    using fst::Fst;
+    using fst::StdArc;
+    using fst::ReadFstKaldi;
+
+    const char *usage =
+        "Generate lattices using on-the-fly composition.\n"
+        "User supplies LM used to generate decoding graph, and desired LM;\n"
+        "this decoder applies the difference during decoding\n"
+        "Usage: latgen-biglm-faster-combine-mapped [options] model-in (fst-in|fsts-rspecifier) "
+        "oldlm-fst-in newlm-fst-in features-rspecifier"
+        " lattice-wspecifier [ words-wspecifier [alignments-wspecifier] ]\n";
+    ParseOptions po(usage);
+    Timer timer;
+    bool allow_partial = false;
+    BaseFloat acoustic_scale = 0.1;
+    LatticeBiglmFasterDecoderCombineConfig config;
+    
+    std::string word_syms_filename;
+    config.Register(&po);
+    po.Register("acoustic-scale", &acoustic_scale, "Scaling factor for acoustic likelihoods");
+
+    po.Register("word-symbol-table", &word_syms_filename, "Symbol table for words [for debug output]");
+    po.Register("allow-partial", &allow_partial, "If true, produce output even if end state was not reached.");
+    
+    po.Read(argc, argv);
+
+    if (po.NumArgs() < 6 || po.NumArgs() > 8) {
+      po.PrintUsage();
+      exit(1);
+    }
+    
+    std::string model_in_filename = po.GetArg(1),
+        fst_in_str = po.GetArg(2),
+        old_lm_fst_rxfilename = po.GetArg(3),
+        new_lm_fst_rxfilename = po.GetArg(4),
+        feature_rspecifier = po.GetArg(5),
+        lattice_wspecifier = po.GetArg(6),
+        words_wspecifier = po.GetOptArg(7),
+        alignment_wspecifier = po.GetOptArg(8);
+    
+    TransitionModel trans_model;
+    ReadKaldiObject(model_in_filename, &trans_model);
+
+    VectorFst<StdArc> *old_lm_fst = fst::CastOrConvertToVectorFst(
+        fst::ReadFstKaldiGeneric(old_lm_fst_rxfilename));
+    ApplyProbabilityScale(-1.0, old_lm_fst); // Negate old LM probs...
+    
+    VectorFst<StdArc> *new_lm_fst = fst::CastOrConvertToVectorFst(
+        fst::ReadFstKaldiGeneric(new_lm_fst_rxfilename));
+
+    fst::BackoffDeterministicOnDemandFst<StdArc> old_lm_dfst(*old_lm_fst);
+    fst::BackoffDeterministicOnDemandFst<StdArc> new_lm_dfst(*new_lm_fst);
+    fst::ComposeDeterministicOnDemandFst<StdArc> compose_dfst(&old_lm_dfst,
+                                                              &new_lm_dfst);
+    fst::CacheDeterministicOnDemandFst<StdArc> cache_dfst(&compose_dfst, 1e7);
+
+    bool determinize = config.determinize_lattice;
+    CompactLatticeWriter compact_lattice_writer;
+    LatticeWriter lattice_writer;
+    if (! (determinize ? compact_lattice_writer.Open(lattice_wspecifier)
+           : lattice_writer.Open(lattice_wspecifier)))
+      KALDI_ERR << "Could not open table for writing lattices: "
+                 << lattice_wspecifier;
+
+    Int32VectorWriter words_writer(words_wspecifier);
+
+    Int32VectorWriter alignment_writer(alignment_wspecifier);
+
+    fst::SymbolTable *word_syms = NULL;
+    if (word_syms_filename != "") 
+      if (!(word_syms = fst::SymbolTable::ReadText(word_syms_filename)))
+        KALDI_ERR << "Could not read symbol table from file "
+                   << word_syms_filename;
+
+    double tot_like = 0.0;
+    kaldi::int64 frame_count = 0;
+    int num_success = 0, num_fail = 0;
+
+
+    if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
+      SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
+      // Input FST is just one FST, not a table of FSTs.
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
+
+      {
+        LatticeBiglmFasterDecoderCombine decoder(*decode_fst, config, &cache_dfst);
+        timer.Reset();
+    
+        for (; !feature_reader.Done(); feature_reader.Next()) {
+          std::string utt = feature_reader.Key();
+          Matrix<BaseFloat> features (feature_reader.Value());
+          feature_reader.FreeCurrent();
+          if (features.NumRows() == 0) {
+            KALDI_WARN << "Zero-length utterance: " << utt;
+            num_fail++;
+            continue;
+          }
+                
+          DecodableMatrixScaledMapped decodable(trans_model, features, acoustic_scale);
+
+          double like;
+          if (DecodeUtterance(decoder, decodable, trans_model, word_syms,
+                              utt, acoustic_scale, determinize, allow_partial,
+                              &alignment_writer, &words_writer,
+                              &compact_lattice_writer, &lattice_writer,
+                              &like)) {
+            tot_like += like;
+            frame_count += features.NumRows();
+            num_success++;
+          } else num_fail++;
+        }
+      }
+      delete decode_fst; // delete this only after decoder goes out of scope.
+    } else { // We have different FSTs for different utterances.
+      assert(0);
+    }
+      
+    double elapsed = timer.Elapsed();
+    KALDI_LOG << "Time taken "<< elapsed
+              << "s: real-time factor assuming 100 frames/sec is "
+              << (elapsed*100.0/frame_count);
+    KALDI_LOG << "Done " << num_success << " utterances, failed for "
+              << num_fail;
+    KALDI_LOG << "Overall log-likelihood per frame is " << (tot_like/frame_count) << " over "
+              << frame_count<<" frames.";
+
+    delete word_syms;
+    if (num_success != 0) return 0;
+    else return 1;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}

--- a/src/bin/latgen-biglm-faster-mapped.cc
+++ b/src/bin/latgen-biglm-faster-mapped.cc
@@ -1,0 +1,281 @@
+// bin/latgen-biglm-faster-mapped .cc
+
+// Copyright      2019  Hang Lyu
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "tree/context-dep.h"
+#include "hmm/transition-model.h"
+#include "fstext/fstext-lib.h"
+#include "decoder/decodable-matrix.h"
+#include "base/timer.h"
+#include "decoder/lattice-biglm-faster-decoder.h"
+
+
+namespace kaldi {
+// In the futher, it will be put into "decoder/decoder-wrappers"
+//
+// Takes care of output.  Returns true on success.
+bool DecodeUtterance(LatticeBiglmFasterDecoder &decoder, // not const but is really an input.
+                     DecodableInterface &decodable, // not const but is really an input.
+                     const TransitionModel &trans_model,
+                     const fst::SymbolTable *word_syms,
+                     std::string utt,
+                     double acoustic_scale,
+                     bool determinize,
+                     bool allow_partial,
+                     Int32VectorWriter *alignment_writer,
+                     Int32VectorWriter *words_writer,
+                     CompactLatticeWriter *compact_lattice_writer,
+                     LatticeWriter *lattice_writer,
+                     double *like_ptr) {  // puts utterance's like in like_ptr on success.
+  using fst::VectorFst;
+
+  if (!decoder.Decode(&decodable)) {
+    KALDI_WARN << "Failed to decode file " << utt;
+    return false;
+  }
+  if (!decoder.ReachedFinal()) {
+    if (allow_partial) {
+      KALDI_WARN << "Outputting partial output for utterance " << utt
+                 << " since no final-state reached\n";
+    } else {
+      KALDI_WARN << "Not producing output for utterance " << utt
+                 << " since no final-state reached and "
+                 << "--allow-partial=false.\n";
+      return false;
+    }
+  }
+
+  double likelihood;
+  LatticeWeight weight;
+  int32 num_frames;
+  { // First do some stuff with word-level traceback...
+    VectorFst<LatticeArc> decoded;
+    decoder.GetBestPath(&decoded);
+    if (decoded.NumStates() == 0)
+      // Shouldn't really reach this point as already checked success.
+      KALDI_ERR << "Failed to get traceback for utterance " << utt;
+
+    std::vector<int32> alignment;
+    std::vector<int32> words;
+    GetLinearSymbolSequence(decoded, &alignment, &words, &weight);
+    num_frames = alignment.size();
+    if (words_writer->IsOpen())
+      words_writer->Write(utt, words);
+    if (alignment_writer->IsOpen())
+      alignment_writer->Write(utt, alignment);
+    if (word_syms != NULL) {
+      std::cerr << utt << ' ';
+      for (size_t i = 0; i < words.size(); i++) {
+        std::string s = word_syms->Find(words[i]);
+        if (s == "")
+          KALDI_ERR << "Word-id " << words[i] <<" not in symbol table.";
+        std::cerr << s << ' ';
+      }
+      std::cerr << '\n';
+    }
+    likelihood = -(weight.Value1() + weight.Value2());
+  }
+
+  // Get lattice, and do determinization if requested.
+  Lattice lat;
+  decoder.GetRawLattice(&lat);
+  if (lat.NumStates() == 0)
+    KALDI_ERR << "Unexpected problem getting lattice for utterance " << utt;
+  fst::Connect(&lat);
+  if (determinize) {
+    CompactLattice clat;
+    if (!DeterminizeLatticePhonePrunedWrapper(
+            trans_model,
+            &lat,
+            decoder.GetOptions().lattice_beam,
+            &clat,
+            decoder.GetOptions().det_opts))
+      KALDI_WARN << "Determinization finished earlier than the beam for "
+                 << "utterance " << utt;
+    // We'll write the lattice without acoustic scaling.
+    if (acoustic_scale != 0.0)
+      fst::ScaleLattice(fst::AcousticLatticeScale(1.0 / acoustic_scale), &clat);
+    compact_lattice_writer->Write(utt, clat);
+  } else {
+    Lattice fst;
+    decoder.GetRawLattice(&fst);
+    if (fst.NumStates() == 0)
+      KALDI_ERR << "Unexpected problem getting lattice for utterance "
+                << utt;
+    fst::Connect(&fst); // Will get rid of this later... shouldn't have any
+    // disconnected states there, but we seem to.
+    if (acoustic_scale != 0.0) // We'll write the lattice without acoustic scaling
+      fst::ScaleLattice(fst::AcousticLatticeScale(1.0 / acoustic_scale), &fst); 
+    lattice_writer->Write(utt, fst);
+  }
+  KALDI_LOG << "Log-like per frame for utterance " << utt << " is "
+            << (likelihood / num_frames) << " over "
+            << num_frames << " frames.";
+  KALDI_VLOG(2) << "Cost for utterance " << utt << " is "
+                << weight.Value1() << " + " << weight.Value2();
+  *like_ptr = likelihood;
+  return true;
+}
+
+}
+
+
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    typedef kaldi::int32 int32;
+    using fst::SymbolTable;
+    using fst::VectorFst;
+    using fst::Fst;
+    using fst::StdArc;
+    using fst::ReadFstKaldi;
+
+    const char *usage =
+        "Generate lattices using on-the-fly composition.\n"
+        "User supplies LM used to generate decoding graph, and desired LM;\n"
+        "this decoder applies the difference during decoding\n"
+        "Usage: latgen-biglm-faster-mapped [options] model-in (fst-in|fsts-rspecifier) "
+        "oldlm-fst-in newlm-fst-in features-rspecifier"
+        " lattice-wspecifier [ words-wspecifier [alignments-wspecifier] ]\n";
+    ParseOptions po(usage);
+    Timer timer;
+    bool allow_partial = false;
+    BaseFloat acoustic_scale = 0.1;
+    LatticeBiglmFasterDecoderConfig config;
+    
+    std::string word_syms_filename;
+    config.Register(&po);
+    po.Register("acoustic-scale", &acoustic_scale, "Scaling factor for acoustic likelihoods");
+
+    po.Register("word-symbol-table", &word_syms_filename, "Symbol table for words [for debug output]");
+    po.Register("allow-partial", &allow_partial, "If true, produce output even if end state was not reached.");
+    
+    po.Read(argc, argv);
+
+    if (po.NumArgs() < 6 || po.NumArgs() > 8) {
+      po.PrintUsage();
+      exit(1);
+    }
+    
+    std::string model_in_filename = po.GetArg(1),
+        fst_in_str = po.GetArg(2),
+        old_lm_fst_rxfilename = po.GetArg(3),
+        new_lm_fst_rxfilename = po.GetArg(4),
+        feature_rspecifier = po.GetArg(5),
+        lattice_wspecifier = po.GetArg(6),
+        words_wspecifier = po.GetOptArg(7),
+        alignment_wspecifier = po.GetOptArg(8);
+    
+    TransitionModel trans_model;
+    ReadKaldiObject(model_in_filename, &trans_model);
+
+    VectorFst<StdArc> *old_lm_fst = fst::CastOrConvertToVectorFst(
+        fst::ReadFstKaldiGeneric(old_lm_fst_rxfilename));
+    ApplyProbabilityScale(-1.0, old_lm_fst); // Negate old LM probs...
+    
+    VectorFst<StdArc> *new_lm_fst = fst::CastOrConvertToVectorFst(
+        fst::ReadFstKaldiGeneric(new_lm_fst_rxfilename));
+
+    fst::BackoffDeterministicOnDemandFst<StdArc> old_lm_dfst(*old_lm_fst);
+    fst::BackoffDeterministicOnDemandFst<StdArc> new_lm_dfst(*new_lm_fst);
+    fst::ComposeDeterministicOnDemandFst<StdArc> compose_dfst(&old_lm_dfst,
+                                                              &new_lm_dfst);
+    fst::CacheDeterministicOnDemandFst<StdArc> cache_dfst(&compose_dfst, 1e7);
+
+    bool determinize = config.determinize_lattice;
+    CompactLatticeWriter compact_lattice_writer;
+    LatticeWriter lattice_writer;
+    if (! (determinize ? compact_lattice_writer.Open(lattice_wspecifier)
+           : lattice_writer.Open(lattice_wspecifier)))
+      KALDI_ERR << "Could not open table for writing lattices: "
+                 << lattice_wspecifier;
+
+    Int32VectorWriter words_writer(words_wspecifier);
+
+    Int32VectorWriter alignment_writer(alignment_wspecifier);
+
+    fst::SymbolTable *word_syms = NULL;
+    if (word_syms_filename != "") 
+      if (!(word_syms = fst::SymbolTable::ReadText(word_syms_filename)))
+        KALDI_ERR << "Could not read symbol table from file "
+                   << word_syms_filename;
+
+    double tot_like = 0.0;
+    kaldi::int64 frame_count = 0;
+    int num_success = 0, num_fail = 0;
+
+
+    if (ClassifyRspecifier(fst_in_str, NULL, NULL) == kNoRspecifier) {
+      SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
+      // Input FST is just one FST, not a table of FSTs.
+      Fst<StdArc> *decode_fst = fst::ReadFstKaldiGeneric(fst_in_str);
+
+      {
+        LatticeBiglmFasterDecoder decoder(*decode_fst, config, &cache_dfst);
+        timer.Reset();
+    
+        for (; !feature_reader.Done(); feature_reader.Next()) {
+          std::string utt = feature_reader.Key();
+          Matrix<BaseFloat> features (feature_reader.Value());
+          feature_reader.FreeCurrent();
+          if (features.NumRows() == 0) {
+            KALDI_WARN << "Zero-length utterance: " << utt;
+            num_fail++;
+            continue;
+          }
+                
+          DecodableMatrixScaledMapped decodable(trans_model, features, acoustic_scale);
+
+          double like;
+          if (DecodeUtterance(decoder, decodable, trans_model, word_syms,
+                              utt, acoustic_scale, determinize, allow_partial,
+                              &alignment_writer, &words_writer,
+                              &compact_lattice_writer, &lattice_writer,
+                              &like)) {
+            tot_like += like;
+            frame_count += features.NumRows();
+            num_success++;
+          } else num_fail++;
+        }
+      }
+      delete decode_fst; // delete this only after decoder goes out of scope.
+    } else { // We have different FSTs for different utterances.
+      assert(0);
+    }
+      
+    double elapsed = timer.Elapsed();
+    KALDI_LOG << "Time taken "<< elapsed
+              << "s: real-time factor assuming 100 frames/sec is "
+              << (elapsed*100.0/frame_count);
+    KALDI_LOG << "Done " << num_success << " utterances, failed for "
+              << num_fail;
+    KALDI_LOG << "Overall log-likelihood per frame is " << (tot_like/frame_count) << " over "
+              << frame_count<<" frames.";
+
+    delete word_syms;
+    if (num_success != 0) return 0;
+    else return 1;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}

--- a/src/decoder/Makefile
+++ b/src/decoder/Makefile
@@ -7,7 +7,7 @@ TESTFILES =
 
 OBJFILES = training-graph-compiler.o lattice-simple-decoder.o lattice-faster-decoder.o \
    lattice-faster-online-decoder.o simple-decoder.o faster-decoder.o \
-   decoder-wrappers.o grammar-fst.o decodable-matrix.o
+   decoder-wrappers.o grammar-fst.o decodable-matrix.o lattice-biglm-faster-decoder-combine.o
 
 LIBNAME = kaldi-decoder
 

--- a/src/decoder/lattice-biglm-faster-decoder-combine.cc
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.cc
@@ -1,0 +1,1461 @@
+// decoder/lattice-biglm-faster-decoder-combine.cc
+
+// Copyright 2013-2019  Johns Hopkins University (Author: Daniel Povey)
+//                2019  Zhehuai Chen
+//                2019  Hang Lyu               
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "decoder/lattice-biglm-faster-decoder-combine.h"
+#include "lat/lattice-functions.h"
+
+namespace kaldi {
+
+template<typename Token>
+BucketQueue<Token>::BucketQueue(BaseFloat cost_scale) :
+    cost_scale_(cost_scale) {
+  // NOTE: we reserve plenty of elements to avoid expensive reallocations
+  // later on. Normally, the size is a little bigger than (adaptive_beam +
+  // 15) * cost_scale.
+  int32 bucket_size = (15 + 20) * cost_scale_;
+  buckets_.resize(bucket_size);
+  bucket_offset_ = 15 * cost_scale_;
+  first_nonempty_bucket_index_ = bucket_size - 1;
+  first_nonempty_bucket_ = &buckets_[first_nonempty_bucket_index_];
+  bucket_size_tolerance_ = 1.2 * bucket_size;
+}
+
+template<typename Token>
+void BucketQueue<Token>::Push(Token *tok) {
+  size_t bucket_index = std::floor(tok->tot_cost * cost_scale_) +
+                        bucket_offset_;
+  if (bucket_index >= buckets_.size()) {
+    int32 margin = 10;  // a margin which is used to reduce re-allocate
+                        // space frequently
+    if (static_cast<int32>(bucket_index) > 0) {
+      buckets_.resize(bucket_index + margin);
+    } else {  // less than 0
+      int32 increase_size = - static_cast<int32>(bucket_index) + margin;
+      buckets_.resize(buckets_.size() + increase_size);
+      // translation
+      for (size_t i = buckets_.size() - 1; i >= increase_size; i--) {
+        buckets_[i].swap(buckets_[i - increase_size]);
+      }
+      bucket_offset_ = bucket_offset_ + increase_size;
+      bucket_index += increase_size;
+      first_nonempty_bucket_index_ = bucket_index;
+    }
+    first_nonempty_bucket_ = &buckets_[first_nonempty_bucket_index_];
+  }
+  tok->in_queue = true;
+  buckets_[bucket_index].push_back(tok);
+  if (bucket_index < first_nonempty_bucket_index_) {
+    first_nonempty_bucket_index_ = bucket_index;
+    first_nonempty_bucket_ = &buckets_[first_nonempty_bucket_index_];
+  }
+}
+
+template<typename Token>
+Token* BucketQueue<Token>::Pop() {
+  while (true) {
+    if (!first_nonempty_bucket_->empty()) {
+      Token *ans = first_nonempty_bucket_->back();
+      first_nonempty_bucket_->pop_back();
+      if (ans->in_queue) {  // If ans->in_queue is false, this means it is a
+                            // duplicate instance of this Token that was left
+                            // over when a Token's best_cost changed, and the
+                            // Token has already been processed(so conceptually,
+                            // it is not in the queue).
+        ans->in_queue = false;
+        return ans;
+      }
+    }
+    if (first_nonempty_bucket_->empty()) {
+      for (; first_nonempty_bucket_index_ + 1 < buckets_.size();
+           first_nonempty_bucket_index_++) {
+        if (!buckets_[first_nonempty_bucket_index_].empty()) break;
+      }
+      first_nonempty_bucket_ = &buckets_[first_nonempty_bucket_index_];
+      if (first_nonempty_bucket_->empty()) return NULL;
+    }
+  }
+}
+
+template<typename Token>
+void BucketQueue<Token>::Clear() {
+  for (size_t i = first_nonempty_bucket_index_; i < buckets_.size(); i++) {
+    buckets_[i].clear();
+  }
+  if (buckets_.size() > bucket_size_tolerance_) {
+    buckets_.resize(bucket_size_tolerance_);
+    bucket_offset_ = 15 * cost_scale_;
+  }
+  first_nonempty_bucket_index_ = buckets_.size() - 1;
+  first_nonempty_bucket_ = &buckets_[first_nonempty_bucket_index_];
+}
+
+// instantiate this class once for each thing you have to decode.
+template <typename FST, typename Token>
+LatticeBiglmFasterDecoderCombineTpl<FST, Token>::LatticeBiglmFasterDecoderCombineTpl(
+    const FST &fst,
+    const LatticeBiglmFasterDecoderCombineConfig &config,
+    fst::DeterministicOnDemandFst<FST::Arc> *lm_diff_fst):
+    fst_(&fst), delete_fst_(false), lm_diff_fst_(lm_diff_fst), config_(config),
+    num_toks_(0), cur_queue_(config_.cost_scale) {
+  config.Check();
+  cur_toks_.reserve(1000);
+  next_toks_.reserve(1000);
+}
+
+
+template <typename FST, typename Token>
+LatticeBiglmFasterDecoderCombineTpl<FST, Token>::LatticeBiglmFasterDecoderCombineTpl(
+    const LatticeBiglmFasterDecoderCombineConfig &config, FST *fst,
+    fst::DeterministicOnDemandFst<FST::ARC> *lm_diff_fst):
+    fst_(fst), delete_fst_(true), lm_diff_fst_(lm_diff_fst), config_(config),
+    num_toks_(0), cur_queue_(config_.cost_scale) {
+  config.Check();
+  cur_toks_.reserve(1000);
+  next_toks_.reserve(1000);
+}
+
+
+template <typename FST, typename Token>
+LatticeBiglmFasterDecoderCombineTpl<FST, Token>::~LatticeBiglmFasterDecoderCombineTpl() {
+  ClearActiveTokens();
+  if (delete_fst_) delete fst_;
+}
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::InitDecoding() {
+  // clean up from last time:
+  cost_offsets_.clear();
+  ClearActiveTokens();
+
+  num_toks_ = 0;
+  warned_ = false;
+  warned_noarc_ = false;
+  decoding_finalized_ = false;
+  complete_frame_ = -1;
+
+  final_costs_.clear();
+  adaptive_beam_ = config_.beam;
+
+  for (size_t i = 0; i < token_map_.size(); ++i) {
+    token_map_[i]->clear();
+    best_token_map_[i]->clear();
+  }
+  token_map_.resize(1);
+  best_token_map_.resize(1);
+  best_token_.resize(1);
+
+  // initialize
+  token_map_[0] = new PairIdToTokenMap();
+  best_token_map_[0] = new StateIdToTokenMap();
+
+  StateId start_state = fst_->Start();
+  KALDI_ASSERT(start_state != fst::kNoStateId);
+  active_toks_.resize(1);
+  Token *start_tok = new Token(0.0, 0.0, start_state, 0, NULL, NULL, NULL);
+  active_toks_[0].toks = start_tok;
+  (*token_map_[0])[start_state] = start_tok;  // initialize current tokens map
+  (*best_token_map_[0])[start_state] = start_tok;
+  best_token_[0] = start_tok;
+  num_toks_++;
+  cost_offsets_.resize(1);
+  cost_offsets_[0] = 0.0;
+}
+
+// Returns true if any kind of traceback is available (not necessarily from
+// a final state).  It should only very rarely return false; this indicates
+// an unusual search error.
+template <typename FST, typename Token>
+bool LatticeBiglmFasterDecoderCombineTpl<FST, Token>::Decode(
+    DecodableInterface *decodable) {
+  InitDecoding();
+
+  // We use 1-based indexing for frames in this decoder (if you view it in
+  // terms of features), but note that the decodable object uses zero-based
+  // numbering, which we have to correct for when we call it.
+  while (!decodable->IsLastFrame(NumFramesDecoded() - 1)) {
+    ProcessForFrame(decodable);
+    if (NumFramesDecoded() % config_.backfill_interval == 0)
+      complete_frame_ = DoBackfill();
+    // Only the tokens and forwardlinks of the complete expanded frames will
+    // be processed for saving memory.
+    if (complete_frame_ % config_.prune_interval == 0)
+      PruneActiveTokens(config_.lattice_beam * config_.prune_scale);
+  }
+  // A complete token list of the last frame will be generated in FinalizeDecoding()
+  FinalizeDecoding();
+
+  // Returns true if we have any kind of traceback available (not necessarily
+  // to the end state; query ReachedFinal() for that).
+  return !active_toks_.empty() && active_toks_.back().toks != NULL;
+}
+
+
+// Outputs an FST corresponding to the single best path through the lattice.
+template <typename FST, typename Token>
+bool LatticeBiglmFasterDecoderCombineTpl<FST, Token>::GetBestPath(
+    Lattice *olat,
+    bool use_final_probs) {
+  Lattice raw_lat;
+  GetRawLattice(&raw_lat, use_final_probs);
+  ShortestPath(raw_lat, olat);
+  return (olat->NumStates() != 0);
+}
+
+
+// Outputs an FST corresponding to the raw, state-level lattice
+template <typename FST, typename Token>
+bool LatticeBiglmFasterDecoderCombineTpl<FST, Token>::GetRawLattice(
+    Lattice *ofst,
+    bool use_final_probs) {
+  typedef LatticeArc Arc;
+  typedef Arc::StateId StateId;
+  typedef Arc::Weight Weight;
+  typedef Arc::Label Label;
+  // Note: you can't use the old interface (Decode()) if you want to
+  // get the lattice with use_final_probs = false.  You'd have to do
+  // InitDecoding() and then AdvanceDecoding().
+  if (decoding_finalized_ && !use_final_probs)
+    KALDI_ERR << "You cannot call FinalizeDecoding() and then call "
+              << "GetRawLattice() with use_final_probs == false";
+
+  if (!decoding_finalized_ && use_final_probs) {
+    // Process the non-emitting arcs for the unfinished last frame.
+    ProcessNonemitting();
+  }
+
+
+  unordered_map<Token*, BaseFloat> final_costs_local;
+
+  const unordered_map<Token*, BaseFloat> &final_costs =
+      (decoding_finalized_ ? final_costs_ : final_costs_local);
+  if (!decoding_finalized_ && use_final_probs)
+    ComputeFinalCosts(&final_costs_local, NULL, NULL);
+
+  ofst->DeleteStates();
+  // num-frames plus one (since frames are one-based, and we have
+  // an extra frame for the start-state).
+  int32 num_frames = active_toks_.size() - 1;
+  KALDI_ASSERT(num_frames > 0);
+  const int32 bucket_count = num_toks_/2 + 3;
+  unordered_map<Token*, StateId> tok_map(bucket_count);
+  // First create all states.
+  std::vector<Token*> token_list;
+  for (int32 f = 0; f <= num_frames; f++) {
+    if (active_toks_[f].toks == NULL) {
+      KALDI_WARN << "GetRawLattice: no tokens active on frame " << f
+                 << ": not producing lattice.\n";
+      return false;
+    }
+    TopSortTokens(active_toks_[f].toks, &token_list);
+    for (size_t i = 0; i < token_list.size(); i++)
+      if (token_list[i] != NULL)
+        tok_map[token_list[i]] = ofst->AddState();
+  }
+  // The next statement sets the start state of the output FST.  Because we
+  // topologically sorted the tokens, state zero must be the start-state.
+  ofst->SetStart(0);
+
+  KALDI_VLOG(4) << "init:" << num_toks_/2 + 3 << " buckets:"
+                << tok_map.bucket_count() << " load:" << tok_map.load_factor()
+                << " max:" << tok_map.max_load_factor();
+  // Now create all arcs.
+  for (int32 f = 0; f <= num_frames; f++) {
+    for (Token *tok = active_toks_[f].toks; tok != NULL; tok = tok->next) {
+      StateId cur_state = tok_map[tok];
+      for (ForwardLinkT *l = tok->links;
+           l != NULL;
+           l = l->next) {
+        typename unordered_map<Token*, StateId>::const_iterator
+            iter = tok_map.find(l->next_tok);
+        StateId nextstate = iter->second;
+        KALDI_ASSERT(iter != tok_map.end());
+        BaseFloat cost_offset = 0.0;
+        if (l->ilabel != 0) {  // emitting..
+          KALDI_ASSERT(f >= 0 && f < cost_offsets_.size());
+          cost_offset = cost_offsets_[f];
+        }
+        Arc arc(l->ilabel, l->olabel,
+                Weight(l->graph_cost, l->acoustic_cost - cost_offset),
+                nextstate);
+        ofst->AddArc(cur_state, arc);
+      }
+      if (f == num_frames) {
+        if (use_final_probs && !final_costs.empty()) {
+          typename unordered_map<Token*, BaseFloat>::const_iterator
+              iter = final_costs.find(tok);
+          if (iter != final_costs.end())
+            ofst->SetFinal(cur_state, LatticeWeight(iter->second, 0));
+        } else {
+          ofst->SetFinal(cur_state, LatticeWeight::One());
+        }
+      }
+    }
+  }
+  
+  return (ofst->NumStates() > 0);
+}
+
+// This function is now deprecated, since now we do determinization from outside
+// the LatticeFasterDecoder class.  Outputs an FST corresponding to the
+// lattice-determinized lattice (one path per word sequence).
+template <typename FST, typename Token>
+bool LatticeBiglmFasterDecoderCombineTpl<FST, Token>::GetLattice(
+    CompactLattice *ofst,
+    bool use_final_probs) {
+  Lattice raw_fst;
+  GetRawLattice(&raw_fst, use_final_probs);
+  Invert(&raw_fst);  // make it so word labels are on the input.
+  // (in phase where we get backward-costs).
+  fst::ILabelCompare<LatticeArc> ilabel_comp;
+  ArcSort(&raw_fst, ilabel_comp);  // sort on ilabel; makes
+  // lattice-determinization more efficient.
+
+  fst::DeterminizeLatticePrunedOptions lat_opts;
+  lat_opts.max_mem = config_.det_opts.max_mem;
+
+  DeterminizeLatticePruned(raw_fst, config_.lattice_beam, ofst, lat_opts);
+  raw_fst.DeleteStates();  // Free memory-- raw_fst no longer needed.
+  Connect(ofst);  // Remove unreachable states... there might be
+  // a small number of these, in some cases.
+  // Note: if something went wrong and the raw lattice was empty,
+  // we should still get to this point in the code without warnings or failures.
+  return (ofst->NumStates() != 0);
+}
+
+/*
+  A note on the definition of extra_cost.
+
+  extra_cost is used in pruning tokens, to save memory.
+
+  Define the 'forward cost' of a token as zero for any token on the frame
+  we're currently decoding; and for other frames, as the shortest-path cost
+  between that token and a token on the frame we're currently decoding.
+  (by "currently decoding" I mean the most recently processed frame).
+
+  Then define the extra_cost of a token (always >= 0) as the forward-cost of
+  the token minus the smallest forward-cost of any token on the same frame.
+
+  We can use the extra_cost to accurately prune away tokens that we know will
+  never appear in the lattice.  If the extra_cost is greater than the desired
+  lattice beam, the token would provably never appear in the lattice, so we can
+  prune away the token.
+
+  The advantage of storing the extra_cost rather than the forward-cost, is that
+  it is less costly to keep the extra_cost up-to-date when we process new frames.
+  When we process a new frame, *all* the previous frames' forward-costs would change;
+  but in general the extra_cost will change only for a finite number of frames.
+  (Actually we don't update all the extra_costs every time we update a frame; we
+  only do it every 'config_.prune_interval' frames).
+ */
+
+// FindOrAddToken either locates a token in hash map "token_map", or if
+// necessary inserts a new, empty token (i.e. with no forward links) for the
+// current frame.
+// [note: it's inserted if necessary into "token_map", "token_best_map" and
+// also into the singly linked list of tokens active on this frame (whose head
+// is at active_toks_[frame]).  The token_list_index argument is used to index
+// into the active_toks_ array.
+template <typename FST, typename Token>
+inline Token* LatticeBiglmFasterDecoderCombineTpl<FST, Token>::FindOrAddToken(
+    PairId state, int32 token_list_index, BaseFloat tot_cost,
+    Token *backpointer, PairIdToTokenMap *token_map, bool *changed) {
+  // Returns the Token pointer.  Sets "changed" (if non-NULL) to true
+  // if the token was newly created or the cost changed.
+  KALDI_ASSERT(token_list_index < active_toks_.size());
+  Token* &toks = active_toks_[token_list_index].toks;
+  typename PairIdToTokenMap::iterator e_found = token_map->find(state);
+  
+  StateId base_state = PairToBaseState(state);
+  StateId lm_state = PairToLmState(state);
+  typename StateIdToTokenMap::iterator e_best_found =
+    token_best_map->find(base_state);
+  
+  if (e_found == token_map->end()) {  // no such token presently.
+    const BaseFloat extra_cost = 0.0;
+    cosnt BaseFloat backward_cost = std::numeric_limits<BaseFloat>::infinity();
+    // tokens on the currently final frame have zero extra_cost
+    // as any of them could end up
+    // on the winning path.
+    Token *new_tok = new Token (tot_cost, backward_cost, base_state,
+                                lm_state, NULL, toks, backpointer);
+    // NULL: no forward links yet
+    toks = new_tok;
+    num_toks_++;
+    // insert into the map
+    (*token_map)[state] = new_tok;
+    if (changed) *changed = true;
+    // Check token_best_map
+    return new_tok;
+  } else {
+    Token *tok = e_found->second;  // There is an existing Token for this state.
+    if (tok->tot_cost > tot_cost) {  // replace old token
+      tok->tot_cost = tot_cost;
+      // SetBackpointer() just does tok->backpointer = backpointer in
+      // the case where Token == BackpointerToken, else nothing.
+      tok->SetBackpointer(backpointer);
+      // we don't allocate a new token, the old stays linked in active_toks_
+      // we only replace the tot_cost
+      // in the current frame, there are no forward links (and no extra_cost)
+      // only in ProcessNonemitting we have to delete forward links
+      // in case we visit a state for the second time
+      // those forward links, that lead to this replaced token before:
+      // they remain and will hopefully be pruned later (PruneForwardLinks...)
+      if (changed) *changed = true;
+    } else {
+      if (changed) *changed = false;
+    }
+    return tok;
+  }
+}
+
+// prunes outgoing links for all tokens in active_toks_[frame]
+// it's called by PruneActiveTokens
+// all links, that have link_extra_cost > lattice_beam are pruned
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::PruneForwardLinks(
+    int32 frame_plus_one, bool *backward_costs_changed,
+    bool *links_pruned, BaseFloat delta) {
+  // delta is the amount by which the extra_costs must change
+  // If delta is larger,  we'll tend to go back less far
+  //    toward the beginning of the file.
+  // extra_costs_changed is set to true if extra_cost was changed for any token
+  // links_pruned is set to true if any link in any token was pruned
+
+  *backward_costs_changed = false;
+  *links_pruned = false;
+  KALDI_ASSERT(frame_plus_one >= 0 && frame_plus_one < active_toks_.size());
+  if (active_toks_[frame_plus_one].toks == NULL) {  // empty list; should not happen.
+    if (!warned_) {
+      KALDI_WARN << "No tokens alive [doing pruning].. warning first "
+          "time only for each utterance\n";
+      warned_ = true;
+    }
+  }
+
+  Token* &best_token = best_token_[frame_plus_one];
+  BaseFloat best_cost = best_token->tot_cost + best_token->backward_cost;
+  BaseFloat threshold = best_cost + config_.lattice_beam;
+  // We have to iterate until there is no more change, because the links
+  // are not guaranteed to be in topological order.
+  bool changed = true;  // difference new minus old extra cost >= delta ?
+  while (changed) {
+    changed = false;
+    for (Token *tok = active_toks_[frame_plus_one].toks;
+         tok != NULL; tok = tok->next) {
+      ForwardLinkT *link, *prev_link = NULL;
+      // will recompute tok_extra_cost for tok.
+      BaseFloat tok_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      // tok_extra_cost is the best (min) of link_extra_cost of outgoing links
+      for (link = tok->links; link != NULL; ) {
+        // See if we need to excise this link...
+        Token *next_tok = link->next_tok;
+        BaseFloat link_backward_cost = link->acoustic_cost + link->graph_cost +
+          next_tok->backward_cost;
+        BaseFloat link_cost = link_backward_cost + tok->tot_cost;
+        // link_exta_cost is the difference in score between the best paths
+        // through link source state and through link destination state
+        KALDI_ASSERT(link_cost == link_cost);  // check for NaN
+        if (link_cost > threshold) {  // excise link
+          ForwardLinkT *next_link = link->next;
+          if (prev_link != NULL) prev_link->next = next_link;
+          else tok->links = next_link;
+          delete link;
+          link = next_link;  // advance link but leave prev_link the same.
+          *links_pruned = true;
+        } else {   // keep the link
+          if (link_cost < best_cost) {  // this is just a precaution.
+            if (link_cost < best_cost - 0.01)
+              KALDI_WARN << "This link's cost is smaller than the best one."
+            best_token = tok;
+            best_cost = link_cost;
+            threshold = best_cost + config_.lattice_beam;
+          }
+          if (link_backward_cost < tok_backward_cost)
+            tok_backward_cost = link_backward_cost;
+          prev_link = link;  // move to next link
+          link = link->next;
+        }
+      }  // for all outgoing links
+      if (fabs(tok_backward_cost - tok->backward_cost) > delta)
+        changed = true;   // difference new minus old is bigger than delta
+      tok->backward_cost = tok_backward_cost;
+      // will be +infinity or <= lattice_beam_.
+      // infinity indicates, that no forward link survived pruning
+    }  // for all Token on active_toks_[frame]
+    if (changed) *backward_costs_changed = true;
+
+    // Note: it's theoretically possible that aggressive compiler
+    // optimizations could cause an infinite loop here for small delta and
+    // high-dynamic-range scores.
+  } // while changed
+}
+
+// PruneForwardLinksFinal is a version of PruneForwardLinks that we call
+// on the final frame.  If there are final tokens active, it uses
+// the final-probs for pruning, otherwise it treats all tokens as final.
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::PruneForwardLinksFinal() {
+  KALDI_ASSERT(!active_toks_.empty());
+  int32 frame_plus_one = active_toks_.size() - 1;
+
+  if (active_toks_[frame_plus_one].toks == NULL)  // empty list; should not happen.
+    KALDI_WARN << "No tokens alive at end of file";
+
+  typedef typename unordered_map<Token*, BaseFloat>::const_iterator IterType;
+  ComputeFinalCosts(&final_costs_, &final_relative_cost_, &final_best_cost_);
+  decoding_finalized_ = true;
+
+  // Initialize the backward_costs of the tokens on the final frame.
+  // We will recompute tok_backward_cost.  It has a term in it that corresponds
+  // to the "final-prob", so instead of initializing tok_backward_cost to -alpha
+  // below we set it to the difference between the (score+final_prob) of this
+  // token and the best such (score+final_prob) minus alpha.
+  BaseFloat best_cost = std::numeric_limits<BaseFloat>::infinity();
+  for (Token *tok = active_toks_[frame_plus_one].toks; tok != NULL;
+       tok = tok->next) {
+    BaseFloat final_cost;
+    if (final_costs_.empty()) {
+      final_cost = 0.0;
+    } else {
+      IterType iter = final_costs_.find(tok);
+      if (iter != final_costs_.end())
+        final_cost = iter->second;
+      else
+        final_cost = std::numeric_limits<BaseFloat>::infinity();
+    }
+    tok->backward_cost = -tok->tot_cost + (tok->tot_cost + final_cost -
+        final_best_cost_);  // difference in brackets is >= 0
+    best_cost = min(best_cost, tok->tot_cost + tok->backward_cost);
+  }
+
+  BaseFloat threshold = best_cost + config_.lattice_beam;
+  // Now go through tokens on this frame, pruning forward links...  may have to
+  // iterate a few times until there is no more change, because the list is not
+  // in topological order.  This is a modified version of the code in
+  // PruneForwardLinks, but here we also take account of the final-probs.
+  bool changed = true;
+  BaseFloat delta = 1.0e-05;
+  while (changed) {
+    changed = false;
+    for (Token *tok = active_toks_[frame_plus_one].toks;
+         tok != NULL; tok = tok->next) {
+      ForwardLinkT *link, *prev_link = NULL;
+      // tok_backward_cost will be a "min" over either directly being final, or
+      // being indirectly final through other links, and the loop below may
+      // decrease its value:
+      BaseFloat tok_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      for (link = tok->links; link != NULL; ) {
+        // See if we need to excise this link...
+        Token *next_tok = link->next_tok;
+        BaseFloat link_backward_cost = next_tok->backward_cost + 
+          link->acoustic_cost + link->graph_cost;
+        BaseFloat link_cost = link_backward_cost + tok->tot_cost;
+        if (link_cost > threshold) {  // excise link
+          ForwardLinkT *next_link = link->next;
+          if (prev_link != NULL) prev_link->next = next_link;
+          else tok->links = next_link;
+          delete link;
+          link = next_link; // advance link but leave prev_link the same.
+        } else { // keep the link and update the tok_extra_cost if needed.
+          if (link_cost < best_cost) { // this is just a precaution.
+            if (link_cost < best_cost - 0.01)
+              KALDI_WARN << "Negative extra_cost: " << link_cost;
+            best_cost = link_cost;
+            threshold = best_cost + config_.lattice_beam;
+          }
+          if (link_backward_cost < tok_backward_cost)
+            tok_backward_cost = link_backward_cost;
+          prev_link = link;
+          link = link->next;
+        }
+      }
+      // prune away tokens worse than lattice_beam above best path.  This step
+      // was not necessary in the non-final case because then, this case
+      // showed up as having no forward links.  Here, the tok_extra_cost has
+      // an extra component relating to the final-prob.
+      if (tok_backward_cost > threshold)
+        tok_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      // to be pruned in PruneTokensForFrame
+
+      if (!ApproxEqual(tok->backward_cost, tok_backward_cost, delta))
+        changed = true;
+      tok->backward_cost = tok_backward_cost; // will be +infinity or <= lattice_beam_.
+    }
+  } // while changed
+}
+
+template <typename FST, typename Token>
+BaseFloat LatticeBiglmFasterDecoderCombineTpl<FST, Token>::FinalRelativeCost() const {
+  if (!decoding_finalized_) {
+    BaseFloat relative_cost;
+    ComputeFinalCosts(NULL, &relative_cost, NULL);
+    return relative_cost;
+  } else {
+    // we're not allowed to call that function if FinalizeDecoding() has
+    // been called; return a cached value.
+    return final_relative_cost_;
+  }
+}
+
+
+// Prune away any tokens on this frame that have no forward links.
+// [we don't do this in PruneForwardLinks because it would give us
+// a problem with dangling pointers].
+// It's called by PruneActiveTokens if any forward links have been pruned
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::PruneTokensForFrame(
+    int32 frame_plus_one) {
+  KALDI_ASSERT(frame_plus_one >= 0 && frame_plus_one < active_toks_.size());
+  Token *&toks = active_toks_[frame_plus_one].toks;
+  if (toks == NULL)
+    KALDI_WARN << "No tokens alive [doing pruning]";
+  Token *tok, *next_tok, *prev_tok = NULL;
+  for (tok = toks; tok != NULL; tok = next_tok) {
+    next_tok = tok->next;
+    if (tok->backward_cost == std::numeric_limits<BaseFloat>::infinity()) {
+      // token is unreachable from end of graph; (no forward links survived)
+      // excise tok from list and delete tok.
+      if (prev_tok != NULL) prev_tok->next = tok->next;
+      else toks = tok->next;
+      delete tok;
+      num_toks_--;
+    } else {  // fetch next Token
+      prev_tok = tok;
+    }
+  }
+}
+
+// Go backwards through still-alive tokens, pruning them, starting not from
+// the current frame (where we want to keep all tokens) but from the frame before
+// that.  We go backwards through the frames and stop when we reach a point
+// where the delta-costs are not changing (and the delta controls when we consider
+// a cost to have "not changed").
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::PruneActiveTokens(
+    BaseFloat delta) {
+  int32 cur_frame_plus_one = complete_frame_;
+  int32 num_toks_begin = num_toks_;
+  // The index "f" below represents a "frame plus one", i.e. you'd have to subtract
+  // one to get the corresponding index for the decodable object.
+
+  // TODO: Maybe we needn't reach the begining. T-25 is OK.
+  for (int32 f = cur_frame_plus_one - 1; f >= 0; f--) {
+    // Reason why we need to prune forward links in this situation:
+    // (1) we have never pruned them (new TokenList)
+    // (2) we have not yet pruned the forward links to the next f,
+    // after any of those tokens have changed their extra_cost.
+    if (active_toks_[f].must_prune_forward_links) {
+      bool backward_costs_changed = false, links_pruned = false;
+      PruneForwardLinks(f, &backward_costs_changed, &links_pruned, delta);
+      if (backward_costs_changed && f > 0) // any token has changed extra_cost
+        active_toks_[f-1].must_prune_forward_links = true;
+      if (links_pruned) // any link was pruned
+        active_toks_[f].must_prune_tokens = true;
+      active_toks_[f].must_prune_forward_links = false; // job done
+    }
+    if (f+1 < cur_frame_plus_one &&      // except for last f (no forward links)
+        active_toks_[f+1].must_prune_tokens) {
+      PruneTokensForFrame(f+1);
+      active_toks_[f+1].must_prune_tokens = false;
+    }
+  }
+  KALDI_VLOG(4) << "PruneActiveTokens: pruned tokens from " << num_toks_begin
+                << " to " << num_toks_;
+}
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ComputeFinalCosts(
+    unordered_map<Token*, BaseFloat> *final_costs,
+    BaseFloat *final_relative_cost,
+    BaseFloat *final_best_cost) const {
+  KALDI_ASSERT(!decoding_finalized_);
+  if (final_costs != NULL)
+    final_costs->clear();
+  BaseFloat infinity = std::numeric_limits<BaseFloat>::infinity();
+  BaseFloat best_cost = infinity,
+      best_cost_with_final = infinity;
+
+  // The final tokens are recorded in active_toks_[last_frame]
+  for (Token *tok = active_toks_[active_toks_.size() - 1].toks; tok != NULL;
+       tok = tok->next) {
+    StateId state = tok->base_state;
+    BaseFloat final_cost = fst_->Final(state).Value();
+    BaseFloat cost = tok->tot_cost,
+        cost_with_final = cost + final_cost;
+    best_cost = std::min(cost, best_cost);
+    best_cost_with_final = std::min(cost_with_final, best_cost_with_final);
+    if (final_costs != NULL && final_cost != infinity)
+      (*final_costs)[tok] = final_cost;
+  }
+  if (final_relative_cost != NULL) {
+    if (best_cost == infinity && best_cost_with_final == infinity) {
+      // Likely this will only happen if there are no tokens surviving.
+      // This seems the least bad way to handle it.
+      *final_relative_cost = infinity;
+    } else {
+      *final_relative_cost = best_cost_with_final - best_cost;
+    }
+  }
+  if (final_best_cost != NULL) {
+    if (best_cost_with_final != infinity) { // final-state exists.
+      *final_best_cost = best_cost_with_final;
+    } else { // no final-state exists.
+      *final_best_cost = best_cost;
+    }
+  }
+}
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::AdvanceDecoding(
+    DecodableInterface *decodable,
+    int32 max_num_frames) {
+  if (std::is_same<FST, fst::Fst<fst::StdArc> >::value) {
+    // if the type 'FST' is the FST base-class, then see if the FST type of fst_
+    // is actually VectorFst or ConstFst.  If so, call the AdvanceDecoding()
+    // function after casting *this to the more specific type.
+    if (fst_->Type() == "const") {
+      LatticeBiglmFasterDecoderCombineTpl<fst::ConstFst<fst::StdArc>, Token>
+        *this_cast = reinterpret_cast<LatticeBiglmFasterDecoderCombineTpl<
+        fst::ConstFst<fst::StdArc>, Token>* >(this);
+      this_cast->AdvanceDecoding(decodable, max_num_frames);
+      return;
+    } else if (fst_->Type() == "vector") {
+      LatticeBiglmFasterDecoderCombineTpl<fst::VectorFst<fst::StdArc>, Token>
+        *this_cast = reinterpret_cast<LatticeBiglmFasterDecoderCombineTpl<
+        fst::VectorFst<fst::StdArc>, Token>* >(this);
+      this_cast->AdvanceDecoding(decodable, max_num_frames);
+      return;
+    }
+  }
+
+
+  KALDI_ASSERT(!active_toks_.empty() && !decoding_finalized_ &&
+               "You must call InitDecoding() before AdvanceDecoding");
+  int32 num_frames_ready = decodable->NumFramesReady();
+  // num_frames_ready must be >= num_frames_decoded, or else
+  // the number of frames ready must have decreased (which doesn't
+  // make sense) or the decodable object changed between calls
+  // (which isn't allowed).
+  KALDI_ASSERT(num_frames_ready >= NumFramesDecoded());
+  int32 target_frames_decoded = num_frames_ready;
+  if (max_num_frames >= 0)
+    target_frames_decoded = std::min(target_frames_decoded,
+                                     NumFramesDecoded() + max_num_frames);
+  while (NumFramesDecoded() < target_frames_decoded) {
+    if (NumFramesDecoded() % config_.prune_interval == 0) {
+      PruneActiveTokens(config_.lattice_beam * config_.prune_scale);
+    }
+    ProcessForFrame(decodable);
+  }
+}
+
+// FinalizeDecoding() is a version of PruneActiveTokens that we call
+// (optionally) on the final frame.  Takes into account the final-prob of
+// tokens.  This function used to be called PruneActiveTokensFinal().
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::FinalizeDecoding() {
+  // Process the espilon arcs for the last frame
+  ProcessNonemitting();
+
+  // Do backfill for the last few frames
+  int32 beta_end = std::max(0, active_toks_.size() - config_.beta_interval);
+  InitBeta(NumFramesDecoded());
+  for (int32 frame = NumFramesDecoded() - 1; frame >= beta_end; frame--) {
+    ComputeBetas(frame, config_.lattice_beam * config_.prune_scale);
+    PruneTokensForFrame(frame);
+  }
+  for (int32 frame = complete_frame_; frame <= NumFramesDecoded(); frame++) {
+    ExpandForward(frame, true);
+  }
+
+  int32 final_frame_plus_one = NumFramesDecoded();
+  int32 num_toks_begin = num_toks_;
+  // PruneForwardLinksFinal() prunes final frame (with final-probs), and
+  // sets decoding_finalized_.
+  PruneForwardLinksFinal();
+  for (int32 f = final_frame_plus_one - 1; f >= 0; f--) {
+    bool b1, b2; // values not used.
+    BaseFloat dontcare = 0.0; // delta of zero means we must always update
+    PruneForwardLinks(f, &b1, &b2, dontcare);
+    PruneTokensForFrame(f + 1);
+  }
+  PruneTokensForFrame(0);
+  KALDI_VLOG(4) << "pruned tokens from " << num_toks_begin
+                << " to " << num_toks_;
+}
+
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ProcessForFrame(
+    DecodableInterface *decodable) {
+  KALDI_ASSERT(active_toks_.size() > 0);
+  int32 cur_frame = active_toks_.size() - 1, // frame is the frame-index (zero-
+                                             // based) used to get likelihoods
+                                             // from the decodable object.
+        next_frame = cur_frame + 1;
+
+  active_toks_.resize(active_toks_.size() + 1);
+  token_map_.resize(active_toks_.size());
+  best_token_map_.resize(active_toks_.size());
+  best_token_.resize(active_toks_.size());
+
+  token_map_[next_frame] = new PairIdTokenMap();
+  best_token_map_[next_frame] = new StateIdTokenMap();
+
+  PairIdToTokenMap* &cur_toks = token_map_[cur_frame];
+  PairIdToTokenMap* &next_toks = token_map_[next_frame];
+  StateIdToTokenMap* &cur_best_toks = best_token_map_[cur_frame];
+  StateIdToTokenMap* &next_best_toks = best_token_map_[next_frame];
+
+  if (cur_toks.empty()) {
+    if (!warned_) {
+      KALDI_WARN << "Error, no surviving tokens on frame " << cur_frame;
+      warned_ = true;
+    }
+  }
+
+  cur_queue_.Clear();
+  // Add tokens to queue
+  for (typename StateIdToTokenMap::const_iterator iter = cur_best_toks->begin();
+       iter != cur_best_toks->end(); iter++) {
+    cur_queue_.Push(iter->second);
+  }
+
+  // Declare a local variable so the compiler can put it in a register, since
+  // C++ assumes other threads could be modifying class members.
+  BaseFloat adaptive_beam = adaptive_beam_;
+  // "cur_cutoff" will be kept to the best-seen-so-far token on this frame
+  // + adaptive_beam
+  BaseFloat cur_cutoff = std::numeric_limits<BaseFloat>::infinity();
+  // "next_cutoff" is used to limit a new token in next frame should be handle
+  // or not. It will be updated along with the further processing.
+  // this will be kept updated to the best-seen-so-far token "on next frame"
+  // + adaptive_beam
+  BaseFloat next_cutoff = std::numeric_limits<BaseFloat>::infinity();
+  // "cost_offset" contains the acoustic log-likelihoods on current frame in 
+  // order to keep everything in a nice dynamic range. Reduce roundoff errors.
+  BaseFloat cost_offset = cost_offsets_[cur_frame];
+
+  // Iterator the "cur_queue_" to process non-emittion and emittion arcs in fst.
+  Token *tok = NULL;
+  int32 num_toks_processed = 0;
+  int32 max_active = config_.max_active;
+  for (; num_toks_processed < max_active && (tok = cur_queue_.Pop()) != NULL;
+       num_toks_processed++) {
+    BaseFloat cur_cost = tok->tot_cost;
+    StateId base_state = tok->base_state,
+            lm_state = tok->lm_state;
+    if (cur_cost > cur_cutoff &&
+        num_toks_processed > config_.min_active) { // Don't bother processing
+                                                     // successors.
+      break;  // This is a priority queue. The following tokens will be worse
+    } else if (cur_cost + adaptive_beam < cur_cutoff) {
+      cur_cutoff = cur_cost + adaptive_beam; // a tighter boundary
+    }
+    // If "tok" has any existing forward links, delete them,
+    // because we're about to regenerate them.  This is a kind
+    // of non-optimality (remember, this is the simple decoder),
+    DeleteForwardLinks(tok);  // necessary when re-visiting
+    for (fst::ArcIterator<FST> aiter(*fst_, state);
+         !aiter.Done();
+         aiter.Next()) {
+      const Arc &arc_ref = aiter.Value();
+      bool changed;
+      Arc arc(arc_ref);
+      BaseFloat graph_cost_ori = arc.weight.Value();
+      StateId next_lm_state = PropagateLm(lm_state, &arc);
+
+      if (arc.ilabel == 0) {  // propagate nonemitting
+        BaseFloat graph_cost = arc.weight.Value();
+        BaseFloat tot_cost = cur_cost + graph_cost;
+        if (tot_cost < cur_cutoff) {
+          PairId next_pair = ConstructPair(arc.nextstate, next_lm_state);
+          Token *new_tok = FindOrAddToken(next_pair, cur_frame, tot_cost, tok,
+                                          cur_toks, &changed);
+
+          // Add ForwardLink from tok to new_tok. Put it on the head of
+          // tok->link list
+          tok->links = new ForwardLinkT(new_tok, 0, arc.olabel,
+                                        graph_cost, 0, graph_cost_ori,
+                                        tok->links);
+          
+          // "changed" tells us whether the new token has a different
+          // cost from before, or is new.
+          if (changed) {
+            cur_queue_.Push(new_tok);
+          }
+        }
+      } else {  // propagate emitting
+        BaseFloat graph_cost = arc.weight.Value(),
+                  ac_cost = cost_offset - decodable->LogLikelihood(cur_frame,
+                                                                   arc.ilabel),
+                  cur_cost = tok->tot_cost,
+                  tot_cost = cur_cost + ac_cost + graph_cost;
+        if (tot_cost > next_cutoff) continue;
+        else if (tot_cost + adaptive_beam < next_cutoff) {
+          next_cutoff = tot_cost + adaptive_beam;  // a tighter boundary for
+                                                   // emitting
+        }
+
+        PairId next_pair = ConstructPair(arc.nextstate, next_lm_state);
+        // no change flag is needed
+        Token *next_tok = FindOrAddToken(next_pair, next_frame, tot_cost,
+                                         tok, next_toks, NULL);
+        // Add ForwardLink from tok to next_tok. Put it on the head of tok->link
+        // list
+        tok->links = new ForwardLinkT(next_tok, arc.ilabel, arc.olabel,
+                                      graph_cost, ac_cost, graph_cost_ori,
+                                      tok->links);
+      }
+    }  // for all arcs
+  }  // end of while loop
+
+  // Store the offset on the acoustic likelihoods that we're applying.
+  // Could just do cost_offsets_.push_back(cost_offset), but we
+  // do it this way as it's more robust to future code changes.
+  // Set the cost_offset_ for next frame, it equals "- best_cost_on_next_frame".
+  cost_offsets_.resize(cur_frame + 2, 0.0);
+  cost_offsets_[next_frame] = adaptive_beam - next_cutoff;
+
+  {  // This block updates adaptive_beam_
+    BaseFloat beam_used_this_frame = adaptive_beam;
+    Token *tok = cur_queue_.Pop();
+    if (tok != NULL) {
+      // We hit the max-active contraint, meaning we effectively pruned to a
+      // beam tighter than 'beam'. Work out what this was, it will be used to
+      // update 'adaptive_beam'.
+      BaseFloat best_cost_this_frame = cur_cutoff - adaptive_beam;
+      beam_used_this_frame = tok->tot_cost - best_cost_this_frame;
+    }
+    if (num_toks_processed <= config_.min_active) {
+      // num-toks active is dangerously low, increase the beam even if it
+      // already exceeds the user-specified beam.
+      adaptive_beam_ = std::max<BaseFloat>(
+          config_.beam, beam_used_this_frame + 2.0 * config_.beam_delta);
+    } else {
+      // have adaptive_beam_ approach beam_ in intervals of config_.beam_delta
+      BaseFloat diff_from_beam = beam_used_this_frame - config_.beam;
+      if (std::abs(diff_from_beam) < config_.beam_delta) {
+        adaptive_beam_ = config_.beam;
+      } else {
+        // make it close to beam_
+        adaptive_beam_ = beam_used_this_frame -
+          config_.beam_delta * (diff_from_beam > 0 ? 1 : -1);
+      }
+    }
+  }
+}
+
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ProcessNonemitting() {
+  int32 cur_frame = active_toks_.size() - 1;
+  StateIdToTokenMap &cur_toks = next_toks_;
+
+  cur_queue_.Clear();
+  for (Token* tok = active_toks_[cur_frame].toks; tok != NULL; tok = tok->next)
+    cur_queue_.Push(tok);
+
+  // Declare a local variable so the compiler can put it in a register, since
+  // C++ assumes other threads could be modifying class members.
+  BaseFloat adaptive_beam = adaptive_beam_;
+  // "cur_cutoff" will be kept to the best-seen-so-far token on this frame
+  // + adaptive_beam
+  BaseFloat cur_cutoff = std::numeric_limits<BaseFloat>::infinity();
+
+  Token *tok = NULL;
+  int32 num_toks_processed = 0;
+  int32 max_active = config_.max_active;
+
+  for (; num_toks_processed < max_active && (tok = cur_queue_.Pop()) != NULL;
+       num_toks_processed++) {
+    BaseFloat cur_cost = tok->tot_cost;
+    StateId state = tok->base_state;
+    if (cur_cost > cur_cutoff &&
+        num_toks_processed > config_.min_active) { // Don't bother processing
+                                                     // successors.
+      break;  // This is a priority queue. The following tokens will be worse
+    } else if (cur_cost + adaptive_beam < cur_cutoff) {
+      cur_cutoff = cur_cost + adaptive_beam; // a tighter boundary
+    }
+    // If "tok" has any existing forward links, delete them,
+    // because we're about to regenerate them.  This is a kind
+    // of non-optimality (remember, this is the simple decoder),
+    DeleteForwardLinks(tok);  // necessary when re-visiting
+    for (fst::ArcIterator<FST> aiter(*fst_, state);
+         !aiter.Done();
+         aiter.Next()) {
+      const Arc &arc = aiter.Value();
+      bool changed;
+      if (arc.ilabel == 0) {  // propagate nonemitting
+        BaseFloat graph_cost = arc.weight.Value();
+        BaseFloat tot_cost = cur_cost + graph_cost;
+        if (tot_cost < cur_cutoff) {
+          Token *new_tok = FindOrAddToken(arc.nextstate, cur_frame, tot_cost,
+                                          tok, &cur_toks, &changed);
+
+          // Add ForwardLink from tok to new_tok. Put it on the head of
+          // tok->link list
+          tok->links = new ForwardLinkT(new_tok, 0, arc.olabel,
+                                        graph_cost, 0, tok->links);
+          
+          // "changed" tells us whether the new token has a different
+          // cost from before, or is new.
+          if (changed) {
+            cur_queue_.Push(new_tok);
+          }
+        }
+      }
+    }  // end of for loop
+  }  // end of while loop
+  if (!decoding_finalized_) {
+    // Update cost_offsets_, it equals "- best_cost".
+    cost_offsets_[cur_frame] = adaptive_beam - cur_cutoff;
+    // Needn't to update adaptive_beam_, since we still process this frame in
+    // ProcessForFrame.
+  }
+}
+
+
+
+// static inline
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::DeleteForwardLinks(Token *tok) {
+  ForwardLinkT *l = tok->links, *m;
+  while (l != NULL) {
+    m = l->next;
+    delete l;
+    l = m;
+  }
+  tok->links = NULL;
+}
+
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ClearActiveTokens() {
+  // a cleanup routine, at utt end/begin
+  for (size_t i = 0; i < active_toks_.size(); i++) {
+    // Delete all tokens alive on this frame, and any forward
+    // links they may have.
+    for (Token *tok = active_toks_[i].toks; tok != NULL; ) {
+      DeleteForwardLinks(tok);
+      Token *next_tok = tok->next;
+      delete tok;
+      num_toks_--;
+      tok = next_tok;
+    }
+  }
+  active_toks_.clear();
+  KALDI_ASSERT(num_toks_ == 0);
+}
+
+// static
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::TopSortTokens(
+    Token *tok_list, std::vector<Token*> *topsorted_list) {
+  unordered_map<Token*, int32> token2pos;
+  typedef typename unordered_map<Token*, int32>::iterator IterType;
+  int32 num_toks = 0;
+  for (Token *tok = tok_list; tok != NULL; tok = tok->next)
+    num_toks++;
+  int32 cur_pos = 0;
+  // We assign the tokens numbers num_toks - 1, ... , 2, 1, 0.
+  // This is likely to be in closer to topological order than
+  // if we had given them ascending order, because of the way
+  // new tokens are put at the front of the list.
+  for (Token *tok = tok_list; tok != NULL; tok = tok->next)
+    token2pos[tok] = num_toks - ++cur_pos;
+
+  unordered_set<Token*> reprocess;
+
+  for (IterType iter = token2pos.begin(); iter != token2pos.end(); ++iter) {
+    Token *tok = iter->first;
+    int32 pos = iter->second;
+    for (ForwardLinkT *link = tok->links; link != NULL; link = link->next) {
+      if (link->ilabel == 0) {
+        // We only need to consider epsilon links, since non-epsilon links
+        // transition between frames and this function only needs to sort a list
+        // of tokens from a single frame.
+        IterType following_iter = token2pos.find(link->next_tok);
+        if (following_iter != token2pos.end()) { // another token on this frame,
+                                                 // so must consider it.
+          int32 next_pos = following_iter->second;
+          if (next_pos < pos) { // reassign the position of the next Token.
+            following_iter->second = cur_pos++;
+            reprocess.insert(link->next_tok);
+          }
+        }
+      }
+    }
+    // In case we had previously assigned this token to be reprocessed, we can
+    // erase it from that set because it's "happy now" (we just processed it).
+    reprocess.erase(tok);
+  }
+
+  size_t max_loop = 1000000, loop_count; // max_loop is to detect epsilon cycles.
+  for (loop_count = 0;
+       !reprocess.empty() && loop_count < max_loop; ++loop_count) {
+    std::vector<Token*> reprocess_vec;
+    for (typename unordered_set<Token*>::iterator iter = reprocess.begin();
+         iter != reprocess.end(); ++iter)
+      reprocess_vec.push_back(*iter);
+    reprocess.clear();
+    for (typename std::vector<Token*>::iterator iter = reprocess_vec.begin();
+         iter != reprocess_vec.end(); ++iter) {
+      Token *tok = *iter;
+      int32 pos = token2pos[tok];
+      // Repeat the processing we did above (for comments, see above).
+      for (ForwardLinkT *link = tok->links; link != NULL; link = link->next) {
+        if (link->ilabel == 0) {
+          IterType following_iter = token2pos.find(link->next_tok);
+          if (following_iter != token2pos.end()) {
+            int32 next_pos = following_iter->second;
+            if (next_pos < pos) {
+              following_iter->second = cur_pos++;
+              reprocess.insert(link->next_tok);
+            }
+          }
+        }
+      }
+    }
+  }
+  KALDI_ASSERT(loop_count < max_loop && "Epsilon loops exist in your decoding "
+               "graph (this is not allowed!)");
+
+  topsorted_list->clear();
+  topsorted_list->resize(cur_pos, NULL);  // create a list with NULLs in between.
+  for (IterType iter = token2pos.begin(); iter != token2pos.end(); ++iter)
+    (*topsorted_list)[iter->second] = iter->first;
+}
+
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::InitBeta(int32 frame) {
+  for (Token* tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+    tok->backward_cost = -tok->tot_cost;
+  }
+}
+
+
+template <typename FST, typename Token>
+int32 LatticeBiglmFasterDecoderCombineTpl<FST, Token>::DoBackfill() {
+  // Update Beta
+  int32 beta_end = std::max(0, NumFramesDecoded() - config_.beta_interval);
+  InitBeta(NumFramesDecoded() - 1);
+  for (int32 frame = NumFramesDecoded() - 2; frame >= beta_end; frame--) {
+    ComputeBetas(frame, config_.lattice_beam * config_.prune_scale);
+    PruneTokensForFrame(frame);
+  }
+  int32 expand_best_only_start =
+    NumFramesDecoded() - config_.expand_best_interval;
+  for (int32 frame = beta_end; frame < expand_best_only_start; frame++) {
+    ExpandForward(frame, true);
+  }
+  for (int32 frame = expand_best_only_start; frame < NumFramesDecode() - 1;
+      frame++) {
+    ExpandForward(frame, false);
+  }
+  return expand_best_only_start - 1;
+}
+
+
+template <typename FST, typename Token>
+int32 LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ComputeBeta(int32 frame,
+    BaseFloat delta) {
+  // a. Update the expanded token's beta
+  // We have to iterate until there is no more change, because the links
+  // are not guaranteed to be in topological order.
+  bool changed = true; // difference new minus old extra cost >= delta ?
+  while (changed) {
+    changed = false;
+    for (Token *tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+      if (!tok->expanded) continue;
+      ForwardLink *link;
+      // will recompute tok_backward_cost for expanded tok.
+      BaseFloat tok_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      // tok_backward_cost is the best (min) of link_backward_cost of
+      // outgoing links
+      for (link = tok->links; link != NULL; link = link->next) {
+        Token *next_tok = link->next_tok;
+        BaseFloat link_backward_cost = 
+          std::numeric_limits<BaseFloat>::infinity();
+        link_backward_cost = next_tok->backward_cost + link->acoustic_cost +
+                             link->graph_cost;
+        KALDI_ASSERT(link_backward_cost == link_backward_cost); // check for NaN
+        tok_backward_cost = std::min(tok_backward_cost, link_backward_cost);
+      }
+      if (fabs(tok_backward_cost - tok->backward_cost) > delta)
+        changed = true;  // difference new minus old is bigger than delta
+      tok->backward_cost = tok_backward_cost;
+    } // for all expanded token
+  }
+
+  // b. find the best token for the particular frame
+  Token* &best_tok = best_token_[frame];
+  for (Token *tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+    if (tok->expanded) {  // Get the best token from expanded tokens
+      if (best_tok == NULL || *tok < *best_tok) {
+        best_tok = tok;
+      }
+    }   
+  }
+
+  // c. Build best_token_map with alpha + beta and prune tokens that fall below
+  // the config_.beam
+  best_token_map_[frame]->clear();
+  StateIdToTokenMap* &best_token_map = best_token_map_[frame];
+  for (Token *tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+    if (tok->expanded) {
+      // Prune useless expanded token with beam
+      if ((tok->tot_cost + tok->backward_cost) < (best_tok->tot_cost +
+            best_tok->backward_cost) + config_.beam) {
+        *best_token_map[tok->hclg_state] = tok;
+      } else {  // the expanded token should be pruned.
+        DeleteForwardLinks(tok);
+        tok->backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      }
+    }
+  }
+
+  // d. Update un-expanded tokens
+  for (Token *tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+    if (!tok->expanded) {
+      if (best_token_map.find(tok->hclg) != best_token_map.end()) {
+        tok->backward_cost = best_token_map[tok->hclg];
+        // Prune the worse unexpanded token
+        if ((tok->tot_cost + tok->backward_cost) >=
+            (best_tok->tot_cost + best_tok->backward_cost) + config_.beam) {
+          DeleteForwardLinks(tok);
+          tok->backward_cost = std::numeric_limits<BaseFloat>::infinity();
+        }
+      } else {
+        // Prune the token whose shadowing token has been pruned.
+        DeleteForwardLinks(tok);
+        tok->backward_cost = std::numeric_limits<BaseFloat>::infinity();
+      }
+    }
+  }
+}
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ExpandForward(int32 frame,
+    bool expand_not_best) {
+  std::queue<Token*> queue;
+  // Add the token which should be processed into "queue".
+  // a. Process expanded tokens
+  for (Token *tok = active_toks_[frame].toks; tok != NULL; tok = tok->next) {
+    if (tok->expanded) {
+      if (tok->update_alpha) {
+        KALDI_ASSERT(*best_token_map_[frame].find(tok->hclg_state) !=
+                     *best_token_map_[frame].end());
+        KALDI_ASSERT(*tok < *(*best_token_map_[frame])[tok->hclg_state]);
+        // Check the expanded token whose alpha is updated so that the alphas of
+        // its successor tokens may need to be updated.
+        queue.push(tok);
+      }
+    } else {  // For unexpanded token 
+      if (expand_not_best) {  // expand all survived un-expanded tokens
+        queue.push(tok);
+      } else {  // only the better hclg token
+        KALDI_ASSERT(best_token_map.find(tok->hclg_state) !=
+                     best_token_map.end());
+        if (*tok < *(*best_token_map[frame])[tok->hclg_state]) queue.push(tok);
+      }
+    }
+  }
+
+  while (!queue.empty()) {
+    Token* tok = queue.front();
+    queue.pop();
+    if (tok->expanded) {
+      tok->update_alpha = false;  // Set update_alpha flag
+      for (ForwardLink* link = tok->links; link != NULL; link = link->next) {
+        Token* next_tok = link->next_tok;
+        if (link->ilabel == 0) {  // epsilon
+          BaseFloat link_tot_cost = tok->tot_cost + link->graph_cost;
+          if (link_tot_cost < next_tok->tot_cost) {  // the successor token's
+                                                     // alpha need to be updated
+            next_tok->tot_cost = link_tot_cost;
+            // For un-expanded token, the "update_alpha" flag is meaningless as
+            // it doesn't have successor tokens.
+            if (next_tok->expanded) {
+              next_tok->update_alpha = true;
+              queue.push(next_tok);
+              // next_tok is an expanded token. So, when its alpha is updated,
+              // it may become the best-in-class token
+              if (*next_tok <
+                  *(*best_token_map_[frame])[next_tok->hclg_state]) {
+                (*best_token_map_[frame])[next_tok->hclg_state] = next_tok;
+                // may become the best token in this frame
+                if (*next_tok < *best_token_[frame]) {
+                  best_token_[frame] = next_tok;
+                }
+              }
+            }
+          }
+        } else {  // non-epsilon. Take care of cost_offset_
+          KALDI_ASSERT(active_toks_[frame + 1]);
+          BaseFloat link_tot_cost = tok->tot_cost + link->graph_cost +
+                                    link->acoustic_cost;
+          if (link_tot_cost < next_tok->tot_cost) {  // update successor token's
+                                                     // alpha
+            next_tok->tot_cost = link_tot_cost;
+            if (next_tok->expanded) {
+              next_tok->update_alpha = true;
+              // Needn't add it into queue. It will be processed in next frame.
+              // next_tok is an expanded token. So, when its alpha is updated,
+              // it may become the best-in-class token
+              if (*next_tok <
+                  *(*best_token_map_[frame])[next_tok->hclg_state]) {
+                (*best_token_map_[frame])[next_tok->hclg_state] = next_tok;
+                // may become the best token in this frame
+                if (*next_tok < *best_token_[frame]) {
+                  best_token_[frame] = next_tok;
+                }
+              }
+            }       
+          }
+        }
+      }  // all links
+    } else {  // un-expanded token
+      ExpandTokenBackfill(frame, tok);
+    }
+  }  // while loop
+}
+
+template <typename FST, typename Token>
+void LatticeBiglmFasterDecoderCombineTpl<FST, Token>::ExpandTokenBackfill(
+    int32 frame, Token* tok) {
+  StateIdToTokenMap* &best_token_map = best_token_map_[frame];
+  if (best_token_map->find(tok->hclg_state) == best_token_map->end()) {
+    KALDI_WARN << "The token (" << tok->hclg_state << "," << tok->lm_state
+               << ") doesn't have reference token. It's highly unexpected."
+               << " Set the token's beta to infinity and prune later."
+    tok->backward_cost = std::numeric_limits<BaseFloat>::infinity();
+    return;
+  }
+  Token* &ref_tok = *best_token_map[tok->hclg_state];
+  for (ForwardLink *ref_link = ref_tok->links; ref_link != NULL;
+      ref_link = ref_link->next) {
+    Token* &ref_next_tok = ref_link->next_tok;
+
+    StateId new_hclg_state = ref_next_tok->hclg_state;
+    Arc arc(ref_link->ilabel, ref_link->olabel, ref_link->graph_cost_ori, 0);
+    StateId new_lm_state = PropagateLm(tok->lm_state, &arc);
+    PairId new_pair_id = ConstructPair(new_hclg_state, new_lm_state);
+    BaseFloat ac_cost = ref_link->acoustic_cost,
+              graph_cost = arc.weight.Value(),
+              cur_cost = tok->tot_cost,
+              tot_cost = cur_cost + ac_cost + graph_cost,
+              backward_cost = ref_next_tok->backward_cost,
+    int32 new_frame_index = link->ilabel ? frame + 1 : frame;
+    Token* &toks = link->ilabel ? active_toks_[frame + 1].toks :
+                                  active_toks_[frame].toks;
+    
+    KALDI_ASSERT(token_map_.size() >= new_frame_index + 1);
+    KALDI_ASSERT(best_token_map_.size() == token_map_.size() ==
+        best_token_.size());
+
+    // Process the new token
+    PairIdToTokenMap* &token_map = token_map_[new_frame_index];
+    Token* new_tok;
+    if (token_map->find(new_pair_id) == token_map->end()) {  // a new token
+      // check its alpha_beta is within the beam
+      Token* &best_token = best_token_[new_frame_index];
+      if (tot_cost + backward_cost >
+          best_token->tot_cost + best_token->backward_cost + config_.beam)
+        continue;
+      // create a new token
+      new_tok = new Token(tot_cost, backward_cost, new_hclg_state,
+          new_lm_state, NULL, toks);
+      (*token_map_[new_frame_index])[new_pair_id] = new_tok;
+      if (ref_link->ilabel == 0)
+        queue.push(new_tok);  // TODO
+    } else {  // an existing token
+      new_tok = token_map[new_pair_id];
+      tok->links = new ForwardLink(new_tok, arc.ilabel, arc.olabel,
+                                   graph_cost, ac_cost, tok->links,
+                                   ref_link->graph_cost_ori);
+      // For an existing token, the beta (backward cost) is generated from its 
+      // successors. Use the beta directly. So compare the alpha (forward cost)
+      // only.
+      if (tot_cost < new_tok->tot_cost) {  // update
+        new_tok->tot_cost = tot_cost;
+        new_tok->update_alpha = true;  // indicate the token's tot_cost is
+                                       // updated, update the successors.
+        if (new_tok->expanded) {
+          if (*new_tok <
+              *(*best_token_map_[new_frame_index])[new_tok->hclg_state]) {
+            (*best_token_map_[new_frame_index])[new_tok->hclg_state] = new_tok;
+            if (*new_tok < *best_token_[new_frame_index]) {
+              best_token_[new_frame_index] = new_tok;
+            }
+          }
+        }
+      }
+    }  // end of the processing of one new token
+  }  // end of the for loop
+  tok->expanded = true;  // Set expanded property to true
+  
+  // Recompute the token's beta
+  BaseFloat tok_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+  // tok_backward_cost is the best (min) of link_backward_cost of outgoing links
+  for (ForwardLink *link = tok->links; link != NULL; link = link->next) {
+    Token *next_tok = link->next_tok;
+    BaseFloat link_backward_cost = std::numeric_limits<BaseFloat>::infinity();
+    link_backward_cost = next_tok->backward_cost + link->acoustic_cost + 
+      link->graph_cost;
+    KALDI_ASSERT(link_backward_cost == link_backward_cost); // check for NaN
+    tok_backward_cost = std::min(tok_backward_cost, link_backward_cost);
+  }
+  tok->backward_cost = tok_backward_cost;
+
+  // Check best_token_map_ and best_token_
+  if (*tok < *(*best_token_map_[frame])[tok->hclg_state]) {
+    (*best_token_map_[frame])[tok->hclg_state] = tok;
+    if (*tok < *(best_token_[frame]))
+      best_token_[frame] = tok;
+  }
+}
+
+
+// Instantiate the template for the combination of token types and FST types
+// that we'll need.
+template class LatticeBiglmFasterDecoderCombineTpl<fst::Fst<fst::StdArc>,
+         biglmdecodercombine::StdToken<fst::Fst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::VectorFst<fst::StdArc>,
+         biglmdecodercombine::StdToken<fst::VectorFst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::ConstFst<fst::StdArc>,
+         biglmdecodercombine::StdToken<fst::ConstFst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::GrammarFst,
+         biglmdecodercombine::StdToken<fst::GrammarFst> >;
+
+template class LatticeBiglmFasterDecoderCombineTpl<fst::Fst<fst::StdArc> ,
+         biglmdecodercombine::BackpointerToken<fst::Fst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::VectorFst<fst::StdArc>,
+         biglmdecodercombine::BackpointerToken<fst::VectorFst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::ConstFst<fst::StdArc>,
+         biglmdecodercombine::BackpointerToken<fst::ConstFst<fst::StdArc> > >;
+template class LatticeBiglmFasterDecoderCombineTpl<fst::GrammarFst,
+         biglmdecodercombine::BackpointerToken<fst::GrammarFst> >;
+
+
+} // end namespace kaldi.

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -127,6 +127,7 @@ struct ForwardLink {
   Label olabel_ori;  // olabel on base fst arc
   BaseFloat graph_cost;  // graph cost of traversing arc (contains LM, etc.)
   BaseFloat acoustic_cost;  // acoustic cost (pre-scaled) of traversing arc
+  BaseFloat graph_cost_ori;  // graph cost of base HCLG graph
   ForwardLink *next;  // next in singly-linked list of forward arcs (arcs
                       // in the state-level lattice) from a token.
   inline ForwardLink(Token *next_tok, Label ilabel, Label olabel,
@@ -387,8 +388,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
   using StateId = typename Arc::StateId;
   using Weight = typename Arc::Weight;
   using ForwardLinkT = biglmdecodercombine::ForwardLink<Token>;
-  using uint64 = typename PairId;  // Will be (StateId in fst) +
-                                   // (StateId in lm_diff_fst) << 32
+  using PairId = uint64;  // (StateId in fst) + (StateId in lm_diff_fst) << 32
 
   using StateIdToTokenMap = typename std::unordered_map<StateId, Token*>;
   //using StateIdToTokenMap = typename std::unordered_map<StateId, Token*,
@@ -410,13 +410,13 @@ class LatticeBiglmFasterDecoderCombineTpl {
   // 'fst'.
   LatticeBiglmFasterDecoderCombineTpl(const FST &fst,
       const LatticeBiglmFasterDecoderCombineConfig &config,
-      fst::DeterministicOnDemandFst<FST::Arc> *lm_diff_fst);
+      fst::DeterministicOnDemandFst<Arc> *lm_diff_fst);
 
   // This version of the constructor takes ownership of the fst, and will delete
   // it when this object is destroyed.
   LatticeBiglmFasterDecoderCombineTpl(
       const LatticeBiglmFasterDecoderCombineConfig &config, FST *fst,
-      fst::DeterministicOnDemandFst<FST::Arc> *lm_diff_fst);
+      fst::DeterministicOnDemandFst<Arc> *lm_diff_fst);
 
   void SetOptions(const LatticeBiglmFasterDecoderCombineConfig &config) {
     config_ = config;
@@ -751,7 +751,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
   // delete_fst_ is true if the pointer fst_ needs to be deleted when this
   // object is destroyed.
   bool delete_fst_;
-  fst::DeterministicOnDemandFst<fst::StdArc> *lm_diff_fst_;
+  fst::DeterministicOnDemandFst<Arc> *lm_diff_fst_;
   LatticeBiglmFasterDecoderCombineConfig config_;
 
   std::vector<BaseFloat> cost_offsets_; // This contains, for each

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -1,0 +1,801 @@
+// decoder/lattice-biglm-faster-decoder-combine.h
+
+// Copyright 2013-2019  Johns Hopkins University (Author: Daniel Povey)
+//                2019  Zhehuai Chen
+//                2019  Hang Lyu               
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_DECODER_LATTICE_BIGLM_FASTER_DECODER_COMBINE_H_
+#define KALDI_DECODER_LATTICE_BIGLM_FASTER_DECODER_COMBINE_H_
+
+
+#include "util/stl-utils.h"
+#include "fst/fstlib.h"
+#include "itf/decodable-itf.h"
+#include "fstext/fstext-lib.h"
+#include "lat/determinize-lattice-pruned.h"
+#include "lat/kaldi-lattice.h"
+#include "decoder/grammar-fst.h"
+#include "decoder/lattice-faster-decoder.h"
+
+namespace kaldi {
+
+struct LatticeBiglmFasterDecoderCombineConfig {
+  BaseFloat beam;
+  int32 max_active;
+  int32 min_active;
+  BaseFloat lattice_beam;
+  int32 prune_interval;
+  bool determinize_lattice; // not inspected by this class... used in
+                            // command-line program.
+  BaseFloat beam_delta; // has nothing to do with beam_ratio
+  BaseFloat hash_ratio;
+  BaseFloat cost_scale;
+  BaseFloat prune_scale;   // Note: we don't make this configurable on the command line,
+                           // it's not a very important parameter.  It affects the
+                           // algorithm that prunes the tokens as we go.
+  // Most of the options inside det_opts are not actually queried by the
+  // LatticeFasterDecoder class itself, but by the code that calls it, for
+  // example in the function DecodeUtteranceLatticeFaster.
+  fst::DeterminizeLatticePhonePrunedOptions det_opts;
+
+  int32 backfill_interval;
+  int32 beta_interval;
+  int32 expand_best_interval;
+
+  LatticeBiglmFasterDecoderCombineConfig(): beam(16.0),
+                                       max_active(std::numeric_limits<int32>::max()),
+                                       min_active(200),
+                                       lattice_beam(10.0),
+                                       prune_interval(25),
+                                       determinize_lattice(true),
+                                       beam_delta(0.5),
+                                       hash_ratio(2.0),
+                                       cost_scale(1.0),
+                                       prune_scale(0.1),
+                                       backfill_interval(10),
+                                       beta_interval(15),
+                                       expand_best_interval(10) { }
+  void Register(OptionsItf *opts) {
+    det_opts.Register(opts);
+    opts->Register("beam", &beam, "Decoding beam.  Larger->slower, more accurate.");
+    opts->Register("max-active", &max_active, "Decoder max active states.  Larger->slower; "
+                   "more accurate");
+    opts->Register("min-active", &min_active, "Decoder minimum #active states.");
+    opts->Register("lattice-beam", &lattice_beam, "Lattice generation beam.  Larger->slower, "
+                   "and deeper lattices");
+    opts->Register("prune-interval", &prune_interval, "Interval (in frames) at "
+                   "which to prune tokens");
+    opts->Register("determinize-lattice", &determinize_lattice, "If true, "
+                   "determinize the lattice (lattice-determinization, keeping only "
+                   "best pdf-sequence for each word-sequence).");
+    opts->Register("beam-delta", &beam_delta, "Increment used in decoding-- this "
+                   "parameter is obscure and relates to a speedup in the way the "
+                   "max-active constraint is applied.  Larger is more accurate.");
+    opts->Register("hash-ratio", &hash_ratio, "Setting used in decoder to "
+                   "control hash behavior");
+    opts->Register("cost-scale", &cost_scale, "A scale that we multiply the "
+                   "token costs by before intergerizing; a larger value means "
+                   "more buckets and precise.");
+    opts->Register("backfill-interval", &backfill_interval, "Interval (in "
+                   "frames) at which to do backfill.");
+    opts->Register("beta-interval", &beta_interval, "Interval (in frames) at "
+                   "which to compute betas.");
+    opts->Register("expand-best-interval", &expand_best_interval, "Interval "
+                   "(in frame) at which to only expand best-in-class tokens.");
+  }
+  void Check() const {
+    KALDI_ASSERT(beam > 0.0 && max_active > 1 && lattice_beam > 0.0
+                 && min_active <= max_active
+                 && prune_interval > 0 && beam_delta > 0.0 && hash_ratio >= 1.0
+                 && prune_scale > 0.0 && prune_scale < 1.0);
+  }
+};
+
+
+namespace biglmdecodercombine {
+// We will template the decoder on the token type as well as the FST type; this
+// is a mechanism so that we can use the same underlying decoder code for
+// versions of the decoder that support quickly getting the best path
+// (LatticeFasterOnlineDecoder, see lattice-faster-online-decoder.h) and also
+// those that do not (LatticeFasterDecoder).
+
+
+// ForwardLinks are the links from a token to a token on the next frame.
+// or sometimes on the current frame (for input-epsilon links).
+template <typename Token>
+struct ForwardLink {
+  using Label = fst::StdArc::Label;
+
+  Token *next_tok;  // the next token [or NULL if represents final-state]
+  Label ilabel;  // ilabel on arc
+  Label olabel;  // olabel on arc
+  BaseFloat graph_cost;  // graph cost of traversing arc (contains LM, etc.)
+  BaseFloat acoustic_cost;  // acoustic cost (pre-scaled) of traversing arc
+
+  // Record the graph cost from HCLG.fst so that we needn't revisit HCLG.fst
+  // when expanding
+  BaseFloat graph_cost_ori;
+
+  ForwardLink *next;  // next in singly-linked list of forward arcs (arcs
+                      // in the state-level lattice) from a token.
+  inline ForwardLink(Token *next_tok, Label ilabel, Label olabel,
+                     BaseFloat graph_cost, BaseFloat acoustic_cost,
+                     BaseFloat graph_cost_ori, ForwardLink *next):
+      next_tok(next_tok), ilabel(ilabel), olabel(olabel),
+      graph_cost(graph_cost), acoustic_cost(acoustic_cost),
+      graph_cost_ori(graph_cost_ori), next(next) { }
+};
+
+template <typename Fst>
+struct StdToken {
+  using ForwardLinkT = ForwardLink<StdToken>;
+  using Token = StdToken;
+  using StateId = typename Fst::Arc::StateId;
+
+  // Standard token type for LatticeFasterDecoder.  Each active HCLG
+  // (decoding-graph) state on each frame has one token.
+
+  // tot_cost is the total (LM + acoustic) cost from the beginning of the
+  // utterance up to this point.  (but see cost_offset_, which is subtracted
+  // to keep it in a good numerical range).
+  BaseFloat tot_cost;
+
+  // It will be updated periodly. It will be used in Backfill stage. We will not
+  // expand all shadowing token. The shadowed token whose backward_cost <
+  // best_backward_cost + config_.beam will be expanded. In another word, if we
+  // prune the lattice on each frame rather than prune it periodly, we only
+  // expand the survived tokens after pruning.
+  BaseFloat backward_cost;
+
+  // Record the state id of the token
+  StateId base_state;  // the state in base graph (the HCLG)
+  StateId lm_state;  // the state in LM-diff FST
+
+  // 'links' is the head of singly-linked list of ForwardLinks, which is what we
+  // use for lattice generation.
+  ForwardLinkT *links;
+
+  //'next' is the next in the singly-linked list of tokens for this frame.
+  Token *next;
+
+  // identitfy the token is in current queue or not to prevent duplication in
+  // function ProcessForFrame().
+  bool in_queue;
+
+  // If true, it means we have followed the states in the composed graph and
+  // looked at the successor tokens. (If a token's expanded is true and has no
+  // arcs out of it, it means that we tried to follow them they did not meet the
+  // beam, or they were pruned.
+  bool expanded;
+
+  // Indicate the token's tot_cost is updated or not when we expand shadowed
+  // token. If true, it means the tot_cost of the successors of the token should
+  // be updated.
+  bool update_alpha;
+ 
+
+  // This function does nothing and should be optimized out; it's needed
+  // so we can share the regular LatticeFasterDecoderTpl code and the code
+  // for LatticeFasterOnlineDecoder that supports fast traceback.
+  inline void SetBackpointer (Token *backpointer) { }
+
+  // This constructor just ignores the 'backpointer' argument.  That argument is
+  // needed so that we can use the same decoder code for LatticeFasterDecoderTpl
+  // and LatticeFasterOnlineDecoderTpl (which needs backpointers to support a
+  // fast way to obtain the best path).
+  inline StdToken(BaseFloat tot_cost, BaseFloat backward_cost,
+                  StateId base_state, StateId lm_state,
+                  ForwardLinkT *links, Token *next, Token *backpointer):
+    tot_cost(tot_cost), backward_cost(backward_cost),
+    base_state(base_state), lm_state(lm_state),
+    links(links), next(next), in_queue(false), expanded(false),
+    update_alpha(false) { }
+  
+  // The smaller, the better
+  inline bool operator < (const Token &other) const {
+    if ((tot_cost + backward_cost) ==
+        (other.tot_cost + other.backward_cost)) {
+      return lm_state < other.lm_state;
+    } else {
+      return (tot_cost + backward_cost) <
+             (other.tot_cost + other.backward_cost);
+    }
+  }
+  inline bool operator > (const Token &other) const { return other < (*this); }
+};
+
+template <typename Fst>
+struct BackpointerToken {
+  using ForwardLinkT = ForwardLink<BackpointerToken>;
+  using Token = BackpointerToken;
+  using StateId = typename Fst::Arc::StateId;
+
+  // BackpointerToken is like Token but also
+  // Standard token type for LatticeFasterDecoder.  Each active HCLG
+  // (decoding-graph) state on each frame has one token.
+
+  // tot_cost is the total (LM + acoustic) cost from the beginning of the
+  // utterance up to this point.  (but see cost_offset_, which is subtracted
+  // to keep it in a good numerical range).
+  BaseFloat tot_cost;
+
+  // It will be updated periodly. It will be used in Backfill stage. We will not
+  // expand all shadowing token. The shadowed token whose backward_cost <
+  // best_backward_cost + config_.beam will be expanded. In another word, if we
+  // prune the lattice on each frame rather than prune it periodly, we only
+  // expand the survived tokens after pruning.
+  BaseFloat backward_cost;
+ 
+  // Record the state id of the token
+  StateId base_state;  // the state in base graph (the HCLG)
+  StateId lm_state;  // the state in LM-diff FST
+
+  // 'links' is the head of singly-linked list of ForwardLinks, which is what we
+  // use for lattice generation.
+  ForwardLinkT *links;
+
+  //'next' is the next in the singly-linked list of tokens for this frame.
+  BackpointerToken *next;
+
+  // identitfy the token is in current queue or not to prevent duplication in
+  // function ProcessForFrame().
+  bool in_queue;
+
+  // If true, it means we have followed the states in the composed graph and
+  // looked at the successor tokens. (If a token's expanded is true and has no
+  // arcs out of it, it means that we tried to follow them they did not meet the
+  // beam, or they were pruned.
+  bool expanded;
+
+  // Indicate the token's tot_cost is updated or not when we expand shadowed
+  // token. If true, it means the tot_cost of the successors of the token should
+  // be updated.
+  bool update_alpha;
+
+  // Best preceding BackpointerToken (could be a on this frame, connected to
+  // this via an epsilon transition, or on a previous frame).  This is only
+  // required for an efficient GetBestPath function in
+  // LatticeFasterOnlineDecoderTpl; it plays no part in the lattice generation
+  // (the "links" list is what stores the forward links, for that).
+  Token *backpointer;
+
+
+  inline void SetBackpointer (Token *backpointer) {
+    this->backpointer = backpointer;
+  }
+
+  inline BackpointerToken(BaseFloat tot_cost, BaseFloat backward_cost,
+                          StateId base_state, StateId lm_state,
+                          ForwardLinkT *links, Token *next, Token *backpointer):
+                          tot_cost(tot_cost), backward_cost(backward_cost),
+                          base_state(base_state),
+                          lm_state(lm_state), links(links), next(next), 
+                          in_queue(false), expanded(false), update_alpha(false),
+                          backpointer(backpointer) { }
+
+  // The smaller, the better
+  inline bool operator < (const Token &other) const {
+    if ((tot_cost + backward_cost) ==
+        (other.tot_cost + other.backward_cost)) {
+      return lm_state < other.lm_state;
+    } else {
+      return (tot_cost + backward_cost) <
+             (other.tot_cost + other.backward_cost);
+    }
+  }
+  inline bool operator > (const Token &other) const { return other < (*this); }
+};
+
+}  // namespace decoder
+
+
+template<typename Token>
+class BucketQueue {
+ public:
+  // Constructor. 'cost_scale' is a scale that we multiply the token costs by
+  // before intergerizing; a larger value means more buckets.
+  // 'bucket_offset_' is initialized to "15 * cost_scale_". It is an empirical
+  // value in case we trigger the re-allocation in normal case, since we do in
+  // fact normalize costs to be not far from zero on each frame. 
+  BucketQueue(BaseFloat cost_scale = 1.0);
+
+  // Adds Token to the queue; sets the field tok->in_queue to true (it is not
+  // an error if it was already true).
+  // If a Token was already in the queue but its cost improves, you should
+  // just Push it again. It will be added to (possibly) a different bucket, but
+  // the old entry will remain. We use "tok->in_queue" to decide
+  // an entry is nonexistent or not. When pop a Token off, the field
+  // 'tok->in_queue' is set to false. So the old entry in the queue will be
+  // considered as nonexistent when we try to pop it.
+  void Push(Token *tok);
+
+  // Removes and returns the next Token 'tok' in the queue, or NULL if there
+  // were no Tokens left. Sets tok->in_queue to false for the returned Token.
+  Token* Pop();
+
+  // Clears all the individual buckets. Sets 'first_nonempty_bucket_index_' to
+  // the end of buckets_.
+  void Clear();
+
+ private:
+  // Configuration value that is multiplied by tokens' costs before integerizing
+  // them to determine the bucket index
+  BaseFloat cost_scale_;
+
+  // buckets_ is a list of Tokens 'tok' for each bucket.
+  // If tok->in_queue is false, then the item is considered as not
+  // existing (this is to avoid having to explicitly remove Tokens when their
+  // costs change). The index into buckets_ is determined as follows:
+  // bucket_index = std::floor(tok->cost * cost_scale_);
+  // vec_index = bucket_index - bucket_storage_begin_;
+  // then access buckets_[vec_index].
+  std::vector<std::vector<Token*> > buckets_;
+
+  // An offset that determines how we index into the buckets_ vector;
+  // In the constructor this will be initialized to something like
+  // "15 * cost_scale_" which will make it unlikely that we have to change this
+  // value in future if we get a much better Token (this is expensive because it
+  // involves reallocating 'buckets_').
+  int32 bucket_offset_;
+
+  // first_nonempty_bucket_index_ is an integer in the range [0,
+  // buckets_.size() - 1] which is not larger than the index of the first
+  // nonempty element of buckets_.
+  int32 first_nonempty_bucket_index_;
+
+  // Synchronizes with first_nonempty_bucket_index_.
+  std::vector<Token*> *first_nonempty_bucket_;
+
+  // If the size of the BucketQueue is larger than "bucket_size_tolerance_", we
+  // will resize it to "bucket_size_tolerance_" in Clear. A weird long
+  // BucketQueue might be caused when the min-active was activated and an
+  // unusually large loglikelihood range was encountered.
+  size_t bucket_size_tolerance_;
+};
+
+/** This is the "normal" lattice-generating decoder.
+    See \ref lattices_generation \ref decoders_faster and \ref decoders_simple
+     for more information.
+
+   The decoder is templated on the FST type and the token type.  The token type
+   will normally be StdToken, but also may be BackpointerToken which is to support
+   quick lookup of the current best path (see lattice-faster-online-decoder.h)
+
+   The FST you invoke this decoder with is expected to equal
+   Fst::Fst<fst::StdArc>, a.k.a. StdFst, or GrammarFst.  If you invoke it with
+   FST == StdFst and it notices that the actual FST type is
+   fst::VectorFst<fst::StdArc> or fst::ConstFst<fst::StdArc>, the decoder object
+   will internally cast itself to one that is templated on those more specific
+   types; this is an optimization for speed.
+ */
+template <typename FST, typename Token = biglmdecodercombine::StdToken<FST> >
+class LatticeBiglmFasterDecoderCombineTpl {
+ public:
+  using Arc = typename FST::Arc;
+  using Label = typename Arc::Label;
+  using StateId = typename Arc::StateId;
+  using Weight = typename Arc::Weight;
+  using ForwardLinkT = biglmdecodercombine::ForwardLink<Token>;
+  using uint64 = typename PairId;  // Will be (StateId in fst) +
+                                   // (StateId in lm_diff_fst) << 32
+
+  using StateIdToTokenMap = typename std::unordered_map<StateId, Token*>;
+  //using StateIdToTokenMap = typename std::unordered_map<StateId, Token*,
+  //      std::hash<StateId>, std::equal_to<StateId>,
+  //      fst::PoolAllocator<std::pair<const StateId, Token*> > >;
+  using IterType = typename StateIdToTokenMap::const_iterator;
+
+  using PairIdToTokenMap = typename std::unordered_map<PairId, Token*>;
+  //using PairIdToTokenMap = typename std::unordered_map<PairId, Token*,
+  //      std::hash<PairId>, std::equal_to<PairId>,
+  //      fst::PoolAllocator<std::pair<const PairId, Token*> > >;
+
+
+
+  using BucketQueue = typename kaldi::BucketQueue<Token>;
+
+  // Instantiate this class once for each thing you have to decode.
+  // This version of the constructor does not take ownership of
+  // 'fst'.
+  LatticeBiglmFasterDecoderCombineTpl(const FST &fst,
+      const LatticeBiglmFasterDecoderCombineConfig &config,
+      fst::DeterministicOnDemandFst<FST::Arc> *lm_diff_fst);
+
+  // This version of the constructor takes ownership of the fst, and will delete
+  // it when this object is destroyed.
+  LatticeBiglmFasterDecoderCombineTpl(
+      const LatticeBiglmFasterDecoderCombineConfig &config, FST *fst,
+      fst::DeterministicOnDemandFst<FST::Arc> *lm_diff_fst);
+
+  void SetOptions(const LatticeBiglmFasterDecoderCombineConfig &config) {
+    config_ = config;
+  }
+
+  const LatticeBiglmFasterDecoderCombineConfig &GetOptions() const {
+    return config_;
+  }
+
+  ~LatticeBiglmFasterDecoderCombineTpl();
+
+  /// Decodes until there are no more frames left in the "decodable" object..
+  /// note, this may block waiting for input if the "decodable" object blocks.
+  /// Returns true if any kind of traceback is available (not necessarily from a
+  /// final state).
+  bool Decode(DecodableInterface *decodable);
+
+
+  /// says whether a final-state was active on the last frame.  If it was not, the
+  /// lattice (or traceback) will end with states that are not final-states.
+  bool ReachedFinal() const {
+    return FinalRelativeCost() != std::numeric_limits<BaseFloat>::infinity();
+  }
+
+  /// Outputs an FST corresponding to the single best path through the lattice.
+  /// Returns true if result is nonempty (using the return status is deprecated,
+  /// it will become void).  If "use_final_probs" is true AND we reached the
+  /// final-state of the graph then it will include those as final-probs, else
+  /// it will treat all final-probs as one.  Note: this just calls GetRawLattice()
+  /// and figures out the shortest path.
+  bool GetBestPath(Lattice *ofst,
+                   bool use_final_probs = true);
+
+  /// Outputs an FST corresponding to the raw, state-level
+  /// tracebacks.  Returns true if result is nonempty.
+  /// If "use_final_probs" is true AND we reached the final-state
+  /// of the graph then it will include those as final-probs, else
+  /// it will treat all final-probs as one.
+  /// The raw lattice will be topologically sorted.
+  /// The function can be called during decoding, it will process non-emitting
+  /// arcs from "next_toks_" map to get tokens from both non-emitting and 
+  /// emitting arcs for getting raw lattice.
+  ///
+  /// See also GetRawLatticePruned in lattice-faster-online-decoder.h,
+  /// which also supports a pruning beam, in case for some reason
+  /// you want it pruned tighter than the regular lattice beam.
+  /// We could put that here in future needed.
+  bool GetRawLattice(Lattice *ofst, bool use_final_probs = true);
+
+
+
+  /// [Deprecated, users should now use GetRawLattice and determinize it
+  /// themselves, e.g. using DeterminizeLatticePhonePrunedWrapper].
+  /// Outputs an FST corresponding to the lattice-determinized
+  /// lattice (one path per word sequence).   Returns true if result is nonempty.
+  /// If "use_final_probs" is true AND we reached the final-state of the graph
+  /// then it will include those as final-probs, else it will treat all
+  /// final-probs as one.
+  bool GetLattice(CompactLattice *ofst,
+                  bool use_final_probs = true);
+
+  /// InitDecoding initializes the decoding, and should only be used if you
+  /// intend to call AdvanceDecoding().  If you call Decode(), you don't need to
+  /// call this.  You can also call InitDecoding if you have already decoded an
+  /// utterance and want to start with a new utterance.
+  void InitDecoding();
+
+  /// This will decode until there are no more frames ready in the decodable
+  /// object.  You can keep calling it each time more frames become available.
+  /// If max_num_frames is specified, it specifies the maximum number of frames
+  /// the function will decode before returning.
+  void AdvanceDecoding(DecodableInterface *decodable,
+                       int32 max_num_frames = -1);
+
+  /// This function may be optionally called after AdvanceDecoding(), when you
+  /// do not plan to decode any further.  It does an extra pruning step that
+  /// will help to prune the lattices output by GetLattice and (particularly)
+  /// GetRawLattice more accurately, particularly toward the end of the
+  /// utterance.  It does this by using the final-probs in pruning (if any
+  /// final-state survived); it also does a final pruning step that visits all
+  /// states (the pruning that is done during decoding may fail to prune states
+  /// that are within kPruningScale = 0.1 outside of the beam).  If you call
+  /// this, you cannot call AdvanceDecoding again (it will fail), and you
+  /// cannot call GetLattice() and related functions with use_final_probs =
+  /// false.
+  /// Used to be called PruneActiveTokensFinal().
+  void FinalizeDecoding();
+
+  /// FinalRelativeCost() serves the same purpose as ReachedFinal(), but gives
+  /// more information.  It returns the difference between the best (final-cost
+  /// plus cost) of any token on the final frame, and the best cost of any token
+  /// on the final frame.  If it is infinity it means no final-states were
+  /// present on the final frame.  It will usually be nonnegative.  If it not
+  /// too positive (e.g. < 5 is my first guess, but this is not tested) you can
+  /// take it as a good indication that we reached the final-state with
+  /// reasonable likelihood.
+  BaseFloat FinalRelativeCost() const;
+
+
+  // Returns the number of frames decoded so far.  The value returned changes
+  // whenever we call ProcessForFrame().
+  inline int32 NumFramesDecoded() const { return active_toks_.size() - 1; }
+
+ protected:
+  // we make things protected instead of private, as code in
+  // LatticeFasterOnlineDecoderTpl, which inherits from this, also uses the
+  // internals.
+
+  // Deletes the elements of the singly linked list tok->links.
+  inline static void DeleteForwardLinks(Token *tok);
+
+  // head of per-frame list of Tokens (list is in topological order),
+  // and something saying whether we ever pruned it using PruneForwardLinks.
+  struct TokenList {
+    Token *toks;
+    bool must_prune_forward_links;
+    bool must_prune_tokens;
+    TokenList(): toks(NULL), must_prune_forward_links(true),
+                 must_prune_tokens(true) { }
+  };
+
+  // FindOrAddToken either locates a token in hash map "token_map", or if
+  // necessary inserts a new, empty token (i.e. with no forward links) for the
+  // current frame.
+  // [note: it's inserted if necessary into "token_map", "token_best_map" and
+  // also into the singly linked list of tokens active on this frame (whose head
+  // is at active_toks_[frame]).  The token_list_index argument is used to index
+  // into the active_toks_ array.
+  // Returns the Token pointer.  Sets "changed" (if non-NULL) to true if the
+  // token was newly created or the cost changed.
+  // If Token == StdToken, the 'backpointer' argument has no purpose (and will
+  // hopefully be optimized out).
+  inline Token *FindOrAddToken(PairId state, int32 token_list_index,
+                               BaseFloat tot_cost, Token *backpointer,
+                               PairIdToTokenMap *token_map,
+                               bool *changed);
+
+  // prunes outgoing links for all tokens in active_toks_[frame]
+  // it's called by PruneActiveTokens
+  // all links, that have link_extra_cost > lattice_beam are pruned
+  // delta is the amount by which the extra_costs must change
+  // before we set *extra_costs_changed = true.
+  // If delta is larger,  we'll tend to go back less far
+  //    toward the beginning of the file.
+  // extra_costs_changed is set to true if extra_cost was changed for any token
+  // links_pruned is set to true if any link in any token was pruned
+  void PruneForwardLinks(int32 frame_plus_one, bool *backward_costs_changed,
+                         bool *links_pruned,
+                         BaseFloat delta);
+
+  // This function computes the final-costs for tokens active on the final
+  // frame.  It outputs to final-costs, if non-NULL, a map from the Token*
+  // pointer to the final-prob of the corresponding state, for all Tokens
+  // that correspond to states that have final-probs.  This map will be
+  // empty if there were no final-probs.  It outputs to
+  // final_relative_cost, if non-NULL, the difference between the best
+  // forward-cost including the final-prob cost, and the best forward-cost
+  // without including the final-prob cost (this will usually be positive), or
+  // infinity if there were no final-probs.  [c.f. FinalRelativeCost(), which
+  // outputs this quanitity].  It outputs to final_best_cost, if
+  // non-NULL, the lowest for any token t active on the final frame, of
+  // forward-cost[t] + final-cost[t], where final-cost[t] is the final-cost in
+  // the graph of the state corresponding to token t, or the best of
+  // forward-cost[t] if there were no final-probs active on the final frame.
+  // You cannot call this after FinalizeDecoding() has been called; in that
+  // case you should get the answer from class-member variables.
+  void ComputeFinalCosts(unordered_map<Token*, BaseFloat> *final_costs,
+                         BaseFloat *final_relative_cost,
+                         BaseFloat *final_best_cost) const;
+
+  // PruneForwardLinksFinal is a version of PruneForwardLinks that we call
+  // on the final frame.  If there are final tokens active, it uses
+  // the final-probs for pruning, otherwise it treats all tokens as final.
+  void PruneForwardLinksFinal();
+
+  // Prune away any tokens on this frame that have no forward links.
+  // [we don't do this in PruneForwardLinks because it would give us
+  // a problem with dangling pointers].
+  // It's called by PruneActiveTokens if any forward links have been pruned
+  void PruneTokensForFrame(int32 frame_plus_one);
+
+
+  // Go backwards through still-alive tokens, pruning them if the
+  // forward+backward cost is more than lat_beam away from the best path.  It's
+  // possible to prove that this is "correct" in the sense that we won't lose
+  // anything outside of lat_beam, regardless of what happens in the future.
+  // delta controls when it considers a cost to have changed enough to continue
+  // going backward and propagating the change.  larger delta -> will recurse
+  // less far.
+  void PruneActiveTokens(BaseFloat delta);
+
+  /// Processes non-emitting (epsilon) arcs and emitting arcs for one frame
+  /// together. It takes the emittion tokens in "cur_toks_" from last frame.
+  /// Generates non-emitting tokens for previous frame and emitting tokens for
+  /// next frame.
+  /// Notice: The emitting tokens for the current frame means the token take
+  /// acoustic scores of the current frame. (i.e. the destnations of emitting
+  /// arcs.)
+  void ProcessForFrame(DecodableInterface *decodable);
+
+  /// Processes nonemitting (epsilon) arcs for one frame.
+  /// This function is called from FinalizeDecoding(), and also from
+  /// GetRawLattice() if GetRawLattice() is called before FinalizeDecoding() is
+  /// called.
+  void ProcessNonemitting();
+
+  void ClearActiveTokens();
+  // This function takes a singly linked list of tokens for a single frame, and
+  // outputs a list of them in topological order (it will crash if no such order
+  // can be found, which will typically be due to decoding graphs with epsilon
+  // cycles, which are not allowed).  Note: the output list may contain NULLs,
+  // which the caller should pass over; it just happens to be more efficient for
+  // the algorithm to output a list that contains NULLs.
+  static void TopSortTokens(Token *tok_list,
+                            std::vector<Token*> *topsorted_list);
+
+  // The top-level top. Return the last complete frame (all tokens have been
+  // expanded).
+  // Note: t is the frame that we will expand tokens from. It can be regarded
+  // as the index of token list.
+  // t = NumFramesDecoded() - 1 = active_toks_.size() - 2
+  // Form active_toks_[t - beta_interval] to active_toks_[t] (e.g. [0,14],
+  // 15 frames), update the beta, frame-level best token and best_token_map by
+  // ComputeBeta. Actually, the beta of current frame (t) is set to -alpha.
+  // Form active_toks_[t - beta_interval] to 
+  // active_toks_[t - expand_best_interval] (e.g. [0, 4], 5 frames) will be
+  // expanded completely.
+  // From active_toks_[t - expand_best_interval + 1] to active_toks_[t] (e.g.
+  // [5, 14], 10 frames), only the best-in-class tokens will be expanded.
+  int32 DoBackfill();
+
+  // Set the beta[tok] for all the currently active tokens to -alpha[tok]
+  // instead of to 0 so that the extra_cost pruning is equivalent to
+  // alpha-beta pruning.
+  // In the furture, maybe we will add a scale factor to try a more aggressive
+  // pruning.
+  void InitBeta(int32 frame);
+
+  // This function takes a singly linked list of tokens for a single frame, and
+  // do the following assignments
+  // a. Update the expanded token's beta
+  // b. Find the best token for the particular frame
+  // c. Build best_token_map with alpha + beta and prune tokens that fall below
+  // the beam
+  // d. the unexpanded tokens inherit the beta from corresponding expanded token
+  // Note: We will not prune the ForwardLinks individually. Only the token who
+  // falls below the alpha+beta beam will be deleted with its forwardLinks.
+  // (i.e. if a token is survived, its forwardlinks will not be pruned.) As we
+  // will not e-visit the fst, we hope to keep more explore path for shadowed
+  // token.
+  void ComputeBeta(int32 frame, BaseFloat delta);
+
+
+  // This function does backfill arc expansion on frame t. If "expand_not_best"
+  // is true then we will be expanding tokens even for not-best-in-class tokens.
+  // If "expand_not_best" if false, we will only do expand for best-in-class
+  // tokens.
+  void ExpandForward(int32 frame, bool expand_not_best);
+
+  
+  // The funciton is to expand an un-expanded token using the acoustic scores
+  // from the best-in-class expanded tokens.
+  void ExpandTokenBackfill(int32 frame, Token* tok);
+
+
+  // Update the graph cost according to lm_state and olabel
+  // Return new LM State
+  inline StateId PropagateLm(StateId lm_state, Arc *arc) {
+    if (arc->olabel == 0) {
+      return lm_state;
+    } else {
+      Arc lm_arc;
+      bool ans = lm_diff_fst_->GetArc(lm_state, arc->olabel, &lm_arc);
+      if (!ans) {  // this case is unexpected for statistical LMs
+        if (!warned_noarc_) {
+          warned_noarc_ = true;
+          KALDI_WARN << "No arc available in LM (unlikely to be correct "
+            "if a statistical language model); Will not warn again";
+        }
+        arc->weight = Weight::Zero();
+        return lm_state;  // doesn't really matter what we return here; will be
+                          // pruned.
+      } else {
+        arc->weight = Times(arc->weight, lm_arc.weight);
+        arc->olabel = lm_arc.olabel;  // probably will be the same.
+        return lm_arc.nextstate;  // return the new LM state.
+      }
+    }
+  }
+
+  inline PairId ConstructPair(StateId base_state, StateId lm_state) {
+    return static_cast<PairId>(base_state) + 
+      (static_cast<PairId>(lm_state) << 32);
+  }
+
+  static inline StateId PairToBaseState(PairId state) {
+    return static_cast<StateId>(static_cast<uint32>(state));
+  }
+
+  static inline StateId PairToLmState(PairId state) {
+    return static_cast<StateId>(static_cast<uint32>(state >> 32));
+  }
+
+  KALDI_DISALLOW_COPY_AND_ASSIGN(LatticeBiglmFasterDecoderCombineTpl);
+
+  /// Gets the weight cutoff.
+  /// Notice: In traiditional version, the histogram prunning method is applied
+  /// on a complete token list on one frame. But, in this version, it is used
+  /// on a token list which only contains the emittion part. So the max_active
+  /// and min_active values might be narrowed.
+  std::vector<TokenList> active_toks_; // Lists of tokens, indexed by
+  // frame (members of TokenList are toks, must_prune_forward_links,
+  // must_prune_tokens).
+
+  // fst_ is a pointer to the FST we are decoding from.
+  const FST *fst_;
+  // delete_fst_ is true if the pointer fst_ needs to be deleted when this
+  // object is destroyed.
+  bool delete_fst_;
+  fst::DeterministicOnDemandFst<fst::StdArc> *lm_diff_fst_;
+  LatticeBiglmFasterDecoderCombineConfig config_;
+
+  std::vector<BaseFloat> cost_offsets_; // This contains, for each
+  // frame, an offset that was added to the acoustic log-likelihoods on that
+  // frame in order to keep everything in a nice dynamic range i.e.  close to
+  // zero, to reduce roundoff errors.
+  // Notice: It will only be added to emitting arcs (i.e. cost_offsets_[t] is
+  // added to arcs from "frame t" to "frame t+1").
+  int32 num_toks_; // current total #toks allocated...
+  bool warned_;
+  bool warned_noarc_;  // Use in PropagateLm to indicate the unusual phenomenon.
+                       // Prevent duplicate warnings.
+
+  /// decoding_finalized_ is true if someone called FinalizeDecoding().  [note,
+  /// calling this is optional].  If true, it's forbidden to decode more.  Also,
+  /// if this is set, then the output of ComputeFinalCosts() is in the next
+  /// three variables.  The reason we need to do this is that after
+  /// FinalizeDecoding() calls PruneTokensForFrame() for the final frame, some
+  /// of the tokens on the last frame are freed, so we free the list from toks_
+  /// to avoid having dangling pointers hanging around.
+  bool decoding_finalized_;
+
+  /// Use to record the index of the last complete explored frame. We prune the
+  /// tokens and forwardlinks before that.
+  int32 complete_frame_;
+
+  /// For the meaning of the next 3 variables, see the comment for
+  /// decoding_finalized_ above., and ComputeFinalCosts().
+  unordered_map<Token*, BaseFloat> final_costs_;
+  BaseFloat final_relative_cost_;
+  BaseFloat final_best_cost_;
+
+  BaseFloat adaptive_beam_;  // will be set to beam_ when we start
+  BucketQueue cur_queue_;  // temp variable used in 
+                           // ProcessForFrame/ProcessNonemitting
+
+
+  // Maps from the tuple (t, base_state, lm_state) to token 
+  std::vector<PairIdToTokenMap* > token_map_;
+  // Maps from the tuple (t, base_state) to token. It has two purposes:
+  // (a) For "recent" frames, we only expand un-expanded tokens which are
+  // "best in class" (meaning the best token for the base_state.)
+  // (b) We will use the best token as part of the A* heuristic function when
+  // deciding which un-expanded tokens. To give an estimate of the beta score.
+  // Besides, in exploration stage, as beta is zero, the tokens in
+  // "best_token_map" are equivalent to best token in each base state. 
+  std::vector<StateIdToTokenMap* > best_token_map_;
+  std::vector<Token*> best_token_;
+};
+
+typedef LatticeBiglmFasterDecoderCombineTpl<fst::StdFst,
+        biglmdecodercombine::StdToken<fst::StdFst> > LatticeFasterDecoderCombine;
+
+
+
+} // end namespace kaldi.
+
+#endif

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -67,7 +67,7 @@ struct LatticeBiglmFasterDecoderCombineConfig {
                                        hash_ratio(2.0),
                                        cost_scale(1.0),
                                        prune_scale(0.1),
-                                       backfill_interval(10),
+                                       backfill_interval(5),
                                        beta_interval(15),
                                        expand_best_interval(10) { }
   void Register(OptionsItf *opts) {
@@ -552,6 +552,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
   inline Token *FindOrAddToken(PairId state, int32 token_list_index,
                                BaseFloat tot_cost, Token *backpointer,
                                PairIdToTokenMap *token_map,
+                               StateIdToTokenMap *best_token_map,
                                bool *changed);
 
   // prunes outgoing links for all tokens in active_toks_[frame]
@@ -800,6 +801,11 @@ class LatticeBiglmFasterDecoderCombineTpl {
   // "best_token_map" are equivalent to best token in each base state. 
   std::vector<StateIdToTokenMap* > best_token_map_;
   std::vector<Token*> best_token_;
+  int32 count_ = 0;
+  int32 count1_ = 0;
+  int32 count2_ = 0;
+  int32 count3_ = 0;
+  int32 count4_ = 0;
 };
 
 typedef LatticeBiglmFasterDecoderCombineTpl<fst::StdFst,

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -641,15 +641,15 @@ class LatticeBiglmFasterDecoderCombineTpl {
   // expanded).
   // Note: t is the frame that we will expand tokens from. It can be regarded
   // as the index of token list.
-  // t = NumFramesDecoded() - 1 = active_toks_.size() - 2
-  // Form active_toks_[t - beta_interval] to active_toks_[t] (e.g. [0,14],
-  // 15 frames), update the beta, frame-level best token and best_token_map by
+  // t = NumFramesDecoded() = active_toks_.size() - 1
+  // Form active_toks_[t - beta_interval] to active_toks_[t] (e.g. [0,15]),
+  // update the beta, frame-level best token and best_token_map by
   // ComputeBeta. Actually, the beta of current frame (t) is set to -alpha.
-  // Form active_toks_[t - beta_interval] to 
-  // active_toks_[t - expand_best_interval] (e.g. [0, 4], 5 frames) will be
+  // Form active_toks_[complete_frame_ + 1] to 
+  // active_toks_[t - expand_best_interval - 1] (e.g. [0, 4]) will be
   // expanded completely.
-  // From active_toks_[t - expand_best_interval + 1] to active_toks_[t] (e.g.
-  // [5, 14], 10 frames), only the best-in-class tokens will be expanded.
+  // From active_toks_[t - expand_best_interval] to active_toks_[t - 1] (e.g.
+  // [5, 14]), only the best-in-class tokens will be expanded.
   int32 DoBackfill();
 
   // Set the beta[tok] for all the currently active tokens to -alpha[tok]
@@ -731,6 +731,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
   /// on a complete token list on one frame. But, in this version, it is used
   /// on a token list which only contains the emittion part. So the max_active
   /// and min_active values might be narrowed.
+
   std::vector<TokenList> active_toks_; // Lists of tokens, indexed by
   // frame (members of TokenList are toks, must_prune_forward_links,
   // must_prune_tokens).

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -803,7 +803,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
 };
 
 typedef LatticeBiglmFasterDecoderCombineTpl<fst::StdFst,
-        biglmdecodercombine::StdToken<fst::StdFst> > LatticeFasterDecoderCombine;
+        biglmdecodercombine::StdToken<fst::StdFst> > LatticeBiglmFasterDecoderCombine;
 
 
 

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -393,16 +393,16 @@ class LatticeBiglmFasterDecoderCombineTpl {
   using ForwardLinkT = biglmdecodercombine::ForwardLink<Token>;
   using PairId = uint64;  // (StateId in fst) + (StateId in lm_diff_fst) << 32
 
-  using StateIdToTokenMap = typename std::unordered_map<StateId, Token*>;
-  //using StateIdToTokenMap = typename std::unordered_map<StateId, Token*,
-  //      std::hash<StateId>, std::equal_to<StateId>,
-  //      fst::PoolAllocator<std::pair<const StateId, Token*> > >;
+  //using StateIdToTokenMap = typename std::unordered_map<StateId, Token*>;
+  using StateIdToTokenMap = typename std::unordered_map<StateId, Token*,
+        std::hash<StateId>, std::equal_to<StateId>,
+        fst::PoolAllocator<std::pair<const StateId, Token*> > >;
   using IterType = typename StateIdToTokenMap::const_iterator;
 
-  using PairIdToTokenMap = typename std::unordered_map<PairId, Token*>;
-  //using PairIdToTokenMap = typename std::unordered_map<PairId, Token*,
-  //      std::hash<PairId>, std::equal_to<PairId>,
-  //      fst::PoolAllocator<std::pair<const PairId, Token*> > >;
+  //using PairIdToTokenMap = typename std::unordered_map<PairId, Token*>;
+  using PairIdToTokenMap = typename std::unordered_map<PairId, Token*,
+        std::hash<PairId>, std::equal_to<PairId>,
+        fst::PoolAllocator<std::pair<const PairId, Token*> > >;
 
 
 

--- a/src/decoder/lattice-biglm-faster-decoder-combine.h
+++ b/src/decoder/lattice-biglm-faster-decoder-combine.h
@@ -124,13 +124,9 @@ struct ForwardLink {
   Token *next_tok;  // the next token [or NULL if represents final-state]
   Label ilabel;  // ilabel on arc
   Label olabel;  // olabel on arc
+  Label olabel_ori;  // olabel on base fst arc
   BaseFloat graph_cost;  // graph cost of traversing arc (contains LM, etc.)
   BaseFloat acoustic_cost;  // acoustic cost (pre-scaled) of traversing arc
-
-  // Record the graph cost from HCLG.fst so that we needn't revisit HCLG.fst
-  // when expanding
-  BaseFloat graph_cost_ori;
-
   ForwardLink *next;  // next in singly-linked list of forward arcs (arcs
                       // in the state-level lattice) from a token.
   inline ForwardLink(Token *next_tok, Label ilabel, Label olabel,
@@ -697,7 +693,7 @@ class LatticeBiglmFasterDecoderCombineTpl {
   
   // The funciton is to expand an un-expanded token using the acoustic scores
   // from the best-in-class expanded tokens.
-  void ExpandTokenBackfill(int32 frame, Token* tok);
+  void ExpandTokenBackfill(int32 frame, Token* tok, bool expand_not_best);
 
 
   // Update the graph cost according to lm_state and olabel

--- a/src/fstext/fstext-utils.h
+++ b/src/fstext/fstext-utils.h
@@ -34,6 +34,7 @@
 #include "util/text-utils.h" // for SplitStringToVector
 #include "fst/script/print-impl.h"
 
+
 namespace fst {
 
 /// Returns the highest numbered output symbol id of the FST (or zero
@@ -134,7 +135,6 @@ bool GetLinearSymbolSequence(const Fst<Arc> &fst,
                              vector<I> *isymbols_out,
                              vector<I> *osymbols_out,
                              typename Arc::Weight *tot_weight_out);
-
 
 /// This function converts an FST with a special structure, which is
 /// output by the OpenFst functions ShortestPath and RandGen, and converts


### PR DESCRIPTION
This PR is used to track the A* decoder and ask Dan in a more convenient way.

Firstly, this decoder is based on combine decoder with bucket queue. We use backward_cost(beta) to replace extra_cost. If set the beta[tok] for all the currently active tokens to -alpha[tok], the alpha-beta pruning is equivalent to extra_cost pruning. (I wrote an example in the google doc, Dan, you can check it. In fact, we use cost_offset to make the tot_cost close to 0. When we want to prune forwardlinks and tokens, we have to compare it with the best one's alpha+beta + config_.lattice_beam. From this direction, extra_cost is a little bit better.)
The final frame is a special case. I set beta[tok] = -alpha[tok] + (alpha[tok] + final_cost[tok] - best_cost_with_final). I'm trying to evident whether it is right.


The outline of the code is as follows. 
For each frame, we call ProcessForFrame (explore stage) to generate a semi-complete token list. 
After that, we do backfill periodically (say, backfill_interval = 5). In backfill stage, we will compute the beta for expanded token from frame T to frame T-14 (say, beta_interval = 15) and the un-expanded token will inherit the beta from the corresponding token.  The token whose alpha+beta is fall below beam will be pruned. [Note: I only get rid of a token and its whole forwardlinks. However, I will not prune any forwardlink of an existing token. Because I think we will not re-visit the HCLG, we should keep more opportunities for shadowed tokens]. For frames t-14 throught t-10, we expand all shadowed tokens. For frames t-9 throught t-1, only the best-in-class tokens will be expanded. (This is controlled by expand_best_interval, say, 10).
After the backfill stage, the frames, from t-10 to 0, are completly processed. I call t-10 as the complete_frame_. To save memory, for every prune_interval (say 20) frames, we will PruneForwardLinks and PruneTokens. This process can go back to 0 or T-25. I will do some tests.
At last, in FinalizeDecoding, we will expand the epsilon arcs for the final frame, compute betas for the last few frames, expand the shadowed tokens for the last few frames and prune with final cost.

Do you think the basic procedure is matched with your envisage? I'm trying to do some experiments on minilibrispeech. (Of course, I will refine the code. It's ugly right now.)