### PR TITLE
expose egs as Dataloader

### DIFF
--- a/egs/aishell/s10/chain/egs_dataloader.py
+++ b/egs/aishell/s10/chain/egs_dataloader.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Xiaomi Corporation, Beijing, China (author: Haowen Qiu)
+# Apache 2.0
+
+from multiprocessing import Process
+import datetime
+import glob
+import os
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+
+from kaldi import SequentialNnetChainExampleReader
+import kaldi
+import kaldi_pybind.nnet3 as nnet3
+
+from common import splice_feats
+
+def get_egs_dataloader(egs_dir_or_scp,
+                       egs_left_context,
+                       egs_right_context,
+                       frame_subsampling_factor=3,
+                       world_size=None,
+                       local_rank=None):
+    '''
+    world_size and local_rank is for DistributedDataParallel training.
+    '''
+    dataset = NnetChainExampleScpDataset(egs_dir_or_scp)
+
+    collate_fn = NnetChainExampleCollateFunc(
+        egs_left_context=egs_left_context,
+        egs_right_context=egs_right_context,
+        frame_subsampling_factor=frame_subsampling_factor)
+
+    if local_rank is not None:
+        sampler = torch.utils.data.distributed.DistributedSampler(
+            dataset, num_replicas=world_size, rank=local_rank, shuffle=False)
+    else:
+        sampler = torch.utils.data.SequentialSampler(dataset)
+    
+    dataloader = NnetChainExampleDataLoader(dataset,
+                            sampler=sampler,
+                            collate_fn=collate_fn)
+    return dataloader
+
+
+class NnetChainExampleScpDataset(Dataset):
+
+    def __init__(self, egs_dir_or_scp):
+        '''
+        If egs_dir_or_scp is a directory, we assume that there exist many cegs.*.scp files
+        inside it.
+        '''
+        if os.path.isdir(egs_dir_or_scp):
+            self.scps = glob.glob('{}/cegs.*.scp'.format(egs_dir_or_scp))
+        else:
+            self.scps = [egs_dir_or_scp]
+
+        assert len(self.scps) > 0
+
+    def __len__(self):
+        return len(self.scps)
+
+    def __getitem__(self, i):
+        return self.scps[i]
+
+    def __str__(self):
+        s = 'num egs scp files: {}\n'.format(len(self.scps))
+        return s
+
+
+class NnetChainExampleDataLoader(object):
+    '''
+    Nnet chain example data loader, provides an iterable over the given scp files.
+
+    Arguments:
+        dataset (Dataset): scp files from which to load the egs.
+        sampler (Sampler): defines the strategy to draw samples
+            from the dataset.
+        collate_fn (callable): creates a batch from mergerd eg.
+
+    '''
+
+    def __init__(self, dataset, sampler, collate_fn):
+
+        self.dataset = dataset
+        self.sampler = sampler
+        self.collate_fn = collate_fn
+
+    def __len__(self):
+        return len(self.sampler)
+
+    def __iter__(self):
+        # iterates over one scp file in a `pseudo_epoch`
+        for pseudo_epoch, sample_idx in enumerate(self.sampler):
+            # one sample is one scp file
+            egs_rspecifier = 'scp:' + self.dataset[sample_idx]
+            with SequentialNnetChainExampleReader(egs_rspecifier) as example_reader:
+                for key, eg in example_reader:
+                    batch = self.collate_fn(eg)
+                    yield pseudo_epoch, batch
+
+
+class NnetChainExampleCollateFunc:
+
+    def __init__(self, egs_left_context, egs_right_context,
+                 frame_subsampling_factor=3):
+
+        '''
+        egs_left_context is from egs/info/left_context
+        egs_right_context is from egs/info/right_context
+        '''
+        assert egs_left_context >= 0
+        assert egs_left_context >= 0
+
+        # currently support either no subsampling or
+        # subsampling factor to be 3
+        assert frame_subsampling_factor in [1, 3]
+
+        self.egs_left_context = egs_left_context
+        self.egs_right_context = egs_right_context
+        self.frame_subsampling_factor = frame_subsampling_factor
+        
+    def __call__(self, eg):
+        '''
+        eg is a batch as it has been merged
+        '''
+        assert eg.inputs[0].name == 'input'
+        assert len(eg.outputs) == 1
+        assert eg.outputs[0].name == 'output'
+
+        # the length of below two return values will be 1,
+        # as we have merged egs into one batch
+
+        # TODO(haowen): remove the list wrapping
+        feature_list = []
+        supervision_list = []
+
+        supervision = eg.outputs[0].supervision
+        supervision_list.append(supervision)
+
+        batch_size = supervision.num_sequences
+        frames_per_sequence = (supervision.frames_per_sequence *
+                               self.frame_subsampling_factor) + \
+            self.egs_left_context + self.egs_right_context
+
+
+        _feats = kaldi.FloatMatrix()
+        eg.inputs[0].features.GetMatrix(_feats)
+        feats = _feats.numpy()
+
+        if len(eg.inputs) > 1:
+            _ivectors = kaldi.FloatMatrix()
+            eg.inputs[1].features.GetMatrix(_ivectors)
+            ivectors = _ivectors.numpy()
+
+        assert feats.shape[0] == batch_size * frames_per_sequence
+
+        feat_list = []
+        for i in range(batch_size):
+            start_index = i * frames_per_sequence
+            if self.frame_subsampling_factor == 3:
+                shift = np.random.choice([-1, 0, 1], 1)[0]
+                start_index += shift
+
+            end_index = start_index + frames_per_sequence
+            start_index += 2  # remove the leftmost frame added for frame shift
+            end_index -= 2  # remove the rightmost frame added for frame shift
+            feat = feats[start_index:end_index:, :]
+            if len(eg.inputs) > 1:
+                repeat_ivector = torch.from_numpy(
+                    ivectors[i]).repeat(feat.shape[0], 1)
+                feat = torch.cat(
+                    (torch.from_numpy(feat), repeat_ivector), dim=1).numpy()
+            feat_list.append(feat)
+
+        batched_feat = np.stack(feat_list, axis=0)
+        assert batched_feat.shape[0] == batch_size
+
+        # -4 = -2 -2
+        # the first -2 is from extra left/right context
+        # the second -2 is from lda feats splicing
+        assert batched_feat.shape[1] == frames_per_sequence - 4
+        if len(eg.inputs) > 1:
+            assert batched_feat.shape[2] == feats.shape[-1] + ivectors.shape[-1]
+        else:
+            assert batched_feat.shape[2] == feats.shape[-1]
+
+        torch_feat = torch.from_numpy(batched_feat).float()
+        feature_list.append(torch_feat)
+
+        return feature_list, supervision_list
+
+
+def _test_nnet_chain_example_dataloader():
+    scp_dir = 'exp/chain_pybind/tdnn_sp/egs_chain2_for_training'
+    _test_dataloader_iter(scp_dir)
+
+def _test_dataloader_iter(scp_dir_or_file):
+    egs_left_context = 29
+    egs_right_context = 29
+    frame_subsampling_factor = 3
+
+    dataloader = get_egs_dataloader(
+        scp_dir_or_file,
+        egs_left_context,
+        egs_right_context,
+        frame_subsampling_factor)
+    
+    for i in range(2):
+        batch_idx = 0
+        for pseudo_epoch, batch in dataloader:
+            print('{}: epoch {}, pseudo_epoch {}, batch_idx {}'.format(
+                datetime.datetime.now(), i, pseudo_epoch, batch_idx))
+            batch_idx = batch_idx + 1
+            feature_list, supervision_list = batch
+            assert feature_list[0].shape == (128, 204, 120) \
+                or feature_list[0].shape == (128, 144, 120) \
+                or feature_list[0].shape == (128, 165, 120)
+            assert supervision_list[0].weight == 1
+            assert supervision_list[0].num_sequences == 128  # minibach size is 128
+
+
+if __name__ == '__main__':
+    _test_nnet_chain_example_dataloader()

