### PR TITLE
Add config file support for relative paths

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
@@ -28,7 +28,7 @@ namespace cuda_decoder {
 
 void BatchedThreadedNnet3CudaPipeline::Initialize(
     const fst::Fst<fst::StdArc> &decode_fst, const nnet3::AmNnetSimple &am_nnet,
-    const TransitionModel &trans_model) {
+    const TransitionModel &trans_model, const std::string &path_hint) {
   KALDI_LOG << "BatchedThreadedNnet3CudaPipeline Initialize with "
             << config_.num_control_threads << " control threads, "
             << config_.num_worker_threads << " worker threads"
@@ -38,7 +38,7 @@ void BatchedThreadedNnet3CudaPipeline::Initialize(
   trans_model_ = &trans_model;
   cuda_fst_.Initialize(decode_fst, trans_model_);
 
-  feature_info_ = new OnlineNnet2FeaturePipelineInfo(config_.feature_opts);
+  feature_info_ = new OnlineNnet2FeaturePipelineInfo(config_.feature_opts, path_hint);
   feature_info_->ivector_extractor_info.use_most_recent_ivector = true;
   feature_info_->ivector_extractor_info.greedy_ivector_extractor = true;
 

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -139,7 +139,8 @@ public:
  // allocates reusable objects that are common across all decodings
  void Initialize(const fst::Fst<fst::StdArc> &decode_fst,
                  const nnet3::AmNnetSimple &nnet,
-                 const TransitionModel &trans_model);
+                 const TransitionModel &trans_model, 
+                 const std::string &path_hint);
 
  // deallocates reusable objects
  void Finalize();

--- a/src/cudafeat/online-cuda-feature-pipeline.cc
+++ b/src/cudafeat/online-cuda-feature-pipeline.cc
@@ -22,8 +22,8 @@
 namespace kaldi {
 
 OnlineCudaFeaturePipeline::OnlineCudaFeaturePipeline(
-    const OnlineNnet2FeaturePipelineConfig &config)
-    : info_(config), mfcc(NULL), ivector(NULL) {
+    const OnlineNnet2FeaturePipelineConfig &config, const std::string &path_hint)
+    : info_(config, path_hint), mfcc(NULL), ivector(NULL) {
   if (info_.feature_type == "mfcc") {
     mfcc = new CudaMfcc(info_.mfcc_opts);
   }
@@ -32,13 +32,13 @@ OnlineCudaFeaturePipeline::OnlineCudaFeaturePipeline(
     OnlineIvectorExtractionConfig ivector_extraction_opts;
     ReadConfigFromFile(config.ivector_extraction_config,
                        &ivector_extraction_opts);
-    info_.ivector_extractor_info.Init(ivector_extraction_opts);
+    info_.ivector_extractor_info.Init(ivector_extraction_opts, path_hint);
 
     // Only these ivector options are currently supported
     ivector_extraction_opts.use_most_recent_ivector = true;
     ivector_extraction_opts.greedy_ivector_extractor = true;
 
-    ivector = new IvectorExtractorFastCuda(ivector_extraction_opts);
+    ivector = new IvectorExtractorFastCuda(ivector_extraction_opts, path_hint);
   }
 }
 

--- a/src/cudafeat/online-cuda-feature-pipeline.h
+++ b/src/cudafeat/online-cuda-feature-pipeline.h
@@ -36,7 +36,8 @@ namespace kaldi {
 class OnlineCudaFeaturePipeline {
  public:
   explicit OnlineCudaFeaturePipeline(
-      const OnlineNnet2FeaturePipelineConfig &config);
+      const OnlineNnet2FeaturePipelineConfig &config,
+      const std::string &path_hint="");
 
   void ComputeFeatures(const CuVectorBase<BaseFloat> &cu_wave,
                        BaseFloat sample_freq,

--- a/src/cudafeat/online-ivector-feature-cuda.h
+++ b/src/cudafeat/online-ivector-feature-cuda.h
@@ -29,7 +29,7 @@ namespace kaldi {
 
 class IvectorExtractorFastCuda {
  public:
-  IvectorExtractorFastCuda(const OnlineIvectorExtractionConfig &config)
+  IvectorExtractorFastCuda(const OnlineIvectorExtractionConfig &config, const std::string &path_hint)
       : b_(0), tot_post_(2) {
     if (config.use_most_recent_ivector == false) {
       KALDI_WARN
@@ -40,7 +40,7 @@ class IvectorExtractorFastCuda {
                     "greedy_ivector_extractor=false.";
     }
 
-    info_.Init(config);
+    info_.Init(config, path_hint);
     naive_cmvn_state_ = OnlineCmvnState(info_.global_cmvn_stats);
     Read(config);
     cu_lda_.Resize(info_.lda_mat.NumRows(), info_.lda_mat.NumCols());

--- a/src/online2/online-feature-pipeline.cc
+++ b/src/online2/online-feature-pipeline.cc
@@ -24,7 +24,7 @@ namespace kaldi {
 
 
 OnlineFeaturePipelineConfig::OnlineFeaturePipelineConfig(
-    const OnlineFeaturePipelineCommandLineConfig &config) {
+    const OnlineFeaturePipelineCommandLineConfig &config, const std::string &path_hint) {
   if (config.feature_type == "mfcc" || config.feature_type == "plp" ||
       config.feature_type == "fbank") {
     feature_type = config.feature_type;
@@ -34,21 +34,21 @@ OnlineFeaturePipelineConfig::OnlineFeaturePipelineConfig(
   }
 
   if (config.mfcc_config != "") {
-    ReadConfigFromFile(config.mfcc_config, &mfcc_opts);
+    ReadConfigFromFile(config.mfcc_config, &mfcc_opts, path_hint);
     if (feature_type != "mfcc")
       KALDI_WARN << "--mfcc-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.plp_config != "") {
-    ReadConfigFromFile(config.plp_config, &plp_opts);
+    ReadConfigFromFile(config.plp_config, &plp_opts, path_hint);
     if (feature_type != "plp")
       KALDI_WARN << "--plp-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.fbank_config != "") {
-    ReadConfigFromFile(config.fbank_config, &fbank_opts);
+    ReadConfigFromFile(config.fbank_config, &fbank_opts, path_hint);
     if (feature_type != "fbank")
       KALDI_WARN << "--fbank-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
@@ -56,21 +56,21 @@ OnlineFeaturePipelineConfig::OnlineFeaturePipelineConfig(
 
   add_pitch = config.add_pitch;
   if (config.pitch_config != "") {
-    ReadConfigFromFile(config.pitch_config, &pitch_opts);
+    ReadConfigFromFile(config.pitch_config, &pitch_opts, path_hint);
     if (!add_pitch)
       KALDI_WARN << "--pitch-config option has no effect "
                  << "since you did not supply --add-pitch option.";
   }  // else use the defaults.
 
   if (config.pitch_process_config != "") {
-    ReadConfigFromFile(config.pitch_process_config, &pitch_process_opts);
+    ReadConfigFromFile(config.pitch_process_config, &pitch_process_opts, path_hint);
     if (!add_pitch)
       KALDI_WARN << "--pitch-process-config option has no effect "
                  << "since you did not supply --add-pitch option.";
   }  // else use the defaults.
 
   if (config.cmvn_config != "") {
-    ReadConfigFromFile(config.cmvn_config, &cmvn_opts);
+    ReadConfigFromFile(config.cmvn_config, &cmvn_opts, path_hint);
   }  // else use the defaults.
 
   global_cmvn_stats_rxfilename = config.global_cmvn_stats_rxfilename;
@@ -79,7 +79,7 @@ OnlineFeaturePipelineConfig::OnlineFeaturePipelineConfig(
 
   add_deltas = config.add_deltas;
   if (config.delta_config != "") {
-    ReadConfigFromFile(config.delta_config, &delta_opts);
+    ReadConfigFromFile(config.delta_config, &delta_opts, path_hint);
     if (!add_deltas)
       KALDI_WARN << "--delta-config option has no effect "
                  << "since you did not supply --add-deltas option.";
@@ -87,7 +87,7 @@ OnlineFeaturePipelineConfig::OnlineFeaturePipelineConfig(
 
   splice_feats = config.splice_feats;
   if (config.splice_config != "") {
-    ReadConfigFromFile(config.splice_config, &splice_opts);
+    ReadConfigFromFile(config.splice_config, &splice_opts, path_hint);
     if (!splice_feats)
       KALDI_WARN << "--splice-config option has no effect "
                  << "since you did not supply --splice-feats option.";

--- a/src/online2/online-feature-pipeline.h
+++ b/src/online2/online-feature-pipeline.h
@@ -115,7 +115,8 @@ struct OnlineFeaturePipelineConfig {
       splice_feats(false) { }
 
   OnlineFeaturePipelineConfig(
-      const OnlineFeaturePipelineCommandLineConfig &cmdline_config);
+      const OnlineFeaturePipelineCommandLineConfig &cmdline_config, 
+      const std::string &path_hint="");
 
   BaseFloat FrameShiftInSeconds() const;
 

--- a/src/online2/online-ivector-feature.cc
+++ b/src/online2/online-ivector-feature.cc
@@ -22,12 +22,13 @@
 namespace kaldi {
 
 OnlineIvectorExtractionInfo::OnlineIvectorExtractionInfo(
-    const OnlineIvectorExtractionConfig &config) {
-  Init(config);
+    const OnlineIvectorExtractionConfig &config, const std::string &path_hint) {
+  Init(config, path_hint);
 }
 
 void OnlineIvectorExtractionInfo::Init(
-    const OnlineIvectorExtractionConfig &config) {
+    const OnlineIvectorExtractionConfig &config,
+    const std::string &path_hint) {
   ivector_period = config.ivector_period;
   num_gselect = config.num_gselect;
   min_post = config.min_post;
@@ -47,10 +48,10 @@ void OnlineIvectorExtractionInfo::Init(
       "in the file supplied to --ivector-extractor-config)";
   if (config.lda_mat_rxfilename == "")
     KALDI_ERR << "--lda-matrix option must be set " << note;
-  ReadKaldiObject(config.lda_mat_rxfilename, &lda_mat);
+  ReadKaldiObject(config.lda_mat_rxfilename, &lda_mat, path_hint);
   if (config.global_cmvn_stats_rxfilename == "")
     KALDI_ERR << "--global-cmvn-stats option must be set " << note;
-  ReadKaldiObject(config.global_cmvn_stats_rxfilename, &global_cmvn_stats);
+  ReadKaldiObject(config.global_cmvn_stats_rxfilename, &global_cmvn_stats, path_hint);
   if (config.cmvn_config_rxfilename == "")
     KALDI_ERR << "--cmvn-config option must be set " << note;
   ReadConfigFromFile(config.cmvn_config_rxfilename, &cmvn_opts);
@@ -59,10 +60,10 @@ void OnlineIvectorExtractionInfo::Init(
   ReadConfigFromFile(config.splice_config_rxfilename, &splice_opts);
   if (config.diag_ubm_rxfilename == "")
     KALDI_ERR << "--diag-ubm option must be set " << note;
-  ReadKaldiObject(config.diag_ubm_rxfilename, &diag_ubm);
+  ReadKaldiObject(config.diag_ubm_rxfilename, &diag_ubm, path_hint);
   if (config.ivector_extractor_rxfilename == "")
     KALDI_ERR << "--ivector-extractor option must be set " << note;
-  ReadKaldiObject(config.ivector_extractor_rxfilename, &extractor);
+  ReadKaldiObject(config.ivector_extractor_rxfilename, &extractor, path_hint);
   this->Check();
 }
 

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -180,9 +180,9 @@ struct OnlineIvectorExtractionInfo {
   bool greedy_ivector_extractor;
   BaseFloat max_remembered_frames;
 
-  OnlineIvectorExtractionInfo(const OnlineIvectorExtractionConfig &config);
+  OnlineIvectorExtractionInfo(const OnlineIvectorExtractionConfig &config, const std::string &path_hint="");
 
-  void Init(const OnlineIvectorExtractionConfig &config);
+  void Init(const OnlineIvectorExtractionConfig &config, const std::string &path_hint="");
 
   // This constructor creates a version of this object where everything
   // is empty or zero.

--- a/src/online2/online-nnet2-feature-pipeline.cc
+++ b/src/online2/online-nnet2-feature-pipeline.cc
@@ -23,7 +23,8 @@
 namespace kaldi {
 
 OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
-    const OnlineNnet2FeaturePipelineConfig &config):
+    const OnlineNnet2FeaturePipelineConfig &config,
+    const std::string &path_hint):
     silence_weighting_config(config.silence_weighting_config) {
   if (config.feature_type == "mfcc" || config.feature_type == "plp" ||
       config.feature_type == "fbank") {
@@ -34,21 +35,21 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
   }
 
   if (config.mfcc_config != "") {
-    ReadConfigFromFile(config.mfcc_config, &mfcc_opts);
+    ReadConfigFromFile(config.mfcc_config, &mfcc_opts, path_hint);
     if (feature_type != "mfcc")
       KALDI_WARN << "--mfcc-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.plp_config != "") {
-    ReadConfigFromFile(config.plp_config, &plp_opts);
+    ReadConfigFromFile(config.plp_config, &plp_opts, path_hint);
     if (feature_type != "plp")
       KALDI_WARN << "--plp-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.fbank_config != "") {
-    ReadConfigFromFile(config.fbank_config, &fbank_opts);
+    ReadConfigFromFile(config.fbank_config, &fbank_opts, path_hint);
     if (feature_type != "fbank")
       KALDI_WARN << "--fbank-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
@@ -59,7 +60,8 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
   if (config.online_pitch_config != "") {
     ReadConfigsFromFile(config.online_pitch_config,
                         &pitch_opts,
-                        &pitch_process_opts);
+                        &pitch_process_opts,
+                        path_hint);
     if (!add_pitch)
       KALDI_WARN << "--online-pitch-config option has no effect "
                  << "since you did not supply --add-pitch option.";
@@ -69,8 +71,9 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
     use_ivectors = true;
     OnlineIvectorExtractionConfig ivector_extraction_opts;
     ReadConfigFromFile(config.ivector_extraction_config,
-                       &ivector_extraction_opts);
-    ivector_extractor_info.Init(ivector_extraction_opts);
+                       &ivector_extraction_opts,
+                       path_hint);
+    ivector_extractor_info.Init(ivector_extraction_opts, path_hint);
   } else {
     use_ivectors = false;
   }

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -127,7 +127,7 @@ struct OnlineNnet2FeaturePipelineInfo {
       feature_type("mfcc"), add_pitch(false) { }
 
   OnlineNnet2FeaturePipelineInfo(
-      const OnlineNnet2FeaturePipelineConfig &config);
+      const OnlineNnet2FeaturePipelineConfig &config, const std::string &path_hint="");
 
   BaseFloat FrameShiftInSeconds() const;
 

--- a/src/util/kaldi-io.cc
+++ b/src/util/kaldi-io.cc
@@ -830,7 +830,8 @@ std::istream &Input::Stream() {
 
 
 template <> void ReadKaldiObject(const std::string &filename,
-                                 Matrix<float> *m) {
+                                 Matrix<float> *m,
+                                 const std::string &path_hint) {
   if (!filename.empty() && filename[filename.size() - 1] == ']') {
     // This filename seems to have a 'range'... like foo.ark:4312423[20:30].
     // (the bit in square brackets is the range).
@@ -841,7 +842,8 @@ template <> void ReadKaldiObject(const std::string &filename,
     }
     Matrix<float> temp;
     bool binary_in;
-    Input ki(rxfilename, &binary_in);
+    std::string fqfilename=ResolvePath(rxfilename, path_hint);
+    Input ki(fqfilename, &binary_in);
     temp.Read(ki.Stream(), binary_in);
     if (!ExtractObjectRange(temp, range, m)) {
       KALDI_ERR << "Error extracting range of object: " << filename;
@@ -849,13 +851,15 @@ template <> void ReadKaldiObject(const std::string &filename,
   } else {
     // The normal case, there is no range.
     bool binary_in;
-    Input ki(filename, &binary_in);
+    std::string fqfilename=ResolvePath(filename, path_hint);
+    Input ki(fqfilename, &binary_in);
     m->Read(ki.Stream(), binary_in);
   }
 }
 
 template <> void ReadKaldiObject(const std::string &filename,
-                                 Matrix<double> *m) {
+                                 Matrix<double> *m,
+                                 const std::string &path_hint) {
   if (!filename.empty() && filename[filename.size() - 1] == ']') {
     // This filename seems to have a 'range'... like foo.ark:4312423[20:30].
     // (the bit in square brackets is the range).
@@ -866,7 +870,8 @@ template <> void ReadKaldiObject(const std::string &filename,
     }
     Matrix<double> temp;
     bool binary_in;
-    Input ki(rxfilename, &binary_in);
+    std::string fqfilename=ResolvePath(rxfilename, path_hint);
+    Input ki(fqfilename, &binary_in);
     temp.Read(ki.Stream(), binary_in);
     if (!ExtractObjectRange(temp, range, m)) {
       KALDI_ERR << "Error extracting range of object: " << filename;
@@ -874,7 +879,8 @@ template <> void ReadKaldiObject(const std::string &filename,
   } else {
     // The normal case, there is no range.
     bool binary_in;
-    Input ki(filename, &binary_in);
+    std::string fqfilename=ResolvePath(filename, path_hint);
+    Input ki(fqfilename, &binary_in);
     m->Read(ki.Stream(), binary_in);
   }
 }

--- a/src/util/kaldi-io.h
+++ b/src/util/kaldi-io.h
@@ -29,7 +29,7 @@
 #include <string>
 #include "base/kaldi-common.h"
 #include "matrix/kaldi-matrix.h"
-
+#include "util/parse-options.h"
 
 namespace kaldi {
 
@@ -237,20 +237,24 @@ class Input {
 };
 
 template <class C> void ReadKaldiObject(const std::string &filename,
-                                        C *c) {
+                                        C *c,
+                                        const std::string &path_hint="") {
   bool binary_in;
-  Input ki(filename, &binary_in);
+  std::string fqfilename = ResolvePath(filename, path_hint);
+  Input ki(fqfilename, &binary_in);
   c->Read(ki.Stream(), binary_in);
 }
 
 // Specialize the template for reading matrices, because we want to be able to
 // support reading 'ranges' (row and column ranges), like foo.mat[10:20].
 template <> void ReadKaldiObject(const std::string &filename,
-                                 Matrix<float> *m);
+                                 Matrix<float> *m,
+                                 const std::string &path_hint);
 
 
 template <> void ReadKaldiObject(const std::string &filename,
-                                 Matrix<double> *m);
+                                 Matrix<double> *m,
+                                 const std::string &path_hint);
 
 
 

--- a/src/util/parse-options.h
+++ b/src/util/parse-options.h
@@ -115,7 +115,7 @@ class ParseOptions : public OptionsItf {
   /// registering all options.  This is usually used internally after the
   /// standard --config option is used, but it may also be called from a
   /// program.
-  void ReadConfigFile(const std::string &filename);
+  void ReadConfigFile(const std::string &filename, const std::string &path_hint="");
 
   /// Number of positional parameters (c.f. argc-1).
   int NumArgs() const;
@@ -235,30 +235,32 @@ class ParseOptions : public OptionsItf {
 /// "void Register(OptionsItf *opts)" which it can call to register the
 /// ParseOptions object.
 template<class C> void ReadConfigFromFile(const std::string config_filename,
-                                          C *c) {
+                                          C *c,
+                                          const std::string &path_hint="") {
   std::ostringstream usage_str;
   usage_str << "Parsing config from "
             << "from '" << config_filename << "'";
   ParseOptions po(usage_str.str().c_str());
   c->Register(&po);
-  po.ReadConfigFile(config_filename);
+  po.ReadConfigFile(config_filename, path_hint);
 }
 
 /// This variant of the template ReadConfigFromFile is for if you need to read
 /// two config classes from the same file.
 template<class C1, class C2> void ReadConfigsFromFile(const std::string
                                                       config_filename,
-                                                      C1 *c1, C2 *c2) {
+                                                      C1 *c1, C2 *c2,
+                                                      const std::string &path_hint="") {
   std::ostringstream usage_str;
   usage_str << "Parsing config from "
             << "from '" << config_filename << "'";
   ParseOptions po(usage_str.str().c_str());
   c1->Register(&po);
   c2->Register(&po);
-  po.ReadConfigFile(config_filename);
+  po.ReadConfigFile(config_filename, path_hint);
 }
 
-
+std::string ResolvePath(const std::string &filename, const std::string &path_hint);
 
 }  // namespace kaldi
 


### PR DESCRIPTION
I know I've seen other request and we also like to use config files with relative path, so I've added some support for relative paths of the decoder where nested config files are often used