### PR TITLE
Fix parsing of learning rates and ivector-dim=0

### DIFF
--- a/egs/wsj/s5/steps/nnet3/convert_nnet2_to_nnet3.py
+++ b/egs/wsj/s5/steps/nnet3/convert_nnet2_to_nnet3.py
@@ -100,7 +100,7 @@ class Nnet3Model(object):
     def __init__(self):
         self.input_dim = -1
         self.output_dim = -1
-        self.ivector_dim = -1
+        self.ivector_dim = 0 
         self.counts = defaultdict(int)
         self.num_components = 0
         self.components_read = 0
@@ -121,7 +121,7 @@ class Nnet3Model(object):
         if "<InputDim>" in pairs and self.input_dim == -1:
             self.input_dim = int(pairs["<InputDim>"])
 
-        if "<ConstComponentDim>" in pairs and self.ivector_dim == -1:
+        if "<ConstComponentDim>" in pairs and self.ivector_dim == 0:
             self.ivector_dim = int(pairs["<ConstComponentDim>"])
 
         # remove nnet2 specific tokens and catch descriptors
@@ -163,7 +163,7 @@ class Nnet3Model(object):
                                     config_string=config_string))
 
             f.write("\n# Component nodes\n")
-            if self.ivector_dim != -1:
+            if self.ivector_dim != 0:
                 f.write("input-node name=input dim={0}\n".format(self.input_dim-self.ivector_dim))
                 f.write("input-node name=ivector dim={0}\n".format(self.ivector_dim))
             else:
@@ -294,7 +294,7 @@ def parse_component(line, line_buffer):
 def parse_standard_component(component, line, line_buffer):
     # Ignores stats such as ValueSum and DerivSum
     line = consume_token(component, line)
-    pairs = re.findall("(<\w+>) ([\w.]+)", line)
+    pairs = re.findall("(<\w+>) ([\w.-]+)", line)
 
     return dict(pairs)
 
@@ -364,7 +364,7 @@ def parse_end_of_component(component, line, line_buffer):
 def parse_affine_component(component, line, line_buffer):
     assert ("<LinearParams>" in line)
 
-    pairs = dict(re.findall("(<\w+>) ([\w.]+)", line))
+    pairs = dict(re.findall("(<\w+>) ([\w.-]+)", line))
 
     # read the linear params and bias and convert it to a matrix
     weights = parse_weights(line_buffer)


### PR DESCRIPTION
Fixes #886 

Parsing learning rates would fail if it was written in e-notation (e.g.
1e-5). Also fixes ivector-dim=0 which could result if const component
dim=0 in src nnet2 model.