### PR TITLE
Fixed overlap segment bug

### DIFF
--- a/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
@@ -111,7 +111,7 @@ awk '{print $1}' $tmpdir/segments | \
 join $tmpdir/utt2spk_stm $tmpdir/segments | \
   awk '{ utt=$1; spk=$2; wav=$3; t_beg=$4; t_end=$5;
          if(spk_prev == spk && t_end_prev > t_beg) {
-           print "s/^"utt, wav, t_beg, t_end" $/"utt, wav, t_end_prev, t_end" /;";
+           print "s:[^\\S\\n]+$::;s:^"utt, wav, t_beg, t_end"$:"utt, wav, t_end_prev, t_end":;";
          }
          spk_prev=spk; t_end_prev=t_end;
        }' > $tmpdir/segments_to_fix

--- a/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
@@ -107,11 +107,11 @@ awk '{print $1}' $tmpdir/segments | \
 
 #check and correct the case when segment timings for given speaker overlap themself
 #(important for simulatenous asclite scoring to proceed).
-#There is actually only one such case for devset and automatic segmentetions
+#There is actually only one such case for devset and automatic segmentations
 join $tmpdir/utt2spk_stm $tmpdir/segments | \
   awk '{ utt=$1; spk=$2; wav=$3; t_beg=$4; t_end=$5;
          if(spk_prev == spk && t_end_prev > t_beg) {
-           print "s/^"utt, wav, t_beg, t_end"$/"utt, wav, t_end_prev, t_end"/;";
+           print "s/"utt, wav, t_beg, t_end"/"utt, wav, t_end_prev, t_end"/;";
          }
          spk_prev=spk; t_end_prev=t_end;
        }' > $tmpdir/segments_to_fix

--- a/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
+++ b/egs/ami/s5b/local/ami_sdm_scoring_data_prep.sh
@@ -111,7 +111,7 @@ awk '{print $1}' $tmpdir/segments | \
 join $tmpdir/utt2spk_stm $tmpdir/segments | \
   awk '{ utt=$1; spk=$2; wav=$3; t_beg=$4; t_end=$5;
          if(spk_prev == spk && t_end_prev > t_beg) {
-           print "s/"utt, wav, t_beg, t_end"/"utt, wav, t_end_prev, t_end"/;";
+           print "s/^"utt, wav, t_beg, t_end" $/"utt, wav, t_end_prev, t_end" /;";
          }
          spk_prev=spk; t_end_prev=t_end;
        }' > $tmpdir/segments_to_fix


### PR DESCRIPTION
The segment was not getting replaced, because of which asclite scoring failed for SDM dev set.