### PR TITLE
Fix some feat options interfaces

### DIFF
--- a/src/feat/online-feature.h
+++ b/src/feat/online-feature.h
@@ -231,7 +231,7 @@ struct OnlineCmvnOptions {
                  && modulus > 0);
   }
 
-  void Register(ParseOptions *po) {
+  void Register(OptionsItf *po) {
     po->Register("cmn-window", &cmn_window, "Number of frames of sliding "
                  "context for cepstral mean normalization.");
     po->Register("global-frames", &global_frames, "Number of frames of "

--- a/src/feat/online-feature.h
+++ b/src/feat/online-feature.h
@@ -447,7 +447,7 @@ struct OnlineSpliceOptions {
   int32 left_context;
   int32 right_context;
   OnlineSpliceOptions(): left_context(4), right_context(4) { }
-  void Register(ParseOptions *po) {
+  void Register(OptionsItf *po) {
     po->Register("left-context", &left_context, "Left-context for frame "
                  "splicing prior to LDA");
     po->Register("right-context", &right_context, "Right-context for frame "

--- a/src/feat/pitch-functions.h
+++ b/src/feat/pitch-functions.h
@@ -248,7 +248,7 @@ struct ProcessPitchOptions {
       add_raw_log_pitch(false) { }
 
 
-  void Register(ParseOptions *opts) {
+  void Register(OptionsItf *opts) {
     opts->Register("pitch-scale", &pitch_scale,
                    "Scaling factor for the final normalized log-pitch value");
     opts->Register("pov-scale", &pov_scale,


### PR DESCRIPTION
ProcessPitchOptions,  OnlineCmvnOptions and OnlineSpliceOptions should accept "OptionsItf* ptr" instead of "ParseOptions* ptr" to allow different OptionsItf implementation.