### PR TITLE
[scripts] Enable tighter control of downloaded dependencies (#3543)

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,11 +5,16 @@ CC ?= gcc        # used for sph2pipe
 # CXX = clang++  # Uncomment these lines...
 # CC = clang     # ...to build with Clang.
 
+WGET ?= wget
+
 # Note: OpenFst requires a relatively recent C++ compiler with C++11 support,
 # e.g. g++ >= 4.7, Apple clang >= 5.0 or LLVM clang >= 3.3.
 OPENFST_VERSION ?= 1.6.7
 CUB_VERSION ?= 1.8.0
 OPENBLAS_VERSION ?= 0.3.5
+SCTK_VERSION_PARTIAL ?= 2.4.10
+SCTK_VERSION ?= $(SCTK_VERSION_PARTIAL)-20151007-1312Z
+SPH2PIPE_VERSION = v2.5
 
 # Default features configured for OpenFST; can be overridden in the make command line.
 OPENFST_CONFIGURE ?= --enable-static --enable-shared --enable-far --enable-ngram-fsts
@@ -43,11 +48,11 @@ sclite_cleaned:
 
 distclean:
 	rm -rf openfst-$(OPENFST_VERSION)/
-	rm -rf sctk-2.4.10/
+	rm -rf sctk-$(SCTK_VERSION_PARTIAL)/
 	rm -rf sctk
-	rm -rf sph2pipe_v2.5/
-	rm -rf sph2pipe_v2.5.tar.gz
-	rm -rf sctk-2.4.10-20151007-1312Z.tar.bz2
+	rm -rf sph2pipe_$(SPH2PIPE_VERSION)/
+	rm -rf sph2pipe_$(SPH2PIPE_VERSION).tar.gz
+	rm -rf sctk-$(SCTK_VERSION).tar.bz2
 	rm -rf openfst-$(OPENFST_VERSION).tar.gz
 	rm -f openfst
 	rm -rf libsndfile-1.0.25{,.tar.gz} BeamformIt-3.51{,.tgz}
@@ -89,8 +94,12 @@ openfst-$(OPENFST_VERSION): openfst-$(OPENFST_VERSION).tar.gz
 	tar xozf openfst-$(OPENFST_VERSION).tar.gz
 
 openfst-$(OPENFST_VERSION).tar.gz:
-	wget -T 10 -t 1 http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
-	wget -T 10 -t 3 http://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz
+	if [ -d "$(DOWNLOAD_DIR)" ]; then \
+		cp -p "$(DOWNLOAD_DIR)/openfst-$(OPENFST_VERSION).tar.gz" .; \
+	else \
+		$(WGET) -T 10 -t 1 http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
+		$(WGET) -T 10 -t 3 https://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz; \
+	fi
 
 sclite: sclite_compiled
 
@@ -106,34 +115,44 @@ sctk/.configured: sctk
 	touch sctk/.configured
 
 .PHONY: sctk
-sctk: sctk-2.4.10-20151007-1312Z.tar.bz2
-	tar xojf sctk-2.4.10-20151007-1312Z.tar.bz2 || \
-      tar --exclude '*NONE*html' -xvojf sctk-2.4.10-20151007-1312Z.tar.bz2
-	rm -rf sctk && ln -s sctk-2.4.10 sctk
+sctk: sctk-$(SCTK_VERSION).tar.bz2
+	tar xojf sctk-$(SCTK_VERSION).tar.bz2 || \
+	tar --exclude '*NONE*html' -xvojf sctk-$(SCTK_VERSION).tar.bz2
+	rm -rf sctk && ln -s sctk-$(SCTK_VERSION_PARTIAL) sctk
 
-sctk-2.4.10-20151007-1312Z.tar.bz2:
-	wget -T 10 -t 3 ftp://jaguar.ncsl.nist.gov/pub/sctk-2.4.10-20151007-1312Z.tar.bz2|| \
-	wget --no-check-certificate -T 10 http://www.openslr.org/resources/4/sctk-2.4.10-20151007-1312Z.tar.bz2
+sctk-$(SCTK_VERSION).tar.bz2:
+	if [ -d "$(DOWNLOAD_DIR)" ]; then \
+		cp -p "$(DOWNLOAD_DIR)/sctk-$(SCTK_VERSION).tar.bz2" .; \
+	else \
+		$(WGET) -T 10 https://www.openslr.org/resources/4/sctk-$(SCTK_VERSION).tar.bz2; \
+	fi
 
 sph2pipe: sph2pipe_compiled
 
-sph2pipe_compiled: sph2pipe_v2.5/sph2pipe
+sph2pipe_compiled: sph2pipe_$(SPH2PIPE_VERSION)/sph2pipe
 
-sph2pipe_v2.5/sph2pipe: | sph2pipe_v2.5
-	cd sph2pipe_v2.5/; \
+sph2pipe_$(SPH2PIPE_VERSION)/sph2pipe: | sph2pipe_$(SPH2PIPE_VERSION)
+	cd sph2pipe_$(SPH2PIPE_VERSION)/ && \
 	$(CC) -o sph2pipe  *.c -lm
 
-sph2pipe_v2.5: sph2pipe_v2.5.tar.gz
-	tar --no-same-owner -xzf sph2pipe_v2.5.tar.gz
+sph2pipe_$(SPH2PIPE_VERSION): sph2pipe_$(SPH2PIPE_VERSION).tar.gz
+	tar --no-same-owner -xzf sph2pipe_$(SPH2PIPE_VERSION).tar.gz
 
-sph2pipe_v2.5.tar.gz:
-	wget -T 10 -t 3 http://www.openslr.org/resources/3/sph2pipe_v2.5.tar.gz || \
-	wget --no-check-certificate -T 10  https://sourceforge.net/projects/kaldi/files/sph2pipe_v2.5.tar.gz
-
+sph2pipe_$(SPH2PIPE_VERSION).tar.gz:
+	if [ -d "$(DOWNLOAD_DIR)" ]; then \
+		cp -p "$(DOWNLOAD_DIR)/sph2pipe_$(SPH2PIPE_VERSION).tar.gz" .; \
+	else \
+		$(WGET) -T 10 -t 3 https://www.openslr.org/resources/3/sph2pipe_$(SPH2PIPE_VERSION).tar.gz || \
+		$(WGET) -T 10 https://sourceforge.net/projects/kaldi/files/sph2pipe_$(SPH2PIPE_VERSION).tar.gz; \
+	fi
 
 .PHONY: cub
 cub:
-	wget -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip
+	if [ -d "$(DOWNLOAD_DIR)" ]; then \
+		cp -p "$(DOWNLOAD_DIR)/cub-$(CUB_VERSION).zip" .; \
+	else \
+		$(WGET) -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip; \
+	fi
 	unzip -oq cub-$(CUB_VERSION).zip
 	rm -f cub
 	ln -s cub-$(CUB_VERSION) cub

--- a/tools/extras/install_beamformit.sh
+++ b/tools/extras/install_beamformit.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
+LIBSNDFILE_VERSION=1.0.25
+
+GIT=${GIT:-git}
+WGET=${WGET:-wget}
+
 # Installs beamformit from the location https://github.com/xanguera/BeamformIt
 
 # libsndfile needed by beamformit
-[ ! -f libsndfile-1.0.25.tar.gz ] && \
-  wget http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.25.tar.gz
-[ ! -d libsndfile-1.0.25 ] && \
-  tar xzf libsndfile-1.0.25.tar.gz
+if [ ! -f libsndfile-$LIBSNDFILE_VERSION.tar.gz ]; then
+  if [ -d "$DOWNLOAD_DIR" ]; then
+    cp -p "$DOWNLOAD_DIR/libsndfile-$LIBSNDFILE_VERSION.tar.gz" . || exit 1
+  else
+    $WGET http://www.mega-nerd.com/libsndfile/files/libsndfile-$LIBSNDFILE_VERSION.tar.gz || exit 1
+  fi
+fi
+[ ! -d libsndfile-$LIBSNDFILE_VERSION ] && \
+  tar xzf libsndfile-$LIBSNDFILE_VERSION.tar.gz
 (
-  cd libsndfile-1.0.25
+  cd libsndfile-$LIBSNDFILE_VERSION
   ./configure --prefix=$PWD
   make
   make install
@@ -16,11 +26,11 @@
 
 # building beamformit
 [ ! -d ./BeamformIt ] &&
-  git clone https://github.com/xanguera/BeamformIt
+  $GIT clone https://github.com/xanguera/BeamformIt
 (
   cd BeamformIt
-  git pull
-  cmake -DLIBSND_INSTALL_DIR=$PWD/../libsndfile-1.0.25 .
+  $GIT pull
+  cmake -DLIBSND_INSTALL_DIR=$PWD/../libsndfile-$LIBSNDFILE_VERSION .
   make
 )
 

--- a/tools/extras/install_cffi.sh
+++ b/tools/extras/install_cffi.sh
@@ -5,7 +5,7 @@
 #you may not use this file except in compliance with the License.
 #You may obtain a copy of the License at
 #
-#http://www.apache.org/licenses/LICENSE-2.0
+#https://www.apache.org/licenses/LICENSE-2.0
 #
 #THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
@@ -16,12 +16,12 @@
 #
 # This script is attempting to install cffi a Python/C interface
 # Cffi is used to call Kaldi from Python
-# See the documentation at http://cffi.readthedocs.org/en/latest/
+# See the documentation at https://cffi.readthedocs.io/en/latest/
 # This script is trying to install cffi 0.6(now the latest version
 # Tell us if you need higher version(if it exists).
 #
 # Also dependencies are installed. Namely:
-# * pycparser >= 2.06: http://code.google.com/p/pycparser/
+# * pycparser >= 2.06: https://github.com/eliben/pycparser/releases
 # * py.test
 # 
 # NOT INSTALLED DEPENDENCIES (We are letting you to install it!):
@@ -29,10 +29,12 @@
 # * python-dev (Python headers) and libffi-dev (ffi C library)
 # * a C compiler is required to use CFFI during development, but not to run correctly-installed programs that use CFF
 
+WGET=${WGET:-wget}
+
 echo "**** Installing Cffi and dependencies"
 
 echo "Checking for Python-Dev"
-# copied from http://stackoverflow.com/questions/4848566/check-for-existence-of-python-dev-files-from-bash-script
+# copied from https://stackoverflow.com/questions/4848566/check-for-existence-of-python-dev-files-from-bash-script
 if [ ! -e $(python -c 'from distutils.sysconfig import get_makefile_filename as m; print m()') ]; then 
     echo "On Debian/Ubuntu like system install by 'sudo apt-get python-dev' package."
     echo "On Fedora by 'yum install python-devel'"
@@ -91,26 +93,32 @@ function downloader {
     file=$1; url=$2;
     if [ ! -e "$file" ]; then
         echo "Could not find $file" 
-        echo "Trying to download it via wget!"
+
+        if [ -d "$DOWNLOAD_DIR" ]; then
+          echo "Copying it from $DOWNLOAD_DIR !"
+          cp -p "$DOWNLOAD_DIR/$file" .
+        else
+          echo "Trying to download it via wget!"
         
-        wget --version  >/dev/null 2>&1 || \
-            { echo "This script requires you to first install wget"
-            echo "You can also just download $file from $url"
-            exit 1; }
+          $WGET --version  >/dev/null 2>&1 || \
+              { echo "This script requires you to first install wget"
+              echo "You can also just download $file from $url"
+              exit 1; }
 
-       wget --no-check-certificate -T 10 -t 3 $url
+          $WGET -T 10 -t 3 $url
+        fi
 
-       if [ ! -e $file ]; then
+        if [ ! -e $file ]; then
             echo "Download of $file - failed!"
             echo "Aborting script. Please download and install $file manually!"
-        exit 1;
-       fi
+            exit 1;
+        fi
     fi
 }
 
 echo Downloading and extracting cffi
 cffitar=$cffiname.tar.gz
-cffiurl=http://pypi.python.org/packages/source/c/cffi/cffi-0.6.tar.gz
+cffiurl=https://pypi.python.org/packages/source/c/cffi/cffi-0.6.tar.gz
 downloader $cffitar $cffiurl
 tar -xovzf $cffitar || exit 1
 
@@ -142,8 +150,8 @@ pushd $pytestname
 
 new_path="$prefix/bin"
 export PATH="$PATH:$new_path"
-echo "\nAdding the $new_path to PATH so I can launch the pytest"
-echo "DO THE SAME IN YOUR PERMANENT SETTINGS TO USE THE pytest REGULARLY!\n"
+echo; echo "Adding the $new_path to PATH so I can launch the pytest"
+echo "DO THE SAME IN YOUR PERMANENT SETTINGS TO USE THE pytest REGULARLY!"; echo
 
 python setup.py install --prefix="$prefix" || exit 1
 popd

--- a/tools/extras/install_faster_rnnlm.sh
+++ b/tools/extras/install_faster_rnnlm.sh
@@ -3,6 +3,8 @@
 # The script downloads and installs faster-rnnlm
 # https://github.com/yandex/faster-rnnlm
 
+GIT=${GIT:-git}
+
 set -e
 
 # Make sure we are in the tools/ directory.
@@ -16,10 +18,10 @@ fi
 echo "Installing Faster RNNLM"
 
 if [ ! -d "faster-rnnlm" ]; then
-    git clone https://github.com/yandex/faster-rnnlm.git
+    $GIT clone https://github.com/yandex/faster-rnnlm.git
 fi
 
 cd faster-rnnlm
-git pull
+$GIT pull
 ./build.sh
 ln -sf faster-rnnlm/rnnlm

--- a/tools/extras/install_ffv.sh
+++ b/tools/extras/install_ffv.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+VERSION=1.0.1
+
+WGET=${WGET:-wget}
+
 # Make sure we are in the tools/ directory.
 if [ `basename $PWD` == extras ]; then
   cd ..
@@ -13,20 +17,22 @@ cd pitch_trackers
 
 echo "Installing a package for FFV feature extraction."
 
-if [ -s ffv-1.0.1.tar.gz ]; then
-  echo "*ffv-1.0.1.tar.gz already exists, not getting it."
+if [ -s ffv-$VERSION.tar.gz ]; then
+  echo "*ffv-$VERSION.tar.gz already exists, not getting it."
+elif [ -d "$DOWNLOAD_DIR" ]; then
+  cp -p "$DOWNLOAD_DIR/ffv-$VERSION.tar.gz" . || exit 1
 else
-  ! wget -t 2 http://www.cs.cmu.edu/~kornel/software/ffv-1.0.1.tar.gz && \
-    echo "Error wgetting ffv-1.0.1.tar.gz" && exit 1;
+  ! $WGET -t 2 https://www.cs.cmu.edu/~kornel/software/ffv-$VERSION.tar.gz && \
+    echo "Error wgetting ffv-$VERSION.tar.gz" && exit 1;
 fi
 
-if [ -d ffv-1.0.1 ]; then
-  echo "*It looks like ffv-1.0.1.tar.gz has already been unpacked, not unpacking it."
+if [ -d ffv-$VERSION ]; then
+  echo "*It looks like ffv-$VERSION.tar.gz has already been unpacked, not unpacking it."
 else 
-  ! tar -zxvf ffv-1.0.1.tar.gz && \
-  echo "Error unpacking  ffv-1.0.1.tar.gz [e.g. unpack not installed?]" && exit 1;
+  ! tar -zxvf ffv-$VERSION.tar.gz && \
+  echo "Error unpacking  ffv-$VERSION.tar.gz [e.g. unpack not installed?]" && exit 1;
 fi
-cd ffv-1.0.1
+cd ffv-$VERSION
 
 if [ -f Makefile ]; then
   echo "Makefile already exists, no creating it."

--- a/tools/extras/install_irstlm.sh
+++ b/tools/extras/install_irstlm.sh
@@ -4,6 +4,9 @@
 
 # Begin configuration section.
 # End configuration section
+
+GIT=${GIT:-git}
+
 set -e -o pipefail
 
 
@@ -19,13 +22,12 @@ fi
 
 
 if [ ! -d ./irstlm ] ; then
-  svn=`which git`
-  if [ $? != 0 ]  ; then
+  if ! $GIT --version >&/dev/null ; then
     errcho "****() You need to have git installed"
     exit 1
   fi
   (
-    git clone https://github.com/irstlm-team/irstlm.git irstlm
+    $GIT clone https://github.com/irstlm-team/irstlm.git irstlm
   ) || {
     errcho "****() Error getting the IRSTLM sources. The server hosting it"
     errcho "****() might be down."

--- a/tools/extras/install_jieba.sh
+++ b/tools/extras/install_jieba.sh
@@ -2,6 +2,8 @@
 
 # The script downloads and installs jieba
 
+GIT=${GIT:-git}
+
 set -e
 
 # Make sure we are in the tools/ directory.
@@ -22,7 +24,7 @@ if [ -d ./jieba ] ; then
 fi
 
 if [ ! -d ./jieba ]; then
-  git clone https://github.com/fxsjy/jieba.git || exit 1;
+  $GIT clone https://github.com/fxsjy/jieba.git || exit 1;
 fi
 
 (

--- a/tools/extras/install_kaldi_lm.sh
+++ b/tools/extras/install_kaldi_lm.sh
@@ -2,6 +2,8 @@
 
 # The script downloads and installs kaldi_lm
 
+GIT=${GIT:-git}
+
 set -e
 
 # Make sure we are in the tools/ directory.
@@ -15,7 +17,7 @@ fi
 echo "Installing kaldi_lm"
 
 if [ ! -d "kaldi_lm" ]; then
-  git clone https://github.com/danpovey/kaldi_lm.git || exit 1
+  $GIT clone https://github.com/danpovey/kaldi_lm.git || exit 1
 fi
 
 cd kaldi_lm

--- a/tools/extras/install_liblbfgs.sh
+++ b/tools/extras/install_liblbfgs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
+
 VER=1.10
+
+WGET=${WGET:-wget}
+
 if [ ! -f liblbfgs-$VER.tar.gz ]; then
-  wget https://github.com/downloads/chokkan/liblbfgs/liblbfgs-$VER.tar.gz
+  if [ -d "$DOWNLOAD_DIR" ]; then
+    cp -p "$DOWNLOAD_DIR/liblbfgs-$VER.tar.gz" . || exit 1
+  else
+    $WGET https://github.com/downloads/chokkan/liblbfgs/liblbfgs-$VER.tar.gz || exit 1
+  fi
 fi
 
 tar -xzf liblbfgs-$VER.tar.gz

--- a/tools/extras/install_mikolov_rnnlm.sh
+++ b/tools/extras/install_mikolov_rnnlm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+WGET=${WGET:-wget}
+
 set -e
 
 if [ $# -ne 1 ]; then
@@ -19,10 +21,14 @@ fi
 
 cd $tools_dir
 echo Downloading and installing the rnnlm tools
-# http://www.fit.vutbr.cz/~imikolov/rnnlm/$rnnlm_ver.tgz
+# https://www.fit.vutbr.cz/~imikolov/rnnlm/$rnnlm_ver.tgz
 arc_file="$rnnlm_ver.tgz"
 if [ ! -f "$arc_file" ]; then
-    wget "http://www.fit.vutbr.cz/~imikolov/rnnlm/$rnnlm_ver.tgz" -O "$arc_file" || exit 1;
+    if [ -d "$DOWNLOAD_DIR" ]; then
+        cp -p "$DOWNLOAD_DIR/$arc_file" . || exit 1
+    else
+        $WGET "https://www.fit.vutbr.cz/~imikolov/rnnlm/$rnnlm_ver.tgz" -O "$arc_file" || exit 1;
+    fi
 fi
 mkdir $rnnlm_ver
 cd $rnnlm_ver

--- a/tools/extras/install_miniconda.sh
+++ b/tools/extras/install_miniconda.sh
@@ -1,10 +1,16 @@
- #!/bin/bash
+#!/bin/bash
+
+WGET=${WGET:-wget}
 
 # The script automatically choose default settings of miniconda for installation
 # Miniconda will be installed in the HOME directory. ($HOME/miniconda3).
 # Also don't make miniconda's python as default.
 
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+if [ -d "$DOWNLOAD_DIR" ]; then
+  cp -p "$DOWNLOAD_DIR/Miniconda3-latest-Linux-x86_64.sh" . || exit 1
+else
+  $WGET https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh || exit 1
+fi
 bash Miniconda3-latest-Linux-x86_64.sh -b
 
 $HOME/miniconda3/bin/python -m pip install --user tqdm

--- a/tools/extras/install_mmseg.sh
+++ b/tools/extras/install_mmseg.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-set -e
 
+VERSION=1.3.0
+
+WGET=${WGET:-wget}
+
+set -e
 
 # Make sure we are in the tools/ directory.
 if [ `basename $PWD` == extras ]; then
@@ -35,20 +39,24 @@ else
   fi
 fi
 
-if [ -d ./mmseg-1.3.0 ] ; then
+if [ -d ./mmseg-$VERSION ] ; then
   echo  >&2 "$0: Warning: old installation of mmseg found. You should manually"
   echo  >&2 "  delete the directory tools/mmseg and "
   echo  >&2 "  edit the file tools/env.sh and remove manually all references to it"
   exit 1
 fi
 
-if [ ! -d ./mmseg-1.3.0 ] ; then
-  wget https://pypi.python.org/packages/source/m/mmseg/mmseg-1.3.0.tar.gz
-  tar xf mmseg-1.3.0.tar.gz
+if [ ! -d ./mmseg-$VERSION ] ; then
+  if [ -d "$DOWNLOAD_DIR" ] ; then
+    cp -p "$DOWNLOAD_DIR/mmseg-$VERSION.tar.gz" .
+  else
+    $WGET https://pypi.python.org/packages/source/m/mmseg/mmseg-$VERSION.tar.gz
+  fi
+  tar xf mmseg-$VERSION.tar.gz
 fi
 
 (
-cd mmseg-1.3.0
+cd mmseg-$VERSION
 pyver=`python --version 2>&1 | sed -e 's:.*\([2-3]\.[0-9]\+\).*:\1:g'`
 export PYTHONPATH=$PYTHONPATH:$PWD/lib/python${pyver}/site-packages/:$PWD/lib64/python${pyver}/site-packages/
 # we have to create those dir, as the install target does not create it
@@ -62,23 +70,23 @@ python setup.py install --prefix `pwd`
 ## so that should be pretty reliable) and then we work out the location of
 ## the site-packages directory (typically it would be one level up from
 ## the location of the mmseg.py file but using find seems more reliable
-mmseg_file_lib=$(find ./mmseg-1.3.0/lib/ -type f -name mmseg.py | head -n1)
-mmseg_file_lib64=$(find ./mmseg-1.3.0/lib64/ -type f -name mmseg.py | head -n1)
+mmseg_file_lib=$(find ./mmseg-$VERSION/lib/ -type f -name mmseg.py | head -n1)
+mmseg_file_lib64=$(find ./mmseg-$VERSION/lib64/ -type f -name mmseg.py | head -n1)
 if [ ! -z ${mmseg_file_lib+x} ]; then
   lib_dir=./lib/
 elif [ ! -z ${mmseg_file_lib64+x} ]; then
   lib_dir=./lib64/
 else
-  echo >&2 "$0: ERROR: Didn't find ./mmseg-1.3.0/lib/ or ./mmseg-1.3.0/lib64/"
+  echo >&2 "$0: ERROR: Didn't find ./mmseg-$VERSION/lib/ or ./mmseg-$VERSION/lib64/"
   echo >&2 "  Perhaps your python or system installs python modules into"
   echo >&2 "  a different dir or some other unknown issues arised. Review the output"
   echo >&2 "  of the script and try to figure out what went wrong."
   exit 1
 fi
 
-site_packages_dir=$(cd ./mmseg-1.3.0; find $lib_dir -name "site-packages" -type d | head -n1)
+site_packages_dir=$(cd ./mmseg-$VERSION; find $lib_dir -name "site-packages" -type d | head -n1)
 (
-  echo "export MMSEG=\"$PWD/mmseg-1.3.0\""
+  echo "export MMSEG=\"$PWD/mmseg-$VERSION\""
   echo "export PYTHONPATH=\"\${PYTHONPATH:-}:\$MMSEG/${site_packages_dir}\""
 ) >> env.sh
 

--- a/tools/extras/install_morfessor.sh
+++ b/tools/extras/install_morfessor.sh
@@ -4,11 +4,13 @@
 # Apache 2.0
 #
 
+GIT=${GIT:-git}
+
 echo "#### installing morfessor"
 dirname=morfessor
 if [ ! -d ./$dirname ]; then
   mkdir -p ./$dirname
-  git clone https://github.com/aalto-speech/morfessor.git morfessor ||
+  $GIT clone https://github.com/aalto-speech/morfessor.git morfessor ||
     {
       echo  >&2 "$0: Error git clone operation "
       echo  >&2 "  Failed in cloning the github repository (https://github.com/aalto-speech/morfessor.git)"

--- a/tools/extras/install_mpg123.sh
+++ b/tools/extras/install_mpg123.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
@@ -17,35 +17,43 @@
 # This script attempts to install mpg123, which can be used for decoding 
 # mp2 and mp3 file formats.
 
+VERSION=1.21.0
+
+WGET=${WGET:-wget}
+
 errcho() { echo "$@" 1>&2; }
 
 errcho "****() Installing MPG123"
 
-if [ ! -e mpg123-1.21.0.tar.bz2 ]; then
-    errcho "Could not find the tarball mpg123-1.21.0.tar.bz2"  
-    
-    if ! which wget >&/dev/null; then
-        errcho "This script requires you to first install wget"
-        errcho "You can also just download mpg123-1.21.0.tar.bz2 from"
-        errcho "http://www.mpg123.org/download.shtml)"
-        errcho "and run this installation script again"
-        exit 1;
+if [ ! -e mpg123-$VERSION.tar.bz2 ]; then
+    errcho "Could not find the tarball mpg123-$VERSION.tar.bz2"
+
+    if [ -d "$DOWNLOAD_DIR" ]; then
+        cp -p "$DOWNLOAD_DIR/mpg123-$VERSION.tar.bz2" .
+    else
+        if ! $WGET --version >&/dev/null; then
+            errcho "This script requires you to first install wget"
+            errcho "You can also just download mpg123-$VERSION.tar.bz2 from"
+            errcho "https://www.mpg123.org/download.shtml"
+            errcho "and run this installation script again"
+            exit 1
+        fi
+
+        $WGET -T 10 -t 3 -c "https://downloads.sourceforge.net/project/mpg123/mpg123/$VERSION/mpg123-$VERSION.tar.bz2"
     fi
 
-   wget -T 10 -t 3 -c 'http://downloads.sourceforge.net/project/mpg123/mpg123/1.21.0/mpg123-1.21.0.tar.bz2'
-
-   if [ ! -e mpg123-1.21.0.tar.bz2 ]; then
-        errcho "Download of mpg123-1.21.0.tar.bz2 failed!"
-        errcho "You can also just download mpg123-1.21.0.tar.bz2 from"
-        errcho "http://www.mpg123.org/download.shtml)"
+    if [ ! -e mpg123-$VERSION.tar.bz2 ]; then
+        errcho "Download of mpg123-$VERSION.tar.bz2 failed!"
+        errcho "You can also just download mpg123-$VERSION.tar.bz2 from"
+        errcho "https://www.mpg123.org/download.shtml"
         errcho "and run this installation script again"
-    exit 1;
-   fi
+        exit 1
+    fi
 fi
 
-tar xjf mpg123-1.21.0.tar.bz2|| exit 1
+tar xjf mpg123-$VERSION.tar.bz2 || exit 1
 rm -fr mpg123
-ln -s mpg123-1.21.0  mpg123
+ln -s mpg123-$VERSION  mpg123
 
 (
   cd mpg123

--- a/tools/extras/install_nkf.sh
+++ b/tools/extras/install_nkf.sh
@@ -8,6 +8,10 @@
 # code to designated kanji code such as ISO-2022-JP, UTF-8, and so on.
 # In kaldi, it will be used in egs/csj. (Corpus of Spontaneous Japanese data)
 
+VERSION=2.1.4
+
+WGET=${WGET:-wget}
+
 set -u
 set -e
 
@@ -21,20 +25,24 @@ fi
 
 echo Downloading and installing the nkf tools
 #Download
-if [ ! -f nkf-2.1.4.tar.gz ]; then
-  wget https://osdn.net/dl/nkf/nkf-2.1.4.tar.gz
-  tar -vxzf nkf-2.1.4.tar.gz
+if [ ! -f nkf-$VERSION.tar.gz ]; then
+  if [ -d "${DOWNLOAD_DIR:-}" ]; then
+    cp -p "$DOWNLOAD_DIR/nkf-$VERSION.tar.gz" .
+  else
+    $WGET https://osdn.net/dl/nkf/nkf-$VERSION.tar.gz
+  fi
+  tar -vxzf nkf-$VERSION.tar.gz
 fi
 
 #install
-cd nkf-2.1.4
+cd nkf-$VERSION
 make
 cd ..
 
 #add to env.sh
 if [ -f env.sh ]; then
   wd=`pwd`
-  echo "export NKF=$wd/nkf-2.1.4" >> env.sh
+  echo "export NKF=$wd/nkf-$VERSION" >> env.sh
   echo "export PATH=\${PATH}:\${NKF}" >> env.sh
 fi
 echo Done making the nkf tools

--- a/tools/extras/install_openblas.sh
+++ b/tools/extras/install_openblas.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-
 OPENBLAS_VERSION=0.3.5
+
+WGET=${WGET:-wget}
 
 set -e
 
@@ -16,10 +17,19 @@ if ! command -v gfortran 2>/dev/null; then
 fi
 
 
-rm -rf xianyi-OpenBLAS-* OpenBLAS
+tarball=OpenBLAS-$OPENBLAS_VERSION.tar.gz
 
-wget -t3 -nv -O- $(wget -qO- "https://api.github.com/repos/xianyi/OpenBLAS/releases/tags/v${OPENBLAS_VERSION}" | python -c 'import sys,json;print(json.load(sys.stdin)["tarball_url"])') | tar xzf -
+rm -rf xianyi-OpenBLAS-* OpenBLAS OpenBLAS-*.tar.gz
 
+if [ -d "$DOWNLOAD_DIR" ]; then
+  cp -p "$DOWNLOAD_DIR/$tarball" .
+else
+  url=$($WGET -qO- "https://api.github.com/repos/xianyi/OpenBLAS/releases/tags/v${OPENBLAS_VERSION}" | python -c 'import sys,json;print(json.load(sys.stdin)["tarball_url"])')
+  test -n "$url"
+  $WGET -t3 -nv -O $tarball "$url"
+fi
+
+tar xzf $tarball
 mv xianyi-OpenBLAS-* OpenBLAS
 
 make PREFIX=$(pwd)/OpenBLAS/install USE_THREAD=0 -C OpenBLAS all install

--- a/tools/extras/install_pfile_utils.sh
+++ b/tools/extras/install_pfile_utils.sh
@@ -3,14 +3,22 @@
 # BABEL setup that was done by Yajie Miao.  We don't expect these tools will
 # be used very heavily.
 
+VERSION=v3_33
+
+WGET=${WGET:-wget}
+
 ! which pkg-config >/dev/null  && \
    echo "pkg-config is not installed, this will not work.  Ask your sysadmin to install it" && exit 1;
 
-if [ ! -s quicknet-v3_33.tar.gz ]; then
-  wget ftp://ftp.icsi.berkeley.edu/pub/real/davidj/quicknet-v3_33.tar.gz || exit 1
+if [ ! -s quicknet-$VERSION.tar.gz ]; then
+  if [ -d "$DOWNLOAD_DIR" ]; then
+    cp -p "$DOWNLOAD_DIR/quicknet-$VERSION.tar.gz" . || exit 1
+  else
+    $WGET ftp://ftp.icsi.berkeley.edu/pub/real/davidj/quicknet-$VERSION.tar.gz || exit 1
+  fi
 fi
-tar -xvzf quicknet-v3_33.tar.gz
-cd quicknet-v3_33/
+tar -xvzf quicknet-$VERSION.tar.gz
+cd quicknet-$VERSION/
 ./configure --prefix=`pwd`  || exit 1
 make install  || exit 1
 cd ..

--- a/tools/extras/install_phonetisaurus.sh
+++ b/tools/extras/install_phonetisaurus.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+GIT=${GIT:-git}
+
 set -u
 set -e
 
@@ -40,12 +43,12 @@ fi
 
 
 if [ ! -d ./phonetisaurus-g2p ] ; then
-  git clone https://github.com/AdolfVonKleist/Phonetisaurus.git phonetisaurus-g2p ||
+  $GIT clone https://github.com/AdolfVonKleist/Phonetisaurus.git phonetisaurus-g2p ||
   {
     echo  >&2 "$0: Warning: git clone operation ended unsuccessfully"
     echo  >&2 "  I will assume this is because you don't have https support"
     echo  >&2 "  compiled into your git "
-    git clone http://github.com/AdolfVonKleist/Phonetisaurus.git phonetisaurus-g2p
+    $GIT clone https://github.com/AdolfVonKleist/Phonetisaurus.git phonetisaurus-g2p
 
     if [ $? -ne 0 ]; then
       echo  >&2 "$0: Error git clone operation ended unsuccessfully"
@@ -59,7 +62,7 @@ fi
     export TOOLS=${PWD}
     cd phonetisaurus-g2p
     #checkout the current kaldi tag
-    git checkout -b kaldi kaldi
+    $GIT checkout -b kaldi kaldi
     ./configure --with-openfst-includes=${TOOLS}/openfst/include --with-openfst-libs=${TOOLS}/openfst/lib
     make
 )

--- a/tools/extras/install_pocolm.sh
+++ b/tools/extras/install_pocolm.sh
@@ -4,6 +4,8 @@
 #           2016  Johns Hopkins University (author: Daniel Povey)
 # Apache 2.0
 
+GIT=${GIT:-git}
+
 set -u
 set -e
 
@@ -23,7 +25,7 @@ if [ -d pocolm ]; then
 fi
 
 echo Downloading and installing the pocolm tools
-git clone https://github.com/danpovey/pocolm.git || exit 1;
+$GIT clone https://github.com/danpovey/pocolm.git || exit 1;
 cd pocolm/src
 make || exit 1;
 echo Done making the pocolm tools

--- a/tools/extras/install_portaudio.sh
+++ b/tools/extras/install_portaudio.sh
@@ -5,7 +5,7 @@
 #you may not use this file except in compliance with the License.
 #You may obtain a copy of the License at
 #
-#http://www.apache.org/licenses/LICENSE-2.0
+#https://www.apache.org/licenses/LICENSE-2.0
 #
 #THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
@@ -33,29 +33,36 @@
 #(always assuming that you installed XCode, wget and
 #the Linux environment stuff on MacOS)
 
+VERSION=v19_20111121
+
+WGET=${WGET:-wget}
+
 echo "****() Installing portaudio"
 
-if [ ! -e pa_stable_v19_20111121.tgz ]; then
-    echo "Could not find portaudio tarball pa_stable_v19_20111121.tgz"
+if [ ! -e pa_stable_$VERSION.tgz ]; then
+    echo "Could not find portaudio tarball pa_stable_$VERSION.tgz"
     echo "Trying to download it via wget!"
 
-    if ! which wget >&/dev/null; then
-        echo "This script requires you to first install wget"
-        echo "You can also just download pa_stable_v19_20111121.tgz from"
-        echo "http://www.portaudio.com/download.html)"
-        exit 1;
+    if [ -d "$DOWNLOAD_DIR" ]; then
+        cp -p "$DOWNLOAD_DIR/pa_stable_$VERSION.tgz" .
+    else
+        if ! $WGET --version >&/dev/null; then
+            echo "This script requires you to first install wget"
+            echo "You can also just download pa_stable_$VERSION.tgz from"
+            echo "http://www.portaudio.com/download.html)"
+            exit 1;
+        fi
+        $WGET -T 10 -t 3 http://www.portaudio.com/archives/pa_stable_$VERSION.tgz
     fi
 
-   wget -T 10 -t 3 http://www.portaudio.com/archives/pa_stable_v19_20111121.tgz
-
-   if [ ! -e pa_stable_v19_20111121.tgz ]; then
-        echo "Download of pa_stable_v19_20111121.tgz - failed!"
+    if [ ! -e pa_stable_$VERSION.tgz ]; then
+        echo "Download of pa_stable_$VERSION.tgz - failed!"
         echo "Aborting script. Please download and install port audio manually!"
-    exit 1;
-   fi
+        exit 1;
+    fi
 fi
 
-tar -xovzf pa_stable_v19_20111121.tgz || exit 1
+tar -xovzf pa_stable_$VERSION.tgz || exit 1
 
 read -d '' pa_patch << "EOF"
 --- portaudio/Makefile.in	2012-08-05 10:42:05.000000000 +0300

--- a/tools/extras/install_sacc.sh
+++ b/tools/extras/install_sacc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+WGET=${WGET:-wget}
+
 # Make sure we are in the tools/ directory.
 if [ `basename $PWD` == extras ]; then
   cd ..
@@ -13,8 +15,10 @@ mkdir -p pitch_trackers/sacc
 cd pitch_trackers/sacc
 if [ -s SAcC_GLNXA64.zip ]; then
   echo "*SAcC_GLNXA64.zip already exists, not getting it."
+elif [ -d "$DOWNLOAD_DIR" ]; then
+  cp -p "$DOWNLOAD_DIR/SAcC_GLNXA64.zip" . || exit 1
 else
-  ! wget -t 2 http://labrosa.ee.columbia.edu/projects/SAcC/SAcC_GLNXA64.zip && \
+  ! $WGET -t 2 https://labrosa.ee.columbia.edu/projects/SAcC/SAcC_GLNXA64.zip && \
     echo "Error wgetting SAcC_GLNXA64.zip" && exit 1;
 fi
 
@@ -27,8 +31,10 @@ fi
 
 if [ -f MCRInstaller_glnxa64.bin ]; then
   echo "*It looks like you already downloaded MCRInstaller_glnxa64.bin, not getting it."
+elif [ -d "$DOWNLOAD_DIR" ]; then
+  cp -p "$DOWNLOAD_DIR/MCRInstaller_glnxa64.bin" . || exit 1
 else
-  ! wget -t 2 http://www.ee.columbia.edu/~dpwe/tmp/MCRInstaller_glnxa64.bin && \
+  ! $WGET -t 2 https://www.ee.columbia.edu/~dpwe/tmp/MCRInstaller_glnxa64.bin && \
    echo "Error getting MCRInstaller_glnxa64.bin" && exit 1;
 fi
 

--- a/tools/extras/install_sequitur.sh
+++ b/tools/extras/install_sequitur.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+GIT=${GIT:-git}
+
 set -u
 set -e
 
@@ -49,12 +52,12 @@ if [ -d ./g2p ] || [ -d sequitur ] ; then
 fi
 
 if [ ! -d ./sequitur-g2p ] ; then
-  git clone https://github.com/sequitur-g2p/sequitur-g2p.git sequitur-g2p ||
+  $GIT clone https://github.com/sequitur-g2p/sequitur-g2p.git sequitur-g2p ||
   {
     echo  >&2 "$0: Warning: git clone operation ended unsuccessfully"
     echo  >&2 "  I will assume this is because you don't have https support"
     echo  >&2 "  compiled into your git "
-    git clone git@github.com:sequitur-g2p/sequitur-g2p.git sequitur-g2p
+    $GIT clone git@github.com:sequitur-g2p/sequitur-g2p.git sequitur-g2p
 
     if [ $? -ne 0 ]; then
       echo  >&2 "$0: Error git clone operation ended unsuccessfully"
@@ -66,10 +69,10 @@ else
   echo >&2 "$0: Updating the repository -- we will try to merge with local changes (if you have any)"
   (
     cd sequitur-g2p/
-    git pull
+    $GIT pull
     # this would work also, but would drop all local modifications
-    #git fetch
-    #git reset --hard origin/master
+    #$GIT fetch
+    #$GIT reset --hard origin/master
   ) || {
     echo >&2 "Failed to do git pull, delete the sequitur dir and run again";
     exit 1

--- a/tools/extras/install_speex.sh
+++ b/tools/extras/install_speex.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
@@ -23,34 +23,42 @@
 # I just let it be like this at this moment, and may add a patch to resolve this
 # later.
 
+VERSION=1.2rc1
+
+WGET=${WGET:-wget}
+
 echo "****() Installing Speex"
 
-if [ ! -e speex-1.2rc1.tar.gz ]; then
-    echo "Could not find Speex tarball speex-1.2rc1.tar.gz"
+if [ ! -e speex-$VERSION.tar.gz ]; then
+    echo "Could not find Speex tarball speex-$VERSION.tar.gz"
     echo "Trying to download it via wget!"
     
     if ! which wget >&/dev/null; then
         echo "This script requires you to first install wget"
-        echo "You can also just download speex-1.2rc1.tar.gz from"
-        echo "http://www.speex.org/downloads/)"
+        echo "You can also just download speex-$VERSION.tar.gz from"
+        echo "https://www.speex.org/downloads/)"
         exit 1;
     fi
 
-   wget -T 10 -t 3 -c http://downloads.xiph.org/releases/speex/speex-1.2rc1.tar.gz
+    if [ -d "$DOWNLOAD_DIR" ]; then
+        cp -p "$DOWNLOAD_DIR/speex-$VERSION.tar.gz" .
+    else
+        $WGET -T 10 -t 3 -c https://downloads.xiph.org/releases/speex/speex-$VERSION.tar.gz
+    fi
 
-   if [ ! -e speex-1.2rc1.tar.gz ]; then
-        echo "Download of speex_v1.2rc1.tar.gz - failed!"
+    if [ ! -e speex-$VERSION.tar.gz ]; then
+        echo "Download of speex-$VERSION.tar.gz - failed!"
         echo "Aborting script. Please download and install Speex manually!"
-    exit 1;
-   fi
+        exit 1;
+    fi
 fi
 
-tar -xovzf speex-1.2rc1.tar.gz|| exit 1
+tar -xovzf speex-$VERSION.tar.gz || exit 1
 rm -fr speex
 
-cd speex-1.2rc1
+cd speex-$VERSION
 ./configure --prefix `pwd`/build
 make; make install
 
 cd ..
-ln -s speex-1.2rc1/build speex 
+ln -s speex-$VERSION/build speex

--- a/tools/extras/install_tensorflow_cc.sh
+++ b/tools/extras/install_tensorflow_cc.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+BAZEL_VERSION=0.15.0
+
+GIT=${GIT:-git}
+WGET=${WGET:-wget}
+
 set -e
 
 #export JAVA_HOME=/LOCATION_ON_YOUR_MACHINE/java/jdk1.8.0_121
@@ -17,7 +22,7 @@ good_version=`echo 1.8 $java_version | awk '{if($1<$2)print 1; else print 0}'`
 if [ $good_version -eq 0 ]; then
   echo You have jdk version = $java_version, which is older than 1.8
   echo You need to download a later than 1.8 JDK version at
-  echo http://www.oracle.com/technetwork/pt/java/javase/downloads/jdk8-downloads-2133151.html
+  echo https://www.oracle.com/technetwork/pt/java/javase/downloads/jdk8-downloads-2133151.html
   echo and set your JAVA_HOME to point to where it is installed
   exit 1
 else
@@ -25,21 +30,35 @@ else
 fi
 
 
-[ ! -f bazel.zip ] && wget https://github.com/bazelbuild/bazel/releases/download/0.15.0/bazel-0.15.0-dist.zip -O bazel.zip
+if [ ! -f bazel-$BAZEL_VERSION-dist.zip ]; then
+  if [ -d "$DOWNLOAD_DIR" ]; then
+    cp -p "$DOWNLOAD_DIR/bazel-$BAZEL_VERSION-dist.zip" .
+  else
+    $WGET https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip
+  fi
+fi
 mkdir -p bazel
 cd bazel
-unzip ../bazel.zip
+unzip ../bazel-$BAZEL_VERSION-dist.zip
 ./compile.sh
 cd ../
 
 # now bazel is built
-[ ! -d tensorflow ] && git clone https://github.com/tensorflow/tensorflow
+[ ! -d tensorflow ] && $GIT clone https://github.com/tensorflow/tensorflow
 cd tensorflow
-git fetch --tags
-git checkout r1.12
+$GIT fetch --tags
+$GIT checkout r1.12
 ./configure
 
-tensorflow/contrib/makefile/download_dependencies.sh
+if $GIT --version >&/dev/null && $WGET --version >&/dev/null
+then
+  tensorflow/contrib/makefile/download_dependencies.sh
+else
+  echo "Please run tensorflow/tensorflow/contrib/makefile/download_dependencies.sh"
+  echo "to download needed dependencies."
+  exit 1
+fi
+
 bazel build -c opt //tensorflow:libtensorflow.so
 bazel build -c opt //tensorflow:libtensorflow_cc.so
 

--- a/tools/extras/install_wpe.sh
+++ b/tools/extras/install_wpe.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+GIT=${GIT:-git}
+
 # Installs nara-wpe with dependencies
 # miniconda should be installed in $HOME/miniconda3/ 
 
@@ -10,6 +12,6 @@ if [ ! -d $miniconda_dir ]; then
 fi
 
 $HOME/miniconda3/bin/python -m pip install soundfile
-git clone https://github.com/fgnt/nara_wpe.git
+$GIT clone https://github.com/fgnt/nara_wpe.git
 cd nara_wpe
 $HOME/miniconda3/bin/python -m pip install --editable .

--- a/tools/extras/travis_install_bindeps.sh
+++ b/tools/extras/travis_install_bindeps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+WGET=${WGET:-wget}
+
 set -e
 
 xroot=${1:-~/xroot}
@@ -9,20 +11,20 @@ cd $xroot
 
 add_deb () {
   echo "Adding deb package $1 to $xroot"
-  wget -nv $1
+  $WGET -nv $1
   dpkg-deb -x ${1##*/} $xroot
 }
 
 # OpenBLAS and Netlib LAPACK binaries from Trusty.
-add_deb http://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke-dev_3.5.0-2ubuntu1_amd64.deb
-add_deb http://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke_3.5.0-2ubuntu1_amd64.deb
-add_deb http://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-dev_0.2.8-6ubuntu1_amd64.deb
-add_deb http://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-base_0.2.8-6ubuntu1_amd64.deb
-add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas-dev_1.2.20110419-7_amd64.deb
-add_deb http://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas3_1.2.20110419-7_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke-dev_3.5.0-2ubuntu1_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/main/l/lapack/liblapacke_3.5.0-2ubuntu1_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-dev_0.2.8-6ubuntu1_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/universe/o/openblas/libopenblas-base_0.2.8-6ubuntu1_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas-dev_1.2.20110419-7_amd64.deb
+add_deb https://mirrors.kernel.org/ubuntu/pool/main/b/blas/libblas3_1.2.20110419-7_amd64.deb
 
 if [[ "$(ccache --version 2>/dev/null | sed -n '1{s/^[a-z ]*//;s/\./0/g;p}')" -lt 30304 ]]; then
-    add_deb http://mirrors.kernel.org/debian/pool/main/c/ccache/ccache_3.3.4-1_amd64.deb
+    add_deb https://mirrors.kernel.org/debian/pool/main/c/ccache/ccache_3.3.4-1_amd64.deb
 fi
 
 # Show extracted package files.


### PR DESCRIPTION
Pull request submitted as discussed in #3543.

Summary of changes:
* Defined environment variables `GIT` and `WGET` which can be set to appropriate invocations of `git(1)` and `wget(1)` respectively that will be used by the various download scripts. Alternately, they can be set to a value like `false` to disable use of the respective command. If the variables are undefined, the scripts set the expected default value of `git` and `wget`.
* Defined environment variable `DOWNLOAD_DIR` which can be set to a directory containing the various tarballs and package files downloaded by the Kaldi scripts. If the variable is set, then the scripts will copy the necessary files from this directory instead of downloading them.
* Upgraded `http://` URLs to `https://` where supported. In a few cases, minor tweaks have been made to reflect current upstream usage (e.g. `readthedocs.org` -> `readthedocs.io`).
* Removed `--no-check-certificate` option from `wget` invocations, to avoid defeating HTTPS security. (I did not find any cases where this option was needed in order to allow a successful download.)
* Moved package version strings into variables to simplify changing their value.
* Fixed minor script irregularities as encountered.

I have tested most of these changes (a handful cannot be run in my testing environment). The general intent is that, if the aforementioned environment variables remain unset, then the scripts will continue to work as they have previously.