### PR TITLE
Make OnlineCmvn internals protected

### DIFF
--- a/src/feat/online-feature.h
+++ b/src/feat/online-feature.h
@@ -386,7 +386,7 @@ class OnlineCmvn: public OnlineFeatureInterface {
   void Freeze(int32 cur_frame);
 
   virtual ~OnlineCmvn();
- private:
+ protected:
 
   /// Smooth the CMVN stats "stats" (which are stored in the normal format as a
   /// 2 x (dim+1) matrix), by possibly adding some stats from "global_stats"


### PR DESCRIPTION
I would like to subclass OnlineCmvn and access its members from the child. Thus making the members protected. 
Not sure if that follows kaldi code policies.