### PR TITLE
[build] several bugs fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ if(${KALDI_USE_PATCH_NUMBER})
 endif()
 
 get_third_party(openfst)
-set(OPENFST_ROOT_DIR ${CMAKE_CURRENT_BINARY_DIR}/openfst)
+set(OPENFST_ROOT_DIR ${CMAKE_BINARY_DIR}/openfst)
 include(third_party/openfst_lib_target)
 link_libraries(fst)
 

--- a/cmake/VersionHelper.cmake
+++ b/cmake/VersionHelper.cmake
@@ -8,6 +8,7 @@ function(get_version)
     execute_process(COMMAND git rev-list --count "${version_commit}..HEAD"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTPUT_VARIABLE patch_number)
+    string(STRIP ${patch_number} patch_number)
 
     set(KALDI_VERSION ${version} PARENT_SCOPE)
     set(KALDI_PATCH_NUMBER ${patch_number} PARENT_SCOPE)


### PR DESCRIPTION
Problem 1:
```sh
$ cmake -DKALDI_USE_PATCH_NUMBER=ON ../
$ make
Scanning dependencies of target fst
[  0%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/compat.cc.o
[  0%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/flags.cc.o
[  1%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/fst-types.cc.o
[  1%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/fst.cc.o
[  1%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/mapped-file.cc.o
[  2%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/properties.cc.o
[  2%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/symbol-table-ops.cc.o
[  2%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/symbol-table.cc.o
[  3%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/util.cc.o
[  3%] Building CXX object CMakeFiles/fst.dir/openfst/src/lib/weight.cc.o
[  3%] Linking CXX static library libfst.a
[  3%] Built target fst
src/base/CMakeFiles/kaldi-base.dir/flags.make:8: *** missing separator.  Stop.
make[1]: *** [CMakeFiles/Makefile2:961: src/base/CMakeFiles/kaldi-base.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
```

and there is an extra new line
```sh
$cat src/base/CMakeFiles/kaldi-base.dir/flags.make
# CMAKE generated file: DO NOT EDIT!
# Generated by "Unix Makefiles" Generator, CMake Version 3.17

# compile CXX with /usr/lib/ccache/c++
CXX_FLAGS =   -std=c++14

CXX_DEFINES = -DHAVE_CLAPACK=1 -DKALDI_NO_PORTAUDIO=1 -DKALDI_VERSION=\"5.5.678
\"

.....
```

Problem 2:  configurations in cmake/third_party/openfst.cmake and CMakeLists.txt are inconsistent.