### PR TITLE
Add PortAudio to Windows generate_solution.pl

### DIFF
--- a/windows/INSTALL.md
+++ b/windows/INSTALL.md
@@ -82,15 +82,13 @@ In the directory `build64`, find the file `openfst.sln` and open it using Visual
  If either of the two won't build, you should stop here and start figuring what's different!
 
 ## Compiling PortAudio
-1. Download PortAudio from http://www.portaudio.com/download.html
-
-2. Extract 
-3. (Optional) Add ASIO Support: http://www.steinberg.net/en/company/developer.html
-4. Open an instance or Powershell or Command Prompt, navigate to the portaudio directory and type:
+1. Download PortAudio from http://www.portaudio.com/download.html and extract the folder
+2. (Optional) Add ASIO Support: http://www.steinberg.net/en/company/developer.html
+3. Open an instance or Powershell or Command Prompt, navigate to the portaudio directory and type:
       $ cmake -G "Visual Studio 15 2017 Win64"
-5. CMake will generate a portaudio.sln in the directory. Open it  
-6. Right click portaudio_static->Properties->C/C++->Code Generation->Runtime Library Change from Multi-Threaded Debug (/MTd) to Multi-threaded Debug DLL (/MDd)
-7. Build portaudio_static
+4. CMake will generate a portaudio.sln in the directory. Open it  
+5. Right click portaudio_static->Properties->C/C++->Code Generation->Runtime Library Change from Multi-Threaded Debug (/MTd) to Multi-threaded Debug DLL (/MDd)
+6. Build
 
 ## Compiling Kaldi
 

--- a/windows/INSTALL.md
+++ b/windows/INSTALL.md
@@ -81,6 +81,17 @@ In the directory `build64`, find the file `openfst.sln` and open it using Visual
 
  If either of the two won't build, you should stop here and start figuring what's different!
 
