### PR TITLE
Select specific gpu, reuse cuda context

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -383,7 +383,6 @@ bool CuDevice::SelectAndInitializeGpuIdWithExistingCudaContext(int dev_id) {
   return true;
 }
 
-
 template <typename TA, typename TB>
 bool greater_pair(const std::pair<TA, TB> &left, const std::pair<TA, TB> &right) {
   return left.second > right.second;

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -348,8 +348,44 @@ bool CuDevice::IsComputeExclusive() {
   }
 }
 
-template<typename TA, typename TB>
-bool greater_pair(const std::pair<TA, TB> &left, const std::pair<TA, TB>& right) {
+bool CuDevice::SelectGpuId(int dev_id) {
+  KALDI_LOG << "Trying to select device: " << dev_id;
+  cudaError_t e = cudaSetDevice(dev_id);
+  if (e != cudaSuccess) {
+    KALDI_WARN << "Cannot select this device: return code " << e
+               << ", Error message: \"" << cudaGetErrorString(e) << "\"";
+    return false;
+  } else {
+    e = cudaDeviceSynchronize();
+    if (e != cudaSuccess) {
+      KALDI_WARN << "Cannot select this device: return code " << e
+                 << ", Error message: \"" << cudaGetErrorString(e) << "\"";
+      return false;
+    }
+  }
+
+  std::string debug_str;
+  int num_gpus = dev_id + 1;  // used for debugging purposes
+  bool got_context = GetCudaContext(num_gpus, &debug_str);
+  if (!got_context) {
+    KALDI_WARN << "Cannot get Cuda Context, Error message: \"" << debug_str
+               << "\"";
+  }
+
+  return true;
+}
+
+bool CuDevice::SelectAndInitializeGpuIdWithExistingCudaContext(int dev_id) {
+  // Make sure the global allocator object has the up-to-date options.
+  g_cuda_allocator.SetOptions(g_allocator_options);
+  if (!CuDevice::SelectGpuId(dev_id)) return false;
+  FinalizeActiveGpu();
+  return true;
+}
+
+
+template <typename TA, typename TB>
+bool greater_pair(const std::pair<TA, TB> &left, const std::pair<TA, TB> &right) {
   return left.second > right.second;
 }
 
@@ -424,6 +460,7 @@ bool CuDevice::SelectGpuIdAuto() {
 
   int dev_id;
   float mem_ratio;
+  bool success;
   do {
     // try to select the GPU in the best to worst order
     // Note we have to check the return codes manually, as the CU_SAFE_CALL
@@ -432,20 +469,11 @@ bool CuDevice::SelectGpuIdAuto() {
     dev_id = free_mem_ratio[max_id].first;
     mem_ratio = free_mem_ratio[max_id].second;
 
-    KALDI_LOG << "Trying to select device: " << dev_id << " (automatically), mem_ratio: " << mem_ratio;
-    e = cudaSetDevice(dev_id);
-    if (e != cudaSuccess) {
-      KALDI_WARN << "Cannot select this device: return code " << e
-                 << ", Error message: \"" << cudaGetErrorString(e) << "\"";
-    } else {
-      e = cudaDeviceSynchronize();
-      if (e != cudaSuccess) {
-        KALDI_WARN << "Cannot select this device: return code " << e
-                   << ", Error message: \"" << cudaGetErrorString(e) << "\"";
-      }
-    }
+    KALDI_LOG << "Device: " << dev_id << ", mem_ratio: " << mem_ratio;
+    success = SelectGpuId(dev_id);
+
     max_id++;
-  } while ((e != cudaSuccess) && (max_id < free_mem_ratio.size()));
+  } while (success && (max_id < free_mem_ratio.size()));
 
   if (e != cudaSuccess) {
     KALDI_WARN << "Failed to (automatically) select any device";

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -154,6 +154,11 @@ class CuDevice {
   ///  "no"       -- Run on CPU.
   void SelectGpuId(std::string use_gpu);
 
+  // Select a specific GPU for computation. Will reuse the existing Cuda Context
+  // for that device. Initialize the necessary handles for GPU use (e.g. cublas
+  // handle)
+  bool SelectAndInitializeGpuIdWithExistingCudaContext(int dev_id);
+
   /// Check if the CUDA GPU is selected for use
   bool Enabled() const {
     return (device_id_ > -1);
@@ -254,6 +259,10 @@ class CuDevice {
   /// SelectGpuId(), if the GPUs are in non-exclusive mode).  Returns true on
   /// success.
   bool SelectGpuIdAuto();
+
+  // Selects GPU given its ID. Called from SelectGpuIdAuto or
+  // SelectGpuIdWithExistingCudaContext
+  bool SelectGpuId(int dev_id);
 
   /// This function, called from SelectGpuId(), is to be called when a
   /// GPU context corresponding to the GPU we want to use exists; it


### PR DESCRIPTION
Adding the possibility to select a specific GPU and reuse the existing Cuda context. Reusing the context allows us to share the GPU with other processes using the same GPU. Useful when ASR is part of a more complex pipeline, with each module using the GPU.
This PR adds a dedicated API to achieve this "select specific GPU and reuse its context" behavior. It does not change the behavior of existing APIs (but refactor some code internally to avoid duplication of code)