### PR TITLE
replace a broken web link in wave-reader.h

### DIFF
--- a/src/feat/wave-reader.h
+++ b/src/feat/wave-reader.h
@@ -22,7 +22,7 @@
 
 /*
 // THE WAVE FORMAT IS SPECIFIED IN:
-// https:// ccrma.stanford.edu/courses/422/projects/WaveFormat/
+// https://en.wikipedia.org/wiki/WAV
 //
 //
 //


### PR DESCRIPTION
issuse: https://github.com/kaldi-asr/kaldi/issues/3266#event-2888443194

replace with wikipedia webpage.