### PR TITLE
Fix return condition and add resize code in online-audio-source.cc

### DIFF
--- a/src/online/online-audio-source.cc
+++ b/src/online/online-audio-source.cc
@@ -177,12 +177,14 @@ bool OnlineVectorSource::Read(Vector<BaseFloat> *data) {
     if (data->Dim() == subsrc.Dim()) {
       data->CopyFromVec(subsrc);
     } else {
+      data->Resize(n_elem);
       for (int32 i = 0; i < subsrc.Dim(); ++i)
         (*data)(i) = subsrc(i);
     }
     pos_ += n_elem;
+    return true;
   }
-  return (pos_ < src_.Dim());
+  return false;
 }
 
 }  // namespace kaldi

--- a/src/online/online-tcp-source.cc
+++ b/src/online/online-tcp-source.cc
@@ -140,6 +140,7 @@ bool OnlineTcpVectorSource::Read(Vector<BaseFloat> *data) {
   int32 n_read = b_read / 2;
 
   short* s_frame = (short*) frame;
+  data->Resize(n_read);
   for (int32 i = 0; i < n_read; i++)
     (*data)(i) = s_frame[i];
 


### PR DESCRIPTION
i used this source for online-audio-client. but when i process last frame of audio. 
that frame is skipped because of this condition. 
i think it's because `pos_ == src_.Dim()` at last frame.
so i changed condition of return. and add resize code for last frame.
it works well in my environment. 
I would appreciate it if you review.