### PR TITLE
[build] fixed broken Docker builds by adding gfortran package

### DIFF
--- a/docker/debian9.8-cpu/Dockerfile
+++ b/docker/debian9.8-cpu/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
         python3 \
         zlib1g-dev \
         ca-certificates \
+	gfortran \
         patch \
         ffmpeg \
 	vim && \

--- a/docker/debian9.8-cpu/Dockerfile
+++ b/docker/debian9.8-cpu/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
         python3 \
         zlib1g-dev \
         ca-certificates \
-	gfortran \
+        gfortran \
         patch \
         ffmpeg \
 	vim && \

--- a/docker/ubuntu16.04-gpu/Dockerfile
+++ b/docker/ubuntu16.04-gpu/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
         python2.7 \
         python3 \
         zlib1g-dev \
+        gfortran \
         ca-certificates \
         patch \
         ffmpeg \


### PR DESCRIPTION
Currently Docker builds are broken, because of a missing package: gfortran - this PR will solve that issue