### PR TITLE
multi_cn prepare_dict.sh

### DIFF
--- a/egs/multi_cn/s5/local/extract_ch.py
+++ b/egs/multi_cn/s5/local/extract_ch.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import sys
+
+def extract():
+#     print (sys.argv)
+    cn_lines = []
+    with open(sys.argv[1],'r') as txt:
+        data = txt.read()
+        index = 1
+        for char in data:
+            if (char == '\n'):
+                index += 1
+            elif (not char.islower() and not char.isupper()):
+                if (index not in cn_lines):
+                    cn_lines.append(index)
+    return cn_lines
+
+
+if __name__ == "__main__":
+    result = extract()
+    print(str(result).strip('[').strip(']'))
+

--- a/egs/multi_cn/s5/local/prepare_dict.sh
+++ b/egs/multi_cn/s5/local/prepare_dict.sh
@@ -48,11 +48,16 @@ perl $dict_dir/cmudict/scripts/make_baseform.pl \
 echo "--- Searching for English OOV words ..."
 awk 'NR==FNR{words[$1]; next;} !($1 in words)' \
   $dict_dir/cmudict/cmudict-plain.txt $dict_dir/lexicon-en/words-en.txt |\
-  egrep -v '<.?s>' > $dict_dir/lexicon-en/words-en-oov.txt || exit 1;
+  egrep -v '<.?s>' > $dict_dir/lexicon-en/words-en-oov-all.txt || exit 1;
 
 awk 'NR==FNR{words[$1]; next;} ($1 in words)' \
   $dict_dir/lexicon-en/words-en.txt $dict_dir/cmudict/cmudict-plain.txt |\
   egrep -v '<.?s>' > $dict_dir/lexicon-en/lexicon-en-iv.txt || exit 1;
+
+rm $dict_dir/lexicon-en/words-en-oov.txt
+rm $dict_dir/lexicon-en/words-en-oov-other.txt
+lines=$(python local/extract_ch.py $dict_dir/lexicon-en/words-en-oov-all.txt)
+awk -v arr="${lines}" -v dict_dir="$dict_dir" 'BEGIN{split(arr,line_arr,","); i=1;}{if(NR==line_arr[i]){ if(i < length(line_arr)){i+=1;} print $0 >> dict_dir"/lexicon-en/words-en-oov-other.txt";} else{print $0 >> dict_dir"/lexicon-en/words-en-oov.txt";} }' $dict_dir/lexicon-en/words-en-oov-all.txt
 
 wc -l $dict_dir/lexicon-en/words-en-oov.txt
 wc -l $dict_dir/lexicon-en/lexicon-en-iv.txt
@@ -163,12 +168,14 @@ cat $dict_dir/cedict/cedict_1_0_ts_utf-8_mdbg.txt | grep -v '#' | awk -F '/' '{p
  ' | sort -k1 > $dict_dir/cedict/ch-dict.txt || exit 1;
 
 echo "--- Searching for Chinese OOV words ..."
+
+cat $dict_dir/lexicon-en/words-en-oov-other.txt $dict_dir/lexicon-ch/words-ch.txt | sort -u > $dict_dir/lexicon-ch/words-ch-all.txt || exit 1;
 awk 'NR==FNR{words[$1]; next;} !($1 in words)' \
-  $dict_dir/cedict/ch-dict.txt $dict_dir/lexicon-ch/words-ch.txt |\
+  $dict_dir/cedict/ch-dict.txt $dict_dir/lexicon-ch/words-ch-all.txt |\
   egrep -v '<.?s>' > $dict_dir/lexicon-ch/words-ch-oov.txt || exit 1;
 
 awk 'NR==FNR{words[$1]; next;} ($1 in words)' \
-  $dict_dir/lexicon-ch/words-ch.txt $dict_dir/cedict/ch-dict.txt |\
+  $dict_dir/lexicon-ch/words-ch-all.txt $dict_dir/cedict/ch-dict.txt |\
   egrep -v '<.?s>' > $dict_dir/lexicon-ch/lexicon-ch-iv.txt || exit 1;
 
 wc -l $dict_dir/lexicon-ch/words-ch-oov.txt

--- a/egs/multi_cn/s5/local/prepare_dict.sh
+++ b/egs/multi_cn/s5/local/prepare_dict.sh
@@ -48,7 +48,7 @@ perl $dict_dir/cmudict/scripts/make_baseform.pl \
 echo "--- Searching for English OOV words ..."
 awk 'NR==FNR{words[$1]; next;} !($1 in words)' \
   $dict_dir/cmudict/cmudict-plain.txt $dict_dir/lexicon-en/words-en.txt |\
-  egrep -v '<.?s>' > $dict_dir/lexicon-en/words-en-oov-all.txt || exit 1;
+  grep -E -v '<.?s>' > $dict_dir/lexicon-en/words-en-oov-all.txt || exit 1;
 
 awk 'NR==FNR{words[$1]; next;} ($1 in words)' \
   $dict_dir/lexicon-en/words-en.txt $dict_dir/cmudict/cmudict-plain.txt |\
@@ -168,7 +168,6 @@ cat $dict_dir/cedict/cedict_1_0_ts_utf-8_mdbg.txt | grep -v '#' | awk -F '/' '{p
  ' | sort -k1 > $dict_dir/cedict/ch-dict.txt || exit 1;
 
 echo "--- Searching for Chinese OOV words ..."
-
 cat $dict_dir/lexicon-en/words-en-oov-other.txt $dict_dir/lexicon-ch/words-ch.txt | sort -u > $dict_dir/lexicon-ch/words-ch-all.txt || exit 1;
 awk 'NR==FNR{words[$1]; next;} !($1 in words)' \
   $dict_dir/cedict/ch-dict.txt $dict_dir/lexicon-ch/words-ch-all.txt |\


### PR DESCRIPTION
Due to execute  prepare_dict.sh :
...
cat $dict_dir/words.txt | grep '[a-zA-Z]' > $dict_dir/lexicon-en/words-en.txt || exit 1;
Divide words like "A股、AB型" into words-en.txt
Include Chinese text

g2p.py --model=conf/g2p_model --apply $dict_dir/lexicon-en/words-en-oov.txt \
  > $dict_dir/lexicon-en/lexicon-en-oov.txt || exit 1; 
Error:
failed to convert "ABå": translation failed
failed to convert "Aå": translation failed