### PR TITLE
wsj align_si.sh fail when analyze_alignments.sh failed

### DIFF
--- a/egs/wsj/s5/steps/align_si.sh
+++ b/egs/wsj/s5/steps/align_si.sh
@@ -101,6 +101,6 @@ else
       "$feats" "ark,t:|gzip -c >$dir/ali.JOB.gz" || exit 1;
 fi
 
-steps/diagnostic/analyze_alignments.sh --cmd "$cmd" $lang $dir
+steps/diagnostic/analyze_alignments.sh --cmd "$cmd" $lang $dir || exit 1;
 
 echo "$0: done aligning data."


### PR DESCRIPTION
Is there a guideline, when Kaldi shouldn't fail, when a subcommand failed?

I ran the CHiME6 eg and `analyze_alignments.sh` failed, but the eg continued.

I am not sure if the `run.sh` should fail when `steps/diagnostic/analyze_alignments.sh` failed.