### PR TITLE
[src] Fix bug in resampling checks for online features

### DIFF
--- a/src/feat/online-feature.cc
+++ b/src/feat/online-feature.cc
@@ -88,10 +88,10 @@ void OnlineGenericBaseFeature<C>::MaybeCreateResampler(
   if (resampler_ != nullptr) {
     KALDI_ASSERT(resampler_->GetInputSamplingRate() == sampling_rate);
     KALDI_ASSERT(resampler_->GetOutputSamplingRate() == expected_sampling_rate);
-  } else if (((sampling_rate > expected_sampling_rate) &&
-              !computer_.GetFrameOptions().allow_downsample) ||
+  } else if (((sampling_rate < expected_sampling_rate) &&
+              computer_.GetFrameOptions().allow_downsample) ||
              ((sampling_rate > expected_sampling_rate) &&
-              !computer_.GetFrameOptions().allow_upsample)) {
+              computer_.GetFrameOptions().allow_upsample)) {
     resampler_.reset(new LinearResample(
         sampling_rate, expected_sampling_rate,
         std::min(sampling_rate / 2, expected_sampling_rate / 2), 6));


### PR DESCRIPTION
The `--allow-upsample` and `--allow-downsample` options were not handled correctly in the code that handles resampling in online feature computation.

Compare with the check for offline feature computation:
https://github.com/kaldi-asr/kaldi/blob/743eb23d897e8b1e78b306e920b906ddfe792c8f/src/feat/feature-common-inl.h#L40