### PR TITLE
Enabling CUDA CMVN

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -215,7 +215,6 @@ private:
    Matrix<BaseFloat> input_features_cpu;
    CuVector<BaseFloat> ivector_features;
    CuMatrix<BaseFloat> input_features;
-   CuMatrix<BaseFloat> spectral_features;
    CuMatrix<BaseFloat> posteriors;
 
    TaskData(const WaveData &wave_data_in)

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -215,6 +215,7 @@ private:
    Matrix<BaseFloat> input_features_cpu;
    CuVector<BaseFloat> ivector_features;
    CuMatrix<BaseFloat> input_features;
+   CuMatrix<BaseFloat> spectral_features;
    CuMatrix<BaseFloat> posteriors;
 
    TaskData(const WaveData &wave_data_in)

--- a/src/cudafeat/feature-online-cmvn-cuda.cu
+++ b/src/cudafeat/feature-online-cmvn-cuda.cu
@@ -87,7 +87,7 @@ __global__ void apply_cmvn_kernel(
 
   for (int c = threadIdx.x; c < num_cols; c += blockDim.x) {
     float2 frame_stats =
-        reinterpret_cast<const float2 __restrict__ *>(&stats[r * lds])[c];
+        reinterpret_cast<const float2* __restrict__>(&stats[r * lds])[c];
 
     float val = feat_in[r * ldi + c];
 
@@ -100,7 +100,7 @@ __global__ void apply_cmvn_kernel(
 
       // stats at the start row of the window that must be removed
       float2 ostats =
-          reinterpret_cast<const float2 __restrict__ *>(&stats[o * lds])[c];
+          reinterpret_cast<const float2* __restrict__>(&stats[o * lds])[c];
 
       // remove start of the window stats
       frame_stats = frame_stats - ostats;

--- a/src/cudafeat/online-cuda-feature-pipeline.cc
+++ b/src/cudafeat/online-cuda-feature-pipeline.cc
@@ -24,6 +24,9 @@ namespace kaldi {
 OnlineCudaFeaturePipeline::OnlineCudaFeaturePipeline(
     const OnlineNnet2FeaturePipelineConfig &config)
     : info_(config), spectral_feat(NULL), ivector(NULL) {
+  spectral_feat = NULL;
+  cmvn = NULL;
+  ivector = NULL;
   if (info_.feature_type == "mfcc") {
     spectral_feat = new CudaSpectralFeatures(info_.mfcc_opts);
   }
@@ -37,7 +40,7 @@ OnlineCudaFeaturePipeline::OnlineCudaFeaturePipeline(
     OnlineCmvnState cmvn_state(global_cmvn_stats);
     CudaOnlineCmvnState cu_cmvn_state(cmvn_state);
     cmvn = new CudaOnlineCmvn(info_.cmvn_opts, cu_cmvn_state);
-  }
+  } 
 
   if (info_.use_ivectors) {
     OnlineIvectorExtractionConfig ivector_extraction_opts;
@@ -50,7 +53,7 @@ OnlineCudaFeaturePipeline::OnlineCudaFeaturePipeline(
     ivector_extraction_opts.greedy_ivector_extractor = true;
 
     ivector = new IvectorExtractorFastCuda(ivector_extraction_opts);
-  }
+  } 
 }
 
 OnlineCudaFeaturePipeline::~OnlineCudaFeaturePipeline() {
@@ -73,7 +76,6 @@ void OnlineCudaFeaturePipeline::ComputeFeatures(
   }
 
   if (info_.use_cmvn) {
-    // Can we do this in place?
     cmvn->ComputeFeatures(*input_features, input_features);
   }
 

--- a/src/cudafeat/online-cuda-feature-pipeline.h
+++ b/src/cudafeat/online-cuda-feature-pipeline.h
@@ -48,7 +48,9 @@ class OnlineCudaFeaturePipeline {
  private:
   OnlineNnet2FeaturePipelineInfo info_;
   CudaSpectralFeatures *spectral_feat;
+  CudaOnlineCmvn *cmvn;
   IvectorExtractorFastCuda *ivector;
+  Matrix<double> global_cmvn_stats;
 };
 }  // namespace kaldi
 


### PR DESCRIPTION
This adds the plumbing so that --cmvn-config can be used with GPU feature extraction.

It also fixes one complaint that we saw from a Windows compiler.