### PR TITLE
[scripts] fix python comp. in librispeech textnorm

### DIFF
--- a/egs/librispeech/s5/local/lm/normalize_text.sh
+++ b/egs/librispeech/s5/local/lm/normalize_text.sh
@@ -39,10 +39,10 @@ for b in $(cat $in_list); do
   [[ -f "$in_file" ]] || { echo "WARNING: $in_file does not exists"; continue; }
   out_file=$out_root/$id/$id.txt
   mkdir -p $out_root/$id
-  $PYTHON local/lm/python/pre_filter.py $in_file /dev/stdout |\
-    $PYTHON local/lm/python/text_pre_process.py /dev/stdin /dev/stdout |\
+  python local/lm/python/pre_filter.py $in_file /dev/stdout |\
+    python local/lm/python/text_pre_process.py /dev/stdin /dev/stdout |\
     nsw_expand -format opl /dev/stdin |\
-    $PYTHON local/lm/python/text_post_process.py /dev/stdin $out_file /dev/null || exit 1
+    python local/lm/python/text_post_process.py /dev/stdin $out_file /dev/null || exit 1
   processed=$((processed + 1))
   echo "Processing of $id has finished at $(date '+%T %F') [$processed texts ready so far]"
 done


### PR DESCRIPTION
During text normalization for librispeech my calculation crashed
because `$PYTHON` in normalize_text.sh is calling the system
python and not the python from my virtual enviroment.

Is there any reason to use `$PYTHON` and not `python`?
When inside a virtual env `python` will point to this python (and pip packages).
When outside a virtual env `python` will point to the system python like now.