### PR TITLE
Add online-batched-cuda-cmvn.

### DIFF
--- a/src/cudafeat/Makefile
+++ b/src/cudafeat/Makefile
@@ -10,7 +10,8 @@ TESTFILES =
 ifeq ($(CUDA), true)
   OBJFILES +=  feature-window-cuda.o feature-spectral-cuda.o feature-online-cmvn-cuda.o \
 							 online-ivector-feature-cuda-kernels.o online-ivector-feature-cuda.o \
-							 online-cuda-feature-pipeline.o
+							 online-cuda-feature-pipeline.o src/cudafeat/feature-online-batched-cmvn-cuda.o \
+							 src/cudafeat/feature-online-batched-cmvn-cuda-kernels.o
 endif
 
 LIBNAME = kaldi-cudafeat

--- a/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
@@ -1,0 +1,294 @@
+// cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <cub/cub.cuh>
+#include "cudafeat/feature-online-batched-cmvn-cuda-kernels.h"
+
+__device__ inline float2 operator-(const float2 &a, const float2 &b) {
+  float2 retval;
+  retval.x = a.x - b.x;
+  retval.y = a.y - b.y;
+  return retval;
+}
+__device__ inline float2 operator+(const float2 &a, const float2 &b) {
+  float2 retval;
+  retval.x = a.x + b.x;
+  retval.y = a.y + b.y;
+  return retval;
+}
+
+__device__ inline void atomicAdd(float2 *addr, float2 val) {
+  atomicAdd(reinterpret_cast<float *>(addr), val.x);
+  atomicAdd(reinterpret_cast<float *>(addr) + 1, val.y);
+}
+
+__device__ inline void operator+=(float2 &a, float2 &b) {
+  // overloading +=
+  a.x += b.x;
+  a.y += b.y;
+}
+
+namespace kaldi {
+// threadIdx.x = frame  (up to 1024?)
+// blockIdx.x = feature
+// blockIdx.y = batch id
+__global__ void compute_cmvn_stats_kernel(
+    int32_t feat_dim, int32_t chunk_size, int32_t stats_coarsening_factor,
+    int32_t cmn_window, const float *in_data, int32_t ldi, int32_t stridei,
+    float *stats_data, int32_t lds, const LaneDesc *lanes, int32_t num_lanes) {
+  typedef cub::BlockScan<float2, 1024> BlockScan;
+  __shared__ typename BlockScan::TempStorage temp_storage;
+
+  int32_t lane = blockIdx.y;
+  int32_t feat = blockIdx.x;  // feature for this block
+  int32_t tidx = threadIdx.x;
+
+  // width of a window of stats data
+  int32_t num_fragments = (chunk_size + cmn_window) / stats_coarsening_factor;
+
+  // function to compute window location based on frame
+  auto SIDX = [&](int frame, int feat) {
+    int row = feat;
+    int col = (frame / stats_coarsening_factor) % num_fragments;
+    return row * num_fragments + col;
+  };
+
+  LaneDesc desc = lanes[lane];
+  ChannelId channel = desc.channel;
+  int32_t num_chunk_frames = desc.num_chunk_frames;
+
+  // compute memory offsets for batch
+  float2 *sdata = reinterpret_cast<float2 *>(stats_data + channel * lds);
+
+  // batch is rows, cols is chunk_size x feat_dim, where feat_dim is
+  // padded to ldi
+  const float *idata = in_data + lane * stridei;
+
+  // starting frame of audio
+  int32_t start_frame = desc.current_frame;
+
+  float2 running_sum = {0.0f, 0.0f};
+
+  // load previous running sum if this is not the first frame
+  if (start_frame > 0) running_sum = sdata[SIDX(start_frame - 1, feat)];
+
+  // for each frame compute prefix sum
+  for (int32_t f = 0; f < num_chunk_frames; f += blockDim.x) {
+    int frame = f + tidx;
+
+    float val = 0.0f;
+    if (frame < num_chunk_frames) {
+      // uncoalesced
+      val = idata[frame * ldi + feat];
+    }
+
+    float2 sum = {val, val * val};
+    float2 psum;   // row prefix sum
+    float2 total;  // total count
+
+    BlockScan(temp_storage).InclusiveSum(sum, psum, total);
+
+    // offset by running sum
+    psum = psum + running_sum;
+
+    // increase running sum by new total
+    running_sum = running_sum + total;
+
+    // The last thread of each fragement will write their value to stats
+    bool write = (frame < num_chunk_frames && frame % stats_coarsening_factor ==
+                                                  stats_coarsening_factor - 1);
+
+    // last frame will always write
+    // this fagment may not have full stats
+    // use our frame to fill in those stats
+    if (f == num_chunk_frames - 1) {
+      // This thread will write
+      write = true;
+
+      // number of frames in my fragement with stats
+      int32_t in_frame = f % stats_coarsening_factor + 1;
+      // number of frames int my fragement without stats
+      int32_t not_in_frame = stats_coarsening_factor - in_frame;
+
+      // multiply this frame stats by the number of frames not counted
+      float2 add = make_float2(sum.x * not_in_frame, sum.y * not_in_frame);
+
+      // if the fragment is full add will be (0,0)
+      // Add in stats
+      psum += add;
+    }
+
+    if (write) {
+      // un-coalesced
+      sdata[SIDX(start_frame + frame, feat)] = psum;
+    }
+  }
+}
+
+// For each channel in batch size, compute coarsened stats in rolling
+// window
+void compute_cmvn_stats(int32_t feat_dim, int32_t chunk_size,
+                        int32_t stats_coarsening_factor, int32_t cmn_window,
+                        const float *in_data, int32_t ldi, int32_t stridei,
+                        float *stats_data, int32_t lds, const LaneDesc *lanes,
+                        int32_t num_lanes) {
+  int threads = 1024;
+  dim3 blocks(feat_dim, num_lanes);
+
+  compute_cmvn_stats_kernel<<<blocks, threads>>>(
+      feat_dim, chunk_size, stats_coarsening_factor, cmn_window, in_data, ldi,
+      stridei, stats_data, lds, lanes, num_lanes);
+};
+
+// threadIdx.x = feature (32?)
+// threadIdx.y, blockIdx.x = frame
+// blockIdx.y = batch id
+__global__ void apply_cmvn_kernel(
+    int32_t cmvn_window, bool var_norm, bool mean_norm, int32_t feat_dim,
+    int32_t chunk_size, int32_t stats_coarsening_factor,
+    const float *__restrict__ in_data, int32_t ldi, int32_t stridei,
+    const float *__restrict__ stats_data, int32_t lds,
+    const float *__restrict__ global_stats, int32_t ldg, int32_t global_frames,
+    const float *__restrict__ speaker_stats, int32_t ldss,
+    int32_t speaker_frames, float *out_data, int32_t ldo, int32_t strideo,
+    const LaneDesc *lanes, int32_t num_lanes) {
+  int32_t lane = blockIdx.y;
+  LaneDesc desc = lanes[lane];
+  ChannelId channel = desc.channel;
+
+  // compute memory offsets for batch
+  const float2 *sdata =
+      reinterpret_cast<const float2 *>(stats_data + channel * lds);
+  // batch is rows, cols is chunk_size x feat_dim, where feat_dim is
+  // padded to ldi
+  const float *idata = in_data + lane * stridei;
+  float *odata = out_data + lane * strideo;
+
+  // width of a window of stats data
+  int32_t num_fragments = (chunk_size + cmvn_window) / stats_coarsening_factor;
+
+  // function to compute window location based on frame
+  auto SIDX = [&](int frame, int feat) {
+    int row = feat;
+    int col = (frame / stats_coarsening_factor) % num_fragments;
+    return row * num_fragments + col;
+  };
+
+  int32_t current_frame = desc.current_frame;
+  int32_t num_chunk_frames = desc.num_chunk_frames;
+  for (int f = blockIdx.x * blockDim.y + threadIdx.y; f < num_chunk_frames;
+       f += blockDim.y * gridDim.x) {
+    int frame = current_frame + f;
+
+    for (int feat = threadIdx.x; feat < feat_dim; feat += blockDim.x) {
+      // Compute stats for frame
+      float2 frame_stats = sdata[SIDX(frame, feat)];
+      // load value
+      float val = idata[f * ldi + feat];
+
+      // compute window length
+      float window_length = min(frame + 1, cmvn_window);
+
+      // possibly remove stats -cmvn window away
+      if (frame >= cmvn_window) {
+        float2 old_frame_stats = sdata[SIDX(frame - cmvn_window, feat)];
+        frame_stats = frame_stats - old_frame_stats;
+      }
+
+      // Smooth stats by speaker frames if necessary
+      float smooth_frames = cmvn_window - window_length;
+      if (smooth_frames > 0 && speaker_frames > 0) {
+        float count_from_speaker = min(smooth_frames, (float)speaker_frames);
+        float speaker_count = speaker_stats[feat_dim];
+
+        if (count_from_speaker > 0.0) {
+          float alpha = count_from_speaker / speaker_count;
+
+          frame_stats.x += alpha * speaker_stats[feat];  // update mean
+          frame_stats.y +=
+              alpha * speaker_stats[ldss + feat];  // update variance
+          window_length += alpha * speaker_count;  // update window length
+
+          // recompute smooth frames now that we have speaker stats
+          smooth_frames = cmvn_window - window_length;
+        }
+      }  // end speaker smooth
+
+      // Smooth stats by global frames if necessary
+      if (smooth_frames > 0 && global_frames > 0) {
+        float count_from_global = min(smooth_frames, (float)global_frames);
+        float global_count = global_stats[feat_dim];
+
+        if (count_from_global > 0.0) {
+          float alpha = count_from_global / global_count;
+
+          frame_stats.x += alpha * global_stats[feat];        // update mean
+          frame_stats.y += alpha * global_stats[ldg + feat];  // update variance
+          window_length += alpha * global_count;  // update window length
+        }
+      }  // end global smooth
+
+      float mean = frame_stats.x / window_length;
+      float var = frame_stats.y / window_length - mean * mean;
+
+      float floor = 1e-20;
+      if (var < floor) {
+        // avoid dividing by zero
+        var = floor;
+      }
+      if (!var_norm) {
+        // skip variance normalization
+        var = 1.0f;
+      }
+      if (!mean_norm) {
+        // skip mean normalization
+        mean = 0.0f;
+      }
+
+      // shift by mean and scale by variance
+      float oval = (val - mean) / sqrtf(var);
+
+      odata[f * ldo + feat] = oval;
+    }  // end feat loop
+  }    // end frame loop
+}
+
+void apply_cmvn(int32_t cmvn_window, bool var_norm, bool mean_norm,
+                int32_t feat_dim, int32_t chunk_size,
+                int32_t stats_coarsening_factor, const float *in_data,
+                int32_t ldi, int32_t stridei, const float *stats_data,
+                int32_t lds, const float *global_stats, int32_t ldg,
+                int32_t global_frames, const float *speaker_stats, int32_t ldss,
+                int32_t speaker_frames, float *out_data, int32_t ldo,
+                int32_t strideo, const LaneDesc *lanes, int32_t num_lanes) {
+  // round threads to neared warp
+  int threadsx = 64;
+  int threadsy = 512 / threadsx;
+  dim3 threads(threadsx, threadsy);
+
+  int blocksx = (chunk_size + threadsy - 1) / threadsy;
+  int blocksy = num_lanes;
+  dim3 blocks(blocksx, blocksy);
+
+  apply_cmvn_kernel<<<blocks, threads>>>(
+      cmvn_window, var_norm, mean_norm, feat_dim, chunk_size,
+      stats_coarsening_factor, in_data, ldi, stridei, stats_data, lds,
+      global_stats, ldg, global_frames, speaker_stats, ldss, speaker_frames,
+      out_data, ldo, strideo, lanes, num_lanes);
+}
+
+}  // namespace kaldi

