### PR TITLE
WIP: Add OnlineCMVN to Online NNET2 pipeline.  This is used in some models…

### DIFF
--- a/src/online2/online-nnet2-feature-pipeline.cc
+++ b/src/online2/online-nnet2-feature-pipeline.cc
@@ -64,6 +64,17 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
       KALDI_WARN << "--online-pitch-config option has no effect "
                  << "since you did not supply --add-pitch option.";
   }  // else use the defaults.
+  if (config.cmvn_config != "") {
+    use_cmvn = true;
+    std::cout << "Reading cmvn config opts from " << config.cmvn_config << std::endl;
+    ReadConfigFromFile(config.cmvn_config, &cmvn_opts);
+    global_cmvn_stats_rxfilename = config.global_cmvn_stats_rxfilename;
+    if (global_cmvn_stats_rxfilename == "")
+      KALDI_ERR << "--global-cmvn-stats option is required with cmvn_conf.";
+  } else { // else user the defaults
+    use_cmvn = false;
+  }
+  
 
   if (config.ivector_extraction_config != "") {
     use_ivectors = true;
@@ -79,6 +90,27 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
 OnlineNnet2FeaturePipeline::OnlineNnet2FeaturePipeline(
     const OnlineNnet2FeaturePipelineInfo &info):
     info_(info) {
+  if (info.global_cmvn_stats_rxfilename != "")
+    ReadKaldiObject(info.global_cmvn_stats_rxfilename, &global_cmvn_stats_);
+  Init();
+}
+
+void OnlineNnet2FeaturePipeline::SetCmvnState(const OnlineCmvnState &cmvn_state) {
+  cmvn_feature_->SetState(cmvn_state);
+}
+
+void OnlineNnet2FeaturePipeline::GetCmvnState(OnlineCmvnState *cmvn_state) {
+  int32 frame = cmvn_feature_->NumFramesReady() - 1;
+  // the following call will crash if no frames are ready.
+  cmvn_feature_->GetState(frame, cmvn_state);
+}
+
+
+// Init() is to be called from the constructor; it assumes the pointer
+// members are all uninitialized but config_ and lda_mat_ are
+// initialized.
+void OnlineNnet2FeaturePipeline::Init() 
+{
   if (info_.feature_type == "mfcc") {
     base_feature_ = new OnlineMfcc(info_.mfcc_opts);
   } else if (info_.feature_type == "plp") {
@@ -89,16 +121,39 @@ OnlineNnet2FeaturePipeline::OnlineNnet2FeaturePipeline(
     KALDI_ERR << "Code error: invalid feature type " << info_.feature_type;
   }
 
+  if (info_.use_cmvn)
+  {
+    KALDI_ASSERT(global_cmvn_stats_.NumRows() != 0);
+    if (info_.add_pitch) {
+      int32 global_dim = global_cmvn_stats_.NumCols() - 1;
+      int32 dim = base_feature_->Dim();
+      KALDI_ASSERT(global_dim >= dim);
+      if (global_dim > dim) {
+        Matrix<BaseFloat> last_col(global_cmvn_stats_.ColRange(global_dim, 1));
+        global_cmvn_stats_.Resize(global_cmvn_stats_.NumRows(), dim + 1,
+                                  kCopyData);
+        global_cmvn_stats_.ColRange(dim, 1).CopyFromMat(last_col);
+      }
+    }
+    Matrix<double> global_cmvn_stats_dbl(global_cmvn_stats_);
+    OnlineCmvnState initial_state(global_cmvn_stats_dbl);
+    cmvn_feature_ = new OnlineCmvn(info_.cmvn_opts, initial_state, base_feature_);
+    feature_plus_optional_cmvn_ = cmvn_feature_;
+  } else {
+    cmvn_feature_ = NULL;
+    feature_plus_optional_cmvn_ = base_feature_;
+  }
+
   if (info_.add_pitch) {
     pitch_ = new OnlinePitchFeature(info_.pitch_opts);
     pitch_feature_ = new OnlineProcessPitch(info_.pitch_process_opts,
                                             pitch_);
-    feature_plus_optional_pitch_ = new OnlineAppendFeature(base_feature_,
+    feature_plus_optional_pitch_ = new OnlineAppendFeature(feature_plus_optional_cmvn_,
                                                            pitch_feature_);
   } else {
     pitch_ = NULL;
     pitch_feature_ = NULL;
-    feature_plus_optional_pitch_ = base_feature_;
+    feature_plus_optional_pitch_ = feature_plus_optional_cmvn_;
   }
 
   if (info_.use_ivectors) {
@@ -168,8 +223,10 @@ OnlineNnet2FeaturePipeline::~OnlineNnet2FeaturePipeline() {
   if (final_feature_ != feature_plus_optional_pitch_)
     delete final_feature_;
   delete ivector_feature_;
-  if (feature_plus_optional_pitch_ != base_feature_)
+  if (feature_plus_optional_pitch_ != feature_plus_optional_cmvn_)
     delete feature_plus_optional_pitch_;
+  if (feature_plus_optional_cmvn_ != base_feature_)
+    delete feature_plus_optional_cmvn_;
   delete pitch_feature_;
   delete pitch_;
   delete base_feature_;


### PR DESCRIPTION
… (e.g.

CVTE).  This is optional and off by default.  It applies CMVN before
applying pitch.  This code is essentially copied out of
"online2/online-feature-pipeline.cc/h".

Dan i'm pushing this now as I'd like to discuss if you would be open to
this.  If this is accepted we will also emulate these changes in the
cuda pipeline.

Patch set provided by Levi Barnes.