### PR TITLE
Make stack trace display more user friendly

### DIFF
--- a/src/base/kaldi-error-test.cc
+++ b/src/base/kaldi-error-test.cc
@@ -1,6 +1,5 @@
 // base/kaldi-error-test.cc
 
-// Copyright 2019 LAIX (Yi Sun)
 // Copyright 2009-2011  Microsoft Corporation
 
 // See ../../COPYING for clarification regarding multiple authors
@@ -40,12 +39,16 @@ void UnitTestError() {
 void VerifySymbolRange(const std::string &trace, const bool want_found,
                        const std::string &want_symbol) {
   size_t begin, end;
-  const bool found = internal::LocateSymbolRange(
-      "./kaldi-error-test(_ZN5kaldi13UnitTestErrorEv+0xb) [0x804965d]", &begin,
-      &end);
-  KALDI_ASSERT(found == want_found);
-  if (found) {
-    KALDI_ASSERT(trace.substr(begin, end) == want_symbol);
+  const bool found = internal::LocateSymbolRange(trace, &begin, &end);
+  if (found != want_found) {
+    KALDI_ERR << "Found mismatch, got " << found << " want " << want_found;
+  }
+  if (!found) {
+    return;
+  }
+  const std::string symbol = trace.substr(begin, end - begin);
+  if (symbol != want_symbol) {
+    KALDI_ERR << "Symbol mismatch, got " << symbol << " want " << want_symbol;
   }
 }
 
@@ -72,6 +75,8 @@ void TestLocateSymbolRange() {
 } // namespace kaldi
 
 int main() {
+  kaldi::TestLocateSymbolRange();
+
   kaldi::SetProgramName("/foo/bar/kaldi-error-test");
   try {
     kaldi::UnitTestError();
@@ -80,5 +85,4 @@ int main() {
   } catch (kaldi::KaldiFatalError &e) {
     std::cout << "The error we generated was: '" << e.KaldiMessage() << "'\n";
   }
-  kaldi::TestLocateSymbolRange();
 }

--- a/src/base/kaldi-error-test.cc
+++ b/src/base/kaldi-error-test.cc
@@ -33,9 +33,6 @@ void UnitTestError() {
   }
 }
 
-#ifdef HAVE_EXECINFO_H
-#ifdef HAVE_CXXABI_H
-
 void VerifySymbolRange(const std::string &trace, const bool want_found,
                        const std::string &want_symbol) {
   size_t begin, end;
@@ -68,9 +65,6 @@ void TestLocateSymbolRange() {
       R"TRACE(29  libsystem_pthread.dylib             0x00007fff6fe4f2eb _pthread_body + 126)TRACE",
       true, "_pthread_body");
 }
-
-#endif // HAVE_CXXABI_H
-#endif // HAVE_EXECINFO_H
 
 } // namespace kaldi
 

--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -97,7 +97,7 @@ bool LocateSymbolRange(const std::string &trace_name, size_t *begin,
 static std::string Demangle(std::string trace_name) {
 #ifndef HAVE_CXXABI_H
   return trace_name;
-#endif // HAVE_CXXABI_H
+#else  // HAVE_CXXABI_H
   // Try demangle the symbol. We are trying to support the following formats
   // produced by different platforms:
   //
@@ -122,6 +122,7 @@ static std::string Demangle(std::string trace_name) {
   }
   return trace_name.substr(0, begin) + symbol +
          trace_name.substr(end, std::string::npos);
+#endif // HAVE_CXXABI_H
 }
 #endif // HAVE_EXECINFO_H
 

--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -76,7 +76,7 @@ bool LocateSymbolRange(const std::string &trace_name, size_t *begin,
                        size_t *end) {
   // Find the first '_' with leading ' ' or '('.
   *begin = std::string::npos;
-  for (int i = 1; i < trace_name.size(); i++) {
+  for (size_t i = 1; i < trace_name.size(); i++) {
     if (trace_name[i] != '_') {
       continue;
     }

--- a/src/base/kaldi-error.cc
+++ b/src/base/kaldi-error.cc
@@ -1,5 +1,6 @@
 // base/kaldi-error.cc
 
+// Copyright 2019 LAIX (Yi Sun)
 // Copyright 2019 SmartAction LLC (kkm)
 // Copyright 2016 Brno University of Technology (author: Karel Vesely)
 // Copyright 2009-2011  Microsoft Corporation;  Lukas Burget;  Ondrej Glembek
@@ -20,22 +21,21 @@
 // limitations under the License.
 
 #ifdef HAVE_EXECINFO_H
-#include <execinfo.h>  // To get stack trace in error messages.
+#include <execinfo.h> // To get stack trace in error messages.
 // If this #include fails there is an error in the Makefile, it does not
 // support your platform well. Make sure HAVE_EXECINFO_H is undefined,
 // and the code will compile.
 #ifdef HAVE_CXXABI_H
-#include <cxxabi.h>  // For name demangling.
+#include <cxxabi.h> // For name demangling.
 // Useful to decode the stack trace, but only used if we have execinfo.h
-#endif  // HAVE_CXXABI_H
-#endif  // HAVE_EXECINFO_H
+#endif // HAVE_CXXABI_H
+#endif // HAVE_EXECINFO_H
 
 #include "base/kaldi-common.h"
 #include "base/kaldi-error.h"
 #include "base/version.h"
 
 namespace kaldi {
-
 
 /***** GLOBAL VARIABLES FOR LOGGING *****/
 
@@ -50,7 +50,6 @@ void SetProgramName(const char *basename) {
   // an empty string when zero-initialized but not yet constructed.
   program_name = basename;
 }
-
 
 /***** HELPER FUNCTIONS *****/
 
@@ -70,40 +69,60 @@ static const char *GetShortFileName(const char *path) {
   return prev;
 }
 
-
 /***** STACK TRACE *****/
 
-#ifdef HAVE_EXECINFO_H
-static std::string Demangle(std::string trace_name) {
-#ifdef HAVE_CXXABI_H
-  // At input the string looks like:
-  //   ./kaldi-error-test(_ZN5kaldi13UnitTestErrorEv+0xb) [0x804965d]
-  // We want to extract the name e.g. '_ZN5kaldi13UnitTestErrorEv"
-  // and demangle it.
-
-  // Try to locate '(' and '+', take the string in between.
-  size_t begin(trace_name.find("(")),
-         end(trace_name.rfind("+"));
-  if (begin != std::string::npos && end != std::string::npos && begin < end) {
-    trace_name = trace_name.substr(begin + 1, end - (begin + 1));
+namespace internal {
+bool LocateSymbolRange(const std::string &trace_name, size_t *begin,
+                       size_t *end) {
+  *begin = trace_name.find("(_");
+  if (*begin == std::string::npos) {
+    *begin = trace_name.find(" _");
+    if (*begin == std::string::npos) {
+      return false;
+    }
   }
-  // Try to demangle function name.
+  *end = trace_name.find_first_of(" +", *begin);
+  return *end != std::string::npos;
+}
+} // namespace internal
+
+#ifdef HAVE_EXECINFO_H
+static std::string MaybeDemangle(std::string trace_name) {
+#ifndef HAVE_CXXABI_H
+  return trace_name;
+#endif // HAVE_CXXABI_H
+  // Try demangle the symbol. We are trying to support the following formats
+  // produced by different platforms:
+  //
+  // Linux:
+  //   ./kaldi-error-test(_ZN5kaldi13UnitTestErrorEv+0xb) [0x804965d]
+  //
+  // Mac:
+  //   0 server 0x000000010f67614d _ZNK5kaldi13MessageLogger10LogMessageEv + 813
+  //
+  // We want to extract the name e.g., '_ZN5kaldi13UnitTestErrorEv' and
+  // demangle it info a readable name like kaldi::UnitTextError.
+  size_t begin, end;
+  if (!internal::LocateSymbolRange(trace_name, &begin, &end)) {
+    return trace_name;
+  }
+  std::string symbol = trace_name.substr(begin, end - begin);
   int status;
-  char *demangled_name = abi::__cxa_demangle(trace_name.c_str(), 0, 0, &status);
-  if (status == 0 && demangled_name != NULL) {
-    trace_name = demangled_name;
+  char *demangled_name = abi::__cxa_demangle(symbol.c_str(), 0, 0, &status);
+  if (status == 0 && demangled_name != nullptr) {
+    symbol = demangled_name;
     free(demangled_name);
   }
-#endif  // HAVE_CXXABI_H
-  return trace_name;
+  return trace_name.substr(0, begin) + symbol +
+         trace_name.substr(end, std::string::npos);
 }
-#endif  // HAVE_EXECINFO_H
+#endif // HAVE_EXECINFO_H
 
 static std::string KaldiGetStackTrace() {
   std::string ans;
 #ifdef HAVE_EXECINFO_H
   const size_t KALDI_MAX_TRACE_SIZE = 50;
-  const size_t KALDI_MAX_TRACE_PRINT = 20;  // Must be even.
+  const size_t KALDI_MAX_TRACE_PRINT = 50; // Must be even.
   // Buffer for the trace.
   void *trace[KALDI_MAX_TRACE_SIZE];
   // Get the trace.
@@ -117,27 +136,26 @@ static std::string KaldiGetStackTrace() {
   ans += "[ Stack-Trace: ]\n";
   if (size <= KALDI_MAX_TRACE_PRINT) {
     for (size_t i = 0; i < size; i++) {
-      ans += Demangle(trace_symbol[i]) + "\n";
+      ans += MaybeDemangle(trace_symbol[i]) + "\n";
     }
-  } else {  // Print out first+last (e.g.) 5.
-    for (size_t i = 0; i < KALDI_MAX_TRACE_PRINT/2; i++) {
-      ans += Demangle(trace_symbol[i]) + "\n";
+  } else { // Print out first+last (e.g.) 5.
+    for (size_t i = 0; i < KALDI_MAX_TRACE_PRINT / 2; i++) {
+      ans += MaybeDemangle(trace_symbol[i]) + "\n";
     }
     ans += ".\n.\n.\n";
-    for (size_t i = size - KALDI_MAX_TRACE_PRINT/2; i < size; i++) {
-      ans += Demangle(trace_symbol[i]) + "\n";
+    for (size_t i = size - KALDI_MAX_TRACE_PRINT / 2; i < size; i++) {
+      ans += MaybeDemangle(trace_symbol[i]) + "\n";
     }
     if (size == KALDI_MAX_TRACE_SIZE)
-      ans += ".\n.\n.\n";  // Stack was too long, probably a bug.
+      ans += ".\n.\n.\n"; // Stack was too long, probably a bug.
   }
 
   // We must free the array of pointers allocated by backtrace_symbols(),
   // but not the strings themselves.
   free(trace_symbol);
-#endif  // HAVE_EXECINFO_H
+#endif // HAVE_EXECINFO_H
   return ans;
 }
-
 
 /***** KALDI LOGGING *****/
 
@@ -146,7 +164,7 @@ MessageLogger::MessageLogger(LogMessageEnvelope::Severity severity,
   // Obviously, we assume the strings survive the destruction of this object.
   envelope_.severity = severity;
   envelope_.func = func;
-  envelope_.file = GetShortFileName(file);  // Points inside 'file'.
+  envelope_.file = GetShortFileName(file); // Points inside 'file'.
   envelope_.line = line;
 }
 
@@ -164,29 +182,29 @@ void MessageLogger::LogMessage() const {
     full_message << "VLOG[" << envelope_.severity << "] (";
   } else {
     switch (envelope_.severity) {
-    case LogMessageEnvelope::kInfo :
+    case LogMessageEnvelope::kInfo:
       full_message << "LOG (";
       break;
-    case LogMessageEnvelope::kWarning :
+    case LogMessageEnvelope::kWarning:
       full_message << "WARNING (";
       break;
-    case LogMessageEnvelope::kAssertFailed :
+    case LogMessageEnvelope::kAssertFailed:
       full_message << "ASSERTION_FAILED (";
       break;
-    case LogMessageEnvelope::kError :
-    default:  // If not the ERROR, it still an error!
+    case LogMessageEnvelope::kError:
+    default: // If not the ERROR, it still an error!
       full_message << "ERROR (";
       break;
     }
   }
   // Add other info from the envelope and the message text.
   full_message << program_name.c_str() << "[" KALDI_VERSION "]" << ':'
-               << envelope_.func  << "():" << envelope_.file << ':'
+               << envelope_.func << "():" << envelope_.file << ':'
                << envelope_.line << ") " << GetMessage().c_str();
 
   // Add stack trace for errors and assertion failures, if available.
   if (envelope_.severity < LogMessageEnvelope::kWarning) {
-    const std::string& stack_trace = KaldiGetStackTrace();
+    const std::string &stack_trace = KaldiGetStackTrace();
     if (!stack_trace.empty()) {
       full_message << "\n\n" << stack_trace;
     }
@@ -197,18 +215,16 @@ void MessageLogger::LogMessage() const {
   std::cerr << full_message.str();
 }
 
-
 /***** KALDI ASSERTS *****/
 
-void KaldiAssertFailure_(const char *func, const char *file,
-                         int32 line, const char *cond_str) {
+void KaldiAssertFailure_(const char *func, const char *file, int32 line,
+                         const char *cond_str) {
   MessageLogger::Log() =
-    MessageLogger (LogMessageEnvelope::kAssertFailed, func, file, line)
+      MessageLogger(LogMessageEnvelope::kAssertFailed, func, file, line)
       << "Assertion failed: (" << cond_str << ")";
-  fflush(NULL);  // Flush all pending buffers, abort() may not flush stderr.
+  fflush(NULL); // Flush all pending buffers, abort() may not flush stderr.
   std::abort();
 }
-
 
 /***** THIRD-PARTY LOG-HANDLER *****/
 
@@ -218,4 +234,4 @@ LogHandler SetLogHandler(LogHandler handler) {
   return old_handler;
 }
 
-}  // namespace kaldi
+} // namespace kaldi


### PR DESCRIPTION
This CL does the following:

1. Support stack trace produced by Mac OS X execinfo.h, which looks like
```
0 server 0x000000010f67614d _ZNK5kaldi13MessageLogger10LogMessageEv + 813
```

2. Keep stack trace information when demangling. The previous implementation strips line numbers.

3. Print more stack trace lines as 10 lines is usually not enough to show the whole Kaldi call stack.
 