### PR TITLE
[src] fixing catch by copy

### DIFF
--- a/src/fstbin/fstdeterminizestar.cc
+++ b/src/fstbin/fstdeterminizestar.cc
@@ -129,7 +129,7 @@ int main(int argc, char *argv[]) {
             // of scope anyway.
           }
           fst_writer.Write(key, fst);
-        } catch (const std::runtime_error e) {
+        } catch (const std::runtime_error &e) {
           KALDI_WARN << "Error during determinization for key " << key;
         }
       }


### PR DESCRIPTION
@danpovey  I don't think this matters too much, but helps with removing extra warning in gcc >8
The catch by const reference is the preferred way anyway