### PR TITLE
chime6: fix post_output.vec file

### DIFF
--- a/egs/chime6/s5_track2/local/segmentation/tuning/train_stats_sad_1a.sh
+++ b/egs/chime6/s5_track2/local/segmentation/tuning/train_stats_sad_1a.sh
@@ -143,7 +143,7 @@ if [ $stage -le 7 ]; then
   # Dev (using -c 0.25)
   # MISSED SPEECH =   1188.59 secs (  3.3 percent of scored time)
   # FALARM SPEECH =    539.37 secs (  1.5 percent of scored time)
-  echo "[ 30 2 1 ]" > $dir/post_output.vec || exit 1
+  echo " [ 30 2 1 ]" > $dir/post_output.vec || exit 1
 
   echo 3 > $dir/frame_subsampling_factor
 fi


### PR DESCRIPTION
I got an error in `steps/libs/common.py` in `line 413` in the function `read_matrix_ascii` for the file `exp/segmentation_1a/tdnn_stats_sad_1a/post_output.vec`.
The code expected a white space in front of the brace (i.e. `' ['`).

I compared the generated `$dir/post_output.vec` with the downloaded file and the downloaded file has the white space.