--- a/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.h
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.h
@@ -1,0 +1,44 @@
+// cudafeat/feature-online-batched-cmvn-cuda-kernels.h
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_CUDAFEAT_FEATURE_ONLINE_BATCHED_CMVN_CUDA_KERNELS_H_
+#define KALDI_CUDAFEAT_FEATURE_ONLINE_BATCHED_CMVN_CUDA_KERNELS_H_
+
+#include "cudafeat/lane-desc.h"
+
+namespace kaldi {
+
+// ld{i,o} = size of inner dimension of matrix alloction
+// stride{i,o} = stride between consecutive batch matrices
+
+void compute_cmvn_stats(int32_t feat_dim, int32_t chunk_size,
+                        int32_t stats_coarsening_factor, int32_t cmn_window,
+                        const float *in_data, int32_t ldi, int32_t stridei,
+                        float *stats_data, int32_t lds, const LaneDesc *lanes,
+                        int32_t num_lanes);
+
+void apply_cmvn(int32_t cmvn_window, bool var_norm, bool mean_norm,
+                int32_t feat_dim, int32_t chunk_size,
+                int32_t stats_coarsening_factor, const float *in_data,
+                int32_t ldi, int32_t stridei, const float *stats_data,
+                int32_t lds, const float *global_stats, int32_t ldg,
+                int32_t global_frames, const float *speaker_stats, int32_t ldss,
+                int32_t speaker_frames, float *out_data, int32_t ldo,
+                int32_t strideo, const LaneDesc *lanes, int32_t num_lanes);
+}  // namespace kaldi
+
+#endif

