### PR TITLE
split.scp.pl improve error msg

### DIFF
--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -225,7 +225,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
         $error = 1;
     }
     $linesperscp = int( $numlines / $numscps); # the "whole part"..
-    $linesperscp >= 1 || die "$0: You are splitting into too many pieces! [reduce \$nj ($nj) to be smaller than the number of lines ($numlines) in $inscp]\n";
+    $linesperscp >= 1 || die "$0: You are splitting into too many pieces! [reduce \$nj ($numscps) to be smaller than the number of lines ($numlines) in $inscp]\n";
     $remainder = $numlines - ($linesperscp * $numscps);
     ($remainder >= 0 && $remainder < $numlines) || die "bad remainder $remainder";
     # [just doing int() rounds down].

--- a/egs/wsj/s5/utils/split_scp.pl
+++ b/egs/wsj/s5/utils/split_scp.pl
@@ -225,7 +225,7 @@ if ($utt2spk_file ne "") {  # We have the --utt2spk option...
         $error = 1;
     }
     $linesperscp = int( $numlines / $numscps); # the "whole part"..
-    $linesperscp >= 1 || die "$0: You are splitting into too many pieces! [reduce \$nj]\n";
+    $linesperscp >= 1 || die "$0: You are splitting into too many pieces! [reduce \$nj ($nj) to be smaller than the number of lines ($numlines) in $inscp]\n";
     $remainder = $numlines - ($linesperscp * $numscps);
     ($remainder >= 0 && $remainder < $numlines) || die "bad remainder $remainder";
     # [just doing int() rounds down].


### PR DESCRIPTION
I tried to execute the CHiME-6 baseline and got the error msg:
```
utils/split_scp.pl: You are splitting into too many pieces! [reduce $nj]
```
this was not really helpful.
Now it produces
```
utils/split_scp.pl: You are splitting into too many pieces! [reduce $nj (10) to be smaller than the number of lines (9) in data/eval_beamformit_dereverb/wav.scp]
```
