### PR TITLE
fix the folder name in run_tdnn_discriminative.sh

### DIFF
--- a/egs/librispeech/s5/local/chain/run_tdnn_discriminative.sh
+++ b/egs/librispeech/s5/local/chain/run_tdnn_discriminative.sh
@@ -95,8 +95,8 @@ if [ $frame_subsampling_factor -ne 1 ]; then
 
     data_dirs=
     for x in `seq -$[frame_subsampling_factor/2] $[frame_subsampling_factor/2]`; do
-      steps/shift_feats.sh --cmd "$train_cmd --max-jobs-run 40" --nj 350 \
-        $x $train_data_dir exp/shift_hires ${train_data_dir}_fs$x
+      utils/data/shift_feats.sh --cmd "$train_cmd --max-jobs-run 40" --nj 350 \
+        $x $train_data_dir exp/shift_hires
       utils/fix_data_dir.sh ${train_data_dir}_fs$x
       data_dirs="$data_dirs ${train_data_dir}_fs$x"
       awk -v nfs=$x '{print "fs"nfs"-"$0}' $train_ivector_dir/ivector_online.scp >> ${train_ivector_dir}_fs/ivector_online.scp

--- a/egs/librispeech/s5/local/chain/run_tdnn_discriminative.sh
+++ b/egs/librispeech/s5/local/chain/run_tdnn_discriminative.sh
@@ -96,7 +96,7 @@ if [ $frame_subsampling_factor -ne 1 ]; then
     data_dirs=
     for x in `seq -$[frame_subsampling_factor/2] $[frame_subsampling_factor/2]`; do
       steps/shift_feats.sh --cmd "$train_cmd --max-jobs-run 40" --nj 350 \
-        $x $train_data_dir exp/shift_hires mfcc_hires
+        $x $train_data_dir exp/shift_hires ${train_data_dir}_fs$x
       utils/fix_data_dir.sh ${train_data_dir}_fs$x
       data_dirs="$data_dirs ${train_data_dir}_fs$x"
       awk -v nfs=$x '{print "fs"nfs"-"$0}' $train_ivector_dir/ivector_online.scp >> ${train_ivector_dir}_fs/ivector_online.scp


### PR DESCRIPTION
In egs/librispeech/s5/local/chain/run_tdnn_discriminative.sh, the mfcc_hires folder is not referred anywhere else.