--- a/src/cudafeat/feature-online-batched-cmvn-cuda.cc
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda.cc
@@ -1,0 +1,84 @@
+// cudafeat/feature-online-batched-cmvn-cuda.cc
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cudafeat/feature-online-batched-cmvn-cuda.h"
+#include "cudafeat/feature-online-batched-cmvn-cuda-kernels.h"
+
+namespace kaldi {
+
+CudaOnlineBatchedCmvn::CudaOnlineBatchedCmvn(
+    const OnlineCmvnOptions &opts, const CudaOnlineCmvnState &cmvn_state,
+    int32_t feat_dim, int32_t chunk_size, int32_t num_channels,
+    int32_t stats_coarsening_factor)
+    : opts_(opts),
+      cmvn_state_(cmvn_state),
+      feat_dim_(feat_dim),
+      chunk_size_(chunk_size),
+      num_channels_(num_channels),
+      stats_coarsening_factor_(stats_coarsening_factor) {
+  // This constraint could probably be removed by estimating partial frames
+  KALDI_ASSERT(opts_.cmn_window % stats_coarsening_factor_ == 0);
+  KALDI_ASSERT(chunk_size % stats_coarsening_factor_ == 0);
+
+  // Number of fragements we need to keep around for each chunk
+  num_fragments_ = (chunk_size + opts_.cmn_window) / stats_coarsening_factor_;
+
+  stats_fragments_.Resize(num_channels_, feat_dim * num_fragments_ * 2);
+}
+
+CudaOnlineBatchedCmvn::~CudaOnlineBatchedCmvn() {}
+
+// Computes a chunk of features for each channel included in channels
+void CudaOnlineBatchedCmvn::ComputeFeaturesBatched(
+    int32_t num_lanes, const LaneDesc *lanes,
+    const CuMatrixBase<BaseFloat> &feats_in, CuMatrix<BaseFloat> *feats_out) {
+  if (num_lanes == 0) return;
+
+  // Step 1:
+  // Compute windows sum/sum2 prefix along columns of feets
+  // For audio chunk compute sum, sum2 and fill in stats
+  // need to coarsen data by coarsening factor,
+  // 1 out of coarsening factor threads actually write prefixs out
+  // need to handle rolling window (modular indexing)
+  // if partial frame of audio use mixture of global/current stats to fill in
+  compute_cmvn_stats(feats_in.NumCols(), chunk_size_, stats_coarsening_factor_,
+                     opts_.cmn_window, feats_in.Data(), feats_in.Stride(),
+                     feats_in.Stride() * chunk_size_, stats_fragments_.Data(),
+                     stats_fragments_.Stride(), lanes, num_lanes);
+
+  // Step 2:
+  // Apply CMVN
+  const CuMatrix<float> &gstats = cmvn_state_.global_cmvn_stats;
+  const CuMatrix<float> &sstats = cmvn_state_.speaker_cmvn_stats;
+
+  int global_frames = opts_.global_frames;
+  int speaker_frames = opts_.speaker_frames;
+
+  if (gstats.NumRows() == 0) global_frames = 0;
+  if (sstats.NumRows() == 0) speaker_frames = 0;
+
+  apply_cmvn(opts_.cmn_window, opts_.normalize_variance, opts_.normalize_mean,
+             feats_in.NumCols(), chunk_size_, stats_coarsening_factor_,
+             feats_in.Data(), feats_in.Stride(),
+             feats_in.Stride() * chunk_size_, stats_fragments_.Data(),
+             stats_fragments_.Stride(), gstats.Data(), gstats.Stride(),
+             global_frames, sstats.Data(), sstats.Stride(), speaker_frames,
+             feats_out->Data(), feats_out->Stride(),
+             feats_out->Stride() * chunk_size_, lanes, num_lanes);
+}
+
+}  // namespace kaldi

