### PR TITLE
updated fix_subsegment_feats.pl to handle row_start >= file length 

### DIFF
--- a/egs/wsj/s5/utils/data/fix_subsegment_feats.pl
+++ b/egs/wsj/s5/utils/data/fix_subsegment_feats.pl
@@ -83,12 +83,16 @@ while (<STDIN>) {
   my $row_start = $1;
   my $row_end = $2;
   my $col_range = $3;
-
+  
+  if ($row_start >= $utt2max_frames{$utt}) {
+    print STDERR "Removing $utt because row_start $row_start >= file max length $utt2max_frames{$utt}\n";
+    next;
+  }  
   if ($row_end >= $utt2max_frames{$utt}) {
     print STDERR "Fixed row_end for $utt from $row_end to $utt2max_frames{$utt}-1\n";
     $row_end = $utt2max_frames{$utt} - 1;
-  }
-
+  } 
+   
   if ($row_start ne "") {
     $range = "$row_start:$row_end";
   } else {
@@ -98,6 +102,5 @@ while (<STDIN>) {
   if ($col_range ne "") {
     $range .= ",$col_range";
   }
-
   print ("$utt " . join(" ", @F) . "[" . $range . "]\n");
 }


### PR DESCRIPTION
Should fix [chime-6 SAD model training error](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/chime5/SQC48Gk7Pog/_0kSaxEYAwAJ), or any other instance where feat start >= file length. 
Currently this issue is not caught in fix_subsegment.pl in any way.  
The problematic segment is simply dropped. 