### PR TITLE
Change encoding to utf-8 in data augmentation scripts

### DIFF
--- a/egs/wsj/s5/steps/data/reverberate_data_dir.py
+++ b/egs/wsj/s5/steps/data/reverberate_data_dir.py
@@ -157,7 +157,7 @@ def parse_file_to_dict(file, assert2fields = False, value_processor = None):
     if value_processor is None:
         value_processor = lambda x: x[0]
     dict = {}
-    for line in open(file, 'r'):
+    for line in open(file, 'r', encoding='utf-8'):
         parts = line.split()
         if assert2fields:
             assert(len(parts) == 2)
@@ -168,7 +168,7 @@ def parse_file_to_dict(file, assert2fields = False, value_processor = None):
 def write_dict_to_file(dict, file_name):
     """ This function creates a file and write the content of a dictionary into it
     """
-    file = open(file_name, 'w')
+    file = open(file_name, 'w', encoding='utf-8')
     keys = sorted(dict.keys())
     for key in keys:
         value = dict[key]


### PR DESCRIPTION
The functions `parse_file_to_dict` and `write_dict_to_file` are used in `augment_data_dir.py` to copy Kaldi data directory files, including "text". When "text" contains utf-8 data, the script crashes. This PR fixes the issue.