### PR TITLE
[egs] Bug-fix swbd run_ivector

### DIFF
--- a/egs/swbd/s5c/local/nnet3/run_ivector_common.sh
+++ b/egs/swbd/s5c/local/nnet3/run_ivector_common.sh
@@ -37,8 +37,8 @@ if $speed_perturb; then
     steps/align_fmllr.sh --nj 100 --cmd "$train_cmd" \
       data/${train_set}_sp data/lang exp/tri4 exp/tri4_ali_nodup_sp
   fi
-  train_set=${train_set}_sp
 fi
+train_set=${train_set}_sp
 
 if [ $stage -le 3 ]; then
   mfccdir=mfcc_hires


### PR DESCRIPTION
Moving the variable assignment outside to keep shell working when executing from stage 3.