### PR TITLE
Fix NVCC compilation errors on Windows

### DIFF
--- a/src/cudafeat/feature-online-cmvn-cuda.cu
+++ b/src/cudafeat/feature-online-cmvn-cuda.cu
@@ -35,7 +35,7 @@ __host__ __device__ inline float2 operator+(const float2 &a, const float2 &b) {
 
 #if __CUDA_ARCH__ == 750
 __launch_bounds__ (1024, 1)
-#else
+#else 
 __launch_bounds__ (1024, 2)
 #endif
 __global__ void compute_cmvn_stats_kernel(const float *data, int32_t ldd,
@@ -87,7 +87,7 @@ __global__ void apply_cmvn_kernel(
 
   for (int c = threadIdx.x; c < num_cols; c += blockDim.x) {
     float2 frame_stats =
-        reinterpret_cast<const float2 * __restrict__>(&stats[r * lds])[c];
+        reinterpret_cast<const float2* __restrict__>(&stats[r * lds])[c];
 
     float val = feat_in[r * ldi + c];
 
@@ -100,7 +100,7 @@ __global__ void apply_cmvn_kernel(
 
       // stats at the start row of the window that must be removed
       float2 ostats =
-          reinterpret_cast<const float2 * __restrict__>(&stats[o * lds])[c];
+          reinterpret_cast<const float2* __restrict__>(&stats[o * lds])[c];
 
       // remove start of the window stats
       frame_stats = frame_stats - ostats;

--- a/src/cudafeat/feature-online-cmvn-cuda.cu
+++ b/src/cudafeat/feature-online-cmvn-cuda.cu
@@ -35,7 +35,7 @@ __host__ __device__ inline float2 operator+(const float2 &a, const float2 &b) {
 
 #if __CUDA_ARCH__ == 750
 __launch_bounds__ (1024, 1)
-#else 
+#else
 __launch_bounds__ (1024, 2)
 #endif
 __global__ void compute_cmvn_stats_kernel(const float *data, int32_t ldd,
@@ -87,7 +87,7 @@ __global__ void apply_cmvn_kernel(
 
   for (int c = threadIdx.x; c < num_cols; c += blockDim.x) {
     float2 frame_stats =
-        reinterpret_cast<const float2* __restrict__>(&stats[r * lds])[c];
+        reinterpret_cast<const float2 * __restrict__>(&stats[r * lds])[c];
 
     float val = feat_in[r * ldi + c];
 
@@ -100,7 +100,7 @@ __global__ void apply_cmvn_kernel(
 
       // stats at the start row of the window that must be removed
       float2 ostats =
-          reinterpret_cast<const float2* __restrict__>(&stats[o * lds])[c];
+          reinterpret_cast<const float2 * __restrict__>(&stats[o * lds])[c];
 
       // remove start of the window stats
       frame_stats = frame_stats - ostats;

--- a/src/cudafeat/feature-spectral-cuda.cu
+++ b/src/cudafeat/feature-spectral-cuda.cu
@@ -276,7 +276,7 @@ __device__ inline int32 FirstSampleOfFrame(int32 frame, int32 frame_shift,
 __global__ void extract_window_kernel(
     int32 frame_shift, int32 frame_length, int32 frame_length_padded,
     int32 window_size, bool snip_edges, int32_t sample_offset,
-    const BaseFloat __restrict__ *wave, int32 wave_dim,
+    const BaseFloat * __restrict__ wave, int32 wave_dim,
     BaseFloat *__restrict__ windows, int32_t wlda) {
   int frame = blockIdx.x;
   int tidx = threadIdx.x;
@@ -503,8 +503,8 @@ void CudaSpectralFeatures::ComputeFinalFeatures(int num_frames, BaseFloat vtln_w
                             kTrans, 0.0);
 
      apply_lifter_and_floor_energy<<<num_frames, CU1DBLOCK>>>(
-         cu_features->NumRows(), cu_features->NumCols(), 
-	 mfcc_opts.cepstral_lifter, mfcc_opts.use_energy, 
+         cu_features->NumRows(), cu_features->NumCols(),
+	 mfcc_opts.cepstral_lifter, mfcc_opts.use_energy,
 	 mfcc_opts.energy_floor, cu_signal_log_energy->Data(),
          cu_lifter_coeffs_.Data(), cu_features->Data(), cu_features->Stride());
   } else {

--- a/src/cudamatrix/cu-array.h
+++ b/src/cudamatrix/cu-array.h
@@ -189,8 +189,8 @@ class CuSubArray: public CuArrayBase<T> {
   CuSubArray(const T* data, MatrixIndexT length) {
     // Yes, we're evading C's restrictions on const here, and yes, it can be used
     // to do wrong stuff; unfortunately the workaround would be very difficult.
-    CuArrayBase<T>::data_ = const_cast<T*>(data);
-    CuArrayBase<T>::dim_ = length;
+    this->data_ = const_cast<T*>(data);
+    this->dim_ = length;
   }
 };
 

--- a/src/cudamatrix/cu-vector.h
+++ b/src/cudamatrix/cu-vector.h
@@ -135,15 +135,15 @@ class CuVectorBase {
   void Floor(const CuVectorBase<Real> &src, Real floor_val, MatrixIndexT *floored_count = NULL);
   void Ceiling(const CuVectorBase<Real> &src, Real ceiling_val, MatrixIndexT *ceiled_count = NULL);
   void Pow(const CuVectorBase<Real> &src, Real power);
-  
+
   inline void ApplyFloor(Real floor_val, MatrixIndexT *floored_count = NULL) {
-    this -> Floor(*this, floor_val, floored_count); 
+    this -> Floor(*this, floor_val, floored_count);
   };
-  
+
   inline void ApplyCeiling(Real ceiling_val, MatrixIndexT *ceiled_count = NULL) {
     this -> Ceiling(*this, ceiling_val, ceiled_count);
   };
-  
+
   inline void ApplyPow(Real power) {
     this -> Pow(*this, power);
   };
@@ -329,27 +329,27 @@ class CuSubVector: public CuVectorBase<Real> {
     KALDI_ASSERT(static_cast<UnsignedMatrixIndexT>(origin)+
                  static_cast<UnsignedMatrixIndexT>(length) <=
                  static_cast<UnsignedMatrixIndexT>(t.Dim()));
-    CuVectorBase<Real>::data_ = const_cast<Real*>(t.Data()+origin);
-    CuVectorBase<Real>::dim_ = length;
+    this->data_ = const_cast<Real*>(t.Data()+origin);
+    this->dim_ = length;
   }
   /// Copy constructor
   /// this constructor needed for Range() to work in base class.
   CuSubVector(const CuSubVector &other) : CuVectorBase<Real> () {
-    CuVectorBase<Real>::data_ = other.data_;
-    CuVectorBase<Real>::dim_ = other.dim_;
+    this->data_ = other.data_;
+    this->dim_ = other.dim_;
   }
 
   CuSubVector(const Real* data, MatrixIndexT length) : CuVectorBase<Real> () {
     // Yes, we're evading C's restrictions on const here, and yes, it can be used
     // to do wrong stuff; unfortunately the workaround would be very difficult.
-    CuVectorBase<Real>::data_ = const_cast<Real*>(data);
-    CuVectorBase<Real>::dim_ = length;
+    this->data_ = const_cast<Real*>(data);
+    this->dim_ = length;
   }
 
   /// This operation does not preserve const-ness, so be careful.
   CuSubVector(const CuMatrixBase<Real> &matrix, MatrixIndexT row) {
-    CuVectorBase<Real>::data_ = const_cast<Real*>(matrix.RowData(row));
-    CuVectorBase<Real>::dim_ = matrix.NumCols();
+    this->data_ = const_cast<Real*>(matrix.RowData(row));
+    this->dim_ = matrix.NumCols();
   }
 
 

--- a/src/matrix/kaldi-matrix.h
+++ b/src/matrix/kaldi-matrix.h
@@ -574,6 +574,8 @@ class MatrixBase {
   void SymPosSemiDefEig(VectorBase<Real> *s, MatrixBase<Real> *P,
                         Real check_thresh = 0.001);
 
+  // There are some weird issue with template friend function in a class
+  // template in Windows version of nvcc. This is simple an ugly walkaround.
 #if defined(__NVCC__) && defined(_MSC_VER)
   template<typename Real>
 #endif

--- a/src/matrix/kaldi-matrix.h
+++ b/src/matrix/kaldi-matrix.h
@@ -574,6 +574,7 @@ class MatrixBase {
   void SymPosSemiDefEig(VectorBase<Real> *s, MatrixBase<Real> *P,
                         Real check_thresh = 0.001);
 
+  template<typename Real>
   friend Real kaldi::TraceMatMat<Real>(const MatrixBase<Real> &A,
       const MatrixBase<Real> &B, MatrixTransposeType trans);  // tr (A B)
 

--- a/src/matrix/kaldi-matrix.h
+++ b/src/matrix/kaldi-matrix.h
@@ -574,7 +574,9 @@ class MatrixBase {
   void SymPosSemiDefEig(VectorBase<Real> *s, MatrixBase<Real> *P,
                         Real check_thresh = 0.001);
 
+#if defined(__NVCC__) && defined(_MSC_VER)
   template<typename Real>
+#endif
   friend Real kaldi::TraceMatMat<Real>(const MatrixBase<Real> &A,
       const MatrixBase<Real> &B, MatrixTransposeType trans);  // tr (A B)
 

--- a/src/matrix/kaldi-vector.h
+++ b/src/matrix/kaldi-vector.h
@@ -510,36 +510,36 @@ class SubVector : public VectorBase<Real> {
     KALDI_ASSERT(static_cast<UnsignedMatrixIndexT>(origin)+
                  static_cast<UnsignedMatrixIndexT>(length) <=
                  static_cast<UnsignedMatrixIndexT>(t.Dim()));
-    VectorBase<Real>::data_ = const_cast<Real*> (t.Data()+origin);
-    VectorBase<Real>::dim_   = length;
+    this->data_ = const_cast<Real*> (t.Data()+origin);
+    this->dim_   = length;
   }
 
   /// This constructor initializes the vector to point at the contents
   /// of this packed matrix (SpMatrix or TpMatrix).
   SubVector(const PackedMatrix<Real> &M) {
-    VectorBase<Real>::data_ = const_cast<Real*> (M.Data());
-    VectorBase<Real>::dim_   = (M.NumRows()*(M.NumRows()+1))/2;
+    this->data_ = const_cast<Real*> (M.Data());
+    this->dim_   = (M.NumRows()*(M.NumRows()+1))/2;
   }
 
   /// Copy constructor
   SubVector(const SubVector &other) : VectorBase<Real> () {
     // this copy constructor needed for Range() to work in base class.
-    VectorBase<Real>::data_ = other.data_;
-    VectorBase<Real>::dim_ = other.dim_;
+    this->data_ = other.data_;
+    this->dim_ = other.dim_;
   }
 
   /// Constructor from a pointer to memory and a length.  Keeps a pointer
   /// to the data but does not take ownership (will never delete).
   /// Caution: this constructor enables you to evade const constraints.
   SubVector(const Real *data, MatrixIndexT length) : VectorBase<Real> () {
-    VectorBase<Real>::data_ = const_cast<Real*>(data);
-    VectorBase<Real>::dim_   = length;
+    this->data_ = const_cast<Real*>(data);
+    this->dim_   = length;
   }
 
   /// This operation does not preserve const-ness, so be careful.
   SubVector(const MatrixBase<Real> &matrix, MatrixIndexT row) {
-    VectorBase<Real>::data_ = const_cast<Real*>(matrix.RowData(row));
-    VectorBase<Real>::dim_   = matrix.NumCols();
+    this->data_ = const_cast<Real*>(matrix.RowData(row));
+    this->dim_   = matrix.NumCols();
   }
 
   ~SubVector() {}  ///< Destructor (does nothing; no pointers are owned here).

--- a/src/onlinebin/online-net-client.cc
+++ b/src/onlinebin/online-net-client.cc
@@ -30,6 +30,7 @@
 
 int main(int argc, char *argv[]) {
   try {
+#ifndef KALDI_NO_PORTAUDIO
     using namespace kaldi;
 
     typedef kaldi::int32 int32;
@@ -122,6 +123,9 @@ int main(int argc, char *argv[]) {
     }
     freeaddrinfo(server_addr);
     return 0;
+#else
+    throw std::runtime_error("kaldi is compiled with KALDI_NO_PORTAUDIO");
+#endif
   } catch(const std::exception& e) {
     std::cerr << e.what();
     return -1;


### PR DESCRIPTION
Split out source file changes in #3580 

1. fix Windows version NVCC compilation error, mainly two-phase name lookup problem
2. fix __restrict__ positioning