### PR TITLE
Enable an option to use the GPU for feature extraction

### DIFF
--- a/src/cudadecoder/Makefile
+++ b/src/cudadecoder/Makefile
@@ -23,7 +23,8 @@ LIBNAME = kaldi-cudadecoder
 ADDLIBS = ../cudamatrix/kaldi-cudamatrix.a ../base/kaldi-base.a ../matrix/kaldi-matrix.a \
           ../lat/kaldi-lat.a ../util/kaldi-util.a ../matrix/kaldi-matrix.a ../gmm/kaldi-gmm.a \
           ../fstext/kaldi-fstext.a ../hmm/kaldi-hmm.a ../gmm/kaldi-gmm.a ../transform/kaldi-transform.a \
-          ../tree/kaldi-tree.a ../online2/kaldi-online2.a ../nnet3/kaldi-nnet3.a
+          ../tree/kaldi-tree.a ../online2/kaldi-online2.a ../nnet3/kaldi-nnet3.a \
+					../cudafeat/kaldi-cudafeat.a
 
 # Implicit rule for kernel compilation
 %.o : %.cu


### PR DESCRIPTION
Enable an option to use the GPU for feature extraction in the batched 
threaded nnet3 cuda pipeline.  This is turned on by using the option
--gpu-feature-extract=true.  By default this is on.  We provie the
option to turn it off because in situations where CPU resources
are unconfined you can get slightly higher performance with CPU
feature extraction but in most cases GPU feature extraction is faster
and has more stable performance.  In addition a user may wish to
turn it off to support models where feature extraction is currently
incomplete (e.g. FBANK, PLP, PITCH, etc).  We will add those
features in the future but for now a user wanted to decode those
models should place feature extraction on the host.