### PR TITLE
chime6: train_stats_sad_1a.sh add missing quotes

### DIFF
--- a/egs/chime6/s5_track2/local/segmentation/tuning/train_stats_sad_1a.sh
+++ b/egs/chime6/s5_track2/local/segmentation/tuning/train_stats_sad_1a.sh
@@ -98,7 +98,7 @@ if [ $stage -le 6 ]; then
   num_utts_subset=`perl -e '$n=int($ARGV[0] * 0.005); print ($n > 300 ? 300 : ($n < 12 ? 12 : $n))' $num_utts`
 
   steps/nnet3/train_raw_rnn.py --stage=$train_stage \
-    --feat.cmvn-opts=$cmvn_opts \
+    --feat.cmvn-opts="$cmvn_opts" \
     --egs.chunk-width=$chunk_width \
     --egs.dir="$egs_dir" --egs.stage=$get_egs_stage \
     --egs.chunk-left-context=$extra_left_context \


### PR DESCRIPTION
I got the error `train_raw_rnn.py: error: unrecognized arguments: --norm-vars=false`.

I think the problem is the whitespace in line 65 (code: `cmvn_opts="--norm-means=false --norm-vars=false"`) and the missing quotes in line 101.

@aarora8 Could you check that this change is correct?
I am wondering, because when my bash understanding is correct, nobody should be able to execute the baseline.

