### PR TITLE
[src] Cuda Decoder initial channel fix

### DIFF
--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -358,6 +358,7 @@ void CudaDecoder::ComputeInitialChannel() {
 
   CopyLaneCountersToHostSync();
   PostProcessingMainQueue();
+  ConcatenateData();
   CopyLaneCountersToHostSync();
 
   const int32 main_q_end =


### PR DESCRIPTION
Fixing a bug that can happen in some corner cases. Was adding an invalid emitting arc in the lattice, leading to "Unexpected phone xxx found inside a word" in word-align-lattice.cc.