### PR TITLE
Widen cuda guard in cudafeat makefile.

### DIFF
--- a/src/cudafeat/Makefile
+++ b/src/cudafeat/Makefile
@@ -3,14 +3,12 @@
 all:
 
 include ../kaldi.mk
+ifeq ($(CUDA), true)
 
 TESTFILES = 
 
-OBJFILES =  
 
-ifeq ($(CUDA), true)
-  OBJFILES +=  feature-window-cuda.o feature-mfcc-cuda.o
-endif
+OBJFILES +=  feature-window-cuda.o feature-mfcc-cuda.o
 
 
 LIBNAME = kaldi-cudafeat
@@ -25,5 +23,6 @@ LDLIBS += $(CUDA_LDLIBS)
 
 %.o : %.cu
 	$(CUDATKDIR)/bin/nvcc -c -g $< -o $@ $(CUDA_INCLUDE) $(CUDA_FLAGS) $(CUDA_ARCH) -I../ -I$(OPENFSTINC)
+endif
 
 include ../makefiles/default_rules.mk


### PR DESCRIPTION
The narrower guard in the Makefile produced issues with clang's ar on MacOS when compiling with cuda disabled. GNU ar just skips without error if there are no object files to bundle into the library but clang's ar on MacOS fails the build with an error. 

I widened the ```ifeq ($(CUDA), true)``` similar to `src/cudadecoder/Makefile`.
