### PR TITLE
[egs] propagated bad whitespace fix to validate_dict_dir.pl

### DIFF
--- a/egs/wsj/s5/utils/validate_dict_dir.pl
+++ b/egs/wsj/s5/utils/validate_dict_dir.pl
@@ -60,14 +60,17 @@ sub validate_utf8_whitespaces {
       print STDERR "$0: The current line (nr. $i) has invalid newline\n";
       return 1;
     }
+    my @A = split(" ", $current_line);
+    my $utt_id = $A[0];
     # we replace TAB, LF, CR, and SPACE
     # this is to simplify the test
     if ($current_line =~ /\x{000d}/) {
-      print STDERR "$0: The current line (nr. $i) contains CR (0x0D) character\n";
+      print STDERR "$0: The line for utterance $utt_id contains CR (0x0D) character\n";
       return 1;
     }
     $current_line =~ s/[\x{0009}\x{000a}\x{0020}]/./g;
     if ($current_line =~/\s/) {
+      print STDERR "$0: The line for utterance $utt_id contains disallowed Unicode whitespaces\n";
       return 1;
     }
   }


### PR DESCRIPTION
I faced the same issue as posted in this [thread](https://groups.google.com/forum/#!topic/kaldi-help/dRzaIdgGFYs) for which a [fix](https://github.com/kaldi-asr/kaldi/pull/2541) #2541 was made that enabled logging the line no. that had bad whitespaces. This PR propagates that fix for `utils/validate_dict_dir.pl` script in `wsj/s5` recipe.