### PR TITLE
[tools, build] Allow nested 'make clean' to fail silently when there is nothing to clean

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -40,11 +40,10 @@ check_required_programs:
 clean: openfst_cleaned sclite_cleaned
 
 openfst_cleaned:
-	$(MAKE) -C openfst-$(OPENFST_VERSION) clean
-
+	-$(MAKE) -C openfst-$(OPENFST_VERSION) clean
 
 sclite_cleaned:
-	$(MAKE) -C sctk clean
+	-$(MAKE) -C sctk clean
 
 distclean:
 	rm -rf openfst-$(OPENFST_VERSION)/


### PR DESCRIPTION
`make clean` in tools/ fails if openfst has not been configured.
Let make ignore this failure.