### PR TITLE
add launch bounds to kernel to ensure kernel will launch on all architectures

### DIFF
--- a/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
@@ -46,6 +46,7 @@ namespace kaldi {
 // threadIdx.x = frame  (up to 1024?)
 // blockIdx.x = feature
 // blockIdx.y = batch id
+__launch_bounds__ (1024, 1)
 __global__ void compute_cmvn_stats_kernel(
     int32_t feat_dim, int32_t chunk_size, int32_t stats_coarsening_factor,
     int32_t cmn_window, const float *in_data, int32_t ldi, int32_t stridei,


### PR DESCRIPTION
Without this the kernel can fail to launch on some toolchain/compiler compiler combinations