### PR TITLE
[build] Undo OpenFST Makefile patch hack from #4177

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -86,12 +86,6 @@ else
 endif
 
 openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION) | check_required_programs
-	# modify src/extensions/far/Makefile.am to make it work with gcc >= 5, while keep its timestamp to avoid autoreconf
-	$(eval make_file=openfst-$(OPENFST_VERSION)/src/extensions/far/Makefile.in)
-	$(eval STAMP="$(shell LC_ALL=C date -r $(make_file))")
-	sed -i -r 's~am__DEPENDENCIES_1 =$$~& libfstfar.la~' $(make_file)
-	sed -i -E 's~(@LDADD = libfstfarscript.la) \.\.~\1 libfstfar.la ..~' $(make_file)
-	touch -d $(STAMP) $(make_file)
 	cd openfst-$(OPENFST_VERSION)/ && \
 	./configure --prefix=`pwd` $(OPENFST_CONFIGURE) CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) $(openfst_add_CXXFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
 


### PR DESCRIPTION
Please treat the fix as provisional at this time.

I could not reproduce the problem with the configuration as close as was reported in https://groups.google.com/d/msg/kaldi-help/5smFF2RW9do/P3Ml5iITAgAJ, with the exception of the compiler packaging version: I used g++ 7.3.1 (Red Hat 7.3.1-6) while the problem was reported against the package version 7.3.1-2.

I also could not find similar reports anywhere else. Patching the automake-generated Makefile is a cure worse than the disease, and I certainly disfavor this solution. It will hit us hard when we upgrade OpenFST. And, since the variable `OPENFST_VERSION` can be set in make's command line, this solution is certainly asking for a trouble.

@songmeixu, were you able to actually reproduce the problem? I spent a couple of hours trying everything I could to recreate the exact same build environment, but to no avail. If you have an exact repro, please share, and maybe I'll figure out a prettier fix. If not, let's just roll back this change.

Close: #4124