### PR TITLE
Cmvn gpu memory fix

### DIFF
--- a/src/cudafeat/feature-online-batched-cmvn-cuda.h
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda.h
@@ -40,7 +40,7 @@ class CudaOnlineBatchedCmvn {
 
  private:
   const OnlineCmvnOptions &opts_;
-  const CudaOnlineCmvnState &cmvn_state_;
+  const CudaOnlineCmvnState cmvn_state_;
 
   int32_t feat_dim_;
   int32_t chunk_size_;

--- a/src/cudafeat/feature-online-cmvn-cuda.h
+++ b/src/cudafeat/feature-online-cmvn-cuda.h
@@ -52,7 +52,7 @@ class CudaOnlineCmvn {
 
  private:
   const OnlineCmvnOptions &opts_;
-  const CudaOnlineCmvnState &cmvn_state_;
+  const CudaOnlineCmvnState cmvn_state_;
 };
 }
 


### PR DESCRIPTION
We found some memory corruption which testing GPU CMVN. cmvn_state_ was a reference variable. Fixed that for both online and online-batched CMVN.
Attn: @luitjens 