### PR TITLE
fix displayed WER fraction in CHiME6

### DIFF
--- a/egs/chime6/s5_track2/local/print_dset_error.py
+++ b/egs/chime6/s5_track2/local/print_dset_error.py
@@ -30,6 +30,6 @@ for line in infile:
 
 for arrayid in sorted(array_id_error_dict):
     wer = float(array_id_error_dict[arrayid][1])/float(array_id_error_dict[arrayid][0])*100
-    wer_detail = "%WER {0:5.2f} [ {1} / {2}, {3} ins, {4} del, {5} sub ]".format(wer, array_id_error_dict[arrayid][0], array_id_error_dict[arrayid][1], array_id_error_dict[arrayid][2], array_id_error_dict[arrayid][3], array_id_error_dict[arrayid][4])
+    wer_detail = "%WER {0:5.2f} [ {1} / {2}, {3} ins, {4} del, {5} sub ]".format(wer, array_id_error_dict[arrayid][1], array_id_error_dict[arrayid][0], array_id_error_dict[arrayid][2], array_id_error_dict[arrayid][3], array_id_error_dict[arrayid][4])
     output.write(arrayid + ' ' + wer_detail + '\n')
 


### PR DESCRIPTION
The WER on the CHiME-6 Website (https://chimechallenge.github.io/chime6/track2_software.html) is displayed as
```
U06 %WER 81.18 [ 58881 / 47798, 1638 ins, 30528 del, 15632 sub ]
U06 %WER 85.39 [ 55132 / 47076, 1107 ins, 27768 del, 18201 sub ]
```
`58881 / 47798` should be `47798 / 58881`.
This PR changes the order.

I do not know who is responsible for the website.
@sw005320 do you know, how the numbers on the chime6 website can be corrected?