### PR TITLE
Fix argument passing with asterisk

### DIFF
--- a/egs/chime6/s5_track1/local/prepare_data.sh
+++ b/egs/chime6/s5_track1/local/prepare_data.sh
@@ -22,7 +22,7 @@ fi
 
 set -e -o pipefail
 
-adir=$(utils/make_absolute.sh $1)
+adir=$(utils/make_absolute.sh "$1")
 jdir=$2
 dir=$3
 

--- a/egs/wsj/s5/utils/make_absolute.sh
+++ b/egs/wsj/s5/utils/make_absolute.sh
@@ -5,7 +5,7 @@
 target_file=$1
 
 cd $(dirname $target_file)
-target_file=$(basename $target_file)
+target_file=$(basename "$target_file")
 
 # Iterate down a (possible) chain of symlinks
 while [ -L "$target_file" ]; do


### PR DESCRIPTION
Add double quotes to prevent the parameter be treat as multi argument.
Without the quotes, the script produce unexpected output on Ubuntu 16.04.6, later cause the Error in utils/validate_data_dir.sh line 179 when running the chime6 baseline.