--- a/egs/aishell/s10/chain/egs_dataloader.py
+++ b/egs/aishell/s10/chain/egs_dataloader.py
@@ -12,7 +12,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 
 from kaldi import SequentialNnetChainExampleReader
@@ -182,9 +181,6 @@ class NnetChainExampleCollateFunc:
         batched_feat = np.stack(feat_list, axis=0)
         assert batched_feat.shape[0] == batch_size
 
-        # -4 = -2 -2
-        # the first -2 is from extra left/right context
-        # the second -2 is from lda feats splicing
         assert batched_feat.shape[1] == frames_per_sequence - 4
         if len(eg.inputs) > 1:
             assert batched_feat.shape[2] == feats.shape[-1] + ivectors.shape[-1]

--- a/egs/aishell/s10/chain/model.py
+++ b/egs/aishell/s10/chain/model.py
@@ -70,7 +70,11 @@ output-layer name=output-xent dim=3456 learning-rate-factor=5.0 l2-regularize=0.
 
 
 def constrain_orthonormal_hook(model, unused_x):
-    if model.training == False:
+    if not model.training:
+        return
+    
+    model.ortho_constrain_count = (model.ortho_constrain_count + 1) % 2
+    if model.ortho_constrain_count != 0:
         return
 
     with torch.no_grad():
