### PR TITLE
Small fixes

### DIFF
--- a/src/latbin/lattice-oracle.cc
+++ b/src/latbin/lattice-oracle.cc
@@ -148,7 +148,7 @@ void CountErrors(const fst::StdVectorFst &fst,
 
 bool CheckFst(const fst::StdVectorFst &fst, string name, string key) {
 #ifdef DEBUG
-  StateId numstates = fst.NumStates();
+  fst::StdArc::StateId numstates = fst.NumStates();
   std::cerr << " " << name << " has " << numstates << " states" << std::endl;
   std::stringstream ss;
   ss << name << key << ".fst";

--- a/src/nnet3bin/nnet3-xvector-compute.cc
+++ b/src/nnet3bin/nnet3-xvector-compute.cc
@@ -44,7 +44,7 @@ static void RunNnetComputation(const MatrixBase<BaseFloat> &features,
   output_spec.indexes.resize(1);
   request.outputs.resize(1);
   request.outputs[0].Swap(&output_spec);
-  std::shared_ptr<const NnetComputation> computation(std::move(compiler->Compile(request)));
+  std::shared_ptr<const NnetComputation> computation(compiler->Compile(request));
   Nnet *nnet_to_update = NULL;  // we're not doing any update.
   NnetComputer computer(NnetComputeOptions(), *computation,
                   nnet, nnet_to_update);

--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -134,7 +134,8 @@ case $(uname -m) in
     # We do not know if compiler exists at this point, so double-check the
     # well-known mkl.h file location. The compiler test would still find it if
     # installed in an alternative location (this is unlikely).
-    if [ ! -f /opt/intel/mkl/include/mkl.h ] &&
+    MKL_ROOT="${MKL_ROOT:-/opt/intel/mkl}"
+    if [ ! -f "${MKL_ROOT}/include/mkl.h" ] &&
          ! echo '#include <mkl.h>' | $CXX -I /opt/intel/mkl/include -E - >&/dev/null; then
       if [[ $(uname) == Linux ]]; then
         echo "$0: Intel MKL is not installed. Run extras/install_mkl.sh to install it."


### PR DESCRIPTION
[src] Fix buffer overflow access (ASAN)
[src] fixed warning: moving a temporary object prevents copy elision
[scripts] tools/extras/check_dependencies.sh look for alternative MKL installation at ${MKL_ROOT}
[src] Fixed compilation error when DEBUG is defined