--- a/src/cudafeat/feature-online-batched-cmvn-cuda.h
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda.h
@@ -1,0 +1,68 @@
+// cudafeat/feature-online-batched-cmvn-cuda.h
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef KALDI_CUDAFEAT_FEATURE_ONLINE_BATCHED_CMVN_CUDA_H_
+#define KALDI_CUDAFEAT_FEATURE_ONLINE_BATCHED_CMVN_CUDA_H_
+
+#include "cudafeat/feature-online-cmvn-cuda.h"
+#include "cudafeat/lane-desc.h"
+#include "cudamatrix/cu-matrix.h"
+#include "feat/online-feature.h"
+
+namespace kaldi {
+
+class CudaOnlineBatchedCmvn {
+ public:
+  CudaOnlineBatchedCmvn(const OnlineCmvnOptions &opts,
+                        const CudaOnlineCmvnState &cmvn_state, int32_t feat_dim,
+                        int32_t chunk_size, int32_t num_channels,
+                        int32_t stats_coarsening_factor);
+
+  ~CudaOnlineBatchedCmvn();
+
+  // Computes a chunk of features for each channel included in lanes
+  void ComputeFeaturesBatched(int32_t num_lanes, const LaneDesc *lanes,
+                              const CuMatrixBase<BaseFloat> &feats_in,
+                              CuMatrix<BaseFloat> *feats_out);
+
+ private:
+  const OnlineCmvnOptions &opts_;
+  const CudaOnlineCmvnState &cmvn_state_;
+
+  int32_t feat_dim_;
+  int32_t chunk_size_;
+  int32_t num_channels_;
+
+  // The number of frames for each fragment of stats.
+  // Larger = faster, less memory, but less accurate
+  // Smaller = slower, more memory, but more accurate,
+  // 1 is equivalent to the non-batched version
+  int32_t stats_coarsening_factor_;
+  int32_t num_fragments_;  // window_size / stats_coarsening_factor_
+
+  // This matrix stores prefix sum audio statistics in a rolling
+  // buffer.  The stats are coarsened by stats_coarsening_factor_.
+  // Coarsening reduces memory usage at a potential cost in
+  // accuracy.  Matrix stores both sum and sum2 as float2 but
+  // the matrix type is float as CuMatrix does not support float2.
+  // val.x = sum and val.y = sum^2
+  // Rows = channels, Cols = feat_dim * chunk_size/coarsening factor * 2
+  CuMatrix<float> stats_fragments_;
+};
+
+}  // namespace kaldi
+
+#endif

