### PR TITLE
Split_scp.pl will try and redistribute speakers when there is an imbalance in the preliminary split

### DIFF
--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -54,9 +54,9 @@ $job_id = 0;
 $utt2spk_file = "";
 $utt2dur_file = "";
 $one_based = 0;
-$allow_uneven_splits = 0;
+$allow_uneven_split = 0;
 
-for ($x = 1; $x <= 3 && @ARGV > 0; $x++) {
+for ($x = 1; $x <= 4 && @ARGV > 0; $x++) {
     if ($ARGV[0] eq "-j") {
         shift @ARGV;
         $num_jobs = shift @ARGV;
@@ -76,8 +76,8 @@ for ($x = 1; $x <= 3 && @ARGV > 0; $x++) {
         $one_based = 1;
         shift @ARGV;
     }
-    if ($ARGV[0] eq '--allow-uneven-splits') {
-        $allow_uneven_splits = 1;
+    if ($ARGV[0] eq '--allow-uneven-split') {
+        $allow_uneven_split = 1;
         shift @ARGV;
     }
 }
@@ -197,7 +197,7 @@ if ($utt2spk_file ne "" && $utt2dur_file ne "" ) {  # --utt2spk and --utt2dur
         }
     }
 
-    if ($allow_uneven_splits != 1) {
+    if ($allow_uneven_split != 1) {
         if (($smallest_dur < $largest_dur / 2 && $largest_dur > 3600) ||
             $smallest_dur == 0.0) {
             die "Trying to split data while taking duration into account leads to a " .


### PR DESCRIPTION
This should fix the issues #3653 had.

However, this makes things a good deal more complicated, and while it worked for me on a dataset I manufactured to have a major imbalance in speaker durations, I'm nervous there may be something I missed, would be nice if some people could try it out.  
And it can be a lot slower.

Another option would be to just detect when there is an imbalance and crash with a message telling people to use `utils/data/modify_speaker_duration.sh`. Not ideal either of course I know but just throwing it out there... I think people with datasets that will cause issues will tend to be more experienced users and would appreciate the tip (it will probably speed their builds up).