### PR TITLE
Add a method for backward-compatibility with previous API

### DIFF
--- a/src/online2/online-ivector-feature.cc
+++ b/src/online2/online-ivector-feature.cc
@@ -580,6 +580,7 @@ void OnlineSilenceWeighting::GetDeltaWeights(
   // in this function is at the decoder frame-rate.
   // round up, so we are sure to get weights for at least the frame
   // 'num_frames_ready - 1', and maybe one or two frames afterward.
+  KALDI_ASSERT(num_frames_ready > first_decoder_frame);
   int32 fs = frame_subsampling_factor_,
   num_decoder_frames_ready = (num_frames_ready - first_decoder_frame + fs - 1) / fs;
 

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -500,6 +500,14 @@ class OnlineSilenceWeighting {
       int32 num_frames_ready, int32 first_decoder_frame,
       std::vector<std::pair<int32, BaseFloat> > *delta_weights);
 
+  // A method for backward compatibility, same as above, but for a single
+  // utterance.
+  void GetDeltaWeights(
+      int32 num_frames_ready,
+      std::vector<std::pair<int32, BaseFloat> > *delta_weights) {
+    GetDeltaWeights(num_frames_ready, 0, delta_weights);
+  }
+
  private:
   const TransitionModel &trans_model_;
   const OnlineSilenceWeightingConfig &config_;

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -496,7 +496,7 @@ bool SingleUtteranceNnet2DecoderThreaded::RunNnetEvaluationInternal() {
       silence_weighting_mutex_.lock();
       std::vector<std::pair<int32, BaseFloat> > delta_weights;
       silence_weighting_.GetDeltaWeights(
-          feature_pipeline_.IvectorFeature()->NumFramesReady(), 0,
+          feature_pipeline_.IvectorFeature()->NumFramesReady(),
           &delta_weights);
       silence_weighting_mutex_.unlock();
       feature_pipeline_.IvectorFeature()->UpdateFrameWeights(delta_weights);

--- a/src/online2bin/online2-wav-nnet2-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet2-latgen-faster.cc
@@ -241,7 +241,7 @@ int main(int argc, char *argv[]) {
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
             silence_weighting.GetDeltaWeights(
-                feature_pipeline.IvectorFeature()->NumFramesReady(), 0,
+                feature_pipeline.IvectorFeature()->NumFramesReady(),
                 &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(
                 delta_weights);

--- a/src/online2bin/online2-wav-nnet3-latgen-faster.cc
+++ b/src/online2bin/online2-wav-nnet3-latgen-faster.cc
@@ -251,7 +251,7 @@ int main(int argc, char *argv[]) {
           if (silence_weighting.Active() &&
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
-            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(), 0,
+            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
                                               &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(delta_weights);
           }

--- a/src/online2bin/online2-wav-nnet3-latgen-grammar.cc
+++ b/src/online2bin/online2-wav-nnet3-latgen-grammar.cc
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
           if (silence_weighting.Active() &&
               feature_pipeline.IvectorFeature() != NULL) {
             silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
-            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(), 0,
+            silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
                                               &delta_weights);
             feature_pipeline.IvectorFeature()->UpdateFrameWeights(delta_weights);
           }


### PR DESCRIPTION
A cosmetic update for https://github.com/kaldi-asr/kaldi/pull/3528. Adds a method for backward compatibility and assert for arguments check.