### PR TITLE
Bump OpenBLAS version to 0.3.7 and enable locking

### DIFF
--- a/tools/extras/install_openblas.sh
+++ b/tools/extras/install_openblas.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OPENBLAS_VERSION=0.3.5
+OPENBLAS_VERSION=0.3.7
 
 WGET=${WGET:-wget}
 
@@ -32,4 +32,4 @@ fi
 tar xzf $tarball
 mv xianyi-OpenBLAS-* OpenBLAS
 
-make PREFIX=$(pwd)/OpenBLAS/install USE_THREAD=0 -C OpenBLAS all install
+make PREFIX=$(pwd)/OpenBLAS/install USE_LOCKING=1 USE_THREAD=0 -C OpenBLAS all install


### PR DESCRIPTION
Bumps OpenBLAS version to 0.3.7 for improved performance with Zen architecture. Also sets USE_LOCKING which fixes issue when calling a single-threaded OpenBLAS from several threads in parallel