### PR TITLE
Fixed: steps/cleanup/decode_segmentation_nnet3.sh sorted keys issue.

### DIFF
--- a/egs/wsj/s5/steps/cleanup/decode_segmentation_nnet3.sh
+++ b/egs/wsj/s5/steps/cleanup/decode_segmentation_nnet3.sh
@@ -122,7 +122,7 @@ HCLG=scp:$dir/split_fsts/HCLG.fsts.JOB.scp
 ## Set up features.
 echo "$0: feature type is raw"
 
-feats="ark,s,cs:apply-cmvn $cmvn_opts --utt2spk=ark:$sdata/JOB/utt2spk scp:$sdata/JOB/cmvn.scp scp:$sdata/JOB/feats.scp ark:- |"
+feats="ark,s:apply-cmvn $cmvn_opts --utt2spk=ark:$sdata/JOB/utt2spk scp:$sdata/JOB/cmvn.scp scp:$sdata/JOB/feats.scp ark:- |"
 
 if [ ! -z "$online_ivector_dir" ]; then
   ivector_period=$(cat $online_ivector_dir/ivector_period) || exit 1;


### PR DESCRIPTION
Fixed issue discussed in. https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kaldi-help/OtP73NqOPXk/f1WJceMsAAAJ 

The issue caused the following error message: You prov
ided the "cs" option but are not calling with keys in sorted order  

The changes I made fixed the problem and now the script is running normally.