### PR TITLE
Missing include, CUDA_VERSION is defined in cuda.h

### DIFF
--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -30,6 +30,7 @@
 #include <math_constants.h>
 #include "cudamatrix/cu-kernels-ansi.h"
 #include <cub/block/block_reduce.cuh>
+#include <cuda.h> // for CUDA_VERSION
 
 
 /***********************************************************************


### PR DESCRIPTION
cu-kernels.cu uses CUDA_VERSION, but it is defined in cuda.h, which is not included. Cub includes it, so the bug is currently hidden. Fixed by adding an include for cuda.h