@@ -100,6 +104,8 @@ class ChainModel(nn.Module):
 
         assert len(kernel_size_list) == len(subsampling_factor_list)
         num_layers = len(kernel_size_list)
+        
+        self.ortho_constrain_count = 0
 
         input_dim = feat_dim * 3 + ivector_dim
         

--- a/egs/aishell/s10/chain/train.py
+++ b/egs/aishell/s10/chain/train.py
@@ -121,7 +121,7 @@ def train_one_epoch(dataloader, valid_dataloader, model, device, optimizer, crit
         # `len(dataloader)` returns the number of `pseudo_epoch`
         # in the current worker, that is the number of scp files
         # we will process in this worker.
-        data_fraction = (pseudo_epoch + current_epoch *
+        data_fraction = (pseudo_epoch + 1 + current_epoch *
                          len(dataloader)) / (len(dataloader) * num_epochs)
         _, dropout = _get_dropout_proportions(
             dropout_schedule, data_fraction)[0]

--- a/egs/aishell/s10/local/run_chain.sh
+++ b/egs/aishell/s10/local/run_chain.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-stage=22
+stage=21
 
 nj=10
 
@@ -217,7 +217,7 @@ if [[ $stage -le 19 ]]; then
     nnet3-chain-merge-egs --minibatch-size=$minibatch_size ark:- \
       ark,scp:$dir/$merged_egs_dir/cegs.JOB.ark,$dir/$merged_egs_dir/cegs.JOB.scp || exit 1
 
-  rm $dir/raw_egs/cegs.*.ark
+  rm -f $dir/raw_egs/cegs.*.ark
 fi
 
 training_eg_dir=egs_chain2_for_training
@@ -239,7 +239,7 @@ if [[ $stage -le 20 ]]; then
       ark,scp:$dir/$training_eg_dir/cegs.JOB.ark,$dir/$training_eg_dir/cegs.JOB.scp || exit 1
 
   rm -r $dir/$training_eg_dir/tmp_scp_dir
-  rm $dir/$merged_egs_dir/cegs.*.ark
+  rm -f $dir/$merged_egs_dir/cegs.*.ark
 fi
 
 output_dim=$(grep 'num_leaves' $info_file | awk '{print $NF}')

--- a/egs/aishell/s10/local/run_chain.sh
+++ b/egs/aishell/s10/local/run_chain.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-stage=21
+stage=16
 
 nj=10
 

--- a/egs/aishell/s10/local/run_chain.sh
+++ b/egs/aishell/s10/local/run_chain.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-stage=12
+stage=22
 
 nj=10
 
@@ -20,7 +20,7 @@ train_ivector=false
 num_epochs=6
 dropout_schedule=0,0@0.20,0.5@0.50,0      # you might set this to 0,0 or 0.5,0.5 to train.
 frame_subsampling_factor=3
-feat_type=delta
+feat_type="delta"
 lang=default
 
 . ./path.sh
@@ -148,8 +148,8 @@ fi
 # You should know how to calculate your model's left/right context **manually**
 model_left_context=28
 model_right_context=28
-egs_left_context=$[$model_left_context + 1]
-egs_right_context=$[$model_right_context + 1]
+egs_left_context=$(($model_left_context + 1))
+egs_right_context=$(($model_right_context + 1))
 frames_per_eg=150,110,90
 frames_per_iter=1500000
 minibatch_size=128
@@ -188,18 +188,19 @@ if [ $stage -le 15 ]; then
     ${dir}/raw_egs ${dir}/processed_egs
 fi
 
+num_workers=4
 if [ $stage -le 16 ]; then
   echo "$0: about to randomize egs"
-  steps/chain2/randomize_egs.sh --frames-per-job 3000000 \
+  steps/chain2/randomize_egs.sh --frames-per-job 3000000 --num-workers $num_workers \
     ${dir}/processed_egs ${dir}/egs
 fi
 
 info_file=$dir/raw_egs/info.txt
-feat_dim=$(cat $info_file | grep 'feat_dim' | awk '{print $NF}')
+feat_dim=$(grep 'feat_dim' $info_file | awk '{print $NF}')
 ivector_dim=0
 ivector_period=0
 if $train_ivector; then
-  ivector_dim=$(cat $info_file | grep 'ivector_dim' | awk '{print $NF}')
+  ivector_dim=$(grep 'ivector_dim' $info_file | awk '{print $NF}')
   ivector_period=$(cat $train_ivector_dir/ivector_period)
 fi
 echo "ivector_dim: $ivector_dim", "ivector_period, $ivector_period"
@@ -219,9 +220,31 @@ if [[ $stage -le 19 ]]; then
   rm $dir/raw_egs/cegs.*.ark
 fi
 
-output_dim=$(cat $info_file | grep 'num_leaves' | awk '{print $NF}')
-train_dir=train${train_affix}
+training_eg_dir=egs_chain2_for_training
+# we have to make sure each scp file holding the same number of lines,
+# as we will load them with multiple workers in PyTorch and there is an
+# assumption in DDP training that num-mininbatches should be equal
+# across workers.
 if [[ $stage -le 20 ]]; then
+  echo "$0: align eg numbers in each scp file"
+
+  mkdir -p $dir/$training_eg_dir/tmp_scp_dir
+  steps/chain2/align_eg_numbers.sh $dir/$merged_egs_dir $dir/$training_eg_dir/tmp_scp_dir
+
+  # TODO: make this more efficient as for each ark file there are only few arks
+  #       we really need to copy from other ark files.
+  num_egs=$(ls -1 $dir/$training_eg_dir/tmp_scp_dir/*.scp | wc -l)
+  $train_cmd --max-jobs-run $nj JOB=1:$num_egs $dir/$training_eg_dir/log/copy_egs.JOB.log \
+    nnet3-chain-copy-egs scp:$dir/$training_eg_dir/tmp_scp_dir/cegs.JOB.scp \
+      ark,scp:$dir/$training_eg_dir/cegs.JOB.ark,$dir/$training_eg_dir/cegs.JOB.scp || exit 1
+
+  rm -r $dir/$training_eg_dir/tmp_scp_dir
+  rm $dir/$merged_egs_dir/cegs.*.ark
+fi
+
+output_dim=$(grep 'num_leaves' $info_file | awk '{print $NF}')
+train_dir=train${train_affix}
+if [[ $stage -le 21 ]]; then
   echo "$0: training..."
 
   mkdir -p $dir/$train_dir/tensorboard
@@ -234,30 +257,28 @@ if [[ $stage -le 20 ]]; then
   rm -f $INIT_FILE # delete old one before starting
   init_method=file://$(readlink -f $INIT_FILE)
   # use '127.0.0.1' for training on a single machine
-  # init_method=tcp://127.0.0.1:7275
+  init_method=tcp://127.0.0.1:7275
   echo "$0: init method is $init_method"
 
   num_epochs=$num_epochs
   lr=1e-3
   
-  # use_ddp = false: training model with one GPU
+  # use_ddp = false & world_size = 1: training model with one GPU
   # use_ddp = true & use_multiple_machine = false: training model with multiple GPUs on a single machine
   # use_ddp = true & use_multiple_machine = true:  training model with GPU on multiple machines
 
   use_ddp=true
-  world_size=4
-  use_multiple_machine=true 
+  world_size=$num_workers
+  use_multiple_machine=false
   # you can assign GPUs with --device-ids "$device_ids"
   # device_ids="4, 5, 6, 7"
   if $use_multiple_machine ; then
     # suppose you are using Sun GridEngine
-    cuda_train_cmd=$(echo "$cuda_train_cmd --gpu 1 JOB=1:$world_size $dir/$train_dir/logs/job.JOB.log")
+    cuda_train_cmd="$cuda_train_cmd --gpu 1 JOB=1:$world_size $dir/$train_dir/logs/job.JOB.log"
   else
-    # TODO: for running with multiple GPUs on a single machine (SGE), 
-    #       we should tell SGE how many GPUs we will use on that machine
-    cuda_train_cmd=$(echo "$cuda_train_cmd --gpu $world_size $dir/$train_dir/logs/train.log")
+    cuda_train_cmd="$cuda_train_cmd --gpu $world_size $dir/$train_dir/logs/train.log"
   fi
- 
+  
   $cuda_train_cmd python3 ./chain/train.py \
         --bottleneck-dim $bottleneck_dim \
         --checkpoint=${train_checkpoint:-} \
@@ -271,7 +292,7 @@ if [[ $stage -le 20 ]]; then
         --output-dim $output_dim \
         --prefinal-bottleneck-dim $prefinal_bottleneck_dim \
         --subsampling-factor-list "$subsampling_factor_list" \
-        --train.cegs-dir $dir/$merged_egs_dir \
+        --train.cegs-dir $dir/$training_eg_dir \
         --train.ddp.init-method $init_method \
         --train.ddp.multiple-machine $use_multiple_machine \
         --train.ddp.world-size $world_size \
@@ -284,11 +305,11 @@ if [[ $stage -le 20 ]]; then
         --train.lr $lr \
         --train.num-epochs $num_epochs \
         --train.use-ddp $use_ddp \
-        --train.valid-cegs-scp $dir/egs/train_subset.scp \
+        --train.valid-cegs-scp $dir/processed_egs/train_subset.scp \
         --train.xent-regularize 0.1 || exit 1;
 fi
 
-if [[ $stage -le 21 ]]; then
+if [[ $stage -le 22 ]]; then
   echo "inference: computing likelihood"
   for x in test dev; do
     mkdir -p $dir/$train_dir/inference/$x
@@ -307,7 +328,7 @@ if [[ $stage -le 21 ]]; then
         fi
         feat_scp="data/${x}_hires/online_cmvn_feats.scp"
       fi
-      best_epoch=$(cat $dir/$train_dir/best-epoch-info | grep 'best epoch' | awk '{print $NF}')
+      best_epoch=$(grep 'best epoch' $dir/$train_dir/best-epoch-info | awk '{print $NF}')
       inference_checkpoint=$dir/$train_dir/epoch-${best_epoch}.pt
       $cuda_inference_cmd --gpu 1 $dir/$train_dir/inference/logs/${x}.log \
         python3 ./chain/inference.py \
@@ -333,7 +354,7 @@ if [[ $stage -le 21 ]]; then
   done
 fi
 
-if [[ $stage -le 22 ]]; then
+if [[ $stage -le 23 ]]; then
   # Note: it might appear that this $lang directory is mismatched, and it is as
   # far as the 'topo' is concerned, but this script doesn't read the 'topo' from
   # the lang directory.
@@ -343,7 +364,7 @@ if [[ $stage -le 22 ]]; then
 fi
 
 
-if [[ $stage -le 23 ]]; then
+if [[ $stage -le 24 ]]; then
   echo "decoding"
   for x in test dev; do
     if [[ ! -f $dir/$train_dir/inference/$x/nnet_output.scp ]]; then
@@ -362,7 +383,7 @@ if [[ $stage -le 23 ]]; then
   done
 fi
 
-if [[ $stage -le 24 ]]; then
+if [[ $stage -le 25 ]]; then
   echo "scoring"
 
   for x in test dev; do

--- a/egs/wsj/s5/steps/nnet3/chain2/align_eg_numbers.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/align_eg_numbers.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright   2020 Xiaomi Corporation, Beijing, China(Author: Haowen Qiu).  
+# Apache 2.0.
+#
+# This script manipulates .scp files in the input folder to make sure 
+# they have the same number of lines. It appends lines to those .scp 
+# files with less number of lines by copying lines randomly from all 
+# of other files.
+
+# Begin configuration section.
+cmd=run.pl
+
+srand=0
+stage=0
+
+echo "$0 $*"  # Print the command line for logging
+
+if [ -f path.sh ]; then . ./path.sh; fi
+. parse_options.sh || exit 1;
+
+
+if [ $# != 2 ]; then
+  echo "Usage: $0 [opts] <scp-dir> <output-dir>"
+  echo " e.g.: $0 exp/chain/tdnn1a_sp/merged_egs exp/chain/tdnn1a_sp/egs"
+  echo ""
+  exit 1;
+fi
+
+scp_dir=$1
+dir=$2
+
+# die on error or undefined variable.
+set -e -u
+
+maximum_num_lines=$(wc -l $scp_dir/*.scp | head -n -1 | sort -nr | head -n 1 | awk '{print $1}')
+echo "maximum num lines is $maximum_num_lines"
+
+cat $scp_dir/*.scp > $dir/.tmp
+for file in $scp_dir/*.scp; do
+    dst_file=$dir/$(basename "$file")
+    cp $file $dst_file 
+    num_lines=$(wc -l $file | awk '{print $1}') 
+    for ((i=$num_lines;i<$maximum_num_lines;i++)) do
+        shuf -n 1 $dir/.tmp >> $dst_file
+    done
+done
+rm $dir/.tmp
+
+wait;
+echo "$0: Finished aligning scp file"
+


### PR DESCRIPTION
Expose egs as a Dataloader in PyTorch, training time now decreased from 150mins to 90mins for 6 epochs with 4 workers. 

### **RESULT**
 ||TDNN-F(Pytorch, Adam, delta dropout without ivector ) from @fanlu | TDNN-F(Pytorch, Adam, delta dropout without ivector ) this PR 2nd run | TDNN-F(Pytorch, Adam, delta dropout without ivector ) this PR 1st run | this Pr with commit 0d8aada to make dropout go to zero at the end |
|--|--|--|--|--|
|dev_cer|6.10|6.13|6.18|6.12
|dev_wer|13.86|13.89|13.96|13.92
|test_cer|7.14|7.19|7.20|7.26
|test_wer|15.49|15.54|15.66|15.63
|training_time|151mins|88mins|84mins|

WER/CER increase may come from:
-  **Shuffle**, we do not shuffle egs-minibatch during each epoch.
-  **Dropout**, we use `pseudo_epoch` (one scp file is one pseudo-epoch) to compute `data_fraction` in dropout, that is relatively too much coarse-grained than using `batch_idx`

Note that I have tried  `copy|shuffle|merge` in dataloader (see code below"), but seems that it will take as much time as (or even a little more time than) the original approach (egs as a Dataset), I may do further experiment to look into this:
```
 scp_rspecifier = scp_file_to_process
 egs_rspecifier = 'ark,bg:nnet-chain-copy-egs --frame-shift .. scp:scp_rspecifier ark:- | \
                        nnet3-chain-shuffle-egs --buffer-size .. --srand .. ark:- ark:- | \
                        nnet3-chain-merge-egs --minibatch-size .. ark:- ark:- |'
 with SequentialNnetChainExampleReader(egs_rspecifier) as example_reader:
       for key, eg in example_reader:
             batch = self.collate_fn(eg)
             yield pseudo_epoch, batch
```

### **TODO**
- [ ] Split egs to more scp files (currently 56 files) to see whether it will get fine-grained in `data_fraction` of dropout or not.
- [ ] Do further experiment and trace for approach `copy|shuffle|merge` in dataloader to confirm the bottleneck of this approach.
- [ ] Profile first epoch of training to see why it takes so much time, as we can see now that first epoch training would take most part of time of the whole training time, no matter what approach (egs as dataset or dataloader) we use.