### PR TITLE
[scripts] Fix for how the --fixed-value parameter is applied in adjust_unk_arpa.pl

### DIFF
--- a/egs/wsj/s5/utils/lang/adjust_unk_arpa.pl
+++ b/egs/wsj/s5/utils/lang/adjust_unk_arpa.pl
@@ -55,7 +55,7 @@ while(<STDIN>) {
   if ( @col > 1 && $ngram > 0 && $col[$ngram] eq $unk_word ) {
     if ( $fixed_value eq "true" && $ngram == 1 ) {
       $col[0] = (log($unk_scale) / log(10.0));
-    } else {
+    } elsif ($fixed_value eq "false" ) {
       $col[0] += (log($unk_scale) / log(10.0));
     }
     my $line = join("\t", @col);


### PR DESCRIPTION
The --fixed-value parameter of adjsut_unk_arpa.pl was not having the intended
effect of "higher order n-grams containing the OOV dict entry remaining untouched".
When --fixed-value=true, the unigram entry was getting set correctly, but the
higher order n-grams were also being scaled.