### PR TITLE
fix tools/Makefile about wget

### DIFF
--- a/egs/fisher_swbd/s5/local/fisher_train_lms_fsh.sh
+++ b/egs/fisher_swbd/s5/local/fisher_train_lms_fsh.sh
@@ -31,7 +31,7 @@ export PATH=$PATH:`pwd`/../../../tools/kaldi_lm
    echo Downloading and installing the kaldi_lm tools
    if [ ! -f kaldi_lm.tar.gz ]; then
      wget http://www.danielpovey.com/files/kaldi/kaldi_lm.tar.gz ||
-     wget http://merlin.fit.vutbr.cz/kaldi/kaldi_lm.tar.gz || exit 1;
+     wget -c http://merlin.fit.vutbr.cz/kaldi/kaldi_lm.tar.gz || exit 1;
    fi
    tar -xvzf kaldi_lm.tar.gz || exit 1;
    cd kaldi_lm

--- a/egs/fisher_swbd/s5/local/swbd1_data_download.sh
+++ b/egs/fisher_swbd/s5/local/swbd1_data_download.sh
@@ -36,7 +36,7 @@ if [ ! -d $SWBD_DIR/transcriptions/swb_ms98_transcriptions ]; then
     if [ ! -d swb_ms98_transcriptions ]; then
       echo " *** Downloading trascriptions and dictionary ***" 
       wget http://www.openslr.org/resources/5/switchboard_word_alignments.tar.gz ||
-      wget http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+      wget -c http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
       tar -xf switchboard_word_alignments.tar.gz
     fi
   )

--- a/egs/gale_mandarin/s5/local/gale_prep_dict.sh
+++ b/egs/gale_mandarin/s5/local/gale_prep_dict.sh
@@ -41,7 +41,7 @@ cat $dict_dir/vocab-full.txt | grep -v '[a-zA-Z]' | \
 if [ ! -f $dict_dir/cmudict/cmudict.0.7a ]; then
   echo "--- Downloading CMU dictionary ..."
   svn co http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/  $dict_dir/cmudict || \
-  wget -e robots=off  -r -np -nH --cut-dirs=4 -R index.html http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/ -P $dict_dir  || exit 1
+  wget -c -e robots=off  -r -np -nH --cut-dirs=4 -R index.html http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/ -P $dict_dir  || exit 1
 fi
 
 if [ ! -f $dict_dir/cmudict/scripts/make_baseform.pl ] ; then

--- a/egs/multi_en/s5/local/swbd1_data_download.sh
+++ b/egs/multi_en/s5/local/swbd1_data_download.sh
@@ -44,7 +44,7 @@ if [ ! -d $SWBD_DIR/transcriptions/swb_ms98_transcriptions ]; then
     if [ ! -d swb_ms98_transcriptions ]; then
       echo " *** Downloading trascriptions and dictionary ***" 
       wget http://www.openslr.org/resources/5/switchboard_word_alignments.tar.gz ||
-      wget http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+      wget -c http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
       tar -xf switchboard_word_alignments.tar.gz
     fi
   )

--- a/egs/swbd/s5c/local/swbd1_data_download.sh
+++ b/egs/swbd/s5c/local/swbd1_data_download.sh
@@ -36,7 +36,7 @@ if [ ! -d $SWBD_DIR/transcriptions/swb_ms98_transcriptions ]; then
     if [ ! -d swb_ms98_transcriptions ]; then
       echo " *** Downloading trascriptions and dictionary ***" 
       wget http://www.openslr.org/resources/5/switchboard_word_alignments.tar.gz ||
-      wget http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+      wget -c http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
       tar -xf switchboard_word_alignments.tar.gz
     fi
   )

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -151,7 +151,7 @@ cub:
 	if [ -d "$(DOWNLOAD_DIR)" ]; then \
 		cp -p "$(DOWNLOAD_DIR)/cub-$(CUB_VERSION).zip" .; \
 	else \
