### PR TITLE
Fix stats dump when some utts are missing in bestpath due to errors

### DIFF
--- a/egs/wsj/s5/steps/diagnostic/analyze_lats.sh
+++ b/egs/wsj/s5/steps/diagnostic/analyze_lats.sh
@@ -62,24 +62,12 @@ $cmd $dir/log/analyze_alignments.log \
 grep WARNING $dir/log/analyze_alignments.log
 echo "$0: see stats in $dir/log/analyze_alignments.log"
 
-
-# note: below, some things that would be interpreted by the shell have to be
-# escaped since it needs to be passed to $cmd.
-# the 'paste' command will paste together the phone-indexes and the depths
-# so that one line will be like utt-id1 phone1 phone2 phone3 .. utt-id1 depth1 depth2 depth3 ...
-# the following command computes counts of pairs (phone, lattice-depth) and outputs lines
-# containing 3 integers representing:
-#   phone lattice_depth, count[phone,lattice_depth]
-$cmd JOB=1:$num_jobs $dir/log/lattice_best_path.JOB.log \
-  ali-to-phones --per-frame=true "$model" "ark:gunzip -c $dir/ali_tmp.JOB.gz|" ark,t:- \| \
-  paste /dev/stdin '<(' gunzip -c $dir/depth_tmp.JOB.gz  ')'  \| \
-  perl -ane '$half=@F/2;for($i=1;$i<$half;$i++){$j=$i+$half;$count{$F[$i]." ".$F[$j]}++;}
-  END{for $k (sort keys %count){print "$k $count{$k}\n"}}' \| \
-  gzip -c '>' $dir/depth_stats_tmp.JOB.gz
+$cmd $dir/log/dump_ali_frame.log \
+  ali-to-phones --per-frame=true "$model" "ark:gunzip -c $dir/ali_tmp.*.gz|" "ark,t:|gzip -c >$dir/ali_frame_tmp.gz"
 
 $cmd $dir/log/analyze_lattice_depth_stats.log \
-  gunzip -c "$dir/depth_stats_tmp.*.gz" \| \
-  steps/diagnostic/analyze_lattice_depth_stats.py $lang || exit 1
+  gunzip -c "$dir/depth_tmp.*.gz" \| \
+  steps/diagnostic/analyze_lattice_depth_stats.py $lang "$dir/ali_frame_tmp.gz" || exit 1
 
 grep Overall $dir/log/analyze_lattice_depth_stats.log
 echo "$0: see stats in $dir/log/analyze_lattice_depth_stats.log"
@@ -87,7 +75,7 @@ echo "$0: see stats in $dir/log/analyze_lattice_depth_stats.log"
 
 rm $dir/phone_stats.*.gz
 rm $dir/depth_tmp.*.gz
-rm $dir/depth_stats_tmp.*.gz
+rm $dir/ali_frame_tmp.gz
 rm $dir/ali_tmp.*.gz
 
 exit 0

--- a/egs/wsj/s5/steps/diagnostic/analyze_lattice_depth_stats.py
+++ b/egs/wsj/s5/steps/diagnostic/analyze_lattice_depth_stats.py
@@ -11,6 +11,7 @@ import sys, os
 from collections import defaultdict
 from io import open
 import codecs
+import gzip
 
 # reference: http://www.macfreek.nl/memory/Encoding_of_Python_stdout
 if sys.version_info.major == 2:
@@ -32,6 +33,9 @@ parser.add_argument("--frequency-cutoff-percentage", type = float,
 
 parser.add_argument("lang",
                     help="Language directory, e.g. data/lang.")
+
+parser.add_argument("ali_per_frame",
+                    help="Gzipped alignment per frame, e.g. ali_frame_tmp.gz")
 
 args = parser.parse_args()
 
@@ -83,30 +87,28 @@ for p in [ -1 ] + list(phone_int2text.keys()):
 
 total_frames = 0
 
-while True:
-    line = sys.stdin.readline()
-    if line == '':
-        break
-    a = line.split()
-    if len(a) != 3:
-        sys.exit(u"analyze_lattice_depth_stats.py: reading stdin, could not interpret line: " + line)
-    try:
-        phone, depth, count = [ int(x) for x in a ]
+ali_per_frame = {}
+for line in gzip.open(args.ali_per_frame):
+   uttid, ali = line.split(" ", 1)
+   ali_per_frame[uttid] = ali
 
-        phone_depth_counts[phone][depth] += count
-        total_frames += count
-        if phone in nonsilence:
-            nonsilence_phone = 0
-            phone_depth_counts[nonsilence_phone][depth] += count
-        universal_phone = -1
-        phone_depth_counts[universal_phone][depth] += count
-    except Exception as e:
-        sys.exit(u"analyze_lattice_depth_stats.py: unexpected phone {0} "
-                 u"seen (lang directory mismatch?): line is {1}, error is {2}".format(phone, line, str(e)))
+for line in sys.stdin:
+    uttid, depth = line.split(" ", 1)
+    if uttid in ali_per_frame:
+        apf = ali_per_frame[uttid].split()
+        dpf = depth.split()
+        for p, d in zip(apf, dpf):
+              p, d = int(p), int(d)
+              phone_depth_counts[p][d] += 1
+              total_frames += 1
+              if p in nonsilence:
+                  nonsilence_phone = 0
+                  phone_depth_counts[nonsilence_phone][d] += 1
+              universal_phone = -1
+              phone_depth_counts[universal_phone][d] += 1
 
 if total_frames == 0:
     sys.exit(u"analyze_lattice_depth_stats.py: read no input")
-
 
 # If depth_to_count is a map from depth-in-frames to count,
 # return the depth-in-frames that equals the (fraction * 100)'th


### PR DESCRIPTION
This is not optimal solution yet, so not really recommended for a merge.

The problem is that when some data is broken, lattice-best-path might return error on some lats and skip them in the output. Then paste which merges align output with depth stats gets unsyncronized and the whole thing fails. 

This patch fixes the problem but it creates the single per-frame alignment dump file. Maybe there should be adidtional filter script instead. I'd write it in Python, not sure about perl.
