### PR TITLE
cuda batched decoder pipeline fixes

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -219,11 +219,23 @@ private:
 
    TaskData(const WaveData &wave_data_in)
        : wave_samples(NULL), sample_frequency(0) {
-     raw_data.Resize(
-         wave_data_in.Data().NumRows() * wave_data_in.Data().NumCols(),
-         kUndefined);
-     memcpy(raw_data.Data(), wave_data_in.Data().Data(),
-            raw_data.Dim() * sizeof(BaseFloat));
+     int rows = wave_data_in.Data().NumRows();
+     int cols = wave_data_in.Data().NumCols();
+     int stride = wave_data_in.Data().Stride();
+
+     raw_data.Resize(rows * cols, kUndefined);
+
+     if (stride == cols) {
+       // contigious so use one large memory copy
+       memcpy(raw_data.Data(), wave_data_in.Data().Data(),
+              rows * cols * sizeof(BaseFloat));
+     } else {
+       // data is not contigious so we need to copy one row at a time
+       for (int i = 0; i < rows; i++) {
+         memcpy(raw_data.Data() + i * cols, wave_data_in.Data().RowData(i),
+                cols * sizeof(BaseFloat));
+       }
+     }
      wave_samples =
          std::make_shared<SubVector<BaseFloat>>(raw_data, 0, raw_data.Dim());
      sample_frequency = wave_data_in.SampFreq();

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda.cc
@@ -28,7 +28,6 @@
 #include "nnet3/am-nnet-simple.h"
 #include "nnet3/nnet-utils.h"
 #include "util/kaldi-thread.h"
-
 using namespace kaldi;
 using namespace cuda_decoder;
 
@@ -60,9 +59,9 @@ void GetDiagnosticsAndPrintOutput(const std::string &utt,
   GetLinearSymbolSequence(best_path_lat, &alignment, &words, &weight);
   num_frames = alignment.size();
   likelihood = -(weight.Value1() + weight.Value2());
-  *tot_num_frames += num_frames;
-  *tot_like += likelihood;
   {
+    *tot_num_frames += num_frames;
+    *tot_like += likelihood;
     std::lock_guard<std::mutex> lk(*stdout_mutex);
     KALDI_VLOG(2) << "Likelihood per frame for utterance " << utt << " is "
                   << (likelihood / num_frames) << " over " << num_frames
@@ -85,18 +84,17 @@ void GetDiagnosticsAndPrintOutput(const std::string &utt,
 // Called when a task is complete. Will be called by different threads
 // concurrently,
 // so it must be threadsafe
-void FinishOneDecode(
-    const std::string &utt, const std::string &key,
-    const BatchedThreadedNnet3CudaPipelineConfig &batched_decoder_config,
-    const fst::SymbolTable *word_syms, const bool write_lattice,
-    BatchedThreadedNnet3CudaPipeline *cuda_pipeline, int64 *num_frames,
-    double *tot_like, CompactLatticeWriter *clat_writer,
-    std::mutex *clat_writer_mutex, std::mutex *stdout_mutex,
-    CompactLattice &clat) {
+void FinishOneDecode(const std::string &utt, const std::string &key,
+                     const fst::SymbolTable *word_syms,
+                     BatchedThreadedNnet3CudaPipeline *cuda_pipeline,
+                     int64 *num_frames, double *tot_like,
+                     CompactLatticeWriter *clat_writer,
+                     std::mutex *clat_writer_mutex, std::mutex *stdout_mutex,
+                     CompactLattice &clat) {
   nvtxRangePushA("FinishOneDecode");
   GetDiagnosticsAndPrintOutput(utt, word_syms, clat, stdout_mutex, num_frames,
                                tot_like);
-  if (write_lattice) {
+  {
     std::lock_guard<std::mutex> lk(*clat_writer_mutex);
     clat_writer->Write(utt, clat);
   }
@@ -128,10 +126,10 @@ int main(int argc, char *argv[]) {
     int num_todo = -1;
     int iterations = 1;
     ParseOptions po(usage);
-    std::mutex stdout_mutex, clat_writer_mutex;
+    std::mutex stdout_mutex;
     int pipeline_length = 4000;  // length of pipeline of outstanding requests,
-                                 // this is independent of queue lengths in
-                                 // decoder
+    // this is independent of queue lengths in
+    // decoder
 
     po.Register("write-lattice", &write_lattice,
                 "Output lattice to a file. Setting to false is useful when "
@@ -143,8 +141,7 @@ int main(int argc, char *argv[]) {
                 "After N files are processed the remaining files are ignored. "
                 "Useful for profiling");
     po.Register("iterations", &iterations,
-                "Number of times to decode the corpus. Output will be written "
-                "only once.");
+                "Number of times to decode the corpus.");
 
     // Multi-threaded CPU and batched GPU decoder
     BatchedThreadedNnet3CudaPipelineConfig batched_decoder_config;
@@ -181,7 +178,8 @@ int main(int argc, char *argv[]) {
     SetDropoutTestMode(true, &(am_nnet.GetNnet()));
     nnet3::CollapseModel(nnet3::CollapseModelConfig(), &(am_nnet.GetNnet()));
 
-    CompactLatticeWriter clat_writer(clat_wspecifier);
+    std::vector<CompactLatticeWriter> clat_writers(iterations);
+    std::vector<std::mutex> clat_write_mutexs(iterations);
 
     fst::Fst<fst::StdArc> *decode_fst =
         fst::ReadFstKaldiGeneric(fst_rxfilename);
@@ -203,7 +201,7 @@ int main(int argc, char *argv[]) {
 
     nvtxRangePush("Global Timer");
 
-    int num_groups_done=0;
+    int num_groups_done = 0;
 
     // starting timer here so we
     // can measure throughput
@@ -216,9 +214,14 @@ int main(int argc, char *argv[]) {
       std::string task_group = std::to_string(iter);
       num_task_submitted = 0;
       SequentialTableReader<WaveHolder> wav_reader(wav_rspecifier);
-      if (iter > 0)
-        write_lattice =
-            false;  // write the lattices only on the first iteration
+
+      std::mutex *clat_writer_mutex = &clat_write_mutexs[iter];
+      CompactLatticeWriter *clat_writer = &clat_writers[iter];
+
+      stringstream filename;
+      filename << clat_wspecifier << "-" << iter;
+      clat_writer->Open(filename.str());
+
       for (; !wav_reader.Done(); wav_reader.Next()) {
         nvtxRangePushA("Utterance Iteration");
 
@@ -228,10 +231,10 @@ int main(int argc, char *argv[]) {
 
         std::string utt = wav_reader.Key();
         std::string key = utt;
-        if (iter > 0) {
-          // make key unique for subsequent iterations
-          key = key + "-" + std::to_string(iter);
-        }
+
+        // make key unique for each iteration
+        key = key + "-" + std::to_string(iter);
+
         const WaveData &wave_data = wav_reader.Value();
 
         if (iter == 0) {
@@ -241,13 +244,13 @@ int main(int argc, char *argv[]) {
         }
 
         // Creating a function alias for the callback function of that utterance
-        auto finish_one_decode_lamba = [
-            // Capturing the arguments that will change by copy
-            utt, key, write_lattice,
-            // Capturing the const/global args by reference
-            &word_syms, &batched_decoder_config, &cuda_pipeline,
-            &clat_writer_mutex, &stdout_mutex, &clat_writer, &num_frames,
-            &tot_like]
+        auto finish_one_decode_lamba =
+            [
+                // Capturing the arguments that will change by copy
+                utt, key, clat_writer_mutex, clat_writer,
+                // Capturing the const/global args by reference
+                &word_syms, &cuda_pipeline, &stdout_mutex, &num_frames,
+                &tot_like]
             // The callback function receive the compact lattice as argument
             // if determinize_lattice is true, it is a determinized lattice
             // otherwise, it is a raw lattice converted to compact format
@@ -258,9 +261,8 @@ int main(int argc, char *argv[]) {
               FinishOneDecode(
                   // Captured arguments used to specialize FinishOneDecode for
                   // this task
-                  utt, key, batched_decoder_config, word_syms, write_lattice,
-                  &cuda_pipeline, &num_frames, &tot_like, &clat_writer,
-                  &clat_writer_mutex, &stdout_mutex,
+                  utt, key, word_syms, &cuda_pipeline, &num_frames, &tot_like,
+                  clat_writer, clat_writer_mutex, &stdout_mutex,
                   // Generated lattice that will be passed once the task is
                   // complete
                   clat_in);
@@ -277,7 +279,7 @@ int main(int argc, char *argv[]) {
         nvtxRangePop();
         if (num_todo != -1 && num_task_submitted >= num_todo) break;
       }  // end utterance loop
-        
+      
       std::string group_done;
       // Non-blocking way to check if a group is done
       // returns false if zero groups are ready
@@ -290,12 +292,13 @@ int main(int argc, char *argv[]) {
                   << " Audio: " << total_audio * (iter + 1)
                   << " RealTimeX: " << total_audio * (iter + 1) / total_time;
         num_groups_done++;
+        clat_writers[iter].Close();
       }
-    }    // end iterations loop
+    }  // end iterations loop
 
     // We've submitted all tasks. Now waiting for them to complete
     // We could also have called WaitForAllTasks and CloseAllDecodeHandles
-    while (num_groups_done<iterations) {
+    while (num_groups_done < iterations) {
       // WaitForAnyGroup is blocking. It will hold until one group is ready
       std::string group_done = cuda_pipeline.WaitForAnyGroup();
       cuda_pipeline.CloseAllDecodeHandlesForGroup(group_done);
@@ -306,6 +309,7 @@ int main(int argc, char *argv[]) {
                 << " Audio: " << total_audio * (iter + 1)
                 << " RealTimeX: " << total_audio * (iter + 1) / total_time;
       num_groups_done++;
+      clat_writers[iter].Close();
     }
 
     // number of seconds elapsed since the creation of timer
@@ -322,14 +326,13 @@ int main(int argc, char *argv[]) {
               << " Total Audio: " << total_audio * iterations
               << " RealTimeX: " << total_audio * iterations / total_time;
 
-    delete word_syms;  // will delete if non-NULL.
-
-    clat_writer.Close();
-
     cuda_pipeline.Finalize();
     cudaDeviceSynchronize();
 
+    delete word_syms;  // will delete if non-NULL.
+
     return 0;
+
   } catch (const std::exception &e) {
     std::cerr << e.what();
     return -1;


### PR DESCRIPTION
    bug fix: don't assume stride and number of colums is the same when packing matrix into a vector.

  src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc:
    added additional sanity checking to better report errors in the field.
    no longer pinning memory for copying waves down.  This was causing consistency issues.  It is unclear why the code is not working and will continue to evaluate.
    This optimization doesn't add a lot of perf so we are disabling it for now.
    general cleanup
    fixed bug with tasks array being possibly being resized before being read.

  src/cudadecoderbin/batched-wav-nnet3-cuda.cc:
    Now outputting every iteration as a different lattice.  This way we can score every lattice and better ensure correctness of binary.
    clang-format (removing tabs)