--- a/src/cudafeat/lane-desc.h
+++ b/src/cudafeat/lane-desc.h
@@ -1,0 +1,53 @@
+// cudafeat/lane-desc.h
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CUDAFEAT_LANE_DESC_H_
+#define CUDAFEAT_LANE_DESC_H_
+
+#include <cstdint>
+
+namespace kaldi {
+
+typedef int32_t ChannelId;
+
+// The description for a single channel.
+// A vector of these will be passed into components to
+// control which channels are executed.
+struct LaneDesc {
+  ChannelId channel;
+
+  // number of samples in this chunk
+  int32_t num_chunk_samples;
+
+  // current sample for this chunk
+  int32_t current_sample;
+
+  // number of frames in this chunk.
+  int32_t num_chunk_frames;
+
+  // current frame for this chunk
+  int32_t current_frame;
+
+  // is this the last chunk
+  int32_t last;
+
+  // is this the first chunk
+  int32_t first;
+};
+
+}  // namespace kaldi
+#endif

--- a/src/cudafeatbin/Makefile
+++ b/src/cudafeatbin/Makefile
@@ -9,7 +9,8 @@ LDLIBS += $(CUDA_LDLIBS)
 BINFILES =
 
 ifeq ($(CUDA), true)
-  BINFILES += compute-mfcc-feats-cuda apply-cmvn-online-cuda compute-online-feats-cuda compute-fbank-feats-cuda
+  BINFILES += compute-mfcc-feats-cuda apply-cmvn-online-cuda compute-online-feats-cuda compute-fbank-feats-cuda \
+							apply-batched-cmvn-online-cuda
 endif
 
 OBJFILES =

