### PR TITLE
Fixed online2-tcp-nnet3-decode-faster.cc poll_ret checks

### DIFF
--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -431,7 +431,7 @@ bool TcpServer::ReadChunk(size_t len) {
       KALDI_WARN << "Socket timeout! Disconnecting...";
       break;
     }
-    if (client_set_[0].revents != POLLIN) {
+    if (poll_ret < 0) {
       KALDI_WARN << "Socket error! Disconnecting...";
       break;
     }


### PR DESCRIPTION
Negative return value for `poll_ret` was not checked and `Socket error` is raised every time we pass an audio file to the TcpServer. 