### PR TITLE
Fix install srilm for tar.gz

### DIFF
--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -14,11 +14,12 @@ if [ ! -d liblbfgs-1.10 ]; then
 fi
 
 # http://www.speech.sri.com/projects/srilm/download.html
-if [ ! -f srilm.tgz ]; then
+if [ ! -f srilm.tar.gz ]; then  # Changed format type from tgz to tar.gz as the srilm v1.7.3 downloads as tar.gz
   echo This script cannot install SRILM in a completely automatic
   echo way because you need to put your address in a download form.
   echo Please download SRILM from http://www.speech.sri.com/projects/srilm/download.html
-  echo put it in ./srilm.tgz, then run this script.
+  echo put it in ./srilm.tar.gz , then run this script.
+  echo Note: You may have to rename the downloaded file to remove version name from filename eg: mv srilm-1.7.3.tar.gz srilm.tar.gz
   exit 1
 fi
 
@@ -27,7 +28,7 @@ fi
 
 mkdir -p srilm
 cd srilm
-tar -xvzf ../srilm.tgz
+tar -xvzf ../srilm.tar.gz # Changed format type from tgz to tar.gz
 
 major=`awk -F. '{ print $1 }' RELEASE`
 minor=`awk -F. '{ print $2 }' RELEASE`

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -14,7 +14,7 @@ if [ ! -d liblbfgs-1.10 ]; then
 fi
 
 # http://www.speech.sri.com/projects/srilm/download.html
-if [ ! -f srilm.tar.gz ]; then  # Changed format type from tgz to tar.gz as the srilm v1.7.3 downloads as tar.gz
+if [ ! -f srilm.tgz ] && [ ! -f srilm.tar.gz ]; then  # Changed format type from tgz to tar.gz as the srilm v1.7.3 downloads as tar.gz
   echo This script cannot install SRILM in a completely automatic
   echo way because you need to put your address in a download form.
   echo Please download SRILM from http://www.speech.sri.com/projects/srilm/download.html
@@ -28,7 +28,13 @@ fi
 
 mkdir -p srilm
 cd srilm
-tar -xvzf ../srilm.tar.gz # Changed format type from tgz to tar.gz
+
+
+if [ -f ../srilm.tgz ]; then
+    tar -xvzf ../srilm.tgz # Old SRILM format
+elif [  -f ../srilm.tar.gz ]; then
+    tar -xvzf ../srilm.tar.gz # Changed format type from tgz to tar.gz
+fi
 
 major=`awk -F. '{ print $1 }' RELEASE`
 minor=`awk -F. '{ print $2 }' RELEASE`


### PR DESCRIPTION
The latest download of SRILM are in `tar.gz` format. However, the script could only handle `tgz`. Made a few changes to the script to handle both the formats. Also added a rename file suggestion to user.