### PR TITLE
Fix perl use encoding deprecation

### DIFF
--- a/egs/aidatatang_200zh/s5/local/create_oov_char_lexicon.pl
+++ b/egs/aidatatang_200zh/s5/local/create_oov_char_lexicon.pl
@@ -25,7 +25,7 @@ if($#ARGV != 1) {
   exit;
 }
 
-use encoding utf8;
+use utf8;
 my %prons;
 open(DICT, $ARGV[0]) || die("Can't open dict ".$ARGV[0]."\n");
 foreach (<DICT>) {

--- a/egs/aidatatang_200zh/s5/local/prepare_dict.sh
+++ b/egs/aidatatang_200zh/s5/local/prepare_dict.sh
@@ -177,7 +177,7 @@ wc -l $dict_dir/lexicon-ch/lexicon-ch-iv.txt
 # dictionary in order to get OOV pronunciations
 cat $dict_dir/cedict/ch-dict.txt |\
   perl -e '
-  use encoding utf8;
+  use utf8;
   while (<STDIN>) {
     @A = split(" ", $_);
     $word_len = length($A[0]);
@@ -189,7 +189,7 @@ cat $dict_dir/cedict/ch-dict.txt |\
 # extract chars
 cat $dict_dir/cedict/ch-dict-1.txt | awk '{print $1}' |\
   perl -e '
-  use encoding utf8;
+  use utf8;
   while (<STDIN>) {
     @A = split(" ", $_);
     @chars = split("", $A[0]);

--- a/egs/gale_mandarin/s5/local/gale_prep_dict.sh
+++ b/egs/gale_mandarin/s5/local/gale_prep_dict.sh
@@ -130,7 +130,7 @@ unset LC_ALL
 # are equal
 cat $dict_dir/ch-dict.txt |\
   perl -e '
-  use encoding utf8;
+  use utf8;
   while (<STDIN>) {
     @A = split(" ", $_);
     $word_len = length($A[0]);
@@ -299,4 +299,3 @@ cat $dict_dir/nonsilence_phones.txt | perl -e 'while(<>){ foreach $p (split(" ",
 
 export LC_ALL=C
 echo "$0: Done"
-

--- a/egs/hkust/s5/local/create_oov_char_lexicon.pl
+++ b/egs/hkust/s5/local/create_oov_char_lexicon.pl
@@ -25,7 +25,7 @@ if($#ARGV != 1) {
   exit;
 }
 
-use encoding utf8;
+use utf8;
 my %prons;
 open(DICT, $ARGV[0]) || die("Can't open dict ".$ARGV[0]."\n");
 foreach (<DICT>) {

--- a/egs/hkust/s5/local/hkust_prepare_dict.sh
+++ b/egs/hkust/s5/local/hkust_prepare_dict.sh
@@ -176,7 +176,7 @@ wc -l $dict_dir/lexicon-ch/lexicon-ch-iv.txt
 # dictionary in order to get OOV pronunciations
 cat $dict_dir/cedict/ch-dict.txt |\
   perl -e '
-  use encoding utf8;
+  use utf8;
   while (<STDIN>) {
     @A = split(" ", $_);
     $word_len = length($A[0]);
@@ -188,7 +188,7 @@ cat $dict_dir/cedict/ch-dict.txt |\
 # extract chars
 cat $dict_dir/cedict/ch-dict-1.txt | awk '{print $1}' |\
   perl -e '
-  use encoding utf8;
+  use utf8;
   while (<STDIN>) {
     @A = split(" ", $_);
     @chars = split("", $A[0]);


### PR DESCRIPTION
'use encoding utf8;' ==> 'use utf8;'
This PR fixes #3380 