### PR TITLE
Fix GetDeltaWeights for long-running online decoding

### DIFF
--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -482,7 +482,9 @@ class OnlineSilenceWeighting {
   //
   // The first_decoder_frame is the offset from the start of the stream in
   // pipeline frames when decoder was restarted last time. We do not change
-  // weight for frames earlier than first_decoder_frame.
+  // weight for the frames earlier than first_decoder_frame. Set it to 0 in
+  // case of compilation error to reproduce the previous behavior or for a
+  // single utterance decoding.
   //
   // How many frames of weights it outputs depends on how much "num_frames_ready"
   // increased since last time we called this function, and whether the decoder

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -473,20 +473,29 @@ class OnlineSilenceWeighting {
   void ComputeCurrentTraceback(const LatticeFasterOnlineDecoderTpl<FST> &decoder);
 
   // Calling this function gets the changes in weight that require us to modify
-  // the stats... the output format is (frame-index, delta-weight).  The
-  // num_frames_ready argument is the number of frames available at the input
-  // (or equivalently, output) of the online iVector extractor class, which may
-  // be more than the currently available decoder traceback.  How many frames
-  // of weights it outputs depends on how much "num_frames_ready" increased
-  // since last time we called this function, and whether the decoder traceback
-  // changed.  Negative delta_weights might occur if frames previously
+  // the stats... the output format is (frame-index, delta-weight).
+  //
+  // The num_frames_ready argument is the number of frames available at
+  // the input (or equivalently, output) of the online iVector feature in the
+  // feature pipeline from the stream start. It may be more than the currently
+  // available decoder traceback.
+  //
+  // The first_decoder_frame is the offset from the start of the stream in
+  // pipeline frames when decoder was restarted last time. We do not change
+  // weight for frames earlier than first_decoder_frame.
+  //
+  // How many frames of weights it outputs depends on how much "num_frames_ready"
+  // increased since last time we called this function, and whether the decoder
+  // traceback changed.  Negative delta_weights might occur if frames previously
   // classified as non-silence become classified as silence if the decoder's
   // traceback changes.  You must call this function with "num_frames_ready"
   // arguments that only increase, not decrease, with time.  You would provide
   // this output to class OnlineIvectorFeature by calling its function
   // UpdateFrameWeights with the output.
+  //
+  // Returned frame-index is in pipeline frames from the pipeline start.
   void GetDeltaWeights(
-      int32 num_frames_ready_in,
+      int32 num_frames_ready, int32 first_decoder_frame,
       std::vector<std::pair<int32, BaseFloat> > *delta_weights);
 
  private:

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -496,7 +496,7 @@ bool SingleUtteranceNnet2DecoderThreaded::RunNnetEvaluationInternal() {
       silence_weighting_mutex_.lock();
       std::vector<std::pair<int32, BaseFloat> > delta_weights;
       silence_weighting_.GetDeltaWeights(
-          feature_pipeline_.IvectorFeature()->NumFramesReady(),
+          feature_pipeline_.IvectorFeature()->NumFramesReady(), 0,
           &delta_weights);
       silence_weighting_mutex_.unlock();
       feature_pipeline_.IvectorFeature()->UpdateFrameWeights(delta_weights);

--- a/src/online2/online-nnet2-feature-pipeline.cc
+++ b/src/online2/online-nnet2-feature-pipeline.cc
@@ -129,18 +129,8 @@ void OnlineNnet2FeaturePipeline::GetFrame(int32 frame,
 }
 
 void OnlineNnet2FeaturePipeline::UpdateFrameWeights(
-    const std::vector<std::pair<int32, BaseFloat> > &delta_weights,
-    int32 frame_offset) {
-  if (frame_offset == 0) {
+    const std::vector<std::pair<int32, BaseFloat> > &delta_weights) {
     IvectorFeature()->UpdateFrameWeights(delta_weights);
-  } else {
-    std::vector<std::pair<int32, BaseFloat> > offset_delta_weights;
-    for (size_t i = 0; i < delta_weights.size(); i++) {
-      offset_delta_weights.push_back(std::make_pair(
-          delta_weights[i].first + frame_offset, delta_weights[i].second));
-    }
-    IvectorFeature()->UpdateFrameWeights(offset_delta_weights);
-  }
 }
 
 void OnlineNnet2FeaturePipeline::SetAdaptationState(

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -207,8 +207,7 @@ class OnlineNnet2FeaturePipeline: public OnlineFeatureInterface {
   /// ideally just after calling AcceptWaveform(), or never call it for the
   /// lifetime of this object.
   void UpdateFrameWeights(
-      const std::vector<std::pair<int32, BaseFloat> > &delta_weights,
-      int32 frame_offset = 0);
+      const std::vector<std::pair<int32, BaseFloat> > &delta_weights);
 
   /// Set the adaptation state to a particular value, e.g. reflecting previous
   /// utterances of the same speaker; this will generally be called after

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -283,9 +283,9 @@ int main(int argc, char *argv[]) {
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
             silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
+                                              frame_offset * decodable_opts.frame_subsampling_factor,
                                               &delta_weights);
-            feature_pipeline.UpdateFrameWeights(delta_weights,
-                                                frame_offset * decodable_opts.frame_subsampling_factor);
+            feature_pipeline.UpdateFrameWeights(delta_weights);
           }
 
           decoder.AdvanceDecoding();

--- a/src/online2bin/online2-wav-nnet2-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet2-latgen-faster.cc
@@ -241,7 +241,7 @@ int main(int argc, char *argv[]) {
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
             silence_weighting.GetDeltaWeights(
-                feature_pipeline.IvectorFeature()->NumFramesReady(),
+                feature_pipeline.IvectorFeature()->NumFramesReady(), 0,
                 &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(
                 delta_weights);

--- a/src/online2bin/online2-wav-nnet3-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet3-latgen-faster.cc
@@ -251,7 +251,7 @@ int main(int argc, char *argv[]) {
           if (silence_weighting.Active() &&
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
-            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
+            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(), 0,
                                               &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(delta_weights);
           }

--- a/src/online2bin/online2-wav-nnet3-latgen-grammar.cc
+++ b/src/online2bin/online2-wav-nnet3-latgen-grammar.cc
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
           if (silence_weighting.Active() &&
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
-            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
+            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(), 0,
                                               &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(delta_weights);
           }


### PR DESCRIPTION
Currently bad things happen for long-running online decoding like in tcp decoder. The current code requests delta weights with feature_pipeline.NumFramesReady() that is the whole input pipeline size, meaning hundred thousands of delta weights are returned repeatedly for a long file of 1 hour length on every new utterance. Those delta weights are accumulated in priority queue again and again growing memory to several gigabytes per stream while it could be just a hundred of megabytes. The weight values are not properly estimated too as I believe since the offsets are mixed.

This patch tries to fix the situation. The function GetDeltaWeights uses decoder frame offsets which are reset for every new utterance. Pipeline frame offsets are calculated only when deltaweights are returned.