### PR TITLE
[build] Fix RedHat package names

### DIFF
--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -65,12 +65,17 @@ if have "$CXX" && ! echo "#include <zlib.h>" | $CXX $CXXFLAGS -E - &>/dev/null; 
   add_packages zlib-devel zlib1g-dev
 fi
 
-for f in make automake autoconf patch grep bzip2 gzip unzip wget git sox gfortran; do
+for f in make automake autoconf patch grep bzip2 gzip unzip wget git sox; do
   if ! have $f; then
     echo "$0: $f is not installed."
     add_packages $f
   fi
 done
+
+if ! have gfortran; then
+  echo "$0: gfortran is not installed"
+  add_packages gcc-gfortran gfortran
+fi
 
 if ! have libtoolize && ! have glibtoolize; then
   echo "$0: neither libtoolize nor glibtoolize is installed"
@@ -90,7 +95,7 @@ fi
 pythonok=true
 if ! have python2.7; then
   echo "$0: python2.7 is not installed"
-  add_packages python2.7
+  add_packages python27 python2.7
   pythonok=false
 fi
 


### PR DESCRIPTION
python2.7 package is named python27, and gfortran gcc-gfortran.