### PR TITLE
debug_tcp_server_and_bnfeats

### DIFF
--- a/egs/wsj/s5/steps/nnet3/make_bottleneck_features.sh
+++ b/egs/wsj/s5/steps/nnet3/make_bottleneck_features.sh
@@ -103,7 +103,7 @@ if ! $online_cmvn; then
   feats="ark,s,cs:apply-cmvn $cmvn_opts --utt2spk=ark:$sdata/JOB/utt2spk scp:$sdata/JOB/cmvn.scp scp:$sdata/JOB/feats.scp ark:- |"
 else
   echo "$0: feature type is raw (apply-cmvn-online)"
-  feats="ark,s,cs:apply-cmvn-online $cmvn_opts --spk2utt=ark:$sdata/JOB/spk2utt $srcdir/global_cmvn.stats scp:$sdata/JOB/feats.scp ark:- |"
+  feats="ark,s,cs:apply-cmvn-online $cmvn_opts --spk2utt=ark:$sdata/JOB/spk2utt $nnetdir/global_cmvn.stats scp:$sdata/JOB/feats.scp ark:- |"
 fi
 ivector_feats="scp:utils/filter_scp.pl $sdata/JOB/utt2spk $ivector_dir/ivector_online.scp |"
 

--- a/src/online2bin/online2-tcp-nnet3-decode-faster.cc
+++ b/src/online2bin/online2-tcp-nnet3-decode-faster.cc
@@ -252,6 +252,16 @@ int main(int argc, char *argv[]) {
 
           if (eos) {
             feature_pipeline.InputFinished();
+
+            if (silence_weighting.Active() &&
+                feature_pipeline.IvectorFeature() != NULL) {
+              silence_weighting.ComputeCurrentTraceback(decoder.Decoder());
+              silence_weighting.GetDeltaWeights(feature_pipeline.NumFramesReady(),
+                                                frame_offset * decodable_opts.frame_subsampling_factor,
+                                                &delta_weights);
+              feature_pipeline.UpdateFrameWeights(delta_weights);
+            }
+
             decoder.AdvanceDecoding();
             decoder.FinalizeDecoding();
             frame_offset += decoder.NumFramesDecoded();
@@ -428,7 +438,7 @@ bool TcpServer::ReadChunk(size_t len) {
   while (to_read > 0) {
     poll_ret = poll(client_set_, 1, read_timeout_);
     if (poll_ret == 0) {
-      KALDI_WARN << "Socket timeout! Disconnecting...";
+      KALDI_WARN << "Socket timeout! Disconnecting..." << "(has_read_ = " << has_read_ << ")";
       break;
     }
     if (poll_ret < 0) {


### PR DESCRIPTION
- tcp-server:
  - fixing a bug in ivector extractor with weighted frames,
  - it was occuring during hang-up, the weights were incomplete (not updated...)
  - and it was failing in this way:
  ```ASSERTION_FAILED
  (online2-tcp-nnet3-decode-faster[5.5.675-0185c]:UpdateStatsUntilFrameWeighted():online-ivector-feature.cc:285)
  Assertion failed: (frame >= 0 && frame < this->NumFramesReady() &&
  delta_weights_provided_ && ! updated_with_no_delta_weights_ && frame
  <= most_recent_frame_with_weight_)```

- make_bottleneck_features: there was a bug in CMVN pipeline that i recently introduced (sorry about that...)