-		$(WGET) -T 10 -t 3 -c https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip; \
+		$(WGET) -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip; \
 	fi
 	unzip -oq cub-$(CUB_VERSION).zip
 	rm -f cub

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,7 +98,7 @@ openfst-$(OPENFST_VERSION).tar.gz:
 		cp -p "$(DOWNLOAD_DIR)/openfst-$(OPENFST_VERSION).tar.gz" .; \
 	else \
 		$(WGET) -T 10 -t 1 http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
-		$(WGET) -T 10 -t 3 https://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz; \
+		$(WGET) -T 10 -t 3 -O openfst-$(OPENFST_VERSION).tar.gz https://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz; \
 	fi
 
 sclite: sclite_compiled
@@ -143,7 +143,7 @@ sph2pipe_$(SPH2PIPE_VERSION).tar.gz:
 		cp -p "$(DOWNLOAD_DIR)/sph2pipe_$(SPH2PIPE_VERSION).tar.gz" .; \
 	else \
 		$(WGET) -T 10 -t 3 https://www.openslr.org/resources/3/sph2pipe_$(SPH2PIPE_VERSION).tar.gz || \
-		$(WGET) -T 10 https://sourceforge.net/projects/kaldi/files/sph2pipe_$(SPH2PIPE_VERSION).tar.gz; \
+		$(WGET) -T 10 -O sph2pipe_$(SPH2PIPE_VERSION).tar.gz https://sourceforge.net/projects/kaldi/files/sph2pipe_$(SPH2PIPE_VERSION).tar.gz; \
 	fi
 
 .PHONY: cub

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,7 +98,7 @@ openfst-$(OPENFST_VERSION).tar.gz:
 		cp -p "$(DOWNLOAD_DIR)/openfst-$(OPENFST_VERSION).tar.gz" .; \
 	else \
 		$(WGET) -T 10 -t 1 http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
-		$(WGET) -T 10 -t 3 -O openfst-$(OPENFST_VERSION).tar.gz https://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz; \
+		$(WGET) -T 10 -t 3 -c https://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz; \
 	fi
 
 sclite: sclite_compiled
@@ -143,7 +143,7 @@ sph2pipe_$(SPH2PIPE_VERSION).tar.gz:
 		cp -p "$(DOWNLOAD_DIR)/sph2pipe_$(SPH2PIPE_VERSION).tar.gz" .; \
 	else \
 		$(WGET) -T 10 -t 3 https://www.openslr.org/resources/3/sph2pipe_$(SPH2PIPE_VERSION).tar.gz || \
-		$(WGET) -T 10 -O sph2pipe_$(SPH2PIPE_VERSION).tar.gz https://sourceforge.net/projects/kaldi/files/sph2pipe_$(SPH2PIPE_VERSION).tar.gz; \
+		$(WGET) -T 10 -c https://sourceforge.net/projects/kaldi/files/sph2pipe_$(SPH2PIPE_VERSION).tar.gz; \
 	fi
 
 .PHONY: cub
@@ -151,7 +151,7 @@ cub:
 	if [ -d "$(DOWNLOAD_DIR)" ]; then \
 		cp -p "$(DOWNLOAD_DIR)/cub-$(CUB_VERSION).zip" .; \
 	else \
-		$(WGET) -T 10 -t 3 -O cub-$(CUB_VERSION).zip https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip; \
+		$(WGET) -T 10 -t 3 -c https://github.com/NVlabs/cub/archive/$(CUB_VERSION).zip; \
 	fi
 	unzip -oq cub-$(CUB_VERSION).zip
 	rm -f cub


### PR DESCRIPTION
If first url fail, next url will output with wrong filename (`openfst-1.6.7.tar.gz.1` e.g.):

![image](https://user-images.githubusercontent.com/705582/71229414-5d550500-2320-11ea-9eb5-92a2d28d1665.png)

Modification: keep the normal name by `-O`


