### PR TITLE
Fix the CUDA_VSERION number issue

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -111,7 +111,7 @@ void CuDevice::Initialize() {
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
 
-#if CUDA_VERSION >= 9100
+#if CUDA_VERSION >= 9010
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
     CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_, 
             cudaStreamPerThread));
@@ -271,7 +271,7 @@ void CuDevice::FinalizeActiveGpu() {
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
     
-#if CUDA_VERSION >= 9100 
+#if CUDA_VERSION >= 9010 
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
     CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_,
             cudaStreamPerThread));
@@ -573,7 +573,7 @@ CuDevice::~CuDevice() {
   if (curand_handle_) {
     CURAND_SAFE_CALL(curandDestroyGenerator(curand_handle_));
   }
-#if CUDA_VERSION >= 9100
+#if CUDA_VERSION >= 9010
   if (cusolverdn_handle_) {
     CUSOLVER_SAFE_CALL(cusolverDnDestroy(cusolverdn_handle_));
   }

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -37,7 +37,7 @@
 #include "cudamatrix/cu-allocator.h"
 #include "cudamatrix/cu-common.h"
 
-#if CUDA_VERSION >= 9100
+#if CUDA_VERSION >= 9010
 #include <cusolverDn.h>
 #else
 // cusolver not supported.  
@@ -94,7 +94,7 @@ class CuDevice {
   inline cusparseHandle_t GetCusparseHandle() { return cusparse_handle_; }
   inline curandGenerator_t GetCurandHandle() { return curand_handle_; }
   inline cusolverDnHandle_t GetCusolverDnHandle() { 
-#if CUDA_VERSION < 9100
+#if CUDA_VERSION < 9010
     KALDI_ERR << "CUDA VERSION '" << CUDA_VERSION << "' not new enough to support "
       << "cusolver. Upgrade to at least 9.1";
 #endif


### PR DESCRIPTION
For cuda-9.1, the CUDA_VERSION number is defined as 9010 rather than 9100.
Fix the related codes in Kaldi.