### PR TITLE
bug fix

### DIFF
--- a/egs/wsj/s5/utils/data/combine_short_segments.sh
+++ b/egs/wsj/s5/utils/data/combine_short_segments.sh
@@ -158,7 +158,7 @@ while changed:
                  changed = True
 
 for uniq in sorted(uniq2orig_uniq.keys()):
-    print uniq, uniq2orig_uniq[uniq]
+    print(uniq, uniq2orig_uniq[uniq])
 ' > $dir/uniq_to_orig_uniq
   rm $dir/uniq_sets
 


### PR DESCRIPTION
```
choose_utts_to_combine.py: combined 994636 utterances to 780401 utterances while respecting speaker boundaries, and then to 780398 utterances with merging across speaker boundaries.
  File "<string>", line 25
    print uniq, uniq2orig_uniq[uniq]
             ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(uniq, uniq2orig_uniq[uniq])?
```