### PR TITLE
Fix in cudafeat for Jetson platforms 

### DIFF
--- a/src/cudafeat/online-ivector-feature-cuda.cc
+++ b/src/cudafeat/online-ivector-feature-cuda.cc
@@ -244,11 +244,6 @@ void IvectorExtractorFastCuda::ComputeIvectorFromStats(
   CuMatrix<float> A(quadratic);
 
 #if CUDA_VERSION >= 9010
-  // This is the cusolver return code.  Checking it would require
-  // synchronization.
-  // So we do not check it.
-  int *d_info = NULL;
-
   // query temp buffer size
   int L_work;
   CUSOLVER_SAFE_CALL(
@@ -262,12 +257,12 @@ void IvectorExtractorFastCuda::ComputeIvectorFromStats(
   // perform factorization
   CUSOLVER_SAFE_CALL(cusolverDnSpotrf(
       GetCusolverDnHandle(), CUBLAS_FILL_MODE_LOWER, ivector_dim_, A.Data(),
-      A.Stride(), workspace, L_work, d_info));
+      A.Stride(), workspace, L_work, d_info_));
 
   // solve for rhs
   CUSOLVER_SAFE_CALL(cusolverDnSpotrs(
       GetCusolverDnHandle(), CUBLAS_FILL_MODE_LOWER, ivector_dim_, nrhs,
-      A.Data(), A.Stride(), ivector->Data(), ivector_dim_, d_info));
+      A.Data(), A.Stride(), ivector->Data(), ivector_dim_, d_info_));
 
   CuDevice::Instantiate().Free(workspace);
 #else

--- a/src/cudafeat/online-ivector-feature-cuda.h
+++ b/src/cudafeat/online-ivector-feature-cuda.h
@@ -45,8 +45,12 @@ class IvectorExtractorFastCuda {
     Read(config);
     cu_lda_.Resize(info_.lda_mat.NumRows(), info_.lda_mat.NumCols());
     cu_lda_.CopyFromMat(info_.lda_mat);
+    d_info_ = static_cast<int *>(CuDevice::Instantiate().Malloc(sizeof(int)));
   }
-  ~IvectorExtractorFastCuda() {}
+  ~IvectorExtractorFastCuda() {
+    KALDI_ASSERT(d_info_);
+    CuDevice::Instantiate().Free(d_info_);
+  }
 
   // This function goes directly from features to an i-vector
   // which makes the computation easier to port to GPU
@@ -117,6 +121,9 @@ class IvectorExtractorFastCuda {
   int b_;
   CuVector<BaseFloat> tot_post_;
   float prior_offset_;
+
+  // Buffer used by cusolver
+  int *d_info_;
 };
 }  // namespace kaldi
 


### PR DESCRIPTION
Some platform (e.g. Jetson platforms) were crashing in cudafeat. Fixing the bug by always passing a valid buffer to the cusolver call.