### PR TITLE
Correct typo in endpoint comment.

### DIFF
--- a/src/online2/online-endpoint.h
+++ b/src/online2/online-endpoint.h
@@ -129,7 +129,7 @@ struct OnlineEndpointConfig {
                               /// that we consider as silence for purposes of
                               /// endpointing.
 
-  /// We support four rules.  We terminate decoding if ANY of these rules
+  /// We support five rules.  We terminate decoding if ANY of these rules
   /// evaluates to "true". If you want to add more rules, do it by changing this
   /// code.  If you want to disable a rule, you can set the silence-timeout for
   /// that rule to a very large number.


### PR DESCRIPTION
Fix a typo in comment in `online-endpoint.h`. It says there are four endpoint rules, but there actually are five.