### PR TITLE
Update validate_data_dir.sh

### DIFF
--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -124,10 +124,10 @@ if [ ! -f $data/text ] && ! $no_text; then
 fi
 
 num_utts=`cat $tmpdir/utts | wc -l`
-if [ -f $data/text ]; then
+if ! $no_text; then
   if ! $non_print; then
     # compatible with bin/align-text
-    n_non_print=$(grep -c '[^[:print:][:space:]]' $data/text) && \
+    n_non_print=$(LC_ALL="C.UTF-8" grep -c '[^[:print:][:space:]]' $data/text) && \
     echo "$0: text contains $n_non_print lines with non-printable characters" &&\
     exit 1;
   fi


### PR DESCRIPTION
- line 127: skip text validation when `no_text` is true.
- line 130: `grep '[^[:print:][:space:]]'` says Chinese characters are unprintable.