### PR TITLE
bug-fix: corrected stop-boundary on the awk for-loop when selecting -…

### DIFF
--- a/egs/wsj/s5/utils/subset_data_dir.sh
+++ b/egs/wsj/s5/utils/subset_data_dir.sh
@@ -108,7 +108,7 @@ elif $speakers; then
 elif $perspk; then
   awk '{ n='$numutt'; printf("%s ",$1);
          skip=1; while(n*(skip+1) <= NF-1) { skip++; }
-         for(x=2; x<=NF && x <= n*skip; x += skip) { printf("%s ", $x); }
+         for(x=2; x<=NF && x <= (n*skip+1); x += skip) { printf("%s ", $x); }
          printf("\n"); }' <$srcdir/spk2utt >$destdir/spk2utt
   utils/spk2utt_to_utt2spk.pl < $destdir/spk2utt > $destdir/utt2spk
 else


### PR DESCRIPTION
…-per-spk option. it was off by 1, causing the number of utterances per-speaker to be less than the ones requested.