--- a/src/cudafeatbin/apply-batched-cmvn-online-cuda.cc
+++ b/src/cudafeatbin/apply-batched-cmvn-online-cuda.cc
@@ -1,0 +1,295 @@
+// online2bin/apply-batched-cmvn-online.cc
+
+// cudafeat/online-cuda-batched-feature-pipeline-kernels.h
+//
+// Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+// Justin Luitjens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_profiler_api.h>
+#include <string>
+#include <vector>
+#include "base/kaldi-common.h"
+#include "cudafeat/feature-online-batched-cmvn-cuda.h"
+#include "feat/online-feature.h"
+#include "util/common-utils.h"
+
+using namespace kaldi;
+
+// This class stores data for input and output of this binary.
+struct UtteranceDataHandle {
+  std::string utt;
+  Matrix<BaseFloat> feats_in;
+  Matrix<BaseFloat> feats_out;
+  int32_t num_frames;
+
+  UtteranceDataHandle(const std::string &utt, Matrix<float> &feats)
+      : utt(utt), num_frames(feats.NumRows()) {
+    feats_out.Resize(feats.NumRows(), feats.NumCols(), kUndefined);
+    feats_in.Swap(&feats);
+  }
+};
+
+int main(int argc, char *argv[]) {
+  try {
+    typedef kaldi::int32 int32;
+    using namespace kaldi;
+    const char *usage =
+        "Apply online cepstral mean (and possibly variance) computation "
+        "online,\n"
+        "using the same code as used for online decoding in the 'new' setup "
+        "in\n"
+        "online2/ and online2bin/.'\n"
+        "The computation is done on the device in chunks that are batched. "
+        "spk2utt is not supported.\n"
+        "\n"
+        "Usage: apply-batched-cmvn-online-cuda [options] <global-cmvn-stats> "
+        "<feature-rspecifier> "
+        "<feature-wspecifier>\n"
+        "e.g. apply-batched-cmvn-online-cuda 'matrix-sum "
+        "scp:data/train/cmvn.scp -|' "
+        "data/train/split8/1/feats.scp ark:-\n";
+
+    int32_t num_channels = 200;
+    int32_t batch_size = 100;
+    int32_t chunk_length = 10000;
+    int32_t stats_coarsening_factor = 1;
+
+    int32_t feat_dim = -1;
+
+    ParseOptions po(usage);
+
+    po.Register("num-channels", &num_channels,
+                "The number of"
+                " channels used for compute");
+    po.Register("batch-size", &batch_size,
+                "The number of chunks from"
+                " audio cuts processed in a single batch");
+    po.Register("chunk-length", &chunk_length,
+                "The length of a chunk"
+                " of audio in frames that is processed at one time");
+    po.Register(
+        "stats-coarsening-factor", &stats_coarsening_factor,
+        " Coarsen CMVN stats by this factor.  This reduces memory and time. "
+        " But comes at the potential loss of accuracy.");
+
+    OnlineCmvnOptions cmvn_opts;
+
+    std::string spk2utt_rspecifier;
+    cmvn_opts.Register(&po);
+    CuDevice::RegisterDeviceOptions(&po);
+    RegisterCuAllocatorOptions(&po);
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 3) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+    KALDI_ASSERT(num_channels >= batch_size);
+
+    g_cuda_allocator.SetOptions(g_allocator_options);
+    CuDevice::Instantiate().SelectGpuId("yes");
+    CuDevice::Instantiate().AllowMultithreading();
+
+    LaneDesc *d_lanes = (LaneDesc *)CuDevice::Instantiate().Malloc(
+        sizeof(LaneDesc) * batch_size);
+
+    std::string global_stats_rxfilename = po.GetArg(1),
+                feature_rspecifier = po.GetArg(2),
+                feature_wspecifier = po.GetArg(3);
+
+    // global_cmvn_stats helps us initialize to online CMVN to
+    // reasonable values at the beginning of the utterance.
+    Matrix<double> global_cmvn_stats;
+    ReadKaldiObject(global_stats_rxfilename, &global_cmvn_stats);
+
+    BaseFloatMatrixWriter feature_writer(feature_wspecifier);
+    int32 num_done = 0;
+    int64 tot_t = 0;
+
+    OnlineCmvnState cmvn_state(global_cmvn_stats);
+    CudaOnlineCmvnState cu_cmvn_state(cmvn_state);
+
+    std::vector<ChannelId> free_channels;
+
+    // list of audio handles to be processed
+    std::vector<UtteranceDataHandle> data_handles;
+    // maps currently active channels to their handle index
+    std::map<int, int> channel_to_handle_idx;
+    // Index of next unprocessed audio file
+    int not_done_idx = 0;
+
+    bool first = true;
+    // preload data for batching
+    SequentialBaseFloatMatrixReader feature_reader(feature_rspecifier);
+    for (; !feature_reader.Done(); feature_reader.Next()) {
+      std::string utt = feature_reader.Key();
+      Matrix<BaseFloat> &feats = feature_reader.Value();
+      if (first == true) {
+        feat_dim = feats.NumCols();
+        first = false;
+      }
+
+      data_handles.emplace_back(utt, feats);
+    }
+
+    CudaOnlineBatchedCmvn cuda_cmvn(cmvn_opts, cu_cmvn_state, feat_dim,
+                                    chunk_length, num_channels,
+                                    stats_coarsening_factor);
+
+    CuMatrix<BaseFloat> d_batch_in(batch_size * chunk_length, feat_dim);
+    CuMatrix<BaseFloat> d_batch_out(batch_size * chunk_length, feat_dim);
+
+    std::vector<LaneDesc> lanes;
+
+    for (int i = 0; i < num_channels; i++) {
+      free_channels.push_back(i);
+    }
+
+    // A single pass through this loop will fill the
+    // batch with new work if any is available.
+    // Then process a single iteration of batched cmvn.
+    // At exit each process handle should have valid data
+    // in feats_out.
+    while (true) {
+      // This loop will fill the batch by pulling from the
+      // data_handles vector for new work
+      while (lanes.size() < batch_size && not_done_idx < data_handles.size()) {
+        UtteranceDataHandle &handle = data_handles[not_done_idx];
+        int32_t current_frame = 0;
+        int32_t num_frames = handle.num_frames;
+        int32_t num_chunk_frames = std::min(chunk_length, num_frames);
+
+        // grab a free channel
+        int32_t channel = free_channels.back();
+        free_channels.pop_back();
+
+        LaneDesc desc;
+        desc.channel = channel;
+        desc.current_frame = current_frame;
+        desc.num_chunk_frames = num_chunk_frames;
+        lanes.push_back(desc);
+
+        channel_to_handle_idx[channel] = not_done_idx;
+        not_done_idx++;
+      }
+
+      // No work in lanes, this means corpus is finished
+      if (lanes.size() == 0) break;
+
+      cudaMemcpyAsync(d_lanes, &lanes[0], sizeof(LaneDesc) * lanes.size(),
+                      cudaMemcpyHostToDevice, cudaStreamPerThread);
+
+      // This loop copies a slice from each active audio cut
+      // down to the device for processing
+      for (int lane = 0; lane < lanes.size(); lane++) {
+        LaneDesc &desc = lanes[lane];
+        int32_t channel = desc.channel;
+        int32_t current_frame = desc.current_frame;
+        int32_t num_chunk_frames = desc.num_chunk_frames;
+
+        UtteranceDataHandle &handle =
+            data_handles[channel_to_handle_idx[channel]];
+
+        // Create a submatrix for this slice of data
+        CuSubMatrix<BaseFloat> A(d_batch_in.Range(
+            lane * chunk_length, num_chunk_frames, 0, feat_dim));
+        SubMatrix<BaseFloat> B(handle.feats_in.Range(
+            current_frame, num_chunk_frames, 0, feat_dim));
+
+        // Copy slice down to the device
+        A.CopyFromMat(B);
+      }
+
+      // process batch
+      cuda_cmvn.ComputeFeaturesBatched(lanes.size(), d_lanes, d_batch_in,
+                                       &d_batch_out);
+
+      // At this time the batch is computed.  We now need to copy each slice
+      // into the appropriate output buffer
+      for (int lane = 0; lane < lanes.size(); lane++) {
+        LaneDesc &desc = lanes[lane];
+        ChannelId channel = desc.channel;
+
+        int32_t current_frame = desc.current_frame;
+        int32_t num_chunk_frames = desc.num_chunk_frames;
+
+        UtteranceDataHandle &handle =
+            data_handles[channel_to_handle_idx[channel]];
+
+        // Copy slice back up
+        CuSubMatrix<BaseFloat> A(d_batch_out.Range(
+            lane * chunk_length, num_chunk_frames, 0, feat_dim));
+        SubMatrix<BaseFloat> B(handle.feats_out.Range(
+            current_frame, num_chunk_frames, 0, feat_dim));
+
+        B.CopyFromMat(A);
+      }  // end copy to host loop
+
+      // For each lane check if compute is done.
+      // If completed, remove from channel list and
+      // free the channel.
+      for (int lane = 0; lane < lanes.size();) {
+        LaneDesc &desc = lanes[lane];
+        ChannelId channel = desc.channel;
+
+        UtteranceDataHandle &handle =
+            data_handles[channel_to_handle_idx[channel]];
+
+        // advance channel
+        desc.current_frame += desc.num_chunk_frames;
+        desc.num_chunk_frames =
+            std::min(chunk_length, handle.num_frames - desc.current_frame);
+
+        if (desc.current_frame == handle.num_frames) {
+          // free this channel
+          free_channels.push_back(channel);
+          // Move last lane to this lane
+          lanes[lane] = lanes.back();
+          lanes.pop_back();
+        } else {
+          // This lane is not finished so leave it alone
+          lane++;
+        }
+      }  // end check if done loop
+    }    // end while(true)
+
+    // output all utterances.  In an efficeint implementation
+    // this would be done on demand in a threaded manner.  This
+    // binary is purely for checking correctness and demonstrating
+    // usage and thus this type of optimization is not done.
+    for (int i = 0; i < data_handles.size(); i++) {
+      UtteranceDataHandle &handle = data_handles[i];
+
+      num_done++;
+      tot_t += handle.feats_out.NumRows();
+      feature_writer.Write(handle.utt, handle.feats_out);
+    }
+
+    CuDevice::Instantiate().Free(d_lanes);
+
+    KALDI_LOG << "Applied online CMVN to " << num_done << " files, or " << tot_t
+              << " frames.";
+
+    cudaDeviceSynchronize();
+    cudaProfilerStop();
+
+    return (num_done != 0 ? 0 : 1);
+  } catch (const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}


