### PR TITLE
support dropout in pytorch training

### DIFF
--- a/egs/aishell/s10/chain/tdnnf_layer.py
+++ b/egs/aishell/s10/chain/tdnnf_layer.py
@@ -57,7 +57,7 @@ class SharedDimScaleDropout(nn.Module):
         Continuous scaled dropout that is const over chosen dim (usually across time)
         Multiplies inputs by random mask taken from Uniform([1 - 2\alpha, 1 + 2\alpha])
         '''
-        super(SharedDimScaleDropout, self).__init__()
+        super().__init__()
         self.dim = dim
         self.register_buffer('mask', torch.tensor(0.))
 

--- a/egs/aishell/s10/chain/tdnnf_layer.py
+++ b/egs/aishell/s10/chain/tdnnf_layer.py
@@ -172,7 +172,7 @@ class FactorizedTDNN(nn.Module):
         # since we want to use `stride`
         self.affine = nn.Conv1d(in_channels=bottleneck_dim,
                                 out_channels=dim,
-                                kernel_size=1,
+                                kernel_size=kernel_size,
                                 stride=subsampling_factor)
 
         # batchnorm requires [N, C, T]
@@ -201,7 +201,7 @@ class FactorizedTDNN(nn.Module):
 
         # TODO(fangjun): implement GeneralDropoutComponent in PyTorch
 
-        if self.linear.kernel_size == 3:
+        if self.linear.kernel_size > 1:
             x = self.bypass_scale * input_x[:, :, self.s:-self.s:self.s] + x
         else:
             x = self.bypass_scale * input_x[:, :, ::self.s] + x

--- a/egs/aishell/s10/chain/tdnnf_layer.py
+++ b/egs/aishell/s10/chain/tdnnf_layer.py
@@ -181,17 +181,10 @@ class TDNN(nn.Module):
     def forward(self, x, dropout=0.):
         # input x is of shape: [batch_size, feat_dim, seq_len] = [N, C, T]
         x = self.affine(x)
-        # at this point, x is [N, C, T]
-        
         x = F.relu(x)
-        # at this point, x is [N, C, T]
-
         x = self.batchnorm(x)
-        # at this point, x is [N, C, T]
-
         x = self.dropout(x, alpha=dropout)
-        # at this point, x is [N, C, T]
-
+        # return shape is [N, C, T]
         return x
 
 

--- a/egs/aishell/s10/chain/train.py
+++ b/egs/aishell/s10/chain/train.py
@@ -164,6 +164,11 @@ def train_one_epoch(dataloader, valid_dataloader, model, device, optimizer, crit
                 'train/current_batch_average_objf',
                 curr_batch_objf / curr_batch_weight,
                 batch_idx + current_epoch * len(dataloader))
+            
+            tf_writer.add_scalar(
+                'train/current_dropout',
+                dropout,
+                batch_idx + current_epoch * len(dataloader))
 
             state_dict = model.state_dict()
             for key, value in state_dict.items():

--- a/egs/aishell/s10/cmd.sh
+++ b/egs/aishell/s10/cmd.sh
@@ -13,6 +13,6 @@
 export train_cmd="queue.pl -q all.q --mem 4G"
 export decode_cmd="queue.pl -q all.q --mem 4G"
 export mkgraph_cmd="queue.pl -q all.q --mem 8G"
-export cuda_train_cmd="queue.pl -q v100.q --mem 4G"
-export cuda_inference_cmd="queue.pl -q v100.q --mem 4G"
+export cuda_train_cmd="queue.pl -q g.q --mem 4G"
+export cuda_inference_cmd="queue.pl -q g.q --mem 4G"
 

--- a/egs/aishell/s10/local/decode.sh
+++ b/egs/aishell/s10/local/decode.sh
@@ -11,7 +11,7 @@ lattice_beam=4.0
 max_active=7000 # limit of active tokens
 max_mem=50000000 # approx. limit to memory consumption during minimization in bytes
 min_active=200
-num_threads=20
+num_threads=10
 post_decode_acwt=10  # can be used in 'chain' systems to scale acoustics by 10
 
 . ./path.sh

--- a/egs/aishell/s10/local/run_chain.sh
+++ b/egs/aishell/s10/local/run_chain.sh
@@ -150,7 +150,7 @@ minibatch_size=128
 hidden_dim=1024
 bottleneck_dim=128
 prefinal_bottleneck_dim=256
-kernel_size_list="3, 3, 3, 1, 3, 3, 3, 3, 3, 3, 3, 3" # comma separated list
+kernel_size_list="2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2" # comma separated list
 subsampling_factor_list="1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1" # comma separated list
 
 log_level=info # valid values: debug, info, warning

--- a/egs/aishell/s10/local/run_chain.sh
+++ b/egs/aishell/s10/local/run_chain.sh
@@ -69,7 +69,7 @@ if [[ $stage -le 3 ]]; then
 fi
 
 train_ivector_dir=
-if [ "$train_ivector" = true ]; then
+if $train_ivector; then
   local/run_ivector_common.sh --stage $stage \
                               --nj $nj \
                               --train-set $train_set \
@@ -201,7 +201,7 @@ fi
 feat_dim=$(cat $dir/egs/info/feat_dim)
 ivector_dim=0
 ivector_period=0
-if [ "$train_ivector" = true ]; then
+if $train_ivector; then
   ivector_dim=$(cat $dir/egs/info/ivector_dim)
   ivector_period=$(cat $train_ivector_dir/ivector_period)
 fi
@@ -259,19 +259,19 @@ if [[ $stage -le 17 ]]; then
         --output-dim $output_dim \
         --prefinal-bottleneck-dim $prefinal_bottleneck_dim \
         --subsampling-factor-list "$subsampling_factor_list" \
-        --train.use-ddp $use_ddp \
+        --train.cegs-dir $dir/merged_egs \
         --train.ddp.init-method $init_method \
         --train.ddp.multiple-machine $use_multiple_machine \
         --train.ddp.world-size $world_size \
-        --train.dropout-schedule "$dropout_schedule" \
-        --train.cegs-dir $dir/merged_egs \
         --train.den-fst $dir/den.fst \
+        --train.dropout-schedule "$dropout_schedule" \
         --train.egs-left-context $egs_left_context \
         --train.egs-right-context $egs_right_context \
         --train.l2-regularize 5e-5 \
         --train.leaky-hmm-coefficient 0.1 \
         --train.lr $lr \
         --train.num-epochs $num_epochs \
+        --train.use-ddp $use_ddp \
         --train.valid-cegs-scp $dir/egs/valid_diagnostic.scp \
         --train.xent-regularize 0.1 || exit 1;
 fi
@@ -283,11 +283,11 @@ if [[ $stage -le 18 ]]; then
     if [[ -f $dir/$train_dir/inference/$x/nnet_output.scp ]]; then
       echo "$dir/$train_dir/inference/$x/nnet_output.scp already exists! Skip"
     else
-      if [[ "$train_ivector" = true ]]; then
+      if $train_ivector; then
         ivector_scp="exp/nnet3${nnet3_affix}/ivectors_${x}_hires/ivector_online.scp"
       fi
       feat_scp="data/${x}_hires/feats.scp"
-      if [[ "$online_cmvn" = true ]]; then
+      if $online_cmvn; then
         apply-cmvn-online --spk2utt=ark:data/${x}_hires/spk2utt $dir/egs/global_cmvn.stats \
             scp:data/${x}_hires/feats.scp ark,scp:data/${x}_hires/data/online_cmvn_feats.ark,data/${x}_hires/online_cmvn_feats.scp
         feat_scp="data/${x}_hires/online_cmvn_feats.scp"

--- a/egs/wsj/s5/steps/nnet3/compute_output.sh
+++ b/egs/wsj/s5/steps/nnet3/compute_output.sh
@@ -67,7 +67,8 @@ done
 
 if [ ! -z "$output_name" ] && [ "$output_name" != "output" ]; then
   echo "$0: Using output-name $output_name"
-  model="nnet3-copy --edits='remove-output-nodes name=output;rename-node old-name=$output_name new-name=output' $model - |"
+  # model="nnet3-copy --edits='remove-output-nodes name=output;rename-node old-name=$output_name new-name=output' $model - |"
+  model="nnet3-copy --nnet-config='echo output-node name=output input=$output_name |' $model -|"
 fi
 
 sdata=$data/split$nj;

--- a/egs/wsj/s5/steps/nnet3/compute_output.sh
+++ b/egs/wsj/s5/steps/nnet3/compute_output.sh
@@ -67,8 +67,7 @@ done
 
 if [ ! -z "$output_name" ] && [ "$output_name" != "output" ]; then
   echo "$0: Using output-name $output_name"
-  # model="nnet3-copy --edits='remove-output-nodes name=output;rename-node old-name=$output_name new-name=output' $model - |"
-  model="nnet3-copy --nnet-config='echo output-node name=output input=$output_name |' $model -|"
+  model="nnet3-copy --edits='remove-output-nodes name=output;rename-node old-name=$output_name new-name=output' $model - |"
 fi
 
 sdata=$data/split$nj;

--- a/egs/wsj/s5/utils/parallel/queue.pl
+++ b/egs/wsj/s5/utils/parallel/queue.pl
@@ -176,7 +176,7 @@ option num_threads=1  # Do not add anything to qsub_opts
 option max_jobs_run=* -tc $0
 default gpu=0
 option gpu=0
-option gpu=* -l gpu=$0 -q '*.q'
+option gpu=* -l gpu=$0 -q 'g.q'
 EOF
 
 # Here the configuration options specified by the user on the command line

--- a/egs/wsj/s5/utils/parallel/queue.pl
+++ b/egs/wsj/s5/utils/parallel/queue.pl
@@ -176,7 +176,7 @@ option num_threads=1  # Do not add anything to qsub_opts
 option max_jobs_run=* -tc $0
 default gpu=0
 option gpu=0
-option gpu=* -l gpu=$0 -q 'g.q'
+option gpu=* -l gpu=$0 -q '*.q'
 EOF
 
 # Here the configuration options specified by the user on the command line

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -1247,6 +1247,10 @@ void* AffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   out->CopyRowsFromVec(bias_params_); // copies bias_params_ to each row
   // of *out.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
+  KALDI_VLOG(4) << "Affine" << in.Row(0);
+  KALDI_VLOG(4) << "Affine" << linear_params_.Row(0);
+  KALDI_VLOG(4) << "Affine" << bias_params_;
+  KALDI_VLOG(4) << "Affine" << out->Row(0);
   return NULL;
 }
 
@@ -3394,6 +3398,9 @@ void* FixedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes
                                      CuMatrixBase<BaseFloat> *out) const  {
   out->CopyRowsFromVec(bias_params_); // Adds the bias term first.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
+  KALDI_VLOG(4) << linear_params_.Row(0);
+  KALDI_VLOG(4) << bias_params_;
+  KALDI_VLOG(4) << out->Row(0);
   return NULL;
 }
 
@@ -3432,8 +3439,10 @@ void FixedAffineComponent::Write(std::ostream &os, bool binary) const {
 void FixedAffineComponent::Read(std::istream &is, bool binary) {
   ExpectOneOrTwoTokens(is, binary, "<FixedAffineComponent>", "<LinearParams>");
   linear_params_.Read(is, binary);
+  KALDI_VLOG(4) << linear_params_.Row(0);
   ExpectToken(is, binary, "<BiasParams>");
   bias_params_.Read(is, binary);
+  KALDI_VLOG(4) << bias_params_;
   ExpectToken(is, binary, "</FixedAffineComponent>");
 }
 

--- a/src/nnet3/nnet-simple-component.cc
+++ b/src/nnet3/nnet-simple-component.cc
@@ -1247,10 +1247,6 @@ void* AffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes,
   out->CopyRowsFromVec(bias_params_); // copies bias_params_ to each row
   // of *out.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
-  KALDI_VLOG(4) << "Affine" << in.Row(0);
-  KALDI_VLOG(4) << "Affine" << linear_params_.Row(0);
-  KALDI_VLOG(4) << "Affine" << bias_params_;
-  KALDI_VLOG(4) << "Affine" << out->Row(0);
   return NULL;
 }
 
@@ -3398,9 +3394,6 @@ void* FixedAffineComponent::Propagate(const ComponentPrecomputedIndexes *indexes
                                      CuMatrixBase<BaseFloat> *out) const  {
   out->CopyRowsFromVec(bias_params_); // Adds the bias term first.
   out->AddMatMat(1.0, in, kNoTrans, linear_params_, kTrans, 1.0);
-  KALDI_VLOG(4) << linear_params_.Row(0);
-  KALDI_VLOG(4) << bias_params_;
-  KALDI_VLOG(4) << out->Row(0);
   return NULL;
 }
 
@@ -3439,10 +3432,8 @@ void FixedAffineComponent::Write(std::ostream &os, bool binary) const {
 void FixedAffineComponent::Read(std::istream &is, bool binary) {
   ExpectOneOrTwoTokens(is, binary, "<FixedAffineComponent>", "<LinearParams>");
   linear_params_.Read(is, binary);
-  KALDI_VLOG(4) << linear_params_.Row(0);
   ExpectToken(is, binary, "<BiasParams>");
   bias_params_.Read(is, binary);
-  KALDI_VLOG(4) << bias_params_;
   ExpectToken(is, binary, "</FixedAffineComponent>");
 }
 


### PR DESCRIPTION
- dropout with dropout_scheduler `0,0@0.20,0.5@0.50,0` will give 0.1-0.2 percentage better
- `dataloader.sampler.set_epoch(epoch)` make the result a little better
- change Linear to conv1d in tdnn module to avoid  two permute operation

### Result
***
||tdnn_1c_rd_rmc_rng_without_cleanup | tdnn_1c_rd_rmc_rng|
|--|-- | --|
|dev_cer | 5.92 | 5.99|
|dev_wer | 13.71 | 13.86|
|test_cer | 7.03 | 7.08|
|test_wer | 15.35|15.72|

||TDNN-F(Pytorch, Adam, dropout + ivector ) | TDNN-F(Pytorch, Adam, dropout  without ivector ) |
|--|-- | --|
|dev_cer | 6.00 | 6.13|
|dev_wer | 13.72 | 13.97|
|test_cer | 7.20 | 7.19|
|test_wer | 15.52|15.55|
|global objf|-0.046589|-0.050291|
|valid objf|-0.053605|-0.062898|
|output-affine-norm|76.83|83.2|

@csukuangfj @qindazhu @danpovey please have a reivew.
