### PR TITLE
Batch nnet3 improvements.

### DIFF
--- a/src/cudamatrix/cu-kernels-ansi.h
+++ b/src/cudamatrix/cu-kernels-ansi.h
@@ -814,10 +814,10 @@ void cudaD_mat_copy_range_clamped(
 // the matrices are of size num_rows[i] x num_cols[i] and have a leading
 // dimension of ldo[i] for the output and ldi[i] for the input.
 void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *num_cols, const float **inputs, int32_t *ldi, float **outputs,
     int32_t *ldo);
 void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *num_cols, const double **inputs, int32_t *ldi, double **outputs,
     int32_t *ldo);
 
 // Launches a kernel that does nothing, explicitly using the legacy default stream;

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -3677,7 +3677,8 @@ void _cuda_mat_copy_range_clamped(
 
 template <typename Real> 
 struct MatrixCopyDesc {
-  Real *input, *output;
+  const Real *input;
+  Real *output;
   int32_t ldi, ldo;
   int32_t num_rows, num_cols;
 };
@@ -3704,7 +3705,7 @@ void _cuda_batch_copy_mats(BatchedMatrixCopyDesc<Real> batch_desc) {
   MatrixCopyDesc<Real> desc = batch_desc.batch[bid];
   int32_t num_rows = desc.num_rows;
   int32_t num_cols = desc.num_cols;
-  Real *input = desc.input;
+  const Real *input = desc.input;
   Real *output = desc.output;
   int32_t ldi = desc.ldi;
   int32_t ldo = desc.ldo;
@@ -5530,7 +5531,7 @@ void cudaD_mat_copy_range_clamped(
 }
 
 void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *num_cols, const float **inputs, int32_t *ldi, float **outputs,
     int32_t *ldo) {
 
   dim3 threads(32,32);
@@ -5595,7 +5596,7 @@ void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
 }
 
 void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *num_cols, const double **inputs, int32_t *ldi, double **outputs,
     int32_t *ldo) {
 
   dim3 threads(32,32);

--- a/src/cudamatrix/cu-kernels.h
+++ b/src/cudamatrix/cu-kernels.h
@@ -1580,14 +1580,14 @@ inline void cuda_mat_copy_range_clamped(
 }
 
 inline void cuda_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, float **inputs, int32_t *ldi, float **outputs,
+    int32_t *num_cols, const float **inputs, int32_t *ldi, float **outputs,
     int32_t *ldo) {
   cudaF_batched_copy_mats(num_mats, num_rows, num_cols, inputs, ldi,
       outputs, ldo);
 }
 
 inline void cuda_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
-    int32_t *num_cols, double **inputs, int32_t *ldi, double **outputs,
+    int32_t *num_cols, const double **inputs, int32_t *ldi, double **outputs,
     int32_t *ldo) {
   cudaD_batched_copy_mats(num_mats, num_rows, num_cols, inputs, ldi,
       outputs, ldo);


### PR DESCRIPTION
1) Update batched matrix copy routine to take const pointers for inputs.
2) Use batched copy routines to copy in ivectors and merge task output.
3) fix bug where #else was used instead of #endif when handeling the case where HAVE_CUDA==1 but the device is not initialized.