### PR DESCRIPTION
This is the first of a couple patches to enable
online-batched-cuda-feature-extraction.

Processing occurs across a batch of multiple audio files in
a chunked fashion.  This allows us to do processing before all
audio is present lower latency and to get better device
utilization by batching those chunks together.

The interface for this class is fairly low level as it is ment
to be driven by the online-batched-cuda-feature pipeline which
will be added later.

A binary demonstrating the usage of this class is included in
cudafeatbin/apply-batched-cmvn-online-cuda.cc

Correctness has been tested as follows:

%> ./compute-mfcc-feats-cuda --config=mfcc.conf scp:wav.scp ark,scp:mfcc.ark,mfcc.scp
%> ./apply-batched-cmvn-online-cuda --batch-size=20 global_cmvn.stats "scp:mfcc.scp" "ark,scp:cmvn-cuda-batched.ark,cmvn-cuda-batched.scp"
%> ./apply-cmvn-online-cuda global_cmvn.stats "scp:mfcc.scp" "ark,scp:cmvn-cuda.ark,cmvn-cuda.scp"
%> ../featbin/compare-feats scp:cmvn-cuda.scp scp:cmvn-cuda-batched.scp

Output from last command on a dataset is:

LOG (compare-feats[5.5.1622~4-126aa]:main():compare-feats.cc:111)
Similarity metric for each dimension  [ 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 ]
 (1.0 means identical, the smaller the more different)
 LOG (compare-feats[5.5.1622~4-126aa]:main():compare-feats.cc:116)
 Overall similarity for the two feats is:1 (1.0 means identical, the
 smaller the more different)
 LOG (compare-feats[5.5.1622~4-126aa]:main():compare-feats.cc:119)
 Processed 80 feature files, 0 had errors.
 LOG (compare-feats[5.5.1622~4-126aa]:main():compare-feats.cc:126)
 Features are considered similar since 1 >= 0.99