+## Compiling PortAudio
+1. Download PortAudio from http://www.portaudio.com/download.html
+
+2. Extract 
+3. (Optional) Add ASIO Support: http://www.steinberg.net/en/company/developer.html
+4. Open an instance or Powershell or Command Prompt, navigate to the portaudio directory and type:
+      $ cmake -G "Visual Studio 15 2017 Win64"
+5. CMake will generate a portaudio.sln in the directory. Open it  
+6. Right click portaudio_static->Properties->C/C++->Code Generation->Runtime Library Change from Multi-Threaded Debug (/MTd) to Multi-threaded Debug DLL (/MDd)
+7. Build portaudio_static
+
 ## Compiling Kaldi
 
 1. Checkout Kaldi trunk, using [git](https://git-for-windows.github.io/) from https://github.com/kaldi-asr/kaldi.git

--- a/windows/generate_solution.pl
+++ b/windows/generate_solution.pl
@@ -535,6 +535,7 @@ sub writeProjectFiles {
   print PROJ
 "    <Import Project=\"..\\kaldiwin_win32.props\" />
     <Import Project=\"..\\openfstwin_debug_win32.props\" />
+    <Import Project=\"..\\portaudio.props\" />
   </ImportGroup>
   <ImportGroup Condition=\"'\$(Configuration)|\$(Platform)'=='Debug|x64'\" Label=\"PropertySheets\">
     <Import Project=\"..\\variables.props\" />
@@ -548,6 +549,7 @@ sub writeProjectFiles {
   print PROJ
 "    <Import Project=\"..\\kaldiwin.props\" />
     <Import Project=\"..\\openfstwin_debug.props\" />
+    <Import Project=\"..\\portaudio.props\" />
   </ImportGroup>
   <ImportGroup Condition=\"'\$(Configuration)|\$(Platform)'=='Release|Win32'\" Label=\"PropertySheets\">
     <Import Project=\"..\\variables.props\" />
@@ -561,6 +563,7 @@ sub writeProjectFiles {
   print PROJ
 "    <Import Project=\"..\\kaldiwin_win32.props\" />
     <Import Project=\"..\\openfstwin_release_win32.props\" />
+    <Import Project=\"..\\portaudio.props\" />
   </ImportGroup>
   <ImportGroup Condition=\"'\$(Configuration)|\$(Platform)'=='Release|x64'\" Label=\"PropertySheets\">
     <Import Project=\"..\\variables.props\" />
@@ -572,11 +575,9 @@ sub writeProjectFiles {
 ";
   }
   print PROJ
-"    <Import Project=\"..\\portaudio.props\" />
-";
-  print PROJ
 "    <Import Project=\"..\\kaldiwin.props\" />
     <Import Project=\"..\\openfstwin_release.props\" />
+    <Import Project=\"..\\portaudio.props\" />
   </ImportGroup>
 ";
 

--- a/windows/generate_solution.pl
+++ b/windows/generate_solution.pl
@@ -85,6 +85,7 @@ my @propsFiles = (
   "$Bin/openfstwin_release.props",
   "$Bin/openfstwin_debug_win32.props",
   "$Bin/openfstwin_release_win32.props",
+  "$Bin/portaudio.props",
 );
 
 my %optionalProps = (
@@ -570,6 +571,9 @@ sub writeProjectFiles {
 "    <Import Project=\"..\\cuda_7.0.props\" />
 ";
   }
+  print PROJ
+"    <Import Project=\"..\\portaudio.props\" />
+";
   print PROJ
 "    <Import Project=\"..\\kaldiwin.props\" />
     <Import Project=\"..\\openfstwin_release.props\" />

--- a/windows/portaudio.props
+++ b/windows/portaudio.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <LinkIncremental>
+    </LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(PORTAUDIODIR)\src\common;$(PORTAUDIODIR)\src\os\win;$(PORTAUDIODIR)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(PORTAUDIOLIB)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>portaudio_static_x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/windows/portaudio.props
+++ b/windows/portaudio.props
@@ -7,10 +7,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(PORTAUDIODIR)\src\common;$(PORTAUDIODIR)\src\os\win;$(PORTAUDIODIR)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(PORTAUDIO)\src\common;$(PORTAUDIO)\src\os\win;$(PORTAUDIO)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(PORTAUDIOLIB)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(PORTAUDIOLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>portaudio_static_x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/windows/variables.props.dev
+++ b/windows/variables.props.dev
@@ -5,10 +5,12 @@
     <!-- Change the following paths so they are correct on your machine -->
     <!-- Do not modify anything before this line -->
     <MKLDIR>C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl\</MKLDIR>
-    <OPENBLASDIR>C:\Users\Yenda\Downloads\kaldi-svn\tools\OpenBLAS-v0.2.14-Win64-int32</OPENBLASDIR>
-    <OPENFST>C:\Users\jtrmal\Documents\openfst\</OPENFST>
-    <OPENFSTLIB>C:\Users\jtrmal\Documents\openfst\build64</OPENFSTLIB>
+    <OPENBLASDIR>W:\kaldi-build\kaldi\tools\OpenBLAS-v0.2.19-Win64-int32</OPENBLASDIR>
+    <OPENFST>W:\kaldi-build\kaldi\tools\openfst-21a3f8e2e61e15ea3cc1933bcf43ebf9b36bd7f5\</OPENFST>
+    <OPENFSTLIB>W:\kaldi-build\kaldi\tools\openfst-21a3f8e2e61e15ea3cc1933bcf43ebf9b36bd7f5\build64</OPENFSTLIB>
     <CUBDIR>c:\Users\jtrmal\Documents\cub\</CUBDIR>
+    <PORTAUDIO>W:\kaldi-build\portaudio_src_double</PORTAUDIO>
+    <PORTAUDIOLIB>W:\kaldi-build\portaudio_src_double\Debug</PORTAUDIOLIB>
     <NVTOOLSDIR>C:\Program FIles\NVIDIA Corporation\NvToolsExt\</NVTOOLSDIR>
     <!-- Do not modify anything after this line -->
   </PropertyGroup>
@@ -35,9 +37,18 @@
       <Value>$(CUBDIR)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
+    <BuildMacro Include="PORTAUDIO">
+      <Value>$(PORTAUDIO)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+      <BuildMacro Include="PORTAUDIOLIB">
+      <Value>$(PORTAUDIOLIB)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
     <BuildMacro Include="NVTOOLSDIR">
       <Value>$(NVTOOLSDIR)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
   </ItemGroup>
 </Project>
+

--- a/windows/variables.props.dev
+++ b/windows/variables.props.dev
@@ -5,9 +5,9 @@
     <!-- Change the following paths so they are correct on your machine -->
     <!-- Do not modify anything before this line -->
     <MKLDIR>C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl\</MKLDIR>
-    <OPENBLASDIR>W:\kaldi-build\kaldi\tools\OpenBLAS-v0.2.19-Win64-int32</OPENBLASDIR>
-    <OPENFST>W:\kaldi-build\kaldi\tools\openfst-21a3f8e2e61e15ea3cc1933bcf43ebf9b36bd7f5\</OPENFST>
-    <OPENFSTLIB>W:\kaldi-build\kaldi\tools\openfst-21a3f8e2e61e15ea3cc1933bcf43ebf9b36bd7f5\build64</OPENFSTLIB>
+    <OPENBLASDIR>C:\Users\Yenda\Downloads\kaldi-svn\tools\OpenBLAS-v0.2.14-Win64-int32</OPENBLASDIR>
+    <OPENFST>C:\Users\jtrmal\Documents\openfst\</OPENFST>
+    <OPENFSTLIB>C:\Users\jtrmal\Documents\openfst\build64</OPENFSTLIB>
     <CUBDIR>c:\Users\jtrmal\Documents\cub\</CUBDIR>
     <PORTAUDIO>W:\kaldi-build\portaudio_src_double</PORTAUDIO>
     <PORTAUDIOLIB>W:\kaldi-build\portaudio_src_double\Debug</PORTAUDIOLIB>


### PR DESCRIPTION
This adds PortAudio dependencies to the Visual Studio sln generator script, and provides instructions in INSTALL.md on how to produce a compatible build in PortAudio.