### PR TITLE
[scripts] Let segment_long_utterance honor frame_shift

### DIFF
--- a/egs/wsj/s5/steps/cleanup/segment_long_utterances.sh
+++ b/egs/wsj/s5/steps/cleanup/segment_long_utterances.sh
@@ -226,7 +226,7 @@ if [ $stage -le 4 ]; then
 fi
 
 if [ $stage -le 5 ]; then
-  steps/get_ctm_fast.sh --lmwt $lmwt --cmd "$cmd --mem 4G" \
+  steps/get_ctm_fast.sh --frame_shift $frame_shift --lmwt $lmwt --cmd "$cmd --mem 4G" \
     --print-silence true \
     $data_uniform_seg $lang $decode_dir $decode_dir/ctm_$lmwt
 fi


### PR DESCRIPTION
Summary: 
As titled. Previously the frame_shift parameter was retrieved but never feed into get_ctm.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: