### PR TITLE
GCC9 + OpenFST1.7.3 + C++2a

### DIFF
--- a/src/fstext/context-fst-test.cc
+++ b/src/fstext/context-fst-test.cc
@@ -25,7 +25,8 @@
 
 namespace fst
 {
-
+using std::vector;
+using std::cout;
 
 // GenAcceptorFromSequence generates a linear acceptor (identical input+output symbols) that has this
 // sequence of symbols, and

--- a/src/fstext/context-fst.cc
+++ b/src/fstext/context-fst.cc
@@ -21,6 +21,7 @@
 #include "base/kaldi-error.h"
 
 namespace fst {
+using std::vector;
 
 
 InverseContextFst::InverseContextFst(

--- a/src/fstext/context-fst.h
+++ b/src/fstext/context-fst.h
@@ -68,15 +68,15 @@ namespace fst {
 
 /// Utility function for writing ilabel-info vectors to disk.
 void WriteILabelInfo(std::ostream &os, bool binary,
-                     const vector<vector<int32> > &ilabel_info);
+                     const std::vector<std::vector<int32> > &ilabel_info);
 
 /// Utility function for reading ilabel-info vectors from disk.
 void ReadILabelInfo(std::istream &is, bool binary,
-                    vector<vector<int32> > *ilabel_info);
+                    std::vector<std::vector<int32> > *ilabel_info);
 
 
 /// The following function is mainly of use for printing and debugging.
-SymbolTable *CreateILabelInfoSymbolTable(const vector<vector<int32> > &ilabel_info,
+SymbolTable *CreateILabelInfoSymbolTable(const std::vector<std::vector<int32> > &ilabel_info,
                                          const SymbolTable &phones_symtab,
                                          std::string separator,
                                          std::string disambig_prefix);  // e.g. separator = "/", disambig_prefix = "#"
@@ -106,11 +106,11 @@ SymbolTable *CreateILabelInfoSymbolTable(const vector<vector<int32> > &ilabel_in
                   to 'ifst', which allows us to reconstruct the context
                   fst C.fst.
  */
-void ComposeContext(const vector<int32> &disambig_syms,
+void ComposeContext(const std::vector<int32> &disambig_syms,
                     int32 context_width, int32 central_position,
                     VectorFst<StdArc> *ifst,
                     VectorFst<StdArc> *ofst,
-                    vector<vector<int32> > *ilabels_out,
+                    std::vector<std::vector<int32> > *ilabels_out,
                     bool project_ifst = false);
 
 
@@ -172,8 +172,8 @@ public:
      See \ref graph_context for more details.
   */
   InverseContextFst(Label subsequential_symbol,
-                    const vector<int32>& phones,
-                    const vector<int32>& disambig_syms,
+                    const std::vector<int32>& phones,
+                    const std::vector<int32>& disambig_syms,
                     int32 context_width,
                     int32 central_position);
 
@@ -191,24 +191,24 @@ public:
   // the input symbols of C (i.e. all the output symbols of this
   // InverseContextFst).  See
   // "http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel".
-  const vector<vector<int32> > &IlabelInfo() const {
+  const std::vector<std::vector<int32> > &IlabelInfo() const {
     return ilabel_info_;
   }
 
   // A way to destructively obtain the ilabel-info.  Only do this if you
   // are just about to destroy this object.
-  void SwapIlabelInfo(vector<vector<int32> > *vec) { ilabel_info_.swap(*vec); }
+  void SwapIlabelInfo(std::vector<std::vector<int32> > *vec) { ilabel_info_.swap(*vec); }
 
 private:
 
   /// Returns the state-id corresponding to this vector of phones; creates the
   /// state it if necessary.  Requires seq.size() == context_width_ - 1.
-  StateId FindState(const vector<int32> &seq);
+  StateId FindState(const std::vector<int32> &seq);
 
   /// Finds the label index corresponding to this context-window of phones
   /// (likely of width context_width_).  Inserts it into the
   /// ilabel_info_/ilabel_map_ tables if necessary.
-  Label FindLabel(const vector<int32> &label_info);
+  Label FindLabel(const std::vector<int32> &label_info);
 
   inline bool IsDisambigSymbol(Label lab) { return (disambig_syms_.count(lab) != 0); }
 
@@ -223,7 +223,7 @@ private:
   /// epsilon, instead of a phone-in-context, if the system has right context
   /// and we are very near the beginning of the phone sequence.
   inline void CreatePhoneOrEpsArc(StateId src, StateId dst, Label ilabel,
-                                  const vector<int32> &phone_seq, Arc *arc);
+                                  const std::vector<int32> &phone_seq, Arc *arc);
 
 
   /// If phone_seq is nonempty then this function it left by one and appends
@@ -246,13 +246,13 @@ private:
   // Map type to map from vectors of int32 (representing phonetic contexts,
   // which will be of dimension context_width - 1) to StateId (corresponding to
   // the state index in this FST).
-  typedef unordered_map<vector<int32>, StateId,
+  typedef unordered_map<std::vector<int32>, StateId,
                         kaldi::VectorHasher<int32> > VectorToStateMap;
 
   // Map type to map from vectors of int32 (representing ilabel-info,
   // see http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel) to
   // Label (the output label in this FST).
-  typedef unordered_map<vector<int32>, Label,
+  typedef unordered_map<std::vector<int32>, Label,
                         kaldi::VectorHasher<int32> > VectorToLabelMap;
 
 
@@ -315,7 +315,7 @@ private:
 
   // The inverse of 'state_map_': gives us the phonetic context corresponding to
   // each state-id.
-  vector<vector<int32> > state_seqs_;
+  std::vector<std::vector<int32> > state_seqs_;
 
   // maps from vector<int32>, representing phonetic contexts of length
   // context_width_ - 1, to Label.  These are actually the output labels of this
@@ -330,7 +330,7 @@ private:
   // information about the meaning of each symbol on the input of C
   // aka the output of inv(C).
   // See "http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel".
-  vector<vector<int32> > ilabel_info_;
+  std::vector<std::vector<int32> > ilabel_info_;
 
 };
 

--- a/src/fstext/deterministic-fst-inl.h
+++ b/src/fstext/deterministic-fst-inl.h
@@ -292,7 +292,7 @@ bool LmExampleDeterministicOnDemandFst<Arc>::GetArc(
     // note: if your histories are the other way round, you might just do
     // wseq.pop() here.
   }
-  if (log_prob == -numeric_limits<float>::infinity()) { // assume this
+  if (log_prob == -std::numeric_limits<float>::infinity()) { // assume this
     // is what happens if prob of the word is zero.  Some LMs will never
     // return zero.
     return false; // no arc.

--- a/src/fstext/deterministic-fst-test.cc
+++ b/src/fstext/deterministic-fst-test.cc
@@ -21,32 +21,35 @@
 #include "fstext/fst-test-utils.h"
 #include "util/kaldi-io.h"
 
-#include <sys/stat.h> 
+#include <sys/stat.h>
 
 namespace fst {
+using std::cout;
+using std::cerr;
+using std::endl;
 
-bool FileExists(string strFilename) { 
-  struct stat stFileInfo; 
-  bool blnReturn; 
-  int intStat; 
+bool FileExists(std::string strFilename) {
+  struct stat stFileInfo;
+  bool blnReturn;
+  int intStat;
 
-  // Attempt to get the file attributes 
-  intStat = stat(strFilename.c_str(), &stFileInfo); 
-  if (intStat == 0) { 
-    // We were able to get the file attributes 
-    // so the file obviously exists. 
-    blnReturn = true; 
-  } else { 
-    // We were not able to get the file attributes. 
-    // This may mean that we don't have permission to 
-    // access the folder which contains this file. If you 
-    // need to do that level of checking, lookup the 
-    // return values of stat which will give you 
-    // more details on why stat failed. 
-    blnReturn = false; 
-  } 
-   
-  return blnReturn; 
+  // Attempt to get the file attributes
+  intStat = stat(strFilename.c_str(), &stFileInfo);
+  if (intStat == 0) {
+    // We were able to get the file attributes
+    // so the file obviously exists.
+    blnReturn = true;
+  } else {
+    // We were not able to get the file attributes.
+    // This may mean that we don't have permission to
+    // access the folder which contains this file. If you
+    // need to do that level of checking, lookup the
+    // return values of stat which will give you
+    // more details on why stat failed.
+    blnReturn = false;
+  }
+
+  return blnReturn;
 }
 
 // Simplify writing
@@ -102,9 +105,9 @@ StdVectorFst* CreateResultFst() {
   fst->AddState();    // state 4
   fst->AddArc(4, StdArc(15, 15, 0.5, 5));
 
-  fst->AddState();     // state 5 
+  fst->AddState();     // state 5
   fst->SetFinal(5, 0.6);
-  
+
   return fst;
 }
 
@@ -119,13 +122,13 @@ Weight WalkSinglePath(StdVectorFst *ifst, DeterministicOnDemandFst<StdArc> *dfst
   StateId isrc=ifst->Start();
   StateId dsrc=dfst->Start();
   Weight totalCost = Weight::One();
-  
+
   while (ifst->Final(isrc) == Weight::Zero()) { // while not final
     fst::ArcIterator<StdVectorFst> aiter(*ifst, isrc);
     const StdArc &iarc = aiter.Value();
     if (dfst->GetArc(dsrc, iarc.olabel, &oarc)) {
       Weight cost = Times(iarc.weight, oarc.weight);
-      // cout << "  Matched label "<<iarc.olabel<<" at summed cost "<<cost<<endl;      
+      // cout << "  Matched label "<<iarc.olabel<<" at summed cost "<<cost<<endl;
       totalCost = Times(totalCost, cost);
     } else {
       cout << "  Can't match arc ["<<iarc.ilabel<<","<<iarc.olabel<<","<<iarc.weight<<"] from "<<isrc<<endl;
@@ -136,7 +139,7 @@ Weight WalkSinglePath(StdVectorFst *ifst, DeterministicOnDemandFst<StdArc> *dfst
     dsrc = oarc.nextstate;
   }
   totalCost = Times(totalCost, dfst->Final(dsrc));
-                    
+
   cout << "  Total cost: " << totalCost << endl;
   return totalCost;
 }
@@ -152,7 +155,7 @@ void TestBackoffAndCache() {
   ArcSort(nfst, StdILabelCompare());
   BackoffDeterministicOnDemandFst<StdArc> dfst1a(*nfst);
   CacheDeterministicOnDemandFst<StdArc> dfst1(&dfst1a);
-  
+
   // Compare all arcs in dfst1 with expected result
   for (StateIterator<StdVectorFst> riter(*rfst); !riter.Done(); riter.Next()) {
     StateId rsrc = riter.Value();
@@ -197,9 +200,9 @@ void TestCompose() {
 
   VectorFst<StdArc> path_fst;
   ShortestPath(composed_fst, &path_fst);
-  
+
   BackoffDeterministicOnDemandFst<StdArc> dfst2(composed_fst);
-  
+
   Weight w1 = WalkSinglePath(&path_fst, &dfst1),
       w2 = WalkSinglePath(&path_fst, &dfst2);
   KALDI_ASSERT(ApproxEqual(w1, w2));
@@ -226,4 +229,4 @@ int main() {
   TestBackoffAndCache();
   TestCompose();
 }
-  
+

--- a/src/fstext/determinize-lattice-inl.h
+++ b/src/fstext/determinize-lattice-inl.h
@@ -73,7 +73,7 @@ template<class IntType> class LatticeStringRepository {
   const Entry *Concatenate (const Entry *a, const Entry *b) {
     if (a == NULL) return b;
     else if (b == NULL) return a;
-    vector<IntType> v;
+    std::vector<IntType> v;
     ConvertToVector(b, &v);
     const Entry *ans = a;
     for(size_t i = 0; i < v.size(); i++)
@@ -81,7 +81,7 @@ template<class IntType> class LatticeStringRepository {
     return ans;
   }
   const Entry *CommonPrefix (const Entry *a, const Entry *b) {
-    vector<IntType> a_vec, b_vec;
+    std::vector<IntType> a_vec, b_vec;
     ConvertToVector(a, &a_vec);
     ConvertToVector(b, &b_vec);
     const Entry *ans = NULL;
@@ -94,7 +94,7 @@ template<class IntType> class LatticeStringRepository {
   // removes any elements from b that are not part of
   // a common prefix with a.
   void ReduceToCommonPrefix(const Entry *a,
-                            vector<IntType> *b) {
+                            std::vector<IntType> *b) {
     size_t a_size = Size(a), b_size = b->size();
     while (a_size> b_size) {
       a = a->parent;
@@ -102,7 +102,7 @@ template<class IntType> class LatticeStringRepository {
     }
     if (b_size > a_size)
       b_size = a_size;
-    typename vector<IntType>::iterator b_begin = b->begin();
+    typename std::vector<IntType>::iterator b_begin = b->begin();
     while (a_size != 0) {
       if (a->i != *(b_begin + a_size - 1))
         b_size = a_size - 1;
@@ -116,7 +116,7 @@ template<class IntType> class LatticeStringRepository {
   // removes the first n elements of a.
   const Entry *RemovePrefix(const Entry *a, size_t n) {
     if (n==0) return a;
-    vector<IntType> a_vec;
+    std::vector<IntType> a_vec;
     ConvertToVector(a, &a_vec);
     assert(a_vec.size() >= n);
     const Entry *ans = NULL;
@@ -146,11 +146,11 @@ template<class IntType> class LatticeStringRepository {
     return ans;
   }
 
-  void ConvertToVector(const Entry *entry, vector<IntType> *out) const {
+  void ConvertToVector(const Entry *entry, std::vector<IntType> *out) const {
     size_t length = Size(entry);
     out->resize(length);
     if (entry != NULL) {
-      typename vector<IntType>::reverse_iterator iter = out->rbegin();
+      typename std::vector<IntType>::reverse_iterator iter = out->rbegin();
     while (entry != NULL) {
       *iter = entry->i;
       entry = entry->parent;
@@ -159,7 +159,7 @@ template<class IntType> class LatticeStringRepository {
   }
   }
 
-  const Entry *ConvertFromVector(const vector<IntType> &vec) {
+  const Entry *ConvertFromVector(const std::vector<IntType> &vec) {
     const Entry *e = NULL;
     for(size_t i = 0; i < vec.size(); i++)
       e = Successor(e, vec[i]);
@@ -220,7 +220,7 @@ template<class IntType> class LatticeStringRepository {
       return (*e1 == *e2);
     }
   };
-  typedef unordered_set<const Entry*, EntryKey, EntryEqual> SetType;
+  typedef std::unordered_set<const Entry*, EntryKey, EntryEqual> SetType;
 
   void RebuildHelper(const Entry *to_add, SetType *tmp_set) {
     while(true) {
@@ -287,13 +287,13 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     ofst->SetStart(0);
     // now process transitions.
     for (StateId this_state = 0; this_state < nStates; this_state++) {
-      vector<TempArc> &this_vec(output_arcs_[this_state]);
-      typename vector<TempArc>::const_iterator iter = this_vec.begin(), end = this_vec.end();
+      std::vector<TempArc> &this_vec(output_arcs_[this_state]);
+      typename std::vector<TempArc>::const_iterator iter = this_vec.begin(), end = this_vec.end();
 
       for (;iter != end; ++iter) {
         const TempArc &temp_arc(*iter);
         CompactArc new_arc;
-        vector<Label> seq;
+        std::vector<Label> seq;
         repository_.ConvertToVector(temp_arc.string, &seq);
         CompactWeight weight(temp_arc.weight, seq);
         if (temp_arc.nextstate == kNoStateId) {  // is really final weight.
@@ -307,9 +307,9 @@ template<class Weight, class IntType> class LatticeDeterminizer {
         }
       }
       // Free up memory.  Do this inside the loop as ofst is also allocating memory
-      if (destroy) { vector<TempArc> temp; std::swap(temp, this_vec); }
+      if (destroy) { std::vector<TempArc> temp; std::swap(temp, this_vec); }
     }
-    if (destroy) { vector<vector<TempArc> > temp; std::swap(temp, output_arcs_); }
+    if (destroy) { std::vector<std::vector<TempArc> > temp; std::swap(temp, output_arcs_); }
   }
 
   // Output to standard FST with Weight as its weight type.  We will create extra
@@ -332,12 +332,12 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     }
     ofst->SetStart(0);
     for (OutputStateId this_state = 0; this_state < nStates; this_state++) {
-      vector<TempArc> &this_vec(output_arcs_[this_state]);
+      std::vector<TempArc> &this_vec(output_arcs_[this_state]);
 
-      typename vector<TempArc>::const_iterator iter = this_vec.begin(), end = this_vec.end();
+      typename std::vector<TempArc>::const_iterator iter = this_vec.begin(), end = this_vec.end();
       for (; iter != end; ++iter) {
         const TempArc &temp_arc(*iter);
-        vector<Label> seq;
+        std::vector<Label> seq;
         repository_.ConvertToVector(temp_arc.string, &seq);
 
         if (temp_arc.nextstate == kNoStateId) {  // Really a final weight.
@@ -381,11 +381,11 @@ template<class Weight, class IntType> class LatticeDeterminizer {
       }
       // Free up memory.  Do this inside the loop as ofst is also allocating memory
       if (destroy) {
-        vector<TempArc> temp; temp.swap(this_vec);
+        std::vector<TempArc> temp; temp.swap(this_vec);
       }
     }
     if (destroy) {
-      vector<vector<TempArc> > temp;
+      std::vector<std::vector<TempArc> > temp;
       temp.swap(output_arcs_);
       repository_.Destroy();
     }
@@ -421,11 +421,11 @@ template<class Weight, class IntType> class LatticeDeterminizer {
         iter != initial_hash_.end(); ++iter)
       delete iter->first;
     { InitialSubsetHash tmp; tmp.swap(initial_hash_); }
-    { vector<vector<Element>* > output_states_tmp;
+    { std::vector<std::vector<Element>* > output_states_tmp;
       output_states_tmp.swap(output_states_); }
-    { vector<char> tmp;  tmp.swap(isymbol_or_final_); }
-    { vector<OutputStateId> tmp; tmp.swap(queue_); }
-    { vector<pair<Label, Element> > tmp; tmp.swap(all_elems_tmp_); }
+    { std::vector<char> tmp;  tmp.swap(isymbol_or_final_); }
+    { std::vector<OutputStateId> tmp; tmp.swap(queue_); }
+    { std::vector<std::pair<Label, Element> > tmp; tmp.swap(all_elems_tmp_); }
   }
 
   ~LatticeDeterminizer() {
@@ -451,7 +451,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     for (typename InitialSubsetHash::const_iterator
              iter = initial_hash_.begin();
          iter != initial_hash_.end(); ++iter) {
-      const vector<Element> &vec = *(iter->first);
+      const std::vector<Element> &vec = *(iter->first);
       Element elem = iter->second;
       for (size_t i = 0; i < vec.size(); i++)
         needed_strings.push_back(vec[i].string);
@@ -577,9 +577,9 @@ template<class Weight, class IntType> class LatticeDeterminizer {
 
   class SubsetKey {
    public:
-    size_t operator ()(const vector<Element> * subset) const {  // hashes only the state and string.
+    size_t operator ()(const std::vector<Element> * subset) const {  // hashes only the state and string.
       size_t hash = 0, factor = 1;
-      for (typename vector<Element>::const_iterator iter= subset->begin(); iter != subset->end(); ++iter) {
+      for (typename std::vector<Element>::const_iterator iter= subset->begin(); iter != subset->end(); ++iter) {
         hash *= factor;
         hash += iter->state + reinterpret_cast<size_t>(iter->string);
         factor *= 23531;  // these numbers are primes.
@@ -592,11 +592,11 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // and string, and approximate match on weights.
   class SubsetEqual {
    public:
-    bool operator ()(const vector<Element> * s1, const vector<Element> * s2) const {
+    bool operator ()(const std::vector<Element> * s1, const std::vector<Element> * s2) const {
       size_t sz = s1->size();
       assert(sz>=0);
       if (sz != s2->size()) return false;
-      typename vector<Element>::const_iterator iter1 = s1->begin(),
+      typename std::vector<Element>::const_iterator iter1 = s1->begin(),
           iter1_end = s1->end(), iter2=s2->begin();
       for (; iter1 < iter1_end; ++iter1, ++iter2) {
         if (iter1->state != iter2->state ||
@@ -614,11 +614,11 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // Used only for debug.
   class SubsetEqualStates {
    public:
-    bool operator ()(const vector<Element> * s1, const vector<Element> * s2) const {
+    bool operator ()(const std::vector<Element> * s1, const std::vector<Element> * s2) const {
       size_t sz = s1->size();
       assert(sz>=0);
       if (sz != s2->size()) return false;
-      typename vector<Element>::const_iterator iter1 = s1->begin(),
+      typename std::vector<Element>::const_iterator iter1 = s1->begin(),
           iter1_end = s1->end(), iter2=s2->begin();
       for (; iter1 < iter1_end; ++iter1, ++iter2) {
         if (iter1->state != iter2->state) return false;
@@ -629,7 +629,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
 
   // Define the hash type we use to map subsets (in minimal
   // representation) to OutputStateId.
-  typedef unordered_map<const vector<Element>*, OutputStateId,
+  typedef std::unordered_map<const std::vector<Element>*, OutputStateId,
                         SubsetKey, SubsetEqual> MinimalSubsetHash;
 
   // Define the hash type we use to map subsets (in initial
@@ -637,16 +637,16 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // extra weight. [note: we interpret the Element.state in here
   // as an OutputStateId even though it's declared as InputStateId;
   // these types are the same anyway].
-  typedef unordered_map<const vector<Element>*, Element,
+  typedef std::unordered_map<const std::vector<Element>*, Element,
                         SubsetKey, SubsetEqual> InitialSubsetHash;
 
 
   // converts the representation of the subset from canonical (all states) to
   // minimal (only states with output symbols on arcs leaving them, and final
   // states).  Output is not necessarily normalized, even if input_subset was.
-  void ConvertToMinimal(vector<Element> *subset) {
+  void ConvertToMinimal(std::vector<Element> *subset) {
     assert(!subset->empty());
-    typename vector<Element>::iterator cur_in = subset->begin(),
+    typename std::vector<Element>::iterator cur_in = subset->begin(),
         cur_out = subset->begin(), end = subset->end();
     while (cur_in != end) {
       if(IsIsymbolOrFinal(cur_in->state)) {  // keep it...
@@ -661,16 +661,16 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // Takes a minimal, normalized subset, and converts it to an OutputStateId.
   // Involves a hash lookup, and possibly adding a new OutputStateId.
   // If it creates a new OutputStateId, it adds it to the queue.
-  OutputStateId MinimalToStateId(const vector<Element> &subset) {
+  OutputStateId MinimalToStateId(const std::vector<Element> &subset) {
     typename MinimalSubsetHash::const_iterator iter
         = minimal_hash_.find(&subset);
     if (iter != minimal_hash_.end()) // Found a matching subset.
       return iter->second;
     OutputStateId ans = static_cast<OutputStateId>(output_arcs_.size());
-    vector<Element> *subset_ptr = new vector<Element>(subset);
+    std::vector<Element> *subset_ptr = new std::vector<Element>(subset);
     output_states_.push_back(subset_ptr);
     num_elems_ += subset_ptr->size();
-    output_arcs_.push_back(vector<TempArc>());
+    output_arcs_.push_back(std::vector<TempArc>());
     minimal_hash_[subset_ptr] = ans;
     queue_.push_back(ans);
     return ans;
@@ -679,7 +679,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
 
   // Given a normalized initial subset of elements (i.e. before epsilon closure),
   // compute the corresponding output-state.
-  OutputStateId InitialToStateId(const vector<Element> &subset_in,
+  OutputStateId InitialToStateId(const std::vector<Element> &subset_in,
                                  Weight *remaining_weight,
                                  StringId *common_prefix) {
     typename InitialSubsetHash::const_iterator iter
@@ -693,7 +693,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
       return elem.state;
     }
     // else no matching subset-- have to work it out.
-    vector<Element> subset(subset_in);
+    std::vector<Element> subset(subset_in);
     // Follow through epsilons.  Will add no duplicate states.  note: after
     // EpsilonClosure, it is the same as "canonical" subset, except not
     // normalized (actually we never compute the normalized canonical subset,
@@ -716,7 +716,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     // Before returning "ans", add the initial subset to the hash,
     // so that we can bypass the epsilon-closure etc., next time
     // we process the same initial subset.
-    vector<Element> *initial_subset_ptr = new vector<Element>(subset_in);
+    std::vector<Element> *initial_subset_ptr = new std::vector<Element>(subset_in);
     elem.state = ans;
     initial_hash_[initial_subset_ptr] = elem;
     num_elems_ += initial_subset_ptr->size(); // keep track of memory usage.
@@ -736,7 +736,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     if (weight_comp != 0) return weight_comp;
     // now comparing strings.
     if (a_str == b_str) return 0;
-    vector<IntType> a_vec, b_vec;
+    std::vector<IntType> a_vec, b_vec;
     repository_.ConvertToVector(a_str, &a_vec);
     repository_.ConvertToVector(b_str, &b_vec);
     // First compare their lengths.
@@ -759,15 +759,15 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // Has no side effects except on the string repository.  The "output_subset" is not
   // necessarily normalized (in the sense of there being no common substring), unless
   // input_subset was.
-  void EpsilonClosure(vector<Element> *subset) {
+  void EpsilonClosure(std::vector<Element> *subset) {
     // at input, subset must have only one example of each StateId.  [will still
     // be so at output].  This function follows input-epsilons, and augments the
     // subset accordingly.
 
     std::deque<Element> queue;
-    unordered_map<InputStateId, Element> cur_subset;
-    typedef typename unordered_map<InputStateId, Element>::iterator MapIter;
-    typedef typename vector<Element>::const_iterator VecIter;
+    std::unordered_map<InputStateId, Element> cur_subset;
+    typedef typename std::unordered_map<InputStateId, Element>::iterator MapIter;
+    typedef typename std::vector<Element>::const_iterator VecIter;
 
     for (VecIter iter = subset->begin(); iter != subset->end(); ++iter) {
       queue.push_back(*iter);
@@ -850,7 +850,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // Has no side effects except on the variable repository_, and output_arcs_.
 
   void ProcessFinal(OutputStateId output_state) {
-    const vector<Element> &minimal_subset = *(output_states_[output_state]);
+    const std::vector<Element> &minimal_subset = *(output_states_[output_state]);
     // processes final-weights for this subset.
 
     // minimal_subset may be empty if the graphs is not connected/trimmed, I think,
@@ -858,7 +858,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     bool is_final = false;
     StringId final_string = NULL;  // = NULL to keep compiler happy.
     Weight final_weight = Weight::Zero();
-    typename vector<Element>::const_iterator iter = minimal_subset.begin(), end = minimal_subset.end();
+    typename std::vector<Element>::const_iterator iter = minimal_subset.begin(), end = minimal_subset.end();
     for (; iter != end; ++iter) {
       const Element &elem = *iter;
       Weight this_final_weight = Times(elem.weight, ifst_->Final(elem.state));
@@ -888,7 +888,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // NormalizeSubset normalizes the subset "elems" by
   // removing any common string prefix (putting it in common_str),
   // and dividing by the total weight (putting it in tot_weight).
-  void NormalizeSubset(vector<Element> *elems,
+  void NormalizeSubset(std::vector<Element> *elems,
                        Weight *tot_weight,
                        StringId *common_str) {
     if(elems->empty()) { // just set common_str, tot_weight
@@ -899,7 +899,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
       return;
     }
     size_t size = elems->size();
-    vector<IntType> common_prefix;
+    std::vector<IntType> common_prefix;
     repository_.ConvertToVector((*elems)[0].string, &common_prefix);
     Weight weight = (*elems)[0].weight;
     for (size_t i = 1; i < size; i++) {
@@ -921,8 +921,8 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // Take a subset of Elements that is sorted on state, and
   // merge any Elements that have the same state (taking the best
   // (weight, string) pair in the semiring).
-  void MakeSubsetUnique(vector<Element> *subset) {
-    typedef typename vector<Element>::iterator IterType;
+  void MakeSubsetUnique(std::vector<Element> *subset) {
+    typedef typename std::vector<Element>::iterator IterType;
 
     // This assert is designed to fail (usually) if the subset is not sorted on
     // state.
@@ -959,7 +959,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // associated with each), and any such sets of Elements have to be merged
   // within this routine (we take the [weight, string] pair that's better in the
   // semiring).
-  void ProcessTransition(OutputStateId state, Label ilabel, vector<Element> *subset) {
+  void ProcessTransition(OutputStateId state, Label ilabel, std::vector<Element> *subset) {
     MakeSubsetUnique(subset); // remove duplicates with the same state.
 
     StringId common_str;
@@ -995,7 +995,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
 
   class PairComparator {
    public:
-    inline bool operator () (const pair<Label, Element> &p1, const pair<Label, Element> &p2) {
+    inline bool operator () (const std::pair<Label, Element> &p1, const std::pair<Label, Element> &p2) {
       if (p1.first < p2.first) return true;
       else if (p1.first > p2.first) return false;
       else {
@@ -1016,22 +1016,22 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   // and output_arcs_.
 
   void ProcessTransitions(OutputStateId output_state) {
-    const vector<Element> &minimal_subset = *(output_states_[output_state]);
+    const std::vector<Element> &minimal_subset = *(output_states_[output_state]);
     // it's possible that minimal_subset could be empty if there are
     // unreachable parts of the graph, so don't check that it's nonempty.
-    vector<pair<Label, Element> > &all_elems(all_elems_tmp_); // use class member
+    std::vector<std::pair<Label, Element> > &all_elems(all_elems_tmp_); // use class member
     // to avoid memory allocation/deallocation.
     {
       // Push back into "all_elems", elements corresponding to all
       // non-epsilon-input transitions out of all states in "minimal_subset".
-      typename vector<Element>::const_iterator iter = minimal_subset.begin(), end = minimal_subset.end();
+      typename std::vector<Element>::const_iterator iter = minimal_subset.begin(), end = minimal_subset.end();
       for (;iter != end; ++iter) {
         const Element &elem = *iter;
         for (ArcIterator<Fst<Arc> > aiter(*ifst_, elem.state); ! aiter.Done(); aiter.Next()) {
           const Arc &arc = aiter.Value();
           if (arc.ilabel != 0
               && arc.weight != Weight::Zero()) {  // Non-epsilon transition -- ignore epsilons here.
-            pair<Label, Element> this_pr;
+            std::pair<Label, Element> this_pr;
             this_pr.first = arc.ilabel;
             Element &next_elem(this_pr.second);
             next_elem.state = arc.nextstate;
@@ -1048,9 +1048,9 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     PairComparator pc;
     std::sort(all_elems.begin(), all_elems.end(), pc);
     // now sorted first on input label, then on state.
-    typedef typename vector<pair<Label, Element> >::const_iterator PairIter;
+    typedef typename std::vector<std::pair<Label, Element> >::const_iterator PairIter;
     PairIter cur = all_elems.begin(), end = all_elems.end();
-    vector<Element> this_subset;
+    std::vector<Element> this_subset;
     while (cur != end) {
       // Process ranges that share the same input symbol.
       Label ilabel = cur->first;
@@ -1092,7 +1092,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
     size_t max_state = output_arcs_.size() - 2;  // Don't take the last
     // one as we might be halfway into constructing it.
 
-    vector<OutputStateId> predecessor(max_state+1, kNoStateId);
+    std::vector<OutputStateId> predecessor(max_state+1, kNoStateId);
     for (size_t i = 0; i < max_state; i++) {
       for (size_t j = 0; j < output_arcs_[i].size(); j++) {
         OutputStateId nextstate = output_arcs_[i][j].nextstate;
@@ -1103,13 +1103,13 @@ template<class Weight, class IntType> class LatticeDeterminizer {
           predecessor[nextstate] = i;
       }
     }
-    vector<pair<Label, StringId> > traceback;
+    std::vector<std::pair<Label, StringId> > traceback;
     // 'traceback' is a pair of (ilabel, olabel-seq).
     OutputStateId cur_state = max_state;  // A recently constructed state.
 
     while (cur_state != 0 && cur_state != kNoStateId) {
       OutputStateId last_state = predecessor[cur_state];
-      pair<Label, StringId> p;
+      std::pair<Label, StringId> p;
       size_t i;
       for (i = 0; i < output_arcs_[last_state].size(); i++) {
         if (output_arcs_[last_state][i].nextstate == cur_state) {
@@ -1131,7 +1131,7 @@ template<class Weight, class IntType> class LatticeDeterminizer {
        << "ilabel (olabel olabel) ilabel (olabel) ... :";
     for (ssize_t i = traceback.size() - 1; i >= 0; i--) {
       ss << ' ' << traceback[i].first << " ( ";
-      vector<Label> seq;
+      std::vector<Label> seq;
       repository_.ConvertToVector(traceback[i].second, &seq);
       for (size_t j = 0; j < seq.size(); j++)
         ss << seq[j] << ' ';
@@ -1194,16 +1194,16 @@ template<class Weight, class IntType> class LatticeDeterminizer {
       elem.state = start_id;
       elem.weight = Weight::One();
       elem.string = repository_.EmptyString();  // Id of empty sequence.
-      vector<Element> subset;
+      std::vector<Element> subset;
       subset.push_back(elem);
       EpsilonClosure(&subset); // follow through epsilon-inputs links
       ConvertToMinimal(&subset); // remove all but final states and
       // states with input-labels on arcs out of them.
-      vector<Element> *subset_ptr = new vector<Element>(subset);
+      std::vector<Element> *subset_ptr = new std::vector<Element>(subset);
       assert(output_arcs_.empty() && output_states_.empty());
       // add the new state...
       output_states_.push_back(subset_ptr);
-      output_arcs_.push_back(vector<TempArc>());
+      output_arcs_.push_back(std::vector<TempArc>());
       OutputStateId initial_state = 0;
       minimal_hash_[subset_ptr] = initial_state;
       queue_.push_back(initial_state);
@@ -1213,11 +1213,11 @@ template<class Weight, class IntType> class LatticeDeterminizer {
   KALDI_DISALLOW_COPY_AND_ASSIGN(LatticeDeterminizer);
 
 
-  vector<vector<Element>* > output_states_; // maps from output state to
+  std::vector<std::vector<Element>* > output_states_; // maps from output state to
                                             // minimal representation [normalized].
                                             // View pointers as owned in
                                             // minimal_hash_.
-  vector<vector<TempArc> > output_arcs_;  // essentially an FST in our format.
+  std::vector<std::vector<TempArc> > output_arcs_;  // essentially an FST in our format.
 
   int num_arcs_; // keep track of memory usage: number of arcs in output_arcs_
   int num_elems_; // keep track of memory usage: number of elems in output_states_
@@ -1241,15 +1241,15 @@ template<class Weight, class IntType> class LatticeDeterminizer {
                                      // normalize, there may be an extra weight
                                      // and string.  Owns the pointers
                                     // in its keys.
-  vector<OutputStateId> queue_; // Queue of output-states to process.  Starts with
+  std::vector<OutputStateId> queue_; // Queue of output-states to process.  Starts with
   // state 0, and increases and then (hopefully) decreases in length during
   // determinization.  LIFO queue (queue discipline doesn't really matter).
 
-  vector<pair<Label, Element> > all_elems_tmp_; // temporary vector used in ProcessTransitions.
+  std::vector<std::pair<Label, Element> > all_elems_tmp_; // temporary vector used in ProcessTransitions.
 
   enum IsymbolOrFinal { OSF_UNKNOWN = 0, OSF_NO = 1, OSF_YES = 2 };
 
-  vector<char> isymbol_or_final_; // A kind of cache; it says whether
+  std::vector<char> isymbol_or_final_; // A kind of cache; it says whether
   // each state is (emitting or final) where emitting means it has at least one
   // non-epsilon output arc.  Only accessed by IsIsymbolOrFinal()
 

--- a/src/fstext/determinize-lattice-test.cc
+++ b/src/fstext/determinize-lattice-test.cc
@@ -23,6 +23,8 @@
 #include "base/kaldi-math.h"
 
 namespace fst {
+using std::vector;
+using std::cout;
 
 void TestLatticeStringRepository() {
   typedef int32 IntType;

--- a/src/fstext/determinize-star-test.cc
+++ b/src/fstext/determinize-star-test.cc
@@ -65,16 +65,16 @@ template<class Arc>  void TestDeterminize() {
 
   VectorFst<Arc> *fst = new VectorFst<Arc>();
   int n_syms = 2 + kaldi::Rand() % 5, n_states = 3 + kaldi::Rand() % 10, n_arcs = 5 + kaldi::Rand() % 30, n_final = 1 + kaldi::Rand()%3;  // Up to 2 unique symbols.
-  cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
+  std::cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
   SymbolTable *sptr = NULL;
 
-  vector<Label> all_syms;  // including epsilon.
+  std::vector<Label> all_syms;  // including epsilon.
   // Put symbols in the symbol table from 1..n_syms-1.
   for (size_t i = 0;i < (size_t)n_syms;i++)
     all_syms.push_back(i);
 
   // Create states.
-  vector<StateId> all_states;
+  std::vector<StateId> all_states;
   for (size_t i = 0;i < (size_t)n_states;i++) {
     StateId this_state = fst->AddState();
     if (i == 0) fst->SetStart(i);
@@ -114,7 +114,7 @@ template<class Arc>  void TestDeterminize() {
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
 
-  vector<Label> extra_syms;
+  std::vector<Label> extra_syms;
   if (fst->Start() != kNoStateId) {  // "Connect" did not make it empty....
     PreDeterminize(fst, 1000, &extra_syms);
   }
@@ -206,16 +206,16 @@ template<class Arc>  void TestPush() {
 
   VectorFst<Arc> *fst = new VectorFst<Arc>();
   int n_syms = 2 + kaldi::Rand() % 5, n_states = 3 + kaldi::Rand() % 10, n_arcs = 5 + kaldi::Rand() % 30, n_final = 1 + kaldi::Rand()%3;  // Up to 2 unique symbols.
-  cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
+  std::cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
   SymbolTable *sptr = NULL;
 
-  vector<Label> all_syms;  // including epsilon.
+  std::vector<Label> all_syms;  // including epsilon.
   // Put symbols in the symbol table from 1..n_syms-1.
   for (size_t i = 0;i < (size_t)n_syms;i++)
     all_syms.push_back(i);
 
   // Create states.
-  vector<StateId> all_states;
+  std::vector<StateId> all_states;
   for (size_t i = 0;i < (size_t)n_states;i++) {
     StateId this_state = fst->AddState();
     if (i == 0) fst->SetStart(i);
@@ -255,7 +255,7 @@ template<class Arc>  void TestPush() {
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
 
-  vector<Label> extra_syms;
+  std::vector<Label> extra_syms;
   if (fst->Start() != kNoStateId) {  // "Connect" did not make it empty....
     PreDeterminize(fst, 1000, &extra_syms);
   }
@@ -284,16 +284,16 @@ template<class Arc>  void TestMinimize() {
 
   VectorFst<Arc> *fst = new VectorFst<Arc>();
   int n_syms = 2 + kaldi::Rand() % 5, n_states = 3 + kaldi::Rand() % 10, n_arcs = 5 + kaldi::Rand() % 30, n_final = 1 + kaldi::Rand()%3;  // Up to 2 unique symbols.
-  cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
+  std::cout << "Testing pre-determinize with "<<n_syms<<" symbols, "<<n_states<<" states and "<<n_arcs<<" arcs and "<<n_final<<" final states.\n";
   SymbolTable *sptr =NULL;
 
-  vector<Label> all_syms;  // including epsilon.
+  std::vector<Label> all_syms;  // including epsilon.
   // Put symbols in the symbol table from 1..n_syms-1.
   for (size_t i = 0;i < (size_t)n_syms;i++)
     all_syms.push_back(i);
 
   // Create states.
-  vector<StateId> all_states;
+  std::vector<StateId> all_states;
   for (size_t i = 0;i < (size_t)n_states;i++) {
     StateId this_state = fst->AddState();
     if (i == 0) fst->SetStart(i);
@@ -333,7 +333,7 @@ template<class Arc>  void TestMinimize() {
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
 
-  vector<Label> extra_syms;
+  std::vector<Label> extra_syms;
   if (fst->Start() != kNoStateId) {  // "Connect" did not make it empty....
     PreDeterminize(fst, 1000, &extra_syms);
   }
@@ -451,12 +451,12 @@ template<class Arc, class inttype> void TestStringRepository() {
 
   int N = 100;
   if (sizeof(inttype) == 1) N = 64;
-  vector<vector<Label> > strings(N);
-  vector<inttype> ids(N);
+  std::vector<std::vector<Label> > strings(N);
+  std::vector<inttype> ids(N);
 
   for (int i = 0;i < N;i++) {
     size_t len = kaldi::Rand() % 4;
-    vector<Label> vec;
+    std::vector<Label> vec;
     for (size_t j = 0;j < len;j++) vec.push_back( (kaldi::Rand()%10) + 150*(kaldi::Rand()%2));  // make it have reasonable range.
     if (i < 500 && vec.size() == 0) ids[i] = sr.IdOfEmpty();
     else if (i < 500 && vec.size() == 1) ids[i] = sr.IdOfLabel(vec[0]);
@@ -466,7 +466,7 @@ template<class Arc, class inttype> void TestStringRepository() {
   }
 
   for (int i = 0;i < N;i++) {
-    vector<Label> tmpv;
+    std::vector<Label> tmpv;
     tmpv.push_back(10);  // just put in garbage.
     sr.SeqOfId(ids[i], &tmpv);
     assert(tmpv == strings[i]);
@@ -477,7 +477,7 @@ template<class Arc, class inttype> void TestStringRepository() {
     if (sizeof(inttype) != 1) {
       size_t prefix_len = kaldi::Rand() % (strings[i].size() + 1);
       inttype s2 = sr.RemovePrefix(ids[i], prefix_len);
-      vector<Label> vec2;
+      std::vector<Label> vec2;
       sr.SeqOfId(s2, &vec2);
       for (size_t j = 0;j < strings[i].size()-prefix_len;j++) {
         assert(vec2[j] == strings[i][j+prefix_len]);

--- a/src/fstext/factor-inl.h
+++ b/src/fstext/factor-inl.h
@@ -36,7 +36,7 @@ namespace fst {
 template<class Arc>
 void GetStateProperties(const Fst<Arc> &fst,
                         typename Arc::StateId max_state,
-                        vector<StatePropertiesType> *props) {
+                        std::vector<StatePropertiesType> *props) {
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
   assert(props != NULL);
@@ -67,7 +67,7 @@ void GetStateProperties(const Fst<Arc> &fst,
 
 template<class Arc, class I>
 void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst,
-               vector<vector<I> > *symbols_out) {
+               std::vector<std::vector<I> > *symbols_out) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Label Label;
@@ -75,15 +75,15 @@ void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst,
   assert(symbols_out != NULL);
   ofst->DeleteStates();
   if (fst.Start() < 0) return;  // empty FST.
-  vector<StateId> order;
+  std::vector<StateId> order;
   DfsOrderVisitor<Arc> dfs_order_visitor(&order);
   DfsVisit(fst, &dfs_order_visitor);
   assert(order.size() > 0);
   StateId max_state = *(std::max_element(order.begin(), order.end()));
-  vector<StatePropertiesType> state_properties;
+  std::vector<StatePropertiesType> state_properties;
   GetStateProperties(fst, max_state, &state_properties);
 
-  vector<bool> remove(max_state+1);  // if true, will remove this state.
+  std::vector<bool> remove(max_state+1);  // if true, will remove this state.
 
   // Now identify states that will be removed (made the middle of a chain).
   // The basic rule is that if the FstStateProperties equals
@@ -96,16 +96,16 @@ void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst,
   for (StateId i = 0; i <= max_state; i++)
     remove[i] = (state_properties[i] == (kStateArcsIn|kStateArcsOut)
                  || state_properties[i] == (kStateArcsIn|kStateArcsOut|kStateIlabelsOut));
-  vector<StateId> state_mapping(max_state+1, kNoStateId);
+  std::vector<StateId> state_mapping(max_state+1, kNoStateId);
 
-  typedef unordered_map<vector<I>, Label, kaldi::VectorHasher<I> > SymbolMapType;
+  typedef unordered_map<std::vector<I>, Label, kaldi::VectorHasher<I> > SymbolMapType;
   SymbolMapType symbol_mapping;
   Label symbol_counter = 0;
   {
-    vector<I> eps;
+    std::vector<I> eps;
     symbol_mapping[eps] = symbol_counter++;
   }
-  vector<I> this_sym;  // a temporary used inside the loop.
+  std::vector<I> this_sym;  // a temporary used inside the loop.
   for (size_t i = 0; i < order.size(); i++) {
     StateId state = order[i];
     if (!remove[state]) {  // Process this state...
@@ -154,13 +154,13 @@ template<class Arc>
 void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst1,
             MutableFst<Arc> *ofst2) {
   typedef typename Arc::Label Label;
-  vector<vector<Label> > symbols;
+  std::vector<std::vector<Label> > symbols;
   Factor(fst, ofst2, &symbols);
   CreateFactorFst(symbols, ofst1);
 }
 
 template<class Arc, class I>
-void ExpandInputSequences(const vector<vector<I> > &sequences,
+void ExpandInputSequences(const std::vector<std::vector<I> > &sequences,
                           MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   typedef typename Arc::StateId StateId;
@@ -236,7 +236,7 @@ public:
         kNoEpsilons|kNoIEpsilons|kILabelSorted|kNotILabelSorted;
     return props & ~to_remove;
   }
-  RemoveSomeInputSymbolsMapper(const vector<I> &to_remove):
+  RemoveSomeInputSymbolsMapper(const std::vector<I> &to_remove):
       to_remove_set_(to_remove) {
     KALDI_ASSERT_IS_INTEGER_TYPE(I);
          assert(to_remove_set_.count(0) == 0);  // makes no sense to remove epsilon.
@@ -247,7 +247,7 @@ private:
 
 
 template<class Arc, class I>
-void CreateFactorFst(const vector<vector<I> > &sequences,
+void CreateFactorFst(const std::vector<std::vector<I> > &sequences,
                      MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   typedef typename Arc::StateId StateId;
@@ -282,7 +282,7 @@ void CreateFactorFst(const vector<vector<I> > &sequences,
 
 
 template<class Arc, class I>
-void CreateMapFst(const vector<I> &symbol_map,
+void CreateMapFst(const std::vector<I> &symbol_map,
                   MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   typedef typename Arc::StateId StateId;

--- a/src/fstext/factor-test.cc
+++ b/src/fstext/factor-test.cc
@@ -26,7 +26,7 @@
 
 namespace fst
 {
-
+using std::vector;
 
 // Don't instantiate with log semiring, as RandEquivalent may fail.
 template<class Arc> static void TestFactor() {

--- a/src/fstext/factor.h
+++ b/src/fstext/factor.h
@@ -50,7 +50,7 @@ namespace fst {
    As a side effect it also sorts the FST in depth-first order.  Factor will
    usually do the best job when the olabels have been pushed to the left,
    i.e. if you make a call like
-   
+
      Push<Arc, REWEIGHT_TO_INITIAL>(fsta, &fstb, kPushLabels);
 
    This is because it only creates a chain with olabels on the first arc of the
@@ -63,7 +63,7 @@ namespace fst {
 
 template<class Arc, class I>
 void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst,
-            vector<vector<I> > *symbols);
+            std::vector<std::vector<I> > *symbols);
 
 
 /// This is a more conventional interface of Factor that outputs
@@ -80,7 +80,7 @@ void Factor(const Fst<Arc> &fst, MutableFst<Arc> *ofst1,
 /// in case you did have a symbol table there it would no longer be valid.  It
 /// leaves any weight and output symbols on the first arc of the chain.
 template<class Arc, class I>
-void ExpandInputSequences(const vector<vector<I> > &sequences,
+void ExpandInputSequences(const std::vector<std::vector<I> > &sequences,
                           MutableFst<Arc> *fst);
 
 
@@ -95,7 +95,7 @@ void ExpandInputSequences(const vector<vector<I> > &sequences,
 /// same as calling "ExpandInputSequences".  Use TableCompose (see table-matcher.h)
 /// for efficiency.
 template<class Arc, class I>
-void CreateFactorFst(const vector<vector<I> > &sequences,  
+void CreateFactorFst(const std::vector<std::vector<I> > &sequences,
                      MutableFst<Arc> *fst);
 
 
@@ -105,7 +105,7 @@ void CreateFactorFst(const vector<vector<I> > &sequences,
 /// map to the input symbols of something we compose with it on the right.
 /// Must have symbol_map[0] == 0.
 template<class Arc, class I>
-void CreateMapFst(const vector<I> &symbol_map,
+void CreateMapFst(const std::vector<I> &symbol_map,
                   MutableFst<Arc> *fst);
 
 
@@ -117,7 +117,7 @@ enum  StatePropertiesEnum
   kStateArcsOut = 0x10,
   kStateMultipleArcsOut = 0x20,
   kStateOlabelsOut = 0x40,
-  kStateIlabelsOut = 0x80 }; 
+  kStateIlabelsOut = 0x80 };
 
 typedef unsigned char StatePropertiesType;
 
@@ -127,7 +127,7 @@ typedef unsigned char StatePropertiesType;
 template<class Arc>
 void GetStateProperties(const Fst<Arc> &fst,
                         typename Arc::StateId max_state,
-                        vector<StatePropertiesType> *props);
+                        std::vector<StatePropertiesType> *props);
 
 
 
@@ -137,7 +137,7 @@ class DfsOrderVisitor {
   // c.f. dfs-visit.h.  Used in factor-fst-impl.h
   typedef typename Arc::StateId StateId;
  public:
-  DfsOrderVisitor(vector<StateId> *order): order_(order) { order->clear(); }
+  DfsOrderVisitor(std::vector<StateId> *order): order_(order) { order->clear(); }
   void InitVisit(const Fst<Arc> &fst) {}
   bool InitState(StateId s, StateId) { order_->push_back(s); return true; }
   bool TreeArc(StateId, const Arc&) { return true; }
@@ -146,7 +146,7 @@ class DfsOrderVisitor {
   void FinishState(StateId, StateId, const Arc *) { }
   void FinishVisit() { }
  private:
-  vector<StateId> *order_;
+  std::vector<StateId> *order_;
 };
 
 

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -75,7 +75,7 @@ typename Arc::StateId NumArcs(const ExpandedFst<Arc> &fst) {
 template<class Arc, class I>
 void GetOutputSymbols(const Fst<Arc> &fst,
                       bool include_eps,
-                      vector<I> *symbols) {
+                      std::vector<I> *symbols) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   std::set<I> all_syms;
   for (StateIterator<Fst<Arc> > siter(fst); !siter.Done(); siter.Next()) {
@@ -96,7 +96,7 @@ void GetOutputSymbols(const Fst<Arc> &fst,
 template<class Arc, class I>
 void GetInputSymbols(const Fst<Arc> &fst,
                      bool include_eps,
-                     vector<I> *symbols) {
+                     std::vector<I> *symbols) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   unordered_set<I> all_syms;
   for (StateIterator<Fst<Arc> > siter(fst); !siter.Done(); siter.Next()) {
@@ -116,7 +116,7 @@ void GetInputSymbols(const Fst<Arc> &fst,
 
 
 template<class Arc, class I>
-void RemoveSomeInputSymbols(const vector<I> &to_remove,
+void RemoveSomeInputSymbols(const std::vector<I> &to_remove,
                             MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   RemoveSomeInputSymbolsMapper<Arc, I> mapper(to_remove);
@@ -152,20 +152,20 @@ class MapInputSymbolsMapper {
   }
   // initialize with copy = false only if the "to_remove" argument will not be deleted
   // in the lifetime of this object.
-  MapInputSymbolsMapper(const vector<I> &to_remove, bool copy) {
+  MapInputSymbolsMapper(const std::vector<I> &to_remove, bool copy) {
     KALDI_ASSERT_IS_INTEGER_TYPE(I);
-    if (copy) symbol_mapping_ = new vector<I> (to_remove);
+    if (copy) symbol_mapping_ = new std::vector<I> (to_remove);
     else symbol_mapping_ = &to_remove;
     owned = copy;
   }
   ~MapInputSymbolsMapper() { if (owned && symbol_mapping_ != NULL) delete symbol_mapping_; }
  private:
   bool owned;
-  const vector<I> *symbol_mapping_;
+  const std::vector<I> *symbol_mapping_;
 };
 
 template<class Arc, class I>
-void MapInputSymbols(const vector<I> &symbol_mapping,
+void MapInputSymbols(const std::vector<I> &symbol_mapping,
                      MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   // false == don't copy the "symbol_mapping", retain pointer--
@@ -176,15 +176,15 @@ void MapInputSymbols(const vector<I> &symbol_mapping,
 
 template<class Arc, class I>
 bool GetLinearSymbolSequence(const Fst<Arc> &fst,
-                             vector<I> *isymbols_out,
-                             vector<I> *osymbols_out,
+                             std::vector<I> *isymbols_out,
+                             std::vector<I> *osymbols_out,
                              typename Arc::Weight *tot_weight_out) {
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
 
   Weight tot_weight = Weight::One();
-  vector<I> ilabel_seq;
-  vector<I> olabel_seq;
+  std::vector<I> ilabel_seq;
+  std::vector<I> olabel_seq;
 
   StateId cur_state = fst.Start();
   if (cur_state == kNoStateId) {  // empty sequence.
@@ -219,7 +219,7 @@ bool GetLinearSymbolSequence(const Fst<Arc> &fst,
 // see fstext-utils.h for comment.
 template<class Arc>
 void ConvertNbestToVector(const Fst<Arc> &fst,
-                          vector<VectorFst<Arc> > *fsts_out) {
+                          std::vector<VectorFst<Arc> > *fsts_out) {
   typedef typename Arc::Weight Weight;
   typedef typename Arc::StateId StateId;
   fsts_out->clear();
@@ -278,7 +278,7 @@ void ConvertNbestToVector(const Fst<Arc> &fst,
 template<class Arc>
 void NbestAsFsts(const Fst<Arc> &fst,
                  size_t n,
-                 vector<VectorFst<Arc> > *fsts_out) {
+                 std::vector<VectorFst<Arc> > *fsts_out) {
   KALDI_ASSERT(n > 0);
   KALDI_ASSERT(fsts_out != NULL);
   VectorFst<Arc> nbest_fst;
@@ -287,7 +287,7 @@ void NbestAsFsts(const Fst<Arc> &fst,
 }
 
 template<class Arc, class I>
-void MakeLinearAcceptorWithAlternatives(const vector<vector<I> > &labels,
+void MakeLinearAcceptorWithAlternatives(const std::vector<std::vector<I> > &labels,
                                         MutableFst<Arc> *ofst) {
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
@@ -308,7 +308,7 @@ void MakeLinearAcceptorWithAlternatives(const vector<vector<I> > &labels,
 }
 
 template<class Arc, class I>
-void MakeLinearAcceptor(const vector<I> &labels, MutableFst<Arc> *ofst) {
+void MakeLinearAcceptor(const std::vector<I> &labels, MutableFst<Arc> *ofst) {
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
 
@@ -328,7 +328,7 @@ void MakeLinearAcceptor(const vector<I> &labels, MutableFst<Arc> *ofst) {
 template<class I>
 void GetSymbols(const SymbolTable &symtab,
                 bool include_eps,
-                vector<I> *syms_out) {
+                std::vector<I> *syms_out) {
   KALDI_ASSERT(syms_out != NULL);
   syms_out->clear();
   for (SymbolTableIterator iter(symtab);
@@ -344,7 +344,7 @@ void GetSymbols(const SymbolTable &symtab,
 template<class Arc>
 void SafeDeterminizeWrapper(MutableFst<Arc> *ifst, MutableFst<Arc> *ofst, float delta) {
   typename Arc::Label highest_sym = HighestNumberedInputSymbol(*ifst);
-  vector<typename Arc::Label> extra_syms;
+  std::vector<typename Arc::Label> extra_syms;
   PreDeterminize(ifst,
                  (typename Arc::Label)(highest_sym+1),
                  &extra_syms);
@@ -356,7 +356,7 @@ void SafeDeterminizeWrapper(MutableFst<Arc> *ifst, MutableFst<Arc> *ofst, float 
 template<class Arc>
 void SafeDeterminizeMinimizeWrapper(MutableFst<Arc> *ifst, VectorFst<Arc> *ofst, float delta) {
   typename Arc::Label highest_sym = HighestNumberedInputSymbol(*ifst);
-  vector<typename Arc::Label> extra_syms;
+  std::vector<typename Arc::Label> extra_syms;
   PreDeterminize(ifst,
                  (typename Arc::Label)(highest_sym+1),
                  &extra_syms);
@@ -466,7 +466,7 @@ template<class Arc, class F> // F is functor type from labels to classes.
 bool PrecedingInputSymbolsAreSameClass(bool start_is_epsilon, const Fst<Arc> &fst, const F &f) {
   typedef typename F::Result ClassType;
   typedef typename Arc::StateId StateId;
-  vector<ClassType> classes;
+  std::vector<ClassType> classes;
   ClassType noClass = f(kNoLabel);
 
   if (start_is_epsilon) {
@@ -535,7 +535,7 @@ void MakePrecedingInputSymbolsSameClass(bool start_is_epsilon, MutableFst<Arc> *
   typedef typename F::Result ClassType;
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
-  vector<ClassType> classes;
+  std::vector<ClassType> classes;
   ClassType noClass = f(kNoLabel);
   ClassType epsClass = f(0);
   if (start_is_epsilon) {  // treat having-start-state as epsilon in-transition.
@@ -567,7 +567,7 @@ void MakePrecedingInputSymbolsSameClass(bool start_is_epsilon, MutableFst<Arc> *
   // Work out list of arcs we have to change as (state, arc-offset).
   // Can't do the actual changes in this pass, since we have to add new
   // states which invalidates the iterators.
-  vector<pair<StateId, size_t> > arcs_to_change;
+  std::vector<std::pair<StateId, size_t> > arcs_to_change;
   for (StateIterator<Fst<Arc> > siter(*fst); !siter.Done(); siter.Next()) {
     StateId s = siter.Value();
     for (ArcIterator<Fst<Arc> > aiter(*fst, s); !aiter.Done(); aiter.Next()) {
@@ -579,7 +579,7 @@ void MakePrecedingInputSymbolsSameClass(bool start_is_epsilon, MutableFst<Arc> *
   }
   KALDI_ASSERT(!arcs_to_change.empty());  // since !bad_states.empty().
 
-  std::map<pair<StateId, ClassType>, StateId> state_map;
+  std::map<std::pair<StateId, ClassType>, StateId> state_map;
   // state_map is a map from (bad-state, input-symbol-class) to dummy-state.
 
   for (size_t i = 0; i < arcs_to_change.size(); i++) {
@@ -590,7 +590,7 @@ void MakePrecedingInputSymbolsSameClass(bool start_is_epsilon, MutableFst<Arc> *
 
     // Transition is non-eps transition to "bad" state.  Introduce new state (or find
     // existing one).
-    pair<StateId, ClassType> p(arc.nextstate, f(arc.ilabel));
+    std::pair<StateId, ClassType> p(arc.nextstate, f(arc.ilabel));
     if (state_map.count(p) == 0) {
       StateId newstate = state_map[p] = fst->AddState();
       fst->AddArc(newstate, Arc(0, 0, Weight::One(), arc.nextstate));
@@ -617,7 +617,7 @@ void MakeFollowingInputSymbolsSameClass(bool end_is_epsilon, MutableFst<Arc> *fs
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Weight Weight;
   typedef typename F::Result ClassType;
-  vector<StateId> bad_states;
+  std::vector<StateId> bad_states;
   ClassType noClass = f(kNoLabel);
   ClassType epsClass = f(0);
   for (StateIterator<Fst<Arc> > siter(*fst); !siter.Done(); siter.Next()) {
@@ -640,7 +640,7 @@ void MakeFollowingInputSymbolsSameClass(bool end_is_epsilon, MutableFst<Arc> *fs
     if (bad)
       bad_states.push_back(s);
   }
-  vector<Arc> my_arcs;
+  std::vector<Arc> my_arcs;
   for (size_t i = 0; i < bad_states.size(); i++) {
     StateId s = bad_states[i];
     my_arcs.clear();
@@ -666,7 +666,7 @@ void MakeFollowingInputSymbolsSameClass(bool end_is_epsilon, MutableFst<Arc> *fs
 
 
 template<class Arc>
-VectorFst<Arc>* MakeLoopFst(const vector<const ExpandedFst<Arc> *> &fsts) {
+VectorFst<Arc>* MakeLoopFst(const std::vector<const ExpandedFst<Arc> *> &fsts) {
   typedef typename Arc::Weight Weight;
   typedef typename Arc::StateId StateId;
   typedef typename Arc::Label Label;
@@ -708,7 +708,7 @@ VectorFst<Arc>* MakeLoopFst(const vector<const ExpandedFst<Arc> *> &fsts) {
         && fst->NumArcs(fst_start_state) == 1
         && fst->Final(fst_start_state) == Weight::Zero();
 
-    vector<StateId> state_map(fst_num_states);  // fst state -> ans state
+    std::vector<StateId> state_map(fst_num_states);  // fst state -> ans state
     for (StateId s = 0; s < fst_num_states; s++) {
       if (s == fst_start_state && share_start_state) state_map[s] = loop_state;
       else state_map[s] = ans->AddState();
@@ -819,9 +819,9 @@ bool EqualAlign(const Fst<Arc> &ifst,
     return false;
   }
   // First select path through ifst.
-  vector<StateId> path;
-  vector<size_t> arc_offsets;  // arc taken out of each state.
-  vector<int> nof_ilabels;
+  std::vector<StateId> path;
+  std::vector<size_t> arc_offsets;  // arc taken out of each state.
+  std::vector<int> nof_ilabels;
 
   StateId num_ilabels = 0;
   int retry_no = 0;
@@ -880,7 +880,7 @@ bool EqualAlign(const Fst<Arc> &ifst,
   }
 
   StateId num_self_loops = 0;
-  vector<ssize_t> self_loop_offsets(path.size());
+  std::vector<ssize_t> self_loop_offsets(path.size());
   for (size_t i = 0; i < path.size(); i++)
     if ( (self_loop_offsets[i] = FindSelfLoopWithILabel(ifst, path[i]))
          != static_cast<ssize_t>(-1) )
@@ -957,10 +957,10 @@ void RemoveUselessArcs(MutableFst<Arc> *fst) {
   for (StateIterator<MutableFst<Arc> > siter(*fst);
       !siter.Done();
       siter.Next()) {
-    vector<size_t> arcs_to_delete;
-    vector<Arc> arcs;
+    std::vector<size_t> arcs_to_delete;
+    std::vector<Arc> arcs;
     // pair2arclist lets us look up the arcs
-    std::map<pair<Label, StateId>, vector<size_t> > pair2arclist;
+    std::map<std::pair<Label, StateId>, std::vector<size_t> > pair2arclist;
     StateId state = siter.Value();
     for (ArcIterator<MutableFst<Arc> > aiter(*fst, state);
         !aiter.Done();
@@ -970,10 +970,10 @@ void RemoveUselessArcs(MutableFst<Arc> *fst) {
       arcs.push_back(arc);
       pair2arclist[std::make_pair(arc.ilabel, arc.nextstate)].push_back(pos);
     }
-    typename std::map<pair<Label, StateId>, vector<size_t> >::iterator
+    typename std::map<std::pair<Label, StateId>, std::vector<size_t> >::iterator
         iter = pair2arclist.begin(), end = pair2arclist.end();
     for (; iter!= end; ++iter) {
-      const vector<size_t> &poslist = iter->second;
+      const std::vector<size_t> &poslist = iter->second;
       if (poslist.size() > 1) {  // >1 arc with same ilabel, dest-state
         size_t best_pos = poslist[0];
         Weight best_weight = arcs[best_pos].weight;

--- a/src/fstext/fstext-utils-test.cc
+++ b/src/fstext/fstext-utils-test.cc
@@ -25,6 +25,9 @@
 
 namespace fst
 {
+using std::vector;
+using std::cout;
+
 template<class Arc, class I>
 void TestMakeLinearAcceptor() {
   typedef typename Arc::Label Label;

--- a/src/fstext/fstext-utils.h
+++ b/src/fstext/fstext-utils.h
@@ -56,14 +56,14 @@ typename Arc::StateId NumArcs(const ExpandedFst<Arc> &fst);
 template<class Arc, class I>
 void GetInputSymbols(const Fst<Arc> &fst,
                      bool include_eps,
-                     vector<I> *symbols);
+                     std::vector<I> *symbols);
 
 /// GetOutputSymbols gets the list of symbols on the output of fst
 /// (including epsilon, if include_eps == true)
 template<class Arc, class I>
 void GetOutputSymbols(const Fst<Arc> &fst,
                       bool include_eps,
-                      vector<I> *symbols);
+                      std::vector<I> *symbols);
 
 /// ClearSymbols sets all the symbols on the input and/or
 /// output side of the FST to zero, as specified.
@@ -76,7 +76,7 @@ void ClearSymbols(bool clear_input,
 template<class I>
 void GetSymbols(const SymbolTable &symtab,
                 bool include_eps,
-                vector<I> *syms_out);
+                std::vector<I> *syms_out);
 
 
 
@@ -131,19 +131,19 @@ void MinimizeEncoded(VectorFst<Arc> *fst, float delta = kDelta) {
 /// create that output.
 template<class Arc, class I>
 bool GetLinearSymbolSequence(const Fst<Arc> &fst,
-                             vector<I> *isymbols_out,
-                             vector<I> *osymbols_out,
+                             std::vector<I> *isymbols_out,
+                             std::vector<I> *osymbols_out,
                              typename Arc::Weight *tot_weight_out);
 
 
 /// This function converts an FST with a special structure, which is
 /// output by the OpenFst functions ShortestPath and RandGen, and converts
-/// them into a vector of separate FSTs.  This special structure is that
+/// them into a std::vector of separate FSTs.  This special structure is that
 /// the only state that has more than one (arcs-out or final-prob) is the
 /// start state.  fsts_out is resized to the appropriate size.
 template<class Arc>
 void ConvertNbestToVector(const Fst<Arc> &fst,
-                          vector<VectorFst<Arc> > *fsts_out);
+                          std::vector<VectorFst<Arc> > *fsts_out);
 
 
 /// Takes the n-shortest-paths (using ShortestPath), but outputs
@@ -153,14 +153,14 @@ void ConvertNbestToVector(const Fst<Arc> &fst,
 template<class Arc>
 void NbestAsFsts(const Fst<Arc> &fst,
                  size_t n,
-                 vector<VectorFst<Arc> > *fsts_out);
+                 std::vector<VectorFst<Arc> > *fsts_out);
 
 
 
 
 /// Creates unweighted linear acceptor from symbol sequence.
 template<class Arc, class I>
-void MakeLinearAcceptor(const vector<I> &labels, MutableFst<Arc> *ofst);
+void MakeLinearAcceptor(const std::vector<I> &labels, MutableFst<Arc> *ofst);
 
 
 
@@ -168,7 +168,7 @@ void MakeLinearAcceptor(const vector<I> &labels, MutableFst<Arc> *ofst);
 /// at each position.  Epsilon is treated like a normal symbol here.
 /// Each position in "labels" must have at least one alternative.
 template<class Arc, class I>
-void MakeLinearAcceptorWithAlternatives(const vector<vector<I> > &labels,
+void MakeLinearAcceptorWithAlternatives(const std::vector<std::vector<I> > &labels,
                                         MutableFst<Arc> *ofst);
 
 
@@ -198,14 +198,14 @@ void SafeDeterminizeMinimizeWrapperInLog(VectorFst<StdArc> *ifst, VectorFst<StdA
 /// RemoveSomeInputSymbols removes any symbol that appears in "to_remove", from
 /// the input side of the FST, replacing them with epsilon.
 template<class Arc, class I>
-void RemoveSomeInputSymbols(const vector<I> &to_remove,
+void RemoveSomeInputSymbols(const std::vector<I> &to_remove,
                             MutableFst<Arc> *fst);
 
 // MapInputSymbols will replace any input symbol i that is between 0 and
 // symbol_map.size()-1, with symbol_map[i].  It removes the input symbol
 // table of the FST.
 template<class Arc, class I>
-void MapInputSymbols(const vector<I> &symbol_map,
+void MapInputSymbols(const std::vector<I> &symbol_map,
                      MutableFst<Arc> *fst);
 
 
@@ -304,7 +304,7 @@ void MakeFollowingInputSymbolsSameClass(bool end_is_epsilon, MutableFst<Arc> *fs
 /// less well optimized and would have a lot of final-states.
 
 template<class Arc>
-VectorFst<Arc>* MakeLoopFst(const vector<const ExpandedFst<Arc> *> &fsts);
+VectorFst<Arc>* MakeLoopFst(const std::vector<const ExpandedFst<Arc> *> &fsts);
 
 
 /// ApplyProbabilityScale is applicable to FSTs in the log or tropical semiring.

--- a/src/fstext/grammar-context-fst.cc
+++ b/src/fstext/grammar-context-fst.cc
@@ -22,7 +22,7 @@
 #include "util/stl-utils.h"
 
 namespace fst {
-
+using std::vector;
 
 InverseLeftBiphoneContextFst::InverseLeftBiphoneContextFst(
     Label nonterm_phones_offset,

--- a/src/fstext/grammar-context-fst.h
+++ b/src/fstext/grammar-context-fst.h
@@ -119,10 +119,10 @@ inline int32 GetEncodingMultiple(int32 nonterm_phones_offset) {
   */
 void ComposeContextLeftBiphone(
     int32 nonterm_phones_offset,
-    const vector<int32> &disambig_syms,
+    const std::vector<int32> &disambig_syms,
     const VectorFst<StdArc> &ifst,
     VectorFst<StdArc> *ofst,
-    vector<vector<int32> > *ilabels);
+    std::vector<std::vector<int32> > *ilabels);
 
 
 
@@ -167,8 +167,8 @@ public:
      See \ref graph_context for more details.
   */
   InverseLeftBiphoneContextFst(Label nonterm_phones_offset,
-                               const vector<int32>& phones,
-                               const vector<int32>& disambig_syms);
+                               const std::vector<int32>& phones,
+                               const std::vector<int32>& disambig_syms);
 
   /**
      Here is a note on the state space of InverseLeftBiphoneContextFst;
@@ -221,13 +221,13 @@ public:
   // the input symbols of C (i.e. all the output symbols of this
   // InverseContextFst).  See
   // "http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel".
-  const vector<vector<int32> > &IlabelInfo() const {
+  const std::vector<std::vector<int32> > &IlabelInfo() const {
     return ilabel_info_;
   }
 
   // A way to destructively obtain the ilabel-info.  Only do this if you
   // are just about to destroy this object.
-  void SwapIlabelInfo(vector<vector<int32> > *vec) { ilabel_info_.swap(*vec); }
+  void SwapIlabelInfo(std::vector<std::vector<int32> > *vec) { ilabel_info_.swap(*vec); }
 
 private:
 
@@ -238,13 +238,13 @@ private:
   /// Finds the label index corresponding to this context-window of phones
   /// (likely of width context_width_).  Inserts it into the
   /// ilabel_info_/ilabel_map_ tables if necessary.
-  Label FindLabel(const vector<int32> &label_info);
+  Label FindLabel(const std::vector<int32> &label_info);
 
 
   // Map type to map from vectors of int32 (representing ilabel-info,
   // see http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel) to
   // Label (the output label in this FST).
-  typedef unordered_map<vector<int32>, Label,
+  typedef unordered_map<std::vector<int32>, Label,
                         kaldi::VectorHasher<int32> > VectorToLabelMap;
 
 
@@ -277,7 +277,7 @@ private:
   // information about the meaning of each symbol on the input of C
   // aka the output of inv(C).
   // See "http://kaldi-asr.org/doc/tree_externals.html#tree_ilabel".
-  vector<vector<int32> > ilabel_info_;
+  std::vector<std::vector<int32> > ilabel_info_;
 
 };
 

--- a/src/fstext/lattice-utils-inl.h
+++ b/src/fstext/lattice-utils-inl.h
@@ -40,7 +40,7 @@ void ConvertLattice(
   typedef ArcTpl<CompactWeight> CompactArc;
 
   VectorFst<ArcTpl<Weight> > ffst;
-  vector<vector<Int> > labels;
+  std::vector<std::vector<Int> > labels;
   if (invert) // normal case: want the ilabels as sequences on the arcs of
     Factor(ifst, &ffst, &labels);  // the output... Factor makes seqs of
                                    // ilabels.
@@ -67,7 +67,7 @@ void ConvertLattice(
   for (StateId s = 0; s < num_states; s++) {
     Weight final_weight = ffst.Final(s);
     if (final_weight != Weight::Zero()) {
-      CompactWeight final_compact_weight(final_weight, vector<Int>());
+      CompactWeight final_compact_weight(final_weight, std::vector<Int>());
       ofst->SetFinal(s, final_compact_weight);
     }
     for (ArcIterator<ExpandedFst<Arc> > iter(ffst, s);
@@ -195,7 +195,7 @@ void ConvertLattice(
 
 template<class Weight, class ScaleFloat>
 void ScaleLattice(
-    const vector<vector<ScaleFloat> > &scale,
+    const std::vector<std::vector<ScaleFloat> > &scale,
     MutableFst<ArcTpl<Weight> > *fst) {
   assert(scale.size() == 2 && scale[0].size() == 2 && scale[1].size() == 2);
   if (scale == DefaultLatticeScale()) // nothing to do.

--- a/src/fstext/lattice-utils-test.cc
+++ b/src/fstext/lattice-utils-test.cc
@@ -232,7 +232,7 @@ template<class Weight, class Int> void TestConvertPair(bool invert) {
 // use TestConvertPair when the Weight can be constructed from
 // a pair of floats.
 template<class Weight, class Int> void TestScalePair(bool invert) {
-  vector<vector<double> > scale1 = DefaultLatticeScale(),
+  std::vector<std::vector<double> > scale1 = DefaultLatticeScale(),
       scale2 = DefaultLatticeScale();
   // important that all these numbers exactly representable as floats..
   // exact floating-point comparisons are used in LatticeWeight, and

--- a/src/fstext/lattice-utils.h
+++ b/src/fstext/lattice-utils.h
@@ -127,16 +127,16 @@ void ConvertFstToLattice(
 
 
 /** Returns a default 2x2 matrix scaling factor for LatticeWeight */
-inline vector<vector<double> > DefaultLatticeScale() {
-  vector<vector<double> > ans(2);
+inline std::vector<std::vector<double> > DefaultLatticeScale() {
+  std::vector<std::vector<double> > ans(2);
   ans[0].resize(2, 0.0);
   ans[1].resize(2, 0.0);
   ans[0][0] = ans[1][1] = 1.0;
   return ans;
 }
 
-inline vector<vector<double> > AcousticLatticeScale(double acwt) {
-  vector<vector<double> > ans(2);
+inline std::vector<std::vector<double> > AcousticLatticeScale(double acwt) {
+  std::vector<std::vector<double> > ans(2);
   ans[0].resize(2, 0.0);
   ans[1].resize(2, 0.0);
   ans[0][0] = 1.0;
@@ -144,8 +144,8 @@ inline vector<vector<double> > AcousticLatticeScale(double acwt) {
   return ans;
 }
 
-inline vector<vector<double> > GraphLatticeScale(double lmwt) {
-  vector<vector<double> > ans(2);
+inline std::vector<std::vector<double> > GraphLatticeScale(double lmwt) {
+  std::vector<std::vector<double> > ans(2);
   ans[0].resize(2, 0.0);
   ans[1].resize(2, 0.0);
   ans[0][0] = lmwt;
@@ -153,8 +153,8 @@ inline vector<vector<double> > GraphLatticeScale(double lmwt) {
   return ans;
 }
 
-inline vector<vector<double> > LatticeScale(double lmwt, double acwt) {
-  vector<vector<double> > ans(2);
+inline std::vector<std::vector<double> > LatticeScale(double lmwt, double acwt) {
+  std::vector<std::vector<double> > ans(2);
   ans[0].resize(2, 0.0);
   ans[1].resize(2, 0.0);
   ans[0][0] = lmwt;
@@ -172,7 +172,7 @@ inline vector<vector<double> > LatticeScale(double lmwt, double acwt) {
  */
 template<class Weight, class ScaleFloat>
 void ScaleLattice(
-    const vector<vector<ScaleFloat> > &scale,
+    const std::vector<std::vector<ScaleFloat> > &scale,
     MutableFst<ArcTpl<Weight> > *fst);
 
 /// Removes state-level alignments (the strings that are

--- a/src/fstext/lattice-weight-test.cc
+++ b/src/fstext/lattice-weight-test.cc
@@ -20,6 +20,8 @@
 #include "fstext/lattice-weight.h"
 
 namespace fst {
+using std::vector;
+using std::cout;
 // these typedefs are the same as in ../lat/kaldi-lattice.h, but
 // just used here for testing (doesn't matter if they get out of
 // sync).
@@ -82,7 +84,7 @@ void LatticeWeightTest() {
     bool a = nl(l1, l2);
     bool b = (Plus(l1, l2) == l1 && l1 != l2);
     KALDI_ASSERT(a == b);
-    
+
     KALDI_ASSERT(Compare(l1, Plus(l1, l2)) != 1); // so do not have l1 > l1 + l2
     LatticeWeight l5 = RandomLatticeWeight(), l6 = RandomLatticeWeight();
     {
@@ -100,7 +102,7 @@ void LatticeWeightTest() {
     }
     KALDI_ASSERT(l1.Member() && l2.Member() && l3.Member() && l4.Member()
                  && l5.Member() && l6.Member());
-    if (l2 != LatticeWeight::Zero()) 
+    if (l2 != LatticeWeight::Zero())
       KALDI_ASSERT(ApproxEqual(Divide(Times(l1, l2), l2), l1)); // (a*b) / b = a if b != 0
     KALDI_ASSERT(ApproxEqual(l1, l1.Quantize()));
 
@@ -190,6 +192,6 @@ void CompactLatticeWeightTest() {
 
 int main() {
   fst::LatticeWeightTest();
-  fst::CompactLatticeWeightTest();  
+  fst::CompactLatticeWeightTest();
 }
 

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -37,10 +37,10 @@ template<class FloatType>
 class LatticeWeightTpl;
 
 template <class FloatType>
-inline ostream &operator <<(ostream &strm, const LatticeWeightTpl<FloatType> &w);
+inline std::ostream &operator <<(std::ostream &strm, const LatticeWeightTpl<FloatType> &w);
 
 template <class FloatType>
-inline istream &operator >>(istream &strm, LatticeWeightTpl<FloatType> &w);
+inline std::istream &operator >>(std::istream &strm, LatticeWeightTpl<FloatType> &w);
 
 
 template<class FloatType>
@@ -74,22 +74,22 @@ class LatticeWeightTpl {
   }
 
   static const LatticeWeightTpl Zero() {
-    return LatticeWeightTpl(numeric_limits<T>::infinity(),
-                            numeric_limits<T>::infinity());
+    return LatticeWeightTpl(std::numeric_limits<T>::infinity(),
+                            std::numeric_limits<T>::infinity());
   }
 
   static const LatticeWeightTpl One() {
     return LatticeWeightTpl(0.0, 0.0);
   }
 
-  static const string &Type() {
-    static const string type = (sizeof(T) == 4 ? "lattice4" : "lattice8") ;
+  static const std::string &Type() {
+    static const std::string type = (sizeof(T) == 4 ? "lattice4" : "lattice8") ;
     return type;
   }
 
   static const LatticeWeightTpl NoWeight() {
-    return LatticeWeightTpl(numeric_limits<FloatType>::quiet_NaN(),
-                            numeric_limits<FloatType>::quiet_NaN());
+    return LatticeWeightTpl(std::numeric_limits<FloatType>::quiet_NaN(),
+                            std::numeric_limits<FloatType>::quiet_NaN());
   }
 
   bool Member() const {
@@ -97,22 +97,22 @@ class LatticeWeightTpl {
     // also test for no -inf, and either both or neither
     // must be +inf, and
     if (value1_ != value1_ || value2_ != value2_) return false; // NaN
-    if (value1_ == -numeric_limits<T>::infinity()  ||
-       value2_ == -numeric_limits<T>::infinity()) return false; // -infty not allowed
-    if (value1_ == numeric_limits<T>::infinity() ||
-        value2_ == numeric_limits<T>::infinity()) {
-      if (value1_ != numeric_limits<T>::infinity() ||
-          value2_ != numeric_limits<T>::infinity()) return false; // both must be +infty;
+    if (value1_ == -std::numeric_limits<T>::infinity()  ||
+       value2_ == -std::numeric_limits<T>::infinity()) return false; // -infty not allowed
+    if (value1_ == std::numeric_limits<T>::infinity() ||
+        value2_ == std::numeric_limits<T>::infinity()) {
+      if (value1_ != std::numeric_limits<T>::infinity() ||
+          value2_ != std::numeric_limits<T>::infinity()) return false; // both must be +infty;
       // this is necessary so that the semiring has only one zero.
     }
     return true;
   }
 
   LatticeWeightTpl Quantize(float delta = kDelta) const {
-    if (value1_ + value2_ == -numeric_limits<T>::infinity()) {
-      return LatticeWeightTpl(-numeric_limits<T>::infinity(), -numeric_limits<T>::infinity());
-    } else if (value1_ + value2_ == numeric_limits<T>::infinity()) {
-      return LatticeWeightTpl(numeric_limits<T>::infinity(), numeric_limits<T>::infinity());
+    if (value1_ + value2_ == -std::numeric_limits<T>::infinity()) {
+      return LatticeWeightTpl(-std::numeric_limits<T>::infinity(), -std::numeric_limits<T>::infinity());
+    } else if (value1_ + value2_ == std::numeric_limits<T>::infinity()) {
+      return LatticeWeightTpl(std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity());
     } else if (value1_ + value2_ != value1_ + value2_) { // NaN
       return LatticeWeightTpl(value1_ + value2_, value1_ + value2_);
     } else {
@@ -126,7 +126,7 @@ class LatticeWeightTpl {
 
   // This is used in OpenFst for binary I/O.  This is OpenFst-style,
   // not Kaldi-style, I/O.
-  istream &Read(istream &strm) {
+  std::istream &Read(std::istream &strm) {
     // Always read/write as float, even if T is double,
     // so we can use OpenFst-style read/write and still maintain
     // compatibility when compiling with different FloatTypes
@@ -138,7 +138,7 @@ class LatticeWeightTpl {
 
   // This is used in OpenFst for binary I/O.  This is OpenFst-style,
   // not Kaldi-style, I/O.
-  ostream &Write(ostream &strm) const {
+  std::ostream &Write(std::ostream &strm) const {
     WriteType(strm, value1_);
     WriteType(strm, value2_);
     return strm;
@@ -159,10 +159,10 @@ class LatticeWeightTpl {
   }
 
  protected:
-  inline static void WriteFloatType(ostream &strm, const T &f) {
-    if (f == numeric_limits<T>::infinity())
+  inline static void WriteFloatType(std::ostream &strm, const T &f) {
+    if (f == std::numeric_limits<T>::infinity())
       strm << "Infinity";
-    else if (f == -numeric_limits<T>::infinity())
+    else if (f == -std::numeric_limits<T>::infinity())
       strm << "-Infinity";
     else if (f != f)
       strm << "BadNumber";
@@ -171,15 +171,15 @@ class LatticeWeightTpl {
   }
 
   // Internal helper function, used in ReadNoParen.
-  inline static void ReadFloatType(istream &strm, T &f) {
-    string s;
+  inline static void ReadFloatType(std::istream &strm, T &f) {
+    std::string s;
     strm >> s;
     if (s == "Infinity") {
-      f = numeric_limits<T>::infinity();
+      f = std::numeric_limits<T>::infinity();
     } else if (s == "-Infinity") {
-      f = -numeric_limits<T>::infinity();
+      f = -std::numeric_limits<T>::infinity();
     } else if (s == "BadNumber") {
-      f = numeric_limits<T>::quiet_NaN();
+      f = std::numeric_limits<T>::quiet_NaN();
     } else {
       char *p;
       f = strtod(s.c_str(), &p);
@@ -190,14 +190,14 @@ class LatticeWeightTpl {
 
   // Reads LatticeWeight when there are no parentheses around pair terms...
   // currently the only form supported.
-  inline istream &ReadNoParen(
-      istream &strm, char separator) {
+  inline std::istream &ReadNoParen(
+      std::istream &strm, char separator) {
     int c;
     do {
       c = strm.get();
     } while (isspace(c));
 
-    string s1;
+    std::string s1;
     while (c != separator) {
       if (c == EOF) {
         strm.clear(std::ios::badbit);
@@ -206,15 +206,15 @@ class LatticeWeightTpl {
       s1 += c;
       c = strm.get();
     }
-    istringstream strm1(s1);
+    std::istringstream strm1(s1);
     ReadFloatType(strm1, value1_); // ReadFloatType is class member function
     // read second element
     ReadFloatType(strm, value2_);
     return strm;
   }
 
-  friend istream &operator>> <FloatType>(istream&, LatticeWeightTpl<FloatType>&);
-  friend ostream &operator<< <FloatType>(ostream&, const LatticeWeightTpl<FloatType>&);
+  friend std::istream &operator>> <FloatType>(std::istream&, LatticeWeightTpl<FloatType>&);
+  friend std::ostream &operator<< <FloatType>(std::ostream&, const LatticeWeightTpl<FloatType>&);
 
  private:
   T value1_;
@@ -231,9 +231,9 @@ class LatticeWeightTpl {
 template<class FloatType, class ScaleFloatType>
 inline LatticeWeightTpl<FloatType> ScaleTupleWeight(
     const LatticeWeightTpl<FloatType> &w,
-    const vector<vector<ScaleFloatType> > &scale) {
+    const std::vector<std::vector<ScaleFloatType> > &scale) {
   // Without the next special case we'd get NaNs from infinity * 0
-  if (w.Value1() == numeric_limits<FloatType>::infinity())
+  if (w.Value1() == std::numeric_limits<FloatType>::infinity())
     return LatticeWeightTpl<FloatType>::Zero();
   return LatticeWeightTpl<FloatType>(scale[0][0] * w.Value1() + scale[0][1] * w.Value2(),
                                      scale[1][0] * w.Value1() + scale[1][1] * w.Value2());
@@ -249,7 +249,7 @@ inline PairWeight<TropicalWeightTpl<FloatType>,
                   TropicalWeightTpl<FloatType> > ScaleTupleWeight(
                       const PairWeight<TropicalWeightTpl<FloatType>,
                                        TropicalWeightTpl<FloatType> > &w,
-                      const vector<vector<ScaleFloatType> > &scale) {
+                      const std::vector<std::vector<ScaleFloatType> > &scale) {
   typedef TropicalWeightTpl<FloatType> BaseType;
   typedef PairWeight<BaseType, BaseType> PairType;
   const BaseType zero = BaseType::Zero();
@@ -372,14 +372,14 @@ inline LatticeWeightTpl<FloatType> Divide(const LatticeWeightTpl<FloatType> &w1,
                                           DivideType typ = DIVIDE_ANY) {
   typedef FloatType T;
   T a = w1.Value1() - w2.Value1(), b = w1.Value2() - w2.Value2();
-  if (a != a || b != b || a == -numeric_limits<T>::infinity()
-     || b == -numeric_limits<T>::infinity()) {
+  if (a != a || b != b || a == -std::numeric_limits<T>::infinity()
+     || b == -std::numeric_limits<T>::infinity()) {
     KALDI_WARN << "LatticeWeightTpl::Divide, NaN or invalid number produced. "
                << "[dividing by zero?]  Returning zero";
     return LatticeWeightTpl<T>::Zero();
   }
-  if (a == numeric_limits<T>::infinity() ||
-     b == numeric_limits<T>::infinity())
+  if (a == std::numeric_limits<T>::infinity() ||
+     b == std::numeric_limits<T>::infinity())
     return LatticeWeightTpl<T>::Zero(); // not a valid number if only one is infinite.
   return LatticeWeightTpl<T>(a, b);
 }
@@ -394,7 +394,7 @@ inline bool ApproxEqual(const LatticeWeightTpl<FloatType> &w1,
 }
 
 template <class FloatType>
-inline ostream &operator <<(ostream &strm, const LatticeWeightTpl<FloatType> &w) {
+inline std::ostream &operator <<(std::ostream &strm, const LatticeWeightTpl<FloatType> &w) {
   LatticeWeightTpl<FloatType>::WriteFloatType(strm, w.Value1());
   CHECK(FLAGS_fst_weight_separator.size() == 1);
   strm << FLAGS_fst_weight_separator[0]; // comma by default;
@@ -404,7 +404,7 @@ inline ostream &operator <<(ostream &strm, const LatticeWeightTpl<FloatType> &w)
 }
 
 template <class FloatType>
-inline istream &operator >>(istream &strm, LatticeWeightTpl<FloatType> &w1) {
+inline std::istream &operator >>(std::istream &strm, LatticeWeightTpl<FloatType> &w1) {
   CHECK(FLAGS_fst_weight_separator.size() == 1);
   // separator defaults to ','
   return w1.ReadNoParen(strm, FLAGS_fst_weight_separator[0]);
@@ -435,7 +435,7 @@ class CompactLatticeWeightTpl {
 
   CompactLatticeWeightTpl() { }
 
-  CompactLatticeWeightTpl(const WeightType &w, const vector<IntType> &s):
+  CompactLatticeWeightTpl(const WeightType &w, const std::vector<IntType> &s):
       weight_(w), string_(s) { }
 
   CompactLatticeWeightTpl &operator=(const CompactLatticeWeightTpl<WeightType, IntType> &w) {
@@ -446,30 +446,30 @@ class CompactLatticeWeightTpl {
 
   const W &Weight() const { return weight_; }
 
-  const vector<IntType> &String() const { return string_; }
+  const std::vector<IntType> &String() const { return string_; }
 
   void SetWeight(const W &w) { weight_ = w; }
 
-  void SetString(const vector<IntType> &s) { string_ = s; }
+  void SetString(const std::vector<IntType> &s) { string_ = s; }
 
   static const CompactLatticeWeightTpl<WeightType, IntType> Zero() {
     return CompactLatticeWeightTpl<WeightType, IntType>(
-        WeightType::Zero(), vector<IntType>());
+        WeightType::Zero(), std::vector<IntType>());
   }
 
   static const CompactLatticeWeightTpl<WeightType, IntType> One() {
     return CompactLatticeWeightTpl<WeightType, IntType>(
-        WeightType::One(), vector<IntType>());
+        WeightType::One(), std::vector<IntType>());
   }
 
-  inline static string GetIntSizeString() {
+  inline static std::string GetIntSizeString() {
     char buf[2];
     buf[0] = '0' + sizeof(IntType);
     buf[1] = '\0';
     return buf;
   }
-  static const string &Type() {
-    static const string type = "compact" + WeightType::Type()
+  static const std::string &Type() {
+    static const std::string type = "compact" + WeightType::Type()
         + GetIntSizeString();
     return type;
   }
@@ -482,7 +482,7 @@ class CompactLatticeWeightTpl {
 
   CompactLatticeWeightTpl<WeightType, IntType> Reverse() const {
     size_t s = string_.size();
-    vector<IntType> v(s);
+    std::vector<IntType> v(s);
     for(size_t i = 0; i < s; i++)
       v[i] = string_[s-i-1];
     return CompactLatticeWeightTpl<WeightType, IntType>(weight_, v);
@@ -509,7 +509,7 @@ class CompactLatticeWeightTpl {
 
   // This is used in OpenFst for binary I/O.  This is OpenFst-style,
   // not Kaldi-style, I/O.
-  istream &Read(istream &strm) {
+  std::istream &Read(std::istream &strm) {
     weight_.Read(strm);
     if (strm.fail()){ return strm; }
     int32 sz;
@@ -529,7 +529,7 @@ class CompactLatticeWeightTpl {
 
   // This is used in OpenFst for binary I/O.  This is OpenFst-style,
   // not Kaldi-style, I/O.
-  ostream &Write(ostream &strm) const {
+  std::ostream &Write(std::ostream &strm) const {
     weight_.Write(strm);
     if (strm.fail()){ return strm; }
     int32 sz = static_cast<int32>(string_.size());
@@ -550,7 +550,7 @@ class CompactLatticeWeightTpl {
   }
  private:
   W weight_;
-  vector<IntType> string_;
+  std::vector<IntType> string_;
 
 };
 
@@ -676,9 +676,9 @@ inline CompactLatticeWeightTpl<WeightType, IntType> Times(
     return CompactLatticeWeightTpl<WeightType, IntType>::Zero();
     // special case to ensure zero is unique
   } else {
-    vector<IntType> v;
+    std::vector<IntType> v;
     v.resize(w1.String().size() + w2.String().size());
-    typename vector<IntType>::iterator iter = v.begin();
+    typename std::vector<IntType>::iterator iter = v.begin();
     iter = std::copy(w1.String().begin(), w1.String().end(), iter); // returns end of first range.
     std::copy(w2.String().begin(), w2.String().end(), iter);
     return CompactLatticeWeightTpl<WeightType, IntType>(w, v);
@@ -700,24 +700,24 @@ inline CompactLatticeWeightTpl<WeightType, IntType> Divide(const CompactLatticeW
   }
   WeightType w = Divide(w1.Weight(), w2.Weight());
 
-  const vector<IntType> v1 = w1.String(), v2 = w2.String();
+  const std::vector<IntType> v1 = w1.String(), v2 = w2.String();
   if (v2.size() > v1.size()) {
     KALDI_ERR << "Cannot divide, length mismatch";
   }
-  typename vector<IntType>::const_iterator v1b = v1.begin(),
+  typename std::vector<IntType>::const_iterator v1b = v1.begin(),
       v1e = v1.end(), v2b = v2.begin(), v2e = v2.end();
   if (div == DIVIDE_LEFT) {
     if (!std::equal(v2b, v2e, v1b)) { // v2 must be identical to first part of v1.
       KALDI_ERR << "Cannot divide, data mismatch";
     }
     return CompactLatticeWeightTpl<WeightType, IntType>(
-        w, vector<IntType>(v1b+(v2e-v2b), v1e)); // return last part of v1.
+        w, std::vector<IntType>(v1b+(v2e-v2b), v1e)); // return last part of v1.
   } else if (div == DIVIDE_RIGHT) {
     if (!std::equal(v2b, v2e, v1e-(v2e-v2b))) { // v2 must be identical to last part of v1.
       KALDI_ERR << "Cannot divide, data mismatch";
     }
     return CompactLatticeWeightTpl<WeightType, IntType>(
-        w, vector<IntType>(v1b, v1e-(v2e-v2b))); // return first part of v1.
+        w, std::vector<IntType>(v1b, v1e-(v2e-v2b))); // return first part of v1.
 
   } else {
     KALDI_ERR << "Cannot divide CompactLatticeWeightTpl with DIVIDE_ANY";
@@ -726,7 +726,7 @@ inline CompactLatticeWeightTpl<WeightType, IntType> Divide(const CompactLatticeW
 }
 
 template <class WeightType, class IntType>
-inline ostream &operator <<(ostream &strm, const CompactLatticeWeightTpl<WeightType, IntType> &w) {
+inline std::ostream &operator <<(std::ostream &strm, const CompactLatticeWeightTpl<WeightType, IntType> &w) {
   strm << w.Weight();
   CHECK(FLAGS_fst_weight_separator.size() == 1);
   strm << FLAGS_fst_weight_separator[0]; // comma by default.
@@ -739,7 +739,7 @@ inline ostream &operator <<(ostream &strm, const CompactLatticeWeightTpl<WeightT
 }
 
 template <class WeightType, class IntType>
-inline istream &operator >>(istream &strm, CompactLatticeWeightTpl<WeightType, IntType> &w) {
+inline std::istream &operator >>(std::istream &strm, CompactLatticeWeightTpl<WeightType, IntType> &w) {
   std::string s;
   strm >> s;
   if (strm.fail()) {
@@ -762,7 +762,7 @@ inline istream &operator >>(istream &strm, CompactLatticeWeightTpl<WeightType, I
     return strm;
   }
   // read string part.
-  vector<IntType> string;
+  std::vector<IntType> string;
   const char *c = s2.c_str();
   while(*c != '\0') {
     if (*c == kStringSeparator) // '_'
@@ -787,13 +787,13 @@ class CompactLatticeWeightCommonDivisorTpl {
 
   Weight operator()(const Weight &w1, const Weight &w2) const {
     // First find longest common prefix of the strings.
-    typename vector<IntType>::const_iterator s1b = w1.String().begin(),
+    typename std::vector<IntType>::const_iterator s1b = w1.String().begin(),
         s1e = w1.String().end(), s2b = w2.String().begin(), s2e = w2.String().end();
     while (s1b < s1e && s2b < s2e && *s1b == *s2b) {
       s1b++;
       s2b++;
     }
-    return Weight(Plus(w1.Weight(), w2.Weight()), vector<IntType>(w1.String().begin(), s1b));
+    return Weight(Plus(w1.Weight(), w2.Weight()), std::vector<IntType>(w1.String().begin(), s1b));
   }
 };
 
@@ -807,7 +807,7 @@ class CompactLatticeWeightCommonDivisorTpl {
 template<class Weight, class IntType, class ScaleFloatType>
 inline CompactLatticeWeightTpl<Weight, IntType> ScaleTupleWeight(
     const CompactLatticeWeightTpl<Weight, IntType> &w,
-    const vector<vector<ScaleFloatType> > &scale) {
+    const std::vector<std::vector<ScaleFloatType> > &scale) {
   return CompactLatticeWeightTpl<Weight, IntType>(
       Weight(ScaleTupleWeight(w.Weight(), scale)), w.String());
 }

--- a/src/fstext/pre-determinize-inl.h
+++ b/src/fstext/pre-determinize-inl.h
@@ -253,13 +253,13 @@ inline bool HasBannedPrefixPlusDigits(SymbolTable *symTable, std::string prefix,
   return false;  // doesn't have banned symbol.
 }
 
-template<class T> void CopySetToVector(const std::set<T> s, vector<T> *v) {
+template<class T> void CopySetToVector(const std::set<T> s, std::vector<T> *v) {
   // adds members of s to v, in sorted order from lowest to highest
   // (because the set was in sorted order).
   assert(v != NULL);
   v->resize(s.size());
   typename std::set<T>::const_iterator siter = s.begin();
-  typename vector<T>::iterator viter = v->begin();
+  typename std::vector<T>::iterator viter = v->begin();
   for (;  siter != s.end(); ++siter, ++viter) {
     assert(viter != v->end());
     *viter = *siter;
@@ -268,7 +268,7 @@ template<class T> void CopySetToVector(const std::set<T> s, vector<T> *v) {
 
 // Warning.  This function calls 'new'.
 template<class T>
-vector<T>* InsertMember(const vector<T> m, vector<vector<T>*> *S) {
+std::vector<T>* InsertMember(const std::vector<T> m, std::vector<std::vector<T>*> *S) {
   assert(m.size() > 0);
   T idx = m[0];
   assert(idx>=(T)0 && idx < (T)S->size());
@@ -278,7 +278,7 @@ vector<T>* InsertMember(const vector<T> m, vector<vector<T>*> *S) {
     // It could either be a programming error or a deeper conceptual bug.
     return NULL;  // nothing was inserted.
   } else {
-    vector<T> *ret = (*S)[idx] = new vector<T>(m);  // New copy of m.
+    std::vector<T> *ret = (*S)[idx] = new std::vector<T>(m);  // New copy of m.
     return ret;  // was inserted.
   }
 }
@@ -289,9 +289,9 @@ vector<T>* InsertMember(const vector<T> m, vector<vector<T>*> *S) {
 // not problematic.  We assume that the fst is sorted on input label (so epsilon arcs first)
 // The algorithm is described in section (C) above.  We use the same variable for S and T.
 template<class Arc> void Closure(MutableFst<Arc> *fst, std::set<typename Arc::StateId> *S,
-                                 const vector<bool> &pVec) {
+                                 const std::vector<bool> &pVec) {
   typedef typename Arc::StateId StateId;
-  vector<StateId> Q;
+  std::vector<StateId> Q;
   CopySetToVector(*S, &Q);
   while (Q.size() != 0) {
     StateId s = Q.back();
@@ -301,7 +301,7 @@ template<class Arc> void Closure(MutableFst<Arc> *fst, std::set<typename Arc::St
       if (arc.ilabel != 0) break;  // Break from the loop: due to sorting there will be no
       // more transitions with epsilons as input labels.
       if (!pVec[arc.nextstate]) {  // Next state is not problematic -> we can use this transition.
-        pair< typename std::set<StateId>::iterator, bool > p = S->insert(arc.nextstate);
+        std::pair< typename std::set<StateId>::iterator, bool > p = S->insert(arc.nextstate);
         if (p.second) {  // True means: was inserted into S (wasn't already there).
           Q.push_back(arc.nextstate);
         }
@@ -316,7 +316,7 @@ template<class Arc> void Closure(MutableFst<Arc> *fst, std::set<typename Arc::St
 template<class Arc, class Int>
 void PreDeterminize(MutableFst<Arc> *fst,
                     typename Arc::Label first_new_sym,
-                    vector<Int> *symsOut) {
+                    std::vector<Int> *symsOut) {
   typedef typename Arc::Label Label;
   typedef typename Arc::StateId StateId;
   typedef size_t ArcId;  // Our own typedef, not standard OpenFst.  Use size_t
@@ -357,10 +357,10 @@ void PreDeterminize(MutableFst<Arc> *fst,
     KALDI_VLOG(2) <<  "PreDeterminize: n_states = "<<(n_states)<<", max_state ="<<(max_state);
   }
 
-  vector<bool> p_vec(max_state+1, false);  // compute this next.
+  std::vector<bool> p_vec(max_state+1, false);  // compute this next.
   {  // D(ii): computing the array p. ["problematic states, i.e. states with >1 input transition,
     // counting being the initial state as an input transition"].
-    vector<bool> seen_vec(max_state+1, false);  // rather than counting incoming transitions we just have a bool that says we saw at least one.
+    std::vector<bool> seen_vec(max_state+1, false);  // rather than counting incoming transitions we just have a bool that says we saw at least one.
 
     seen_vec[fst->Start()] = true;
     for (StateIterator<MutableFst<Arc> > siter(*fst); ! siter.Done(); siter.Next()) {
@@ -375,19 +375,19 @@ void PreDeterminize(MutableFst<Arc> *fst,
     }
   }
   // D(iii): set up m(a)
-  std::map<pair<StateId, ArcId>, size_t> m_map;
+  std::map<std::pair<StateId, ArcId>, size_t> m_map;
   // This is the array m, indexed by arcs.  It maps to the index of the symbol we add.
 
 
   // WARNING: we should be sure to clean up this memory before exiting.  Do not return
   // or throw an exception from this function, later than this point, without cleaning up!
   // Note that the vectors are shared between Q and S (they "belong to" S.
-  vector<vector<StateId>* > S(max_state+1, (vector<StateId>*)(void*)0);
-  vector<pair<vector<StateId>*, size_t> > Q;
+  std::vector<std::vector<StateId>* > S(max_state+1, (std::vector<StateId>*)(void*)0);
+  std::vector<std::pair<std::vector<StateId>*, size_t> > Q;
 
   // D(iv): initialize S and Q.
   {
-    vector<StateId> all_seed_states;  // all "problematic" states, plus initial state (if not problematic).
+    std::vector<StateId> all_seed_states;  // all "problematic" states, plus initial state (if not problematic).
     if (!p_vec[fst->Start()])
       all_seed_states.push_back(fst->Start());
     for (StateId s = 0;s<=max_state; s++)
@@ -399,16 +399,16 @@ void PreDeterminize(MutableFst<Arc> *fst,
       closure_s.insert(s);  // insert "seed" state.
       pre_determinize_helpers::Closure(fst, &closure_s, p_vec);  // follow epsilons to non-problematic states.
       // Closure in this case whis will usually not add anything, for typical topologies in speech
-      vector<StateId> closure_s_vec;
+      std::vector<StateId> closure_s_vec;
       pre_determinize_helpers::CopySetToVector(closure_s, &closure_s_vec);
       KALDI_ASSERT(closure_s_vec.size() != 0);
-      vector<StateId> *ptr = pre_determinize_helpers::InsertMember(closure_s_vec, &S);
+      std::vector<StateId> *ptr = pre_determinize_helpers::InsertMember(closure_s_vec, &S);
       KALDI_ASSERT(ptr != NULL);  // Or conceptual bug or programming error.
-      Q.push_back(pair<vector<StateId>*, size_t>(ptr, 0));
+      Q.push_back(std::pair<std::vector<StateId>*, size_t>(ptr, 0));
     }
   }
 
-  vector<bool> d_vec(max_state+1, false);  // "done vector".  Purely for debugging.
+  std::vector<bool> d_vec(max_state+1, false);  // "done vector".  Purely for debugging.
 
 
   size_t num_extra_det_states = 0;
@@ -417,9 +417,9 @@ void PreDeterminize(MutableFst<Arc> *fst,
   while (Q.size() != 0) {
 
     // (D)(v)(a)
-    pair<vector<StateId>*, size_t> cur_pair(Q.back());
+    std::pair<std::vector<StateId>*, size_t> cur_pair(Q.back());
     Q.pop_back();
-    const vector<StateId> &A(*cur_pair.first);
+    const std::vector<StateId> &A(*cur_pair.first);
     size_t n =cur_pair.second;  // next special symbol to add.
 
     // (D)(v)(b)
@@ -430,7 +430,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
 
     // From here is (D)(v)(c).  We work out S_\eps and S_t (for t\neq eps)
     // simultaneously at first.
-    map<Label, set<pair<pair<StateId, ArcId>, StateId> > > arc_hash;
+    std::map<Label, std::set<std::pair<std::pair<StateId, ArcId>, StateId> > > arc_hash;
     // arc_hash is a hash with info of all arcs from states in the set A to
     // non-problematic states.
     // It is a map from ilabel to pair(pair(start-state, arc-offset), end-state).
@@ -446,8 +446,8 @@ void PreDeterminize(MutableFst<Arc> *fst,
         for (ArcIterator<MutableFst<Arc> > aiter(*fst, s); ! aiter.Done(); aiter.Next(), ++arc_id) {
           const Arc &arc = aiter.Value();
 
-          pair<pair<StateId, ArcId>, StateId>
-              this_pair(pair<StateId, ArcId>(s, arc_id), arc.nextstate);
+          std::pair<std::pair<StateId, ArcId>, StateId>
+              this_pair(std::pair<StateId, ArcId>(s, arc_id), arc.nextstate);
           bool inserted = (arc_hash[arc.ilabel].insert(this_pair)).second;
           assert(inserted);  // Otherwise we had a duplicate.
         }
@@ -456,10 +456,10 @@ void PreDeterminize(MutableFst<Arc> *fst,
 
     // (D)(v)(d)
     if (arc_hash.count(0) == 1) {  // We have epsilon transitions out.
-      set<pair<pair<StateId, ArcId>, StateId> >  &eps_set = arc_hash[0];
-      typedef typename set<pair<pair<StateId, ArcId>, StateId> >::iterator set_iter_t;
+      std::set<std::pair<std::pair<StateId, ArcId>, StateId> >  &eps_set = arc_hash[0];
+      typedef typename std::set<std::pair<std::pair<StateId, ArcId>, StateId> >::iterator set_iter_t;
       for (set_iter_t siter = eps_set.begin(); siter != eps_set.end(); ++siter) {
-        const pair<pair<StateId, ArcId>, StateId>  &this_pr = *siter;
+        const std::pair<std::pair<StateId, ArcId>, StateId>  &this_pr = *siter;
         if (p_vec[this_pr.second]) {  // Eps-transition to problematic state.
           assert(m_map.count(this_pr.first) == 0);
           m_map[this_pr.first] = n;
@@ -470,13 +470,13 @@ void PreDeterminize(MutableFst<Arc> *fst,
 
     // (D)(v)(e)
     {
-      typedef typename map<Label, set<pair<pair<StateId, ArcId>, StateId> > >::iterator map_iter_t;
-      typedef typename set<pair<pair<StateId, ArcId>, StateId> >::iterator set_iter_t2;
+      typedef typename std::map<Label, std::set<std::pair<std::pair<StateId, ArcId>, StateId> > >::iterator map_iter_t;
+      typedef typename std::set<std::pair<std::pair<StateId, ArcId>, StateId> >::iterator set_iter_t2;
       for (map_iter_t miter = arc_hash.begin(); miter != arc_hash.end(); ++miter) {
         Label t = miter->first;
-        set<pair<pair<StateId, ArcId>, StateId> >  &S_t = miter->second;
+        std::set<std::pair<std::pair<StateId, ArcId>, StateId> >  &S_t = miter->second;
         if (t != 0) {  // For t != epsilon,
-          set<StateId> V_t;  // set of destination non-problem states.  Will create this set now.
+          std::set<StateId> V_t;  // set of destination non-problem states.  Will create this set now.
 
           // exists_noproblem is true iff |U_t| > 0.
           size_t k = 0;
@@ -485,7 +485,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
           // The if-statement if (|S_t|>1) is pushed inside the loop, as the loop also computes
           // the set V_t.
           for (set_iter_t2 siter = S_t.begin(); siter != S_t.end(); ++siter) {
-            const pair<pair<StateId, ArcId>, StateId>  &this_pr = *siter;
+            const std::pair<std::pair<StateId, ArcId>, StateId>  &this_pr = *siter;
             if (p_vec[this_pr.second]) {  // only consider problematic states (just set T_t)
               if (S_t.size() > 1) {  // This is where we pushed the if-statement in.
                 assert(m_map.count(this_pr.first) == 0);
@@ -499,11 +499,11 @@ void PreDeterminize(MutableFst<Arc> *fst,
           }
           if (V_t.size() != 0) {
             pre_determinize_helpers::Closure(fst, &V_t, p_vec);  // follow epsilons to non-problematic states.
-            vector<StateId> closure_V_t_vec;
+            std::vector<StateId> closure_V_t_vec;
             pre_determinize_helpers::CopySetToVector(V_t, &closure_V_t_vec);
-            vector<StateId> *ptr = pre_determinize_helpers::InsertMember(closure_V_t_vec, &S);
+            std::vector<StateId> *ptr = pre_determinize_helpers::InsertMember(closure_V_t_vec, &S);
             if (ptr != NULL) {  // was inserted.
-              Q.push_back(pair<vector<StateId>*, size_t>(ptr, k));
+              Q.push_back(std::pair<std::vector<StateId>*, size_t>(ptr, k));
             }
           }
         }
@@ -522,7 +522,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
   {  // (D)(vii): compute symbol-table ID's.
     // sets up symsOut array.
     int64 n = -1;
-    for (typename map<pair<StateId, ArcId>, size_t>::iterator m_iter = m_map.begin();
+    for (typename std::map<std::pair<StateId, ArcId>, size_t>::iterator m_iter = m_map.begin();
         m_iter != m_map.end();
         ++m_iter) {
       n = std::max(n, (int64) m_iter->second);  // m_iter->second is of type size_t.
@@ -533,14 +533,14 @@ void PreDeterminize(MutableFst<Arc> *fst,
   }
 
   // (D)(viii): set up hash.
-  map<pair<StateId, size_t>, StateId> h_map;
+  std::map<std::pair<StateId, size_t>, StateId> h_map;
 
   {  // D(ix): add extra symbols!  This is where the work gets done.
 
     // Core part of this is below, search for (*)
     size_t n_states_added = 0;
 
-    for (typename map<pair<StateId, ArcId>, size_t>::iterator m_iter = m_map.begin();
+    for (typename std::map<std::pair<StateId, ArcId>, size_t>::iterator m_iter = m_map.begin();
         m_iter != m_map.end();
         ++m_iter) {
       StateId state = m_iter->first.first;
@@ -555,7 +555,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
       if (arc.ilabel == 0)
         arc.ilabel = (*symsOut)[m_a];
       else {
-        pair<StateId, size_t> pr(arc.nextstate, m_a);
+        std::pair<StateId, size_t> pr(arc.nextstate, m_a);
         if (!h_map.count(pr)) {
           n_states_added++;
           StateId newstate = fst->AddState();
@@ -579,7 +579,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
 
 
 template<class Label> void CreateNewSymbols(SymbolTable *input_sym_table, int nSym,
-                                            std::string prefix, vector<Label> *symsOut) {
+                                            std::string prefix, std::vector<Label> *symsOut) {
   // Creates nSym new symbols named (prefix)0, (prefix)1 and so on.
   // Crashes if it cannot create them because one or more of them were in the symbol
   // table already.
@@ -596,8 +596,8 @@ template<class Label> void CreateNewSymbols(SymbolTable *input_sym_table, int nS
 
 
 // see pre-determinize.h for documentation.
-template<class Arc> void AddSelfLoops(MutableFst<Arc> *fst, vector<typename Arc::Label> &isyms,
-                                      vector<typename Arc::Label> &osyms) {
+template<class Arc> void AddSelfLoops(MutableFst<Arc> *fst, std::vector<typename Arc::Label> &isyms,
+                                      std::vector<typename Arc::Label> &osyms) {
   assert(fst != NULL);
   assert(isyms.size() == osyms.size());
   typedef typename Arc::Label Label;
@@ -648,7 +648,7 @@ template<class Arc> void AddSelfLoops(MutableFst<Arc> *fst, vector<typename Arc:
 }
 
 template<class Arc>
-int64 DeleteISymbols(MutableFst<Arc> *fst, vector<typename Arc::Label> isyms) {
+int64 DeleteISymbols(MutableFst<Arc> *fst, std::vector<typename Arc::Label> isyms) {
 
   // We could do this using the Mapper concept, but this is much easier to understand.
 
@@ -690,7 +690,7 @@ typename Arc::StateId CreateSuperFinal(MutableFst<Arc> *fst) {
   assert(fst != NULL);
   StateId num_states = fst->NumStates();
   StateId num_final = 0;
-  vector<StateId> final_states;
+  std::vector<StateId> final_states;
   for (StateId s = 0; s < num_states; s++) {
     if (fst->Final(s) != Weight::Zero()) {
       num_final++;

--- a/src/fstext/pre-determinize-test.cc
+++ b/src/fstext/pre-determinize-test.cc
@@ -26,6 +26,9 @@
 
 namespace fst
 {
+  using std::vector;
+  using std::cout;
+
 // Don't instantiate with log semiring, as RandEquivalent may fail.
 template<class Arc>  void TestPreDeterminize() {
   typedef typename Arc::Label Label;

--- a/src/fstext/pre-determinize.h
+++ b/src/fstext/pre-determinize.h
@@ -31,11 +31,11 @@ namespace fst {
 
 /* PreDeterminize inserts extra symbols on the input side of an FST as necessary to
    ensure that, after epsilon removal, it will be compactly determinizable by the
-   determinize* algorithm.  By compactly determinizable we mean that 
+   determinize* algorithm.  By compactly determinizable we mean that
    no original FST state is represented in more than one determinized state).
 
    Caution: this code is now only used in testing.
-   
+
    The new symbols start from the value "first_new_symbol", which should be
    higher than the largest-numbered symbol currently in the FST.  The new
    symbols added are put in the array syms_out, which should be empty at start.
@@ -44,7 +44,7 @@ namespace fst {
 template<class Arc, class Int>
 void PreDeterminize(MutableFst<Arc> *fst,
                     typename Arc::Label first_new_symbol,
-                    vector<Int> *syms_out);
+                    std::vector<Int> *syms_out);
 
 
 /* CreateNewSymbols is a helper function used inside PreDeterminize, and is also useful
@@ -53,7 +53,7 @@ void PreDeterminize(MutableFst<Arc> *fst,
 
 template<class Label>
 void CreateNewSymbols(SymbolTable *inputSymTable, int nSym,
-                      std::string prefix, vector<Label> *syms_out);
+                      std::string prefix, std::vector<Label> *syms_out);
 
 /** AddSelfLoops is a function you will probably want to use alongside PreDeterminize,
     to add self-loops to any FSTs that you compose on the left hand side of the one
@@ -72,15 +72,15 @@ void CreateNewSymbols(SymbolTable *inputSymTable, int nSym,
     of symbols on its input and output.
 */
 template<class Arc>
-void AddSelfLoops(MutableFst<Arc> *fst, vector<typename Arc::Label> &isyms,
-                     vector<typename Arc::Label> &osyms);
+void AddSelfLoops(MutableFst<Arc> *fst, std::vector<typename Arc::Label> &isyms,
+                     std::vector<typename Arc::Label> &osyms);
 
 
 /* DeleteSymbols replaces any instances of symbols in the vector symsIn, appearing
    on the input side, with epsilon. */
 /* It returns the number of instances of symbols deleted. */
 template<class Arc>
-int64 DeleteISymbols(MutableFst<Arc> *fst, vector<typename Arc::Label> symsIn);
+int64 DeleteISymbols(MutableFst<Arc> *fst, std::vector<typename Arc::Label> symsIn);
 
 /* CreateSuperFinal takes an FST, and creates an equivalent FST with a single final
    state with no transitions out and unit final weight, by inserting epsilon transitions

--- a/src/fstext/prune-special-test.cc
+++ b/src/fstext/prune-special-test.cc
@@ -39,7 +39,7 @@ static void TestPruneSpecial() {
   {
     FstPrinter<Arc> fstprinter(*ifst, NULL, NULL, NULL, false, true, "\t");
     fstprinter.Print(&std::cout, "standard output");
-    std::cout << endl;
+    std::cout << std::endl;
   }
 
   // Do the special pruning.
@@ -48,7 +48,7 @@ static void TestPruneSpecial() {
   {
     FstPrinter<Arc> fstprinter(ofst1, NULL, NULL, NULL, false, true, "\t");
     fstprinter.Print(&std::cout, "standard output");
-    std::cout << endl;
+    std::cout << std::endl;
   }
 
   // Do the normal pruning.
@@ -57,7 +57,7 @@ static void TestPruneSpecial() {
   {
     FstPrinter<Arc> fstprinter(ofst2, NULL, NULL, NULL, false, true, "\t");
     fstprinter.Print(&std::cout, "standard output");
-    std::cout << endl;
+    std::cout << std::endl;
   }
 
   KALDI_ASSERT(RandEquivalent(ofst1, ofst2,

--- a/src/fstext/rand-fst.h
+++ b/src/fstext/rand-fst.h
@@ -62,7 +62,7 @@ template<class Arc> VectorFst<Arc>* RandFst(RandFstOptions opts = RandFstOptions
  start:
 
   // Create states.
-  vector<StateId> all_states;
+  std::vector<StateId> all_states;
   for (size_t i = 0;i < (size_t)opts.n_states;i++) {
     StateId this_state = fst->AddState();
     if (i == 0) fst->SetStart(i);
@@ -88,7 +88,7 @@ template<class Arc> VectorFst<Arc>* RandFst(RandFstOptions opts = RandFstOptions
     a.ilabel = kaldi::Rand() % opts.n_syms;
     a.olabel = kaldi::Rand() % opts.n_syms;  // same input+output vocab.
     a.weight = (Weight) (opts.weight_multiplier*(kaldi::Rand() % 4));
-    
+
     fst->AddArc(start_state, a);
   }
 
@@ -114,7 +114,7 @@ template<class Arc> VectorFst<Arc>* RandPairFst(RandFstOptions opts = RandFstOpt
  start:
 
   // Create states.
-  vector<StateId> all_states;
+  std::vector<StateId> all_states;
   for (size_t i = 0;i < (size_t)opts.n_states;i++) {
     StateId this_state = fst->AddState();
     if (i == 0) fst->SetStart(i);
@@ -140,7 +140,7 @@ template<class Arc> VectorFst<Arc>* RandPairFst(RandFstOptions opts = RandFstOpt
     a.ilabel = kaldi::Rand() % opts.n_syms;
     a.olabel = kaldi::Rand() % opts.n_syms;  // same input+output vocab.
     a.weight = Weight (opts.weight_multiplier*(kaldi::Rand() % 4), opts.weight_multiplier*(kaldi::Rand() % 4));
-    
+
     fst->AddArc(start_state, a);
   }
 

--- a/src/fstext/remove-eps-local-inl.h
+++ b/src/fstext/remove-eps-local-inl.h
@@ -64,9 +64,9 @@ class RemoveEpsLocalClass {
  private:
   MutableFst<Arc> *fst_;
   StateId non_coacc_state_;  //  use this to delete arcs: make it nextstate
-  vector<StateId> num_arcs_in_;   // The number of arcs into the state, plus one
+  std::vector<StateId> num_arcs_in_;   // The number of arcs into the state, plus one
                                   // if it's the start state.
-  vector<StateId> num_arcs_out_;  // The number of arcs out of the state, plus
+  std::vector<StateId> num_arcs_out_;  // The number of arcs out of the state, plus
                                   // one if it's a final state.
   ReweightPlus reweight_plus_;
 
@@ -174,7 +174,7 @@ class RemoveEpsLocalClass {
     const StateId nextstate = arc.nextstate;
     Weight total_removed = Weight::Zero(),
         total_kept = Weight::Zero();  // totals out of nextstate.
-    vector<Arc> arcs_to_add;  // to add to state s.
+    std::vector<Arc> arcs_to_add;  // to add to state s.
     for (MutableArcIterator<MutableFst<Arc> > aiter_next(fst_, nextstate);
         !aiter_next.Done();
         aiter_next.Next()) {

--- a/src/fstext/remove-eps-local-test.cc
+++ b/src/fstext/remove-eps-local-test.cc
@@ -26,8 +26,8 @@
 
 namespace fst
 {
-
-
+using std::vector;
+using std::cout;
 
 // Don't instantiate with log semiring, as RandEquivalent may fail.
 template<class Arc> static void TestRemoveEpsLocal() {

--- a/src/fstext/table-matcher.h
+++ b/src/fstext/table-matcher.h
@@ -86,7 +86,7 @@ class TableMatcherImpl : public MatcherBase<typename F::Arc> {
   virtual const FST &GetFst() const { return *fst_; }
 
   virtual ~TableMatcherImpl() {
-    vector<ArcId> *const empty = ((vector<ArcId>*)(NULL)) + 1;  // special marker.
+    std::vector<ArcId> *const empty = ((std::vector<ArcId>*)(NULL)) + 1;  // special marker.
     for (size_t i = 0; i < tables_.size(); i++) {
       if (tables_[i] != NULL && tables_[i] != empty)
         delete tables_[i];
@@ -107,12 +107,12 @@ class TableMatcherImpl : public MatcherBase<typename F::Arc> {
     if (match_type_ == MATCH_NONE)
       LOG(FATAL) << "TableMatcher: bad match type";
     s_ = s;
-    vector<ArcId> *const empty = ((vector<ArcId>*)(NULL)) + 1;  // special marker.
+    std::vector<ArcId> *const empty = ((std::vector<ArcId>*)(NULL)) + 1;  // special marker.
     if (static_cast<size_t>(s) >= tables_.size()) {
       assert(s>=0);
       tables_.resize(s+1, NULL);
     }
-    vector<ArcId>* &this_table_ = tables_[s];  // note: ref to ptr.
+    std::vector<ArcId>* &this_table_ = tables_[s];  // note: ref to ptr.
     if (this_table_ == empty) {
       backoff_matcher_.SetState(s);
       return;
@@ -137,7 +137,7 @@ class TableMatcherImpl : public MatcherBase<typename F::Arc> {
         return;  // table would be too sparse.
       }
       // OK, now we are creating the table.
-      this_table_ = new vector<ArcId> (highest_label+1, kNoStateId);
+      this_table_ = new std::vector<ArcId> (highest_label+1, kNoStateId);
       ArcId pos = 0;
       for (aiter.Seek(0); !aiter.Done(); aiter.Next(), pos++) {
         Label label = (match_type_ == MATCH_OUTPUT ?
@@ -232,7 +232,7 @@ class TableMatcherImpl : public MatcherBase<typename F::Arc> {
   Arc loop_;
   ArcIterator<FST> *aiter_;
   StateId s_;
-  vector<vector<ArcId> *> tables_;
+  std::vector<std::vector<ArcId> *> tables_;
   TableMatcherOptions opts_;
   BackoffMatcher backoff_matcher_;
 

--- a/src/fstext/trivial-factor-weight-test.cc
+++ b/src/fstext/trivial-factor-weight-test.cc
@@ -26,6 +26,8 @@
 
 namespace fst
 {
+  using std::cout;
+  using std::vector;
 
 // Don't instantiate with log semiring, as RandEquivalent may fail.
 template<class Arc>  void TestFactor() {

--- a/src/fstext/trivial-factor-weight.h
+++ b/src/fstext/trivial-factor-weight.h
@@ -220,7 +220,7 @@ class TrivialFactorWeightFstImpl
     } else {
       StateId s = elements_.size();
       elements_.push_back(e);
-      element_map_.insert(pair<const Element, StateId>(e, s));
+      element_map_.insert(std::pair<const Element, StateId>(e, s));
       return s;
     }
   }
@@ -238,7 +238,7 @@ class TrivialFactorWeightFstImpl
           PushArc(s, Arc(extra_ilabel_, extra_olabel_, e.weight, dest));
         } // else we're done.  This is a final state.
       } else {  // Can be factored.
-        const pair<Weight, Weight> &p = fit.Value();
+        const std::pair<Weight, Weight> &p = fit.Value();
         StateId dest = FindState(Element(e.state, p.second.Quantize(delta_)));
         PushArc(s, Arc(extra_ilabel_, extra_olabel_, p.first, dest));
       }
@@ -253,7 +253,7 @@ class TrivialFactorWeightFstImpl
           StateId dest = FindState(Element(arc.nextstate, Weight::One()));
           PushArc(s, Arc(arc.ilabel, arc.olabel, arc.weight, dest));
         } else {
-          const pair<Weight, Weight> &p = fit.Value();
+          const std::pair<Weight, Weight> &p = fit.Value();
           StateId dest = FindState(Element(arc.nextstate, p.second.Quantize(delta_)));
           PushArc(s, Arc(arc.ilabel, arc.olabel, p.first, dest));
         }
@@ -263,7 +263,7 @@ class TrivialFactorWeightFstImpl
       if (final_w != Weight::Zero()) {
         FactorIterator fit(final_w);
         if (!fit.Done()) {
-          const pair<Weight, Weight> &p = fit.Value();
+          const std::pair<Weight, Weight> &p = fit.Value();
           StateId dest = FindState(Element(kNoStateId, p.second.Quantize(delta_)));
           PushArc(s, Arc(extra_ilabel_, extra_olabel_, p.first, dest));
         }
@@ -298,7 +298,7 @@ class TrivialFactorWeightFstImpl
   uint32 mode_;               // factoring arc and/or final weights
   Label extra_ilabel_;        // ilabel of arc created when factoring final w's
   Label extra_olabel_;        // olabel of arc created when factoring final w's
-  vector<Element> elements_;  // mapping Fst state to Elements
+  std::vector<Element> elements_;  // mapping Fst state to Elements
   ElementMap element_map_;    // mapping Elements to Fst state
 
 };

--- a/src/gmmbin/gmm-latgen-map.cc
+++ b/src/gmmbin/gmm-latgen-map.cc
@@ -38,6 +38,7 @@
 int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
+    using std::string;
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
     using fst::Fst;
@@ -56,7 +57,7 @@ int main(int argc, char *argv[]) {
     bool binary = true;
     bool allow_partial = true;
     BaseFloat acoustic_scale = 0.1;
-        
+
     std::string word_syms_filename, utt2spk_rspecifier;
     LatticeFasterDecoderConfig decoder_opts;
     decoder_opts.Register(&po);
@@ -109,7 +110,7 @@ int main(int argc, char *argv[]) {
         KALDI_ERR << "Could not open table for writing lattices: "
                   << lattice_wspecifier;
     }
-        
+
     fst::SymbolTable *word_syms = NULL;
     if (word_syms_filename != "") {
       word_syms = fst::SymbolTable::ReadText(word_syms_filename);
@@ -185,7 +186,7 @@ int main(int argc, char *argv[]) {
         }
         AmDiagGmm am_gmm;
         am_gmm.CopyFromAmDiagGmm(gmms_reader.Value(utt));
-        
+
         Matrix<BaseFloat> features(feature_reader.Value());
         feature_reader.FreeCurrent();
         if (features.NumRows() == 0) {
@@ -210,7 +211,7 @@ int main(int argc, char *argv[]) {
         } else num_fail++;
       }  // end looping over all utterances
     }
-    KALDI_LOG << "Average log-likelihood per frame is " 
+    KALDI_LOG << "Average log-likelihood per frame is "
               << (tot_like / frame_count) << " over " << frame_count << " frames.";
 
     double elapsed = timer.Elapsed();

--- a/src/kwsbin/generate-proxy-keywords.cc
+++ b/src/kwsbin/generate-proxy-keywords.cc
@@ -25,6 +25,7 @@
 #include "fstext/prune-special.h"
 
 namespace fst {
+using std::vector;
 
 bool PrintProxyFstPath(const VectorFst<StdArc> &proxy,
                        vector<vector<StdArc::Label> > *path,
@@ -58,6 +59,8 @@ int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
     using namespace fst;
+    using std::vector;
+    using std::string;
     typedef kaldi::int32 int32;
     typedef kaldi::uint64 uint64;
     typedef StdArc::StateId StateId;

--- a/src/kwsbin/kws-search.cc
+++ b/src/kwsbin/kws-search.cc
@@ -159,6 +159,7 @@ int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
     using namespace fst;
+    using std::vector;
     typedef kaldi::int32 int32;
     typedef kaldi::uint32 uint32;
     typedef kaldi::uint64 uint64;

--- a/src/kwsbin/print-proxy-keywords.cc
+++ b/src/kwsbin/print-proxy-keywords.cc
@@ -25,6 +25,7 @@
 #include "fstext/kaldi-fst-io.h"
 
 namespace fst {
+using std::vector;
 
 bool PrintProxyFstPath(const VectorFst<StdArc> &proxy,
                        vector<vector<StdArc::Label> > *path,

--- a/src/lat/arctic-weight.h
+++ b/src/lat/arctic-weight.h
@@ -43,29 +43,29 @@ class ArcticWeightTpl : public FloatWeightTpl<T> {
   ArcticWeightTpl(const ArcticWeightTpl<T> &w) : FloatWeightTpl<T>(w) {}
 
   static const ArcticWeightTpl<T> Zero() {
-    return ArcticWeightTpl<T>(-numeric_limits<T>::infinity()); }
+    return ArcticWeightTpl<T>(-std::numeric_limits<T>::infinity()); }
 
   static const ArcticWeightTpl<T> One() {
     return ArcticWeightTpl<T>(0.0F); }
 
-  static const string &Type() {
-    static const string type = string("arctic") +
+  static const std::string &Type() {
+    static const std::string type = std::string("arctic") +
         FloatWeightTpl<T>::GetPrecisionString();
     return type;
   }
 
   static ArcticWeightTpl<T> NoWeight() {
-    return ArcticWeightTpl<T>(numeric_limits<T>::infinity());
+    return ArcticWeightTpl<T>(std::numeric_limits<T>::infinity());
   }
 
   bool Member() const {
     // First part fails for IEEE NaN
-    return Value() == Value() && Value() != numeric_limits<T>::infinity();
+    return Value() == Value() && Value() != std::numeric_limits<T>::infinity();
   }
 
   ArcticWeightTpl<T> Quantize(float delta = kDelta) const {
-    if (Value() == -numeric_limits<T>::infinity() ||
-        Value() == numeric_limits<T>::infinity() ||
+    if (Value() == -std::numeric_limits<T>::infinity() ||
+        Value() == std::numeric_limits<T>::infinity() ||
         Value() != Value())
       return *this;
     else
@@ -103,9 +103,9 @@ template <class T>
 inline ArcticWeightTpl<T> Times(const ArcticWeightTpl<T> &w1,
                                   const ArcticWeightTpl<T> &w2) {
   T f1 = w1.Value(), f2 = w2.Value();
-  if (f1 == -numeric_limits<T>::infinity())
+  if (f1 == -std::numeric_limits<T>::infinity())
     return w1;
-  else if (f2 == -numeric_limits<T>::infinity())
+  else if (f2 == -std::numeric_limits<T>::infinity())
     return w2;
   else
     return ArcticWeightTpl<T>(f1 + f2);
@@ -126,10 +126,10 @@ inline ArcticWeightTpl<T> Divide(const ArcticWeightTpl<T> &w1,
                                    const ArcticWeightTpl<T> &w2,
                                    DivideType typ = DIVIDE_ANY) {
   T f1 = w1.Value(), f2 = w2.Value();
-  if (f2 == -numeric_limits<T>::infinity())
-    return numeric_limits<T>::quiet_NaN();
-  else if (f1 == -numeric_limits<T>::infinity())
-    return -numeric_limits<T>::infinity();
+  if (f2 == -std::numeric_limits<T>::infinity())
+    return std::numeric_limits<T>::quiet_NaN();
+  else if (f1 == -std::numeric_limits<T>::infinity())
+    return -std::numeric_limits<T>::infinity();
   else
     return ArcticWeightTpl<T>(f1 - f2);
 }

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -30,6 +30,10 @@
 
 namespace fst {
 
+using std::vector;
+using std::pair;
+using std::greater;
+
 // class LatticeDeterminizerPruned is templated on the same types that
 // CompactLatticeWeight is templated on: the base weight (Weight), typically
 // LatticeWeightTpl<float> etc. but could also be e.g. TropicalWeight, and the
@@ -1030,7 +1034,7 @@ template<class Weight, class IntType> class LatticeDeterminizerPruned {
     // an empty FST.
 
     double best_cost = backward_costs_[ifst_->Start()];
-    if (best_cost == numeric_limits<double>::infinity())
+    if (best_cost == std::numeric_limits<double>::infinity())
       KALDI_WARN << "Total weight of input lattice is zero.";
     cutoff_ = best_cost + beam_;
   }

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -1114,7 +1114,7 @@ void CompactLatticeShortestPath(const CompactLattice &clat,
   vector<std::pair<double, StateId> > best_cost_and_pred(clat.NumStates() + 1);
   StateId superfinal = clat.NumStates();
   for (StateId s = 0; s <= clat.NumStates(); s++) {
-    best_cost_and_pred[s].first = numeric_limits<double>::infinity();
+    best_cost_and_pred[s].first = std::numeric_limits<double>::infinity();
     best_cost_and_pred[s].second = fst::kNoStateId;
   }
   best_cost_and_pred[0].first = 0;

--- a/src/latbin/lattice-oracle.cc
+++ b/src/latbin/lattice-oracle.cc
@@ -27,6 +27,8 @@
 
 namespace kaldi {
 
+ using std::string;
+
 typedef fst::StdArc::Label Label;
 typedef std::vector<std::pair<Label, Label>> LabelPairVector;
 

--- a/src/latbin/lattice-reverse.cc
+++ b/src/latbin/lattice-reverse.cc
@@ -32,13 +32,15 @@ int main(int argc, char *argv[]) {
     using fst::VectorFst;
     using fst::StdArc;
 
+    using std::string;
+
     const char *usage =
         "Reverse a lattice in order to rescore the lattice with a RNNLM \n"
         "trained reversed text. An example for its application is at \n"
         "swbd/local/rnnlm/run_lstm_tdnn_back.sh\n"
         "Usage: lattice-reverse lattice-rspecifier lattice-wspecifier\n"
         " e.g.: lattice-reverse ark:forward.lats ark:backward.lats\n";
-    
+
     ParseOptions po(usage);
     std::string include_rxfilename;
     std::string exclude_rxfilename;
@@ -54,10 +56,10 @@ int main(int argc, char *argv[]) {
                 lats_wspecifier = po.GetArg(2);
 
     int32 n_done = 0;
-    
+
     SequentialLatticeReader lattice_reader(lats_rspecifier);
     LatticeWriter lattice_writer(lats_wspecifier);
-    
+
     for (; !lattice_reader.Done(); lattice_reader.Next(), n_done++) {
       string key = lattice_reader.Key();
       Lattice &lat = lattice_reader.Value();
@@ -67,7 +69,7 @@ int main(int argc, char *argv[]) {
     }
 
     KALDI_LOG << "Done reversing " << n_done << " lattices.";
-    
+
     return (n_done != 0 ? 0 : 1);
   } catch(const std::exception &e) {
     std::cerr << e.what();

--- a/src/lm/arpa-lm-compiler-test.cc
+++ b/src/lm/arpa-lm-compiler-test.cc
@@ -72,7 +72,7 @@ static fst::StdVectorFst* CreateGenFst(bool seps, const fst::SymbolTable* pst) {
 }
 
 // Compile given ARPA file.
-ArpaLmCompiler* Compile(bool seps, const string &infile) {
+ArpaLmCompiler* Compile(bool seps, const std::string &infile) {
   ArpaParseOptions options;
   fst::SymbolTable symbols;
   // Use spaces on special symbols, so we rather fail than read them by mistake.
@@ -116,7 +116,7 @@ void AddSelfLoops(fst::StdMutableFst* fst) {
 
 // Compiles infile and then runs kRandomSentences random coverage tests on the
 // compiled FST.
-bool CoverageTest(bool seps, const string &infile) {
+bool CoverageTest(bool seps, const std::string &infile) {
   // Compile ARPA model.
   ArpaLmCompiler* lm_compiler = Compile(seps, infile);
 
@@ -153,7 +153,7 @@ bool CoverageTest(bool seps, const string &infile) {
   return ok;
 }
 
-bool ScoringTest(bool seps, const string &infile, const string& sentence,
+bool ScoringTest(bool seps, const std::string &infile, const std::string& sentence,
                  float expected) {
   ArpaLmCompiler* lm_compiler = Compile(seps, infile);
   const fst::SymbolTable* symbols = lm_compiler->Fst().InputSymbols();
@@ -166,7 +166,7 @@ bool ScoringTest(bool seps, const string &infile, const string& sentence,
     state = AddToChainFsa(&sentFst, state, kBos);
   }
   std::stringstream ss(sentence);
-  string word;
+  std::string word;
   while (ss >> word) {
     int64 word_sym = symbols->Find(word);
     KALDI_ASSERT(word_sym != -1);
@@ -204,7 +204,7 @@ bool ScoringTest(bool seps, const string &infile, const string& sentence,
   return ok;
 }
 
-bool ThrowsExceptionTest(bool seps, const string &infile) {
+bool ThrowsExceptionTest(bool seps, const std::string &infile) {
   try {
     // Make memory cleanup easy in both cases of try-catch block.
     std::unique_ptr<ArpaLmCompiler> compiler(Compile(seps, infile));

--- a/src/nnet2bin/nnet-am-average.cc
+++ b/src/nnet2bin/nnet-am-average.cc
@@ -113,6 +113,7 @@ int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
     using namespace kaldi::nnet2;
+    using std::string;
     typedef kaldi::int32 int32;
     typedef kaldi::int64 int64;
 

--- a/src/nnet3/discriminative-training.cc
+++ b/src/nnet3/discriminative-training.cc
@@ -26,7 +26,7 @@ namespace kaldi {
 namespace discriminative {
 
 DiscriminativeObjectiveInfo::DiscriminativeObjectiveInfo() {
-  std::memset(this, 0, sizeof(*this));
+  std::memset((void *)this, 0, sizeof(*this));
 }
 
 DiscriminativeObjectiveInfo::DiscriminativeObjectiveInfo(int32 num_pdfs) :

--- a/src/nnet3/nnet-chain-example.cc
+++ b/src/nnet3/nnet-chain-example.cc
@@ -357,7 +357,7 @@ void ShiftChainExampleTimes(int32 frame_shift,
       input_end = eg->inputs.end();
   for (; input_iter != input_end; ++input_iter) {
     bool must_exclude = false;
-    std::vector<string>::const_iterator exclude_iter = exclude_names.begin(),
+    std::vector<std::string>::const_iterator exclude_iter = exclude_names.begin(),
         exclude_end = exclude_names.end();
     for (; exclude_iter != exclude_end; ++exclude_iter)
       if (input_iter->name == *exclude_iter)

--- a/src/nnet3/nnet-discriminative-example.cc
+++ b/src/nnet3/nnet-discriminative-example.cc
@@ -23,7 +23,7 @@
 
 namespace kaldi {
 namespace nnet3 {
-
+using std::string;
 
 void NnetDiscriminativeSupervision::Write(std::ostream &os, bool binary) const {
   CheckDim();


### PR DESCRIPTION
@danpovey  for your consideration
This enables compilation with the "latest" GCC and OpenFST. Does not enforce anything newer, just updates the code in case someone attempts to compile it that way.
The changes are mostly due some changes in namespaced symbol lookup (as usually), I don't recall changing anything else.
In headers (.h) I wrote everything with explicit namespace specification (std::vector instead of vector) instead of using "using std::vector" or similar stuff, to prevent potential polution of the namespaces.
For cc files, I was less consistent, generally tried to use "using std::vector" and similar. But those files are generally already messy, you can often times see both vector and std::vector in the same file.
