### PR TITLE
Chain2 bug fixes

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain2/combine_egs.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/combine_egs.sh
@@ -62,17 +62,17 @@ valid_diagnostic_scp_list=
 combine_scp_list=
 
 # we don't copy lang because there wont be a single lang
-check_params="feat_dim left_context right_context left_context_initial right_context_final ivector_dim" 
+check_params="feat_dim left_context right_context left_context_initial right_context_final" 
 ivec_dim=`fgrep ivector_dim ${args[0]}/info.txt | awk '{print $2}'`
-# if [ $ivec_dim -ne 0 ];then check_params="$check_params final.ie.id"; fi
+if [ $ivec_dim -ne 0 ];then check_params="$check_params ivector_dim final.ie.id"; fi
 
 echo "dir_type randomized_chain_egs" > $megs_dir/info.txt
+# frames_per_chunk is not included in check_params because we allow different
+# values for different languages
 for param in $check_params frames_per_chunk; do
     awk "/^$param/" ${args[0]}/info.txt
     
 done >> $megs_dir/info.txt
-# the arguments to grep make sure we only grep the line that starts with excatly the word lang and we take the first such line
-#lang_list=$(for i in `seq 0 $num_langs`; do awk '/^lang/' ${args[0]}/info.txt | awk '{print $2}'; done)
 echo "langs ${lang_list[@]}" >> $megs_dir/info.txt
 
 tot_num_archives=0
@@ -81,7 +81,7 @@ for lang in $(seq 0 $[$num_langs-1]);do
   multi_egs_dir[$lang]=${args[$lang]}
   for f in $required; do
     if [ ! -f ${multi_egs_dir[$lang]}/$f ]; then
-      echo "$0: no such file ${multi_egs_dir[$lang]}/$f." && exit 1;
+      echo "$0: no such file ${multi_egs_dir[$lang]}/$f" && exit 1;
     fi
   done
   num_chunks=$(fgrep num_chunks ${multi_egs_dir[$lang]}/info.txt | awk '{print $2}')

--- a/egs/wsj/s5/steps/nnet3/chain2/get_raw_egs.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/get_raw_egs.sh
@@ -286,11 +286,13 @@ EOF
   if [ ! -z "$online_ivector_dir" ]; then
       ivector_dim=$(feat-to-dim scp:$online_ivector_dir/ivector_online.scp -) || exit 1;
       echo ivector_dim $ivector_dim >> $dir/info.txt
+      steps/nnet2/get_ivector_id.sh $online_ivector_dir || exit 1
       echo final.ie.id `cat $online_ivector_dir/final.ie.id` >> $dir/info.txt
-      ivector_id=`steps/nnet2/get_ivector_id.sh $online_ivector_dir || exit 1`
-      echo ivector_id $ivector_id
-      ivector_period=$(cat $online_ivector_dir/ivector_period) || exit 1;
-      echo ivector_period $ivector_period
+      if [ ! -f $online_ivector_dir/ivector_period ]; then
+        echo "$0: $online_ivector_dir/ivector_period does not exist"
+        exit 1
+      fi
+      ivector_period=$(cat $online_ivector_dir/ivector_period)
       ivector_opts="--online-ivectors=scp:$online_ivector_dir/ivector_online.scp --online-ivector-period=$ivector_period"
   else
       ivector_opts=""

--- a/egs/wsj/s5/steps/nnet3/chain2/get_raw_egs.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/get_raw_egs.sh
@@ -285,7 +285,6 @@ EOF
 
   if [ ! -z "$online_ivector_dir" ]; then
       ivector_dim=$(feat-to-dim scp:$online_ivector_dir/ivector_online.scp -) || exit 1;
-      echo $ivector_dim > $dir/info/ivector_dim
       echo ivector_dim $ivector_dim >> $dir/info.txt
       echo final.ie.id `cat $online_ivector_dir/final.ie.id` >> $dir/info.txt
       ivector_id=`steps/nnet2/get_ivector_id.sh $online_ivector_dir || exit 1`

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -248,7 +248,7 @@ while [ $x -lt $num_iters ]; do
   fi
   [ -f $dir/$x/.error_diagnostic ] && echo "$0: error getting diagnostics on iter $x" && exit 1;
 
-  if [ -f $dir/caqche.$x ]; then
+  if [ -f $dir/cache.$x ]; then
       rm $dir/cache.$x
   fi
   delete_iter=$[x-2]

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -38,9 +38,7 @@ num_jobs_initial=1
 num_jobs_final=1
 initial_effective_lrate=0.001
 final_effective_lrate=0.0001
-groups_per_minibatch=32  # This is how you set the minibatch size.  Note: if
-                         # chunks_per_group=4, this would mean 128 chunks per
-                         # minibatch.
+minibatch_size=32  # This is how you set the minibatch size. 
 
 max_iters_combine=80
 max_models_combine=20
@@ -68,7 +66,12 @@ if [ $# != 2 ]; then
   echo "Usage: $0  [options] <egs-dir>  <model-dir>"
   echo " e.g.: $0 exp/chain/tdnn1a_sp/egs  exp/chain/tdnn1a_sp"
   echo ""
-  echo " TODO: more documentation"
+  echo "This is the default script to train acoustic models for chain2 recipes."
+  echo "The script requires two arguments:"
+  echo "<egs-dir>: directory where egs files are stored"
+  echo "<model-dir>: directory where the final model will be stored"
+  echo ""
+  echo "See the top of the script to check possible options to pass to it."
   exit 1
 fi
 
@@ -123,10 +126,7 @@ num_langs=$(echo $langs | wc -w)
 mkdir -p $dir/log
 
 # Copy models with initial learning rate and dropout options from $dir/init to $dir/0
-#for lang in $langs; do
 if [ $stage -le -1 ]; then
-  # run.pl $dir/log/init_model_default.log \
-  #     nnet3-am-copy  --learning-rate=$lrate $dropout_opt $dir/init/default.mdl $dir/0.mdl
   echo "$0: Copying transition model"
   if [ $num_langs -eq 1 ]; then
       echo "$0: Num langs is 1"
@@ -227,7 +227,7 @@ while [ $x -lt $num_iters ]; do
              $l2_regularize_opt \
              --srand=$srand \
              "nnet3-copy --learning-rate=$lrate $dir/${x}.raw - |" $den_fst_dir \
-             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$groups_per_minibatch ark:- ark:-|" \
+             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$minibatch_size ark:- ark:-|" \
              ${model_out_prefix}.$j.raw || touch $dir/.error &
   done
   wait
@@ -248,8 +248,7 @@ while [ $x -lt $num_iters ]; do
   fi
   [ -f $dir/$x/.error_diagnostic ] && echo "$0: error getting diagnostics on iter $x" && exit 1;
 
-  # TODO: cleanup
-  if [ -f $dir/cache.$x ]; then
+  if [ -f $dir/caqche.$x ]; then
       rm $dir/cache.$x
   fi
   delete_iter=$[x-2]


### PR DESCRIPTION
I have made minor changes to 3 scripts related to chain2. Specifically:

1. `combine_egs.sh`:  final.ie.id is also included in parameter checks
2. `get_raw_egs.sh`: final.ie.id will be created if necessary in the i-vector directory. the script won't show errors due to a command that was there earlier (where `ivector_dim` was also being written to egs/info, which is not what we want)
3. train.sh: `groups_per_minibatch` is now `minibatch_size` (addressing a comment in #3978 )