### PR TITLE
[src] Allow usage of const Fst (#3871, #3870, #3860)

### DIFF
--- a/src/bin/align-mapped.cc
+++ b/src/bin/align-mapped.cc
@@ -34,6 +34,7 @@ int main(int argc, char *argv[]) {
     typedef kaldi::int32 int32;
     using fst::SymbolTable;
     using fst::VectorFst;
+    using fst::Fst;
     using fst::StdArc;
 
     const char *usage =
@@ -75,7 +76,7 @@ int main(int argc, char *argv[]) {
     TransitionModel trans_model;
     ReadKaldiObject(model_in_filename, &trans_model);
 
-    VectorFst<StdArc> *lex_fst = fst::ReadFstKaldi(lex_in_filename);
+    Fst<StdArc> *lex_fst = fst::ReadFstKaldi(lex_in_filename);
     // ownership will be taken by gc.
 
     std::vector<int32> disambig_syms;    


### PR DESCRIPTION
VectorFst is not required. Simply const Fst can be used for ReadFstKaldi.
I tried to build it again and found no issues. 