### PR TITLE
[src] Partial hypothesis for cuda decoder

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -218,7 +218,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
     const std::vector<SubVector<BaseFloat>> &wave_samples,
     const std::vector<bool> &is_first_chunk,
     const std::vector<bool> &is_last_chunk,
-    std::vector<std::string *> *partial_hypotheses) {
+    std::vector<const std::string *> *partial_hypotheses) {
   nvtxRangePushA("DecodeBatch");
   KALDI_ASSERT(corr_ids.size() > 0);
   KALDI_ASSERT(corr_ids.size() == wave_samples.size());
@@ -245,9 +245,10 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
   int features_frame_stride = d_all_features_.Stride();
   if (partial_hypotheses) {
     // We're going to have to generate the partial hypotheses
-    KALDI_ASSERT(
-        word_syms_ &&
-        "You need to set --word-symbol-table to use partial hypotheses");
+    if (word_syms_ == nullptr) {
+      KALDI_ERR << "You need to set --word-symbol-table to use "
+                << "partial hypotheses";
+    }
     cuda_decoder_->AllowPartialHypotheses();
   }
   DecodeBatch(corr_ids, d_features_ptrs_, features_frame_stride,

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -174,11 +174,12 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // hypotheses in partial_hypotheses The pointers in partial_hypotheses are
   // only valid until the next DecodeBatch call - perform a deep copy if
   // necessary
-  void DecodeBatch(const std::vector<CorrelationID> &corr_ids,
-                   const std::vector<SubVector<BaseFloat>> &wave_samples,
-                   const std::vector<bool> &is_first_chunk,
-                   const std::vector<bool> &is_last_chunk,
-                   std::vector<std::string *> *partial_hypotheses = NULL);
+  void DecodeBatch(
+      const std::vector<CorrelationID> &corr_ids,
+      const std::vector<SubVector<BaseFloat>> &wave_samples,
+      const std::vector<bool> &is_first_chunk,
+      const std::vector<bool> &is_last_chunk,
+      std::vector<const std::string *> *partial_hypotheses = nullptr);
 
   // Version providing directly the features. Only runs nnet3 & decoder
   // Used when we want to provide the final ivectors (offline case)
@@ -214,8 +215,8 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   BaseFloat GetSecondsPerChunk() { return seconds_per_chunk_; }
 
   // Used for partial hypotheses
-  void SetSymbolTable(fst::SymbolTable *word_syms) {
-    word_syms_ = word_syms;
+  void SetSymbolTable(const fst::SymbolTable &word_syms) {
+    word_syms_ = &word_syms;
     KALDI_ASSERT(cuda_decoder_);
     cuda_decoder_->SetSymbolTable(word_syms);
   }
@@ -365,7 +366,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   std::unique_ptr<ThreadPoolLight> thread_pool_;
 
   // Used for debugging
-  fst::SymbolTable *word_syms_;
+  const fst::SymbolTable *word_syms_;
   // Used when printing to stdout for debugging purposes
   std::mutex stdout_m_;
 };

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
@@ -245,7 +245,7 @@ class BatchedThreadedNnet3CudaPipeline2 {
   void WaitForAllTasks();
 
   // Used for debug
-  void SetSymbolTable(fst::SymbolTable *word_syms) {
+  void SetSymbolTable(const fst::SymbolTable &word_syms) {
     cuda_online_pipeline_.SetSymbolTable(word_syms);
   }
 

--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -1401,7 +1401,7 @@ __global__ void fill_hashmap_with_main_q_kernel(DeviceParams cst_dev_params,
     const int32 main_q_end = lane_counters->main_q_narcs_and_end.y;
     int32 min_int_cost = lane_counters->min_int_cost;
     CostType min_cost = orderedIntToFloat(min_int_cost);
-    const int32 global_offset = channel_counters->prev_main_q_global_offset;
+    const int32 global_offset = lane_counters->main_q_global_offset;
     KALDI_CUDA_DECODER_1D_KERNEL_LOOP(main_q_idx, main_q_end) {
       // Position of considered token in the main_q
       if (main_q_idx < main_q_end) {
@@ -1415,6 +1415,7 @@ __global__ void fill_hashmap_with_main_q_kernel(DeviceParams cst_dev_params,
           channel_counters->min_int_cost_and_arg_without_final = {
               token_int_cost, global_offset + main_q_idx};
           lane_counters->prev_arg_min_int_cost = main_q_idx;
+          lane_counters->prev_arg_min_int_cost_token = cst_dev_params.d_main_q_info.lane(ilane)[main_q_idx];
         } else {
           // remove offset = min_cost
           CostType token_cost = orderedIntToFloat(token_int_cost) - min_cost;

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -1810,9 +1810,7 @@ void CudaDecoder::GeneratePartialPath(LaneId ilane, ChannelId ichannel) {
     partial_hypotheses.push_back({curr_token_idx, arc_idx});
     // Backtracking until we reconnect with our stored partial path
     if (partial_hypotheses.size() > 1) {
-      auto it = partial_hypotheses.end();
-      it--;
-      it--;
+      auto it = std::prev(partial_hypotheses.end(), 2);
 
       int32 stored_prev_token_idx = it->token_idx;
       if (stored_prev_token_idx != prev_token_idx) {
@@ -1839,7 +1837,7 @@ void CudaDecoder::GeneratePartialPath(LaneId ilane, ChannelId ichannel) {
             partial_hypotheses.push_front(
                 {-1, -1});  // it will be set on next iteration
           }
-          it--;
+          --it;
         }
 
         if (prev_token_idx == 0) {

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
                      "table from file "
                   << word_syms_rxfilename;
       else {
-        cuda_pipeline.SetSymbolTable(word_syms);
+        cuda_pipeline.SetSymbolTable(*word_syms);
       }
     }
 
@@ -252,7 +252,7 @@ int main(int argc, char *argv[]) {
     std::vector<SubVector<BaseFloat>> batch_wave_samples;
 
     // Partial hypotheses
-    std::vector<std::string *> partial_hypotheses;
+    std::vector<const std::string *> partial_hypotheses;
 
     double batch_valid_at = gettime_monotonic();
     bool pipeline_starved_warning_printed = false;

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -123,9 +123,7 @@ int main(int argc, char *argv[]) {
       if (!(word_syms = fst::SymbolTable::ReadText(word_syms_rxfilename)))
         KALDI_ERR << "Could not read symbol table from file "
                   << word_syms_rxfilename;
-      else {
-        cuda_pipeline.SetSymbolTable(word_syms);
-      }
+      cuda_pipeline.SetSymbolTable(*word_syms);
     }
 
     int32 num_task_submitted = 0, num_err = 0;

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
         KALDI_ERR << "Could not read symbol table from file "
                   << word_syms_rxfilename;
       else {
-        //        cuda_pipeline.SetSymbolTable(word_syms);
+        cuda_pipeline.SetSymbolTable(word_syms);
       }
     }
 


### PR DESCRIPTION
Code is ready but setting the WIP flag because we need to finish testing 
 
The cuda decoder can now generates partial hypotheses on the fly. The compute cost for generating those partial hypotheses is very low. The work is done asynchronously while the GPU is working. This work has been integrated in the online pipeline, for the end user getting partial hypotheses just require to add an argument to the DecodeBatch call:

```
  void DecodeBatch(const std::vector<CorrelationID> &corr_ids,
                   const std::vector<SubVector<BaseFloat>> &wave_samples,
                   const std::vector<bool> &is_first_chunk,
                   const std::vector<bool> &is_last_chunk,
                   std::vector<std::string *> *partial_hypotheses = NULL);
```
If partial_hypotheses is not null, the vector will contain the partial hypotheses. The pointers contained by that vector must be used before the next DecodeBatch call.

Easiest way to test is to run the cudadecoderbin/batched-wav-nnet3-cuda-online binary, with `--print-partial-hypotheses=true`. You probably want to reduce the number of parallel channels to be able to read the output, with `--num-parallel-streaming-channels`.

Sample output:
```
main():batched-wav-nnet3-cuda-online.cc:351) ========== BEGIN OF PARTIAL HYPOTHESES ==========
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #3     : HELLO
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #4     : NUMBER
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #5     : THE MUSIC
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #6     : THE
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #7     : A
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #8     : THE
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #9     : AT
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #0     : HE HOPED
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #1     : 
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #2     : AFTER
main():batched-wav-nnet3-cuda-online.cc:356) =========== END OF PARTIAL HYPOTHESES ===========
main():batched-wav-nnet3-cuda-online.cc:351) ========== BEGIN OF PARTIAL HYPOTHESES ==========
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #3     : HELLO
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #4     : NUMBER DEN     
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #5     : THE MUSIC CAME 
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #6     : THE DULL
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #7     : A COLD
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #8     : THE CHAOS
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #9     : AT MOST 
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #0     : HE HOPED THERE WOULD
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #1     : STUFFED INTO   
main():batched-wav-nnet3-cuda-online.cc:353) CORR_ID #2     : AFTER EARLY    
main():batched-wav-nnet3-cuda-online.cc:356) =========== END OF PARTIAL HYPOTHESES ===========

```
Right now only the text version of the partial hypothesis can be returned by the online pipeline. If it's useful to also return the int olabels, we can, but I'd like to keep the high-level API as simple as possible. The endpointing will be handled directly in the decoder.


