### PR TITLE
Fix a potential bug in carpa when calculating backoff logprob

### DIFF
--- a/src/lm/const-arpa-lm.cc
+++ b/src/lm/const-arpa-lm.cc
@@ -815,7 +815,11 @@ float ConstArpaLm::GetNgramLogprobRecurse(
   }
   std::vector<int32> new_hist(hist);
   new_hist.erase(new_hist.begin(), new_hist.begin() + 1);
-  return backoff_logprob + GetNgramLogprobRecurse(word, new_hist);
+  float tmp = GetNgramLogprobRecurse(word, new_hist);
+  if (tmp == std::numeric_limits<float>::min())
+    return tmp;
+  else
+    return backoff_logprob + tmp;
 }
 
 int32* ConstArpaLm::GetLmState(const std::vector<int32>& seq) const {

--- a/src/lm/const-arpa-lm.cc
+++ b/src/lm/const-arpa-lm.cc
@@ -791,7 +791,7 @@ float ConstArpaLm::GetNgramLogprobRecurse(
       // If <unk> is defined, then the word sequence should have already been
       // mapped to <unk> is necessary; this is for the case where <unk> is not
       // defined.
-      return std::numeric_limits<float>::min();
+      return -std::numeric_limits<float>::infinity();
     } else {
       Int32AndFloat logprob_i(*unigram_states_[word]);
       return logprob_i.f;
@@ -815,11 +815,7 @@ float ConstArpaLm::GetNgramLogprobRecurse(
   }
   std::vector<int32> new_hist(hist);
   new_hist.erase(new_hist.begin(), new_hist.begin() + 1);
-  float tmp = GetNgramLogprobRecurse(word, new_hist);
-  if (tmp == std::numeric_limits<float>::min())
-    return tmp;
-  else
-    return backoff_logprob + tmp;
+  return backoff_logprob + GetNgramLogprobRecurse(word, new_hist);
 }
 
 int32* ConstArpaLm::GetLmState(const std::vector<int32>& seq) const {
@@ -1038,7 +1034,7 @@ bool ConstArpaLmDeterministicFst::GetArc(StateId s,
   std::vector<Label> wseq = state_to_wseq_[s];
 
   float logprob = lm_.GetNgramLogprob(ilabel, wseq);
-  if (logprob == std::numeric_limits<float>::min()) {
+  if (logprob == -std::numeric_limits<float>::infinity()) {
     return false;
   }
 


### PR DESCRIPTION
Suppose there is an n-gram **A-B**. If **B** is not in the vocabulary list, it should be treated as *\<unk\>*, or as the -inf prob. In the latter case, it seems that **A-B** should also be -inf, but in current code, it is actually backoff(**A**).
Usually this happens when the language model for rescoring is not the superset of the language model for decoding. Therefore, some words in the lattice may not be recognized when rescoring.
Take an example to show the bad effect. Suppose 1,2,3,... are the states in the lattices, and A,B,C are the words on the edge. Consider this lattice:
1---(A)---2---(B)---3---(C)---5
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\\&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;--(D)---4---(E)--
where **A-D-E** is supposed to be the correct result, and **B** is a low frequency word such that **B** does not appear in the vocabulary list. It can be imagined that the weight of **2-(B)-3** is large, so that the one-best algorithm is less likely to choose this path.
Now, in the rescoring procedure, we subtract the weight of them, so **2-(B)-3** is smaller than others. Normally we do not need to worry about that, because it may soon be added by another large number (as it is low frequency), or removed (as it does not appear in the vocabulary list).
However, since **A-B** will trigger the bug, the probability may be backoff(**A**), which means **2-(B)-3** is not so large, so the result may be mistakenly set to **A-B-C**.
This is also the reason that carpa differs from the fst-like structure. In the fst-like structure, edge near **B** will be removed if **B** is out of vocabulary. It would definitely reduce the error when the language model is small, but it is unexpected when the  model is large. 