### PR TITLE
[tools] Corrected the path of env.sh in the message

### DIFF
--- a/tools/extras/install_irstlm.sh
+++ b/tools/extras/install_irstlm.sh
@@ -73,4 +73,4 @@ fi
 ) >> env.sh
 
 errcho "***() Installation of IRSTLM finished successfully"
-errcho "***() Please source the tools/extras/env.sh in your path.sh to enable it"
+errcho "***() Please source the tools/env.sh in your path.sh to enable it"


### PR DESCRIPTION
The message "***() Please source the tools/extras/env.sh in your path.sh to enable it" was corrected to  "***() Please source the tools/env.sh in your path.sh to enable it" because the script is executed when pwd=tools/ and the env.sh is created in the tools/ directory.