### PR TITLE
bug-fix on subset_data_dir.sh (Issue #3567)

### DIFF
--- a/egs/wsj/s5/utils/subset_data_dir.sh
+++ b/egs/wsj/s5/utils/subset_data_dir.sh
@@ -108,7 +108,7 @@ elif $speakers; then
 elif $perspk; then
   awk '{ n='$numutt'; printf("%s ",$1);
          skip=1; while(n*(skip+1) <= NF-1) { skip++; }
-         for(x=2; x<=NF && x <= n*skip; x += skip) { printf("%s ", $x); }
+         for(x=2; x<=NF && x <= (n*skip+1); x += skip) { printf("%s ", $x); }
          printf("\n"); }' <$srcdir/spk2utt >$destdir/spk2utt
   utils/spk2utt_to_utt2spk.pl < $destdir/spk2utt > $destdir/utt2spk
 else


### PR DESCRIPTION
The script failed to return the number of utterances `per-spk` requested, despite being available in the original spk2utt file.
The stop-boundary on the awk's for-loop was off by 1.

> An example of how affects the spk2utt files

```
$ cat tmpData/spk2utt 
spk1 spk1-utt1 spk1-utt2 spk1-utt3
spk2 spk2-utt1
spk3 spk3-utt1 spk3-utt2
spk4 spk4-utt1 spk4-utt2 spk4-utt3 spk4-utt4
$
$ ./subset_data_dir.sh --per-spk tmpData 2 tmpData-before
$ cat tmpData-before/spk2utt 
spk1 spk1-utt1 
spk2 spk2-utt1 
spk3 spk3-utt1 
spk4 spk4-utt1 spk4-utt3 
$
$ ./subset_data_dir_MOD.sh --per-spk tmpData 2 tmpData-after
$ cat tmpData-after/spk2utt 
spk1 spk1-utt1 spk1-utt2 
spk2 spk2-utt1 
spk3 spk3-utt1 spk3-utt2 
spk4 spk4-utt1 spk4-utt3 
```
Closes  #3567