### PR TITLE
Enable compilation of kaldi pybind without GPU (fix #3825).

### DIFF
--- a/src/pybind/dlpack/dlpack_pybind.cc
+++ b/src/pybind/dlpack/dlpack_pybind.cc
@@ -296,7 +296,7 @@ DLPackCuSubVector<float>* CuSubVectorFromDLPack(py::capsule* capsule) {
                                       tensor->shape[0], managed_tensor);
 #else
   KALDI_ERR << "Kaldi is not compiled with GPU!";
-  return py::none();
+  return nullptr;
 #endif
 }
 
@@ -312,7 +312,7 @@ DLPackCuSubMatrix<float>* CuSubMatrixFromDLPack(py::capsule* capsule) {
                                       tensor->strides[0], managed_tensor);
 #else
   KALDI_ERR << "Kaldi is not compiled with GPU!";
-  return py::none();
+  return nullptr;
 #endif
 }
 


### PR DESCRIPTION
fix #3825 

When GPU is not available, the compilation should pass but if you invoke
a function that requires a GPU, it throws at run time.