### PR TITLE
fix issue #3662

### DIFF
--- a/egs/chime4/s5_1ch/local/rnnlm/tuning/run_lstm_1a.sh
+++ b/egs/chime4/s5_1ch/local/rnnlm/tuning/run_lstm_1a.sh
@@ -66,6 +66,7 @@ if [ $stage -le 0 ]; then
   mkdir -p $text_dir
   cp $srcdir/train.rnn $text_dir/chime4.txt.tmp
   sed -e "s/<RNN_UNK>/<UNK>/g" $text_dir/chime4.txt.tmp > $text_dir/chime4.txt
+  rm $text_dir/chime4.txt.tmp
   cp $srcdir/valid.rnn $text_dir/dev.txt
 fi
 


### PR DESCRIPTION
In this PR, I inserted `rm $text_dir/chime4.txt.tmp` between line 68 and 69 of egs/chime4/s5_1ch/local/rnnlm/tuning/run_lstm_1a.sh. This will avoid a false alarm problem.