### PR TITLE
Change the GPU policy to wait instead of yes

### DIFF
--- a/egs/wsj/s5/steps/nnet3/align.sh
+++ b/egs/wsj/s5/steps/nnet3/align.sh
@@ -59,7 +59,7 @@ sdata=$data/split${nj}
 
 if $use_gpu; then
   queue_opt="--gpu 1"
-  gpu_opt="--use-gpu=yes"
+  gpu_opt="--use-gpu=wait"
 else
   queue_opt=""
   gpu_opt="--use-gpu=no"


### PR DESCRIPTION
This is needed to avoid failures when using more number jobs than number of GPUs. Previously when --use-gpu=yes, when all GPUs are occupied, the job will error out in 20s. Changing to the policy to wait will have correct queuing behavior. @xiaohui-zhang 