### PR TITLE
[egs] Change make_rttm.py to read/write files with UTF-8 encoding

### DIFF
--- a/egs/callhome_diarization/v1/diarization/make_rttm.py
+++ b/egs/callhome_diarization/v1/diarization/make_rttm.py
@@ -34,9 +34,7 @@ where:
 
 import argparse
 import sys
-
-sys.path.append('steps/libs')
-import common as common_lib
+import codecs
 
 
 def get_args():
@@ -63,14 +61,14 @@ def main():
 
   # File containing speaker labels per segment
   seg2label = {}
-  with common_lib.smart_open(args.labels) as labels_file:
+  with codecs.open(args.labels, 'r', 'utf-8') as labels_file:
     for line in labels_file:
       seg, label = line.strip().split()
       seg2label[seg] = label
 
   # Segments file
   reco2segs = {}
-  with common_lib.smart_open(args.segments) as segments_file:
+  with codecs.open(args.segments, 'r', 'utf-8') as segments_file:
     for line in segments_file:
       seg, reco, start, end = line.strip().split()
       try:
@@ -117,7 +115,7 @@ def main():
     new_segs += " " + start + "," + end + "," + label
     merged_segs.append(reco + new_segs)
 
-  with common_lib.smart_open(args.rttm_file, 'w') as rttm_writer:
+  with codecs.open(args.rttm_file, 'w', 'utf-8') as rttm_writer:
     for reco_line in merged_segs:
       segs = reco_line.strip().split()
       reco = segs[0]


### PR DESCRIPTION
The benefits offered by `common_lib.smart_open` would get lost with this change; however, they aren't used in any of the currently checked-in recipes (the only call location is in `cluster.sh` in the same directory, which uses regular file paths).