### PR TITLE
Fix regex filter in Fisher preprocessing script

### DIFF
--- a/egs/fisher_swbd/s5/local/fisher_data_prep.sh
+++ b/egs/fisher_swbd/s5/local/fisher_data_prep.sh
@@ -118,7 +118,7 @@ if [ $stage -le 1 ]; then
      $line1 =~ m/# (.+)\.sph/ || die "Bad first line $line1 in file $file";
      $call_id eq $1 || die "Mismatch call-id $call_id vs $1\n";
      while (<I>) {
-       if (m/([0-9.]+)\s+([0-9.]+) ([AB]):\s*(\S.+\S|\S)\s*$/) {
+       if (m/([0-9.]+)\s+([0-9.]+) ([AB]):\s*(\S.*\S|\S)\s*$/) {
          $start = sprintf("%06d", $1 * 100.0);
          $end = sprintf("%06d", $2 * 100.0);
          length($end) > 6 && die "Time too long $end in file $file";


### PR DESCRIPTION
the regex here seems to ignore transcripts with two letters in them, For example - "20.06 20.46 B: um"

adding this increases the number of valid segments from 1881740 to 1944290 for Fisher.