### PR TITLE
[build] fix "unknown compiler g++" for apple clang >= 11.0

### DIFF
--- a/src/bin/compute-gop.cc
+++ b/src/bin/compute-gop.cc
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
       if (!alignment_reader.HasKey(key)) {
         KALDI_WARN << "No alignment for utterance " << key;
         continue;
-      }       
+      }
       auto alignment = alignment_reader.Value(key);
       Matrix<BaseFloat> &probs = prob_reader.Value();
       if (log_applied) probs.ApplyExp();

--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -44,7 +44,7 @@ case $compiler_ver_info in
         status=1
     fi
     ;;
-  "clang "* )
+  "clang "* | "Apple clang "* )
     clang_ver=$(echo $compiler_ver_info | grep version | sed "s/.*version \([0-9\.]*\).*/\1/")
     clang_ver_num=$(echo $clang_ver | sed 's/\./ /g' | xargs printf "%d%02d")
     if [ $clang_ver_num -lt 303 ]; then


### PR DESCRIPTION
1. The `extras/check_dependencies.sh` gives a false warning `"unknown compiler g++"` under the newest apple clang. Fixed it.
2. Trim some whitespaces (same as the PR #3952)