### PR TITLE
Update kaldi-thread.h includes for MSVC compiler

### DIFF
--- a/src/util/kaldi-thread.h
+++ b/src/util/kaldi-thread.h
@@ -23,6 +23,7 @@
 #define KALDI_THREAD_KALDI_THREAD_H_ 1
 
 #include <thread>
+#include <algorithm>
 #include "itf/options-itf.h"
 #include "util/kaldi-semaphore.h"
 


### PR DESCRIPTION
Adding #include <algorithm> to kaldi-thread.h since building with CMake fails without it at least when using the MSVC compiler