### PR TITLE
bugs of using u0* type dir

### DIFF
--- a/egs/chime6/s5_track1/local/prepare_data.sh
+++ b/egs/chime6/s5_track1/local/prepare_data.sh
@@ -22,7 +22,11 @@ fi
 
 set -e -o pipefail
 
-adir=$(utils/make_absolute.sh $1)
+if [ $mictype != "ref" ];then
+  adir=$(utils/make_absolute.sh $1)
+else
+  adir=$1
+fi
 jdir=$2
 dir=$3
 


### PR DESCRIPTION
For beamformit, the u0* type input dir can not be parsed `utils/make_absolute.sh`, just use the input audio dir is ok