### PR TITLE
[egs] fix utils/data/subsegment_data_dir.sh to copy reco2dur

### DIFF
--- a/egs/wsj/s5/utils/data/subsegment_data_dir.sh
+++ b/egs/wsj/s5/utils/data/subsegment_data_dir.sh
@@ -115,6 +115,11 @@ if [ -f $srcdir/reco2file_and_channel ]; then
   cp $srcdir/reco2file_and_channel $dir
 fi
 
+# copy the source reco2dur
+if [ -f $srcdir/reco2dur ]; then
+  cp $srcdir/reco2dur $dir
+fi
+
 if [ -f $srcdir/segments ]; then
   # we have to map the segments file.
   # What's going on below is a little subtle.


### PR DESCRIPTION
As we discussed in the [the code comments](https://github.com/kaldi-asr/kaldi/commit/921fe30b045b2c1239fc3508dd9f634f1f10a36b#r34216245), here's the PR for that.

The idea: The commit ff0da26f82d044c03bae26434b9ec138b4dd5e0a added new thing, the `perturb_data_dir_speed_3way.sh` compute reco2dur if not exists. But if you treated your data folder with `clean_and_segment_data.sh` or any script that use `subsegment_data_dir.sh` internally, the reco2dur will be missing and it may take very long time to re-compute it. 