### PR TITLE
[src] CudaDecoder endpointing

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -218,7 +218,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
     const std::vector<SubVector<BaseFloat>> &wave_samples,
     const std::vector<bool> &is_first_chunk,
     const std::vector<bool> &is_last_chunk,
-    std::vector<std::string *> *partial_hypotheses) {
+    std::vector<const std::string *> *partial_hypotheses) {
   nvtxRangePushA("DecodeBatch");
   KALDI_ASSERT(corr_ids.size() > 0);
   KALDI_ASSERT(corr_ids.size() == wave_samples.size());
@@ -245,9 +245,10 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
   int features_frame_stride = d_all_features_.Stride();
   if (partial_hypotheses) {
     // We're going to have to generate the partial hypotheses
-    KALDI_ASSERT(
-        word_syms_ &&
-        "You need to set --word-symbol-table to use partial hypotheses");
+    if (word_syms_ == nullptr) {
+      KALDI_ERR << "You need to set --word-symbol-table to use "
+                << "partial hypotheses";
+    }
     cuda_decoder_->AllowPartialHypotheses();
   }
   DecodeBatch(corr_ids, d_features_ptrs_, features_frame_stride,

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -257,7 +257,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
     }
     cuda_decoder_->AllowPartialHypotheses();
   }
-  if (end_points) cuda_decoder_->AllowEndPointing();
+  if (end_points) cuda_decoder_->AllowEndpointing();
 
   DecodeBatch(corr_ids, d_features_ptrs_, features_frame_stride,
               n_input_frames_valid_, d_ivectors_ptrs_, is_first_chunk,

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -174,11 +174,12 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // hypotheses in partial_hypotheses The pointers in partial_hypotheses are
   // only valid until the next DecodeBatch call - perform a deep copy if
   // necessary
-  void DecodeBatch(const std::vector<CorrelationID> &corr_ids,
-                   const std::vector<SubVector<BaseFloat>> &wave_samples,
-                   const std::vector<bool> &is_first_chunk,
-                   const std::vector<bool> &is_last_chunk,
-                   std::vector<std::string *> *partial_hypotheses = NULL);
+  void DecodeBatch(
+      const std::vector<CorrelationID> &corr_ids,
+      const std::vector<SubVector<BaseFloat>> &wave_samples,
+      const std::vector<bool> &is_first_chunk,
+      const std::vector<bool> &is_last_chunk,
+      std::vector<const std::string *> *partial_hypotheses = nullptr);
 
   // Version providing directly the features. Only runs nnet3 & decoder
   // Used when we want to provide the final ivectors (offline case)
@@ -214,8 +215,8 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   BaseFloat GetSecondsPerChunk() { return seconds_per_chunk_; }
 
   // Used for partial hypotheses
-  void SetSymbolTable(fst::SymbolTable *word_syms) {
-    word_syms_ = word_syms;
+  void SetSymbolTable(const fst::SymbolTable &word_syms) {
+    word_syms_ = &word_syms;
     KALDI_ASSERT(cuda_decoder_);
     cuda_decoder_->SetSymbolTable(word_syms);
   }
@@ -365,7 +366,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   std::unique_ptr<ThreadPoolLight> thread_pool_;
 
   // Used for debugging
-  fst::SymbolTable *word_syms_;
+  const fst::SymbolTable *word_syms_;
   // Used when printing to stdout for debugging purposes
   std::mutex stdout_m_;
 };

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -179,7 +179,8 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
       const std::vector<SubVector<BaseFloat>> &wave_samples,
       const std::vector<bool> &is_first_chunk,
       const std::vector<bool> &is_last_chunk,
-      std::vector<const std::string *> *partial_hypotheses = nullptr);
+      std::vector<const std::string *> *partial_hypotheses = nullptr,
+      std::vector<bool> *end_point = nullptr);
 
   // Version providing directly the features. Only runs nnet3 & decoder
   // Used when we want to provide the final ivectors (offline case)

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
@@ -245,7 +245,7 @@ class BatchedThreadedNnet3CudaPipeline2 {
   void WaitForAllTasks();
 
   // Used for debug
-  void SetSymbolTable(fst::SymbolTable *word_syms) {
+  void SetSymbolTable(const fst::SymbolTable &word_syms) {
     cuda_online_pipeline_.SetSymbolTable(word_syms);
   }
 

--- a/src/cudadecoder/cuda-decoder-common.h
+++ b/src/cudadecoder/cuda-decoder-common.h
@@ -385,6 +385,16 @@ __device__ __inline__ void SetSameFSTStateTokensList(int32 offset, int32 size,
   *info_token = {offset, -size};
 }
 
+// Information about the best path head
+// Used by partial hypotheses and endpoiting
+struct BestPathTracebackHead {
+  int index;
+  CostType relative_cost;
+
+  void Reset() { index = -1; }
+  bool IsSet() { return (index != -1); }
+};
+
 // LaneCounters/ChannelCounters
 // The counters are all the singular values associated to a lane/channel
 // For instance  the main queue size. Or the min_cost of all tokens in that
@@ -472,7 +482,6 @@ struct LaneCounters {
   int32 n_within_lattice_beam;
   int32 has_reached_final;  // if there's at least one final token in the queue
   int32 prev_arg_min_int_cost;
-  InfoToken prev_arg_min_int_cost_token;
 };
 
 // Channel counters

--- a/src/cudadecoder/cuda-decoder-common.h
+++ b/src/cudadecoder/cuda-decoder-common.h
@@ -442,6 +442,7 @@ struct LaneCounters {
   int32 main_q_extra_prev_tokens_global_offset;
   // Minimum token for that frame
   IntegerCostType min_int_cost;
+  IntegerCostType int_relative_cost;
   // Current beam. Can be different from default_beam,
   // because of the AdaptiveBeam process, or because of
   // ApplyMaxActiveAndReduceBeam

--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -1414,7 +1414,6 @@ __global__ void fill_hashmap_with_main_q_kernel(DeviceParams cst_dev_params,
           channel_counters->min_int_cost_and_arg_without_final = {
               token_int_cost, global_offset + main_q_idx};
           lane_counters->prev_arg_min_int_cost = main_q_idx;
-          lane_counters->prev_arg_min_int_cost_token = cst_dev_params.d_main_q_info.lane(ilane)[main_q_idx];
         } else {
           // remove offset = min_cost
           CostType token_cost = orderedIntToFloat(token_int_cost) - min_cost;

--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -505,6 +505,7 @@ __global__ void reset_for_frame_and_estimate_cutoff_kernel(
       lane_counters->int_cutoff = INT_MAX;
       lane_counters->min_int_cost = INT_MAX;
       lane_counters->q_overflow = OVERFLOW_NONE;
+      lane_counters->int_relative_cost = INT_MAX;
       lane_counters->aux_q_requested = 0;
       lane_counters->main_q_requested = 0;
       lane_counters->main_q_local_offset = 0;
@@ -1122,8 +1123,7 @@ __launch_bounds__(KALDI_CUDA_DECODER_LARGEST_1D_BLOCK, 1) __global__
 // One add the final_cost[token.state] before looking for the min
 __global__ void get_best_cost_step1_kernel(DeviceParams cst_dev_params,
                                            KernelParams params,
-                                           bool use_final_probs,
-                                           CostType fst_zero) {
+                                           bool use_final_probs) {
   const int nlanes = params.nlanes_used;
   KALDI_CUDA_DECODER_BATCH_KERNEL_LOOP(ilane, nlanes) {
     LaneCounters *lane_counters = cst_dev_params.d_lanes_counters.lane(ilane);
@@ -1151,7 +1151,7 @@ __global__ void get_best_cost_step1_kernel(DeviceParams cst_dev_params,
             cst_dev_params.d_fst_final_costs[token_state];
         IntegerCostType int_cost_with_final =
             floatToOrderedInt(cost + final_cost);
-        if (final_cost != fst_zero) {
+        if (final_cost != cst_dev_params.fst_zero) {
           int2 min_and_arg = {int_cost_with_final,
                               global_idx};  // sort by cost, put it first
           atomicMinI2(&channel_counters->min_int_cost_and_arg_with_final,
@@ -1169,8 +1169,7 @@ __global__ void get_best_cost_step1_kernel(DeviceParams cst_dev_params,
 // and list them into d_list_final_tokens_in_main_q
 __global__ void get_best_cost_step2_kernel(DeviceParams cst_dev_params,
                                            KernelParams params,
-                                           bool use_final_probs,
-                                           CostType fst_zero) {
+                                           bool use_final_probs) {
   const int nlanes = params.nlanes_used;
   KALDI_CUDA_DECODER_BATCH_KERNEL_LOOP(ilane, nlanes) {
     LaneCounters *lane_counters = cst_dev_params.d_lanes_counters.lane(ilane);
@@ -1218,7 +1217,7 @@ __global__ void get_best_cost_step2_kernel(DeviceParams cst_dev_params,
             cst_dev_params.d_fst_final_costs[token_state];
         const CostType token_cost = orderedIntToFloat(token_int_cost);
         // final_cost == fst_zero -> this state is not final
-        token_int_cost = (final_cost != fst_zero)
+        token_int_cost = (final_cost != cst_dev_params.fst_zero)
                              ? floatToOrderedInt(token_cost + final_cost)
                              : INT_MAX;
       }
@@ -1491,7 +1490,7 @@ __global__ void emitting_preprocess_and_list_extra_prev_tokens_step1_kernel(
   __shared__ typename BlockScan::TempStorage sh_temp_storage;
   const int nlanes = params.nlanes_used;
   KALDI_CUDA_DECODER_BATCH_KERNEL_LOOP(ilane, nlanes) {
-    const LaneCounters *lane_counters =
+    LaneCounters *lane_counters =
         cst_dev_params.d_lanes_counters.lane(ilane);
     const int32 main_q_end = lane_counters->main_q_narcs_and_end.y;
     // Final cutoff from last ExpandArc execution
@@ -1562,6 +1561,17 @@ __global__ void emitting_preprocess_and_list_extra_prev_tokens_step1_kernel(
             // avoid a new random memory access
             cst_dev_params.d_main_q_arc_offsets.channel(ichannel)[main_q_idx] =
                 start;
+
+	    // Saving best cost with final cost, to compute the final_extra_cost
+	    // It seems like ~5% of all states are final, so the following atomic may be fine
+	    // if necessary, we could first reduce locally at the CTA level
+	    const CostType final_cost =
+		    cst_dev_params.d_fst_final_costs[token_state];
+	    if(final_cost != cst_dev_params.fst_zero) {
+		    IntegerCostType token_int_cost_with_final = floatToOrderedInt(orderedIntToFloat(token_int_cost) + final_cost);
+		    IntegerCostType int_relative_cost = token_int_cost_with_final; // - 0.0f, the min_cost was reset to 0.0f
+		    atomicMin(&lane_counters->int_relative_cost, int_relative_cost);
+	    }
           }
           // If that FST state has only one token associated to it, we store
           // that token directly in
@@ -2024,20 +2034,18 @@ void FinalizeProcessNonEmittingKernel(const dim3 &grid, const dim3 &block,
 void GetBestCostStep1Kernel(const dim3 &grid, const dim3 &block,
                             const cudaStream_t &st,
                             const DeviceParams &cst_dev_params,
-                            const KernelParams &kernel_params, bool isfinal,
-                            CostType fst_zero) {
+                            const KernelParams &kernel_params, bool isfinal) {
   get_best_cost_step1_kernel<<<grid, block, 0, st>>>(
-      cst_dev_params, kernel_params, isfinal, fst_zero);
+      cst_dev_params, kernel_params, isfinal);
   KALDI_DECODER_CUDA_CHECK_ERROR();
 }
 
 void GetBestCostStep2Kernel(const dim3 &grid, const dim3 &block,
                             const cudaStream_t &st,
                             const DeviceParams &cst_dev_params,
-                            const KernelParams &kernel_params, bool isfinal,
-                            CostType fst_zero) {
+                            const KernelParams &kernel_params, bool isfinal) {
   get_best_cost_step2_kernel<<<grid, block, 0, st>>>(
-      cst_dev_params, kernel_params, isfinal, fst_zero);
+      cst_dev_params, kernel_params, isfinal);
   KALDI_DECODER_CUDA_CHECK_ERROR();
 }
 

--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -1401,7 +1401,7 @@ __global__ void fill_hashmap_with_main_q_kernel(DeviceParams cst_dev_params,
     const int32 main_q_end = lane_counters->main_q_narcs_and_end.y;
     int32 min_int_cost = lane_counters->min_int_cost;
     CostType min_cost = orderedIntToFloat(min_int_cost);
-    const int32 global_offset = channel_counters->prev_main_q_global_offset;
+    const int32 global_offset = lane_counters->main_q_global_offset;
     KALDI_CUDA_DECODER_1D_KERNEL_LOOP(main_q_idx, main_q_end) {
       // Position of considered token in the main_q
       if (main_q_idx < main_q_end) {
@@ -1415,6 +1415,7 @@ __global__ void fill_hashmap_with_main_q_kernel(DeviceParams cst_dev_params,
           channel_counters->min_int_cost_and_arg_without_final = {
               token_int_cost, global_offset + main_q_idx};
           lane_counters->prev_arg_min_int_cost = main_q_idx;
+          lane_counters->prev_arg_min_int_cost_token = cst_dev_params.d_main_q_info.lane(ilane)[main_q_idx];
         } else {
           // remove offset = min_cost
           CostType token_cost = orderedIntToFloat(token_int_cost) - min_cost;

--- a/src/cudadecoder/cuda-decoder-kernels.h
+++ b/src/cudadecoder/cuda-decoder-kernels.h
@@ -66,6 +66,8 @@ struct DeviceParams {
   int32 max_active;
   int32 adaptive_beam_static_segment;
   int32 adaptive_beam_bin_width;
+
+  CostType fst_zero;
 };
 
 // KernelParams contains all the kernels arguments that change between kernel
@@ -184,14 +186,12 @@ void FinalizeProcessNonEmittingKernel(const dim3 &grid, const dim3 &block,
 void GetBestCostStep1Kernel(const dim3 &grid, const dim3 &block,
                             const cudaStream_t &st,
                             const DeviceParams &cst_dev_params,
-                            const KernelParams &kernel_params, bool isfinal,
-                            CostType fst_zero);
+                            const KernelParams &kernel_params, bool isfinal);
 
 void GetBestCostStep2Kernel(const dim3 &grid, const dim3 &block,
                             const cudaStream_t &st,
                             const DeviceParams &cst_dev_params,
-                            const KernelParams &kernel_params, bool isfinal,
-                            CostType fst_zero);
+                            const KernelParams &kernel_params, bool isfinal);
 
 void GetBestCostStep3Kernel(const dim3 &grid, const dim3 &block,
                             const cudaStream_t &st,
@@ -200,7 +200,7 @@ void GetBestCostStep3Kernel(const dim3 &grid, const dim3 &block,
 
 typedef unsigned char BinId;
 
-}  // namespace kaldi
 }  // namespace cuda_decoder
+}  // namespace kaldi
 
 #endif  // KALDI_CUDA_DECODER_CUDA_DECODER_KERNELS_H_

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -1810,9 +1810,7 @@ void CudaDecoder::GeneratePartialPath(LaneId ilane, ChannelId ichannel) {
     partial_hypotheses.push_back({curr_token_idx, arc_idx});
     // Backtracking until we reconnect with our stored partial path
     if (partial_hypotheses.size() > 1) {
-      auto it = partial_hypotheses.end();
-      it--;
-      it--;
+      auto it = std::prev(partial_hypotheses.end(), 2);
 
       int32 stored_prev_token_idx = it->token_idx;
       if (stored_prev_token_idx != prev_token_idx) {
@@ -1839,7 +1837,7 @@ void CudaDecoder::GeneratePartialPath(LaneId ilane, ChannelId ichannel) {
             partial_hypotheses.push_front(
                 {-1, -1});  // it will be set on next iteration
           }
-          it--;
+          --it;
         }
 
         if (prev_token_idx == 0) {

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -245,10 +245,11 @@ class CudaDecoder {
     partial_traceback_ = generate_partial_hypotheses_ = true;
   }
 
-  void AllowEndPointing() {
-    KALDI_ASSERT(
-        "You must call SetOutputFrameShiftInSeconds() to use endpointing" &&
-        frame_shift_seconds_ != FLT_MAX);
+  void AllowEndpointing() {
+    if (frame_shift_seconds_ == FLT_MAX) {
+      KALDI_ERR << "You must call SetOutputFrameShiftInSeconds() "
+                << "to use endpointing";
+    }
     partial_traceback_ = endpointing_ = true;
   }
 
@@ -493,7 +494,7 @@ class CudaDecoder {
   bool partial_traceback_;
   BaseFloat frame_shift_seconds_;
 
-  std::set<int> silence_phones_;
+  std::set<int32> silence_phones_;
 
   // The CudaFst data structure contains the FST graph
   // in the CSR format, on both the GPU and CPU memory

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -752,9 +752,10 @@ class CudaDecoder {
   std::vector<int32> h_n_extra_prev_tokens_lane_offsets_;
   // Index of the best index for the last frame. Used by endpointing/partial
   // results
-  std::vector<int32> h_argmin_token_cost_;
-  std::vector<InfoToken> h_argmin_token_cost_token_;
-  std::vector<CostType> h_relative_cost_;
+
+  std::vector<BestPathTracebackHead> h_best_path_traceback_head_;
+  std::vector<BestPathTracebackHead>
+      h_all_channels_prev_best_path_traceback_head_;
   // Partial path so far on a given channel
 
   // Partial hypotheses to be used by user

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
                      "table from file "
                   << word_syms_rxfilename;
       else {
-        cuda_pipeline.SetSymbolTable(word_syms);
+        cuda_pipeline.SetSymbolTable(*word_syms);
       }
     }
 
@@ -252,7 +252,7 @@ int main(int argc, char *argv[]) {
     std::vector<SubVector<BaseFloat>> batch_wave_samples;
 
     // Partial hypotheses
-    std::vector<std::string *> partial_hypotheses;
+    std::vector<const std::string *> partial_hypotheses;
 
     double batch_valid_at = gettime_monotonic();
     bool pipeline_starved_warning_printed = false;

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -123,9 +123,7 @@ int main(int argc, char *argv[]) {
       if (!(word_syms = fst::SymbolTable::ReadText(word_syms_rxfilename)))
         KALDI_ERR << "Could not read symbol table from file "
                   << word_syms_rxfilename;
-      else {
-        cuda_pipeline.SetSymbolTable(word_syms);
-      }
+      cuda_pipeline.SetSymbolTable(*word_syms);
     }
 
     int32 num_task_submitted = 0, num_err = 0;

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
         KALDI_ERR << "Could not read symbol table from file "
                   << word_syms_rxfilename;
       else {
-        //        cuda_pipeline.SetSymbolTable(word_syms);
+        cuda_pipeline.SetSymbolTable(word_syms);
       }
     }
 


### PR DESCRIPTION
Built on top of #4101. Probably better to look at the diff once #4101 has been merged.

Implements endpointing directly into the cuda decoder. 

Uses the rules as defined in online2/online-endpoint.h. From a user point of view, setting the high level parameters on endpointing and passing a vector in the DecodeBatch should be enough:

```
  void DecodeBatch(const std::vector<CorrelationID> &corr_ids,
                   const std::vector<SubVector<BaseFloat>> &wave_samples,
                   const std::vector<bool> &is_first_chunk,
                   const std::vector<bool> &is_last_chunk,
                   std::vector<std::string *> *partial_hypotheses = NULL,
                   std::vector<bool> *end_points = NULL)
```
Parameters (from online2/online-endpoint.h):

```
--endpoint.rule1.max-relative-cost : This endpointing rule requires relative-cost of final-states to be <= this value (describes how good the probability of final-states is). (float, default = inf)
--endpoint.rule1.min-trailing-silence : This endpointing rule requires duration of trailing silence(in seconds) to be >= this value. (float, default = 5)
--endpoint.rule1.min-utterance-length : This endpointing rule requires utterance-length (in seconds) to be >= this value. (float, default = 0)
--endpoint.rule1.must-contain-nonsilence : If true, for this endpointing rule to apply there mustbe nonsilence in the best-path traceback. (bool, default = false)
```

Easiest way to test is to pass `--print-endpoints=true` to the binary `src/cudadecoderbin/batched-wav-nnet3-cuda-online`

Internally, it provides all the necessary metrics (relative cost, number of silence phones on current best path, total length). Those rules can be modified through the command line parameters. 