### PR TITLE
minor typo fix in validate data directory

### DIFF
--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -36,8 +36,8 @@ while [ $# -ne 0 ] ; do
     "--no-wav")
       no_wav=true;
       ;;
-    "--no-spk-short")
-      no_spk_short=true;
+    "--no-spk-sort")
+      no_spk_sort=true;
       ;;
     *)
       if ! [ -z "$data" ] ; then


### PR DESCRIPTION
Minor typo fix  in the validate data directory from `no-spk-short` to `no-spk-sort`