### PR TITLE
LDA output dim should be LDA matrix dim, not input feature dim

### DIFF
--- a/src/cudafeat/online-ivector-feature-cuda.cc
+++ b/src/cudafeat/online-ivector-feature-cuda.cc
@@ -45,7 +45,7 @@ void IvectorExtractorFastCuda::GetIvector(const CuMatrixBase<BaseFloat> &feats,
   int lda_cols = cu_lda_.NumCols();
 
   // normalized pipeline
-  CuMatrix<BaseFloat> lda_feats_normalized(rows, cols, kUndefined);
+  CuMatrix<BaseFloat> lda_feats_normalized(rows, lda_rows, kUndefined);
   {
     CudaOnlineCmvn cmvn(info_.cmvn_opts, naive_cmvn_state_);
     CuMatrix<BaseFloat> cmvn_feats(rows, cols, kUndefined);
@@ -81,7 +81,7 @@ void IvectorExtractorFastCuda::GetIvector(const CuMatrixBase<BaseFloat> &feats,
   }
 
   // non-normalized pipeline
-  CuMatrix<BaseFloat> lda_feats(feats.NumRows(), feats.NumCols(), kUndefined);
+  CuMatrix<BaseFloat> lda_feats(rows, lda_rows, kUndefined);
   {
     CuMatrix<BaseFloat> spliced_feats;
 


### PR DESCRIPTION
I have a setup with feature dim 20 (instead of standard 40) and ivector dim 40 (lda matrix 40x141), this model doesn't work with gpu feature extractor currently since it assumes that lda output has dim 20 which it takes from the features.

This patch should fix the probelm.