### PR TITLE
Fix minor bug in steps/data/reverberate_data_dir.py

### DIFF
--- a/egs/wsj/s5/steps/data/reverberate_data_dir.py
+++ b/egs/wsj/s5/steps/data/reverberate_data_dir.py
@@ -136,7 +136,10 @@ def pick_item_with_probability(x):
         collection (list or dictionary) where the values contain a field called probability
     """
     if isinstance(x, dict):
-        plist = list(set(x.values()))
+        keylist = list(x.keys())
+        keylist.sort()
+        random.shuffle(keylist)
+        plist = [x[k] for k in keylist]
     else:
         plist = x
     total_p = sum(item.probability for item in plist)


### PR DESCRIPTION
Hi Dan, I notice that there is some problems with this script. The original version cannot produce the exact result. You can reproduce the bug with /export/c10/hzili1/tools/kaldi_11_21/egs/sre16/v2/debug_reverb.sh. Basically the problem is that you cannot assume that after converting set to list the order is always the same.

Thanks,
Zili