### PR TITLE
add context manager support for IO

### DIFF
--- a/src/pybind/kaldi/table.py
+++ b/src/pybind/kaldi/table.py
@@ -83,6 +83,10 @@ class _SequentialReaderBase(object):
     def __enter__(self):
         return self
 
+    def __exit__(self, type, value, traceback):
+        if self.IsOpen():
+            self.Close()
+
     def __iter__(self):
         while not self.Done():
             key = self.Key()
@@ -243,6 +247,10 @@ class _RandomAccessReaderBase(object):
     def __enter__(self):
         return self
 
+    def __exit__(self, type, value, traceback):
+        if self.IsOpen():
+            self.Close()
+
     def __contains__(self, key):
         return self.HasKey(key)
 
@@ -386,6 +394,10 @@ class _WriterBase(object):
     def __enter__(self):
         return self
 
+    def __exit__(self, type, value, traceback):
+        if self.IsOpen():
+            self.Close()
+    
     def __setitem__(self, key, value):
         self.Write(key, value)
 

--- a/src/pybind/tests/test_kaldi_pybind.py
+++ b/src/pybind/tests/test_kaldi_pybind.py
@@ -58,6 +58,18 @@ class TestKaldiPybind(unittest.TestCase):
         np.testing.assert_array_equal(value.numpy(), gold)
 
         matrix_reader.Close()
+
+        # test with context manager
+        kp_matrix[0, 0] = 20
+        with kaldi.MatrixWriter(wspecifier) as writer:
+            writer.Write('id_2', kp_matrix)
+        with kaldi.SequentialMatrixReader(rspecifier) as reader:
+            key = reader.Key()
+            self.assertEqual(key, "id_2")
+            value = reader.Value()
+            gold = np.array([[20, 0, 0], [0, 0, 0]])
+            np.testing.assert_array_equal(value.numpy(), gold)
+        
         os.remove('test.ark')
 
     def test_matrix_reader_iterator(self):

--- a/src/pybind/tests/test_table_types.py
+++ b/src/pybind/tests/test_table_types.py
@@ -124,6 +124,13 @@ class TestTableTypes(unittest.TestCase):
             np.testing.assert_array_almost_equal(
                 reader.Value(key).numpy(), data[key])
         reader.Close()
+        
+        # test RandomAccessReader with context manager        
+        with kaldi.RandomAccessMatrixReader(rspecifier) as reader:
+            for key in data.keys():
+                self.assertTrue(reader.HasKey(key))
+                np.testing.assert_array_almost_equal(
+                    reader.Value(key).numpy(), data[key])
 
         shutil.rmtree(tmp)
 


### PR DESCRIPTION
`with` statement in Python is now supported for `Reader` and `Writer`, for example:

- `with kaldi.MatrixWriter(wspecifier) as writer:`
- `with kaldi.SequentialMatrixReader(rspecifier) as reader:`