### PR TITLE
[scripts] remove temporary files installing OpenBLAS, ignore .vscode …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,8 +153,10 @@ GSYMS
 /tools/python/
 /tools/ngram-1.3.7.tar.gz
 /tools/ngram-1.3.7/
+/tools/OpenBLAS*.tar.gz
 
 # These CMakeLists.txt files are all genareted on the fly at the moment.
 # They are added here to avoid accidently checkin.
 /src/**/CMakeLists.txt
 /build*
+.vscode

--- a/tools/extras/install_openblas.sh
+++ b/tools/extras/install_openblas.sh
@@ -33,3 +33,7 @@ tar xzf $tarball
 mv xianyi-OpenBLAS-* OpenBLAS
 
 make PREFIX=$(pwd)/OpenBLAS/install USE_LOCKING=1 USE_THREAD=0 -C OpenBLAS all install
+if [ $? -eq 0 ]; then
+   echo "OpenBLAS is installed successfully."
+   rm $tarball
+fi


### PR DESCRIPTION
* Remove temporary after installing OpenBLAS with `tools/extras/install_openblas.sh`.
* Inogre .vscode for [visual code studio](https://code.visualstudio.com/)