### PR TITLE
Fix fstmakecontextfst making C.fst with duplicated arcs on disambig symbols

### DIFF
--- a/src/fstbin/fstmakecontextfst.cc
+++ b/src/fstbin/fstmakecontextfst.cc
@@ -114,10 +114,6 @@ int main(int argc, char *argv[]) {
       int32 sym = phone_syms[i];
       loop_fst.AddArc(0, StdArc(sym, sym, TropicalWeight::One(), 0));
     }
-    for (size_t i = 0; i < disambig_in.size(); i++) {
-      int32 sym = disambig_in[i];
-      loop_fst.AddArc(0, StdArc(sym, sym, TropicalWeight::One(), 0));
-    }
 
     std::vector<std::vector<int32> > ilabels;
     VectorFst<StdArc> context_fst;


### PR DESCRIPTION
Fix [#3810](https://github.com/kaldi-asr/kaldi/issues/3810)

Now disambig symbols will not be added to C.fst twice
