### PR TITLE
fix cudadecoder sigsegv crash when using BatchedThreadedNnet3CudaPipeline::CloseDecodeHandle

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
@@ -785,8 +785,6 @@ void BatchedThreadedNnet3CudaPipeline::CompleteTask(CudaDecoder *cuda_decoder,
   if (task->callback)  // if callable
     task->callback(task->dlat);
 
-  task->finished = true;
-
   {
     std::lock_guard<std::mutex> lk(group_tasks_mutex_);
     --all_group_tasks_not_done_;
@@ -796,6 +794,8 @@ void BatchedThreadedNnet3CudaPipeline::CompleteTask(CudaDecoder *cuda_decoder,
     //    << std::endl;
     if (left_in_group == 0) group_done_cv_.notify_all();
   }
+
+  task->finished = true;
 }
 
 void BatchedThreadedNnet3CudaPipeline::DeterminizeOneLattice(TaskState *task) {


### PR DESCRIPTION
Process crashed when calling the following api in BatchedThreadedNnet3CudaPipeline concurrently:

1. BatchedThreadedNnet3CudaPipeline::OpenDecodeHandle;
2. BatchedThreadedNnet3CudaPipeline::GetLattice;
3. BatchedThreadedNnet3CudaPipeline::CloseDecodeHandle;

We found there is mutex competition between CompleteTask & CloseDecodeHandle:
- CompleteTask: 
  1. set task->finished = true
  2. std::lock_guard<std::mutex> lk(group_tasks_mutex_);
  3. --group_tasks_not_done_[task->group]; (crash if task has already been erased in the CloseDecodeHandle)

- CloseDecodeHandle: 
  1. while (task->finished != true) kaldi::Sleep(SLEEP_BACKOFF_S); 
  2. std::lock_guard<std::mutex> lock(tasks_lookup_mutex_);
  3. tasks_lookup_.erase(it); 

Fixing: manipulate group_tasks_not_done_ before marking task done.

--------------------------------------------------------------------------------------------------------------------------
The crash information:

A fatal error has been detected by the Java Runtime Environment:

SIGSEGV (0xb) at pc=0x00007f7dd840bfe8, pid=895821, tid=0x00007f74aa876700

JRE version: Java(TM) SE Runtime Environment (8.0_201-b09) (build 1.8.0_201-b09)
Java VM: Java HotSpot(TM) 64-Bit Server VM (25.201-b09 mixed mode linux-amd64 compressed oops)
Problematic frame:
C  [libkaldi-cudadecoder.so+0x48fe8]  std::_Rb_tree<std::string, std::pair<std::string const, int>, std::_Select1st<std::pair<std::string const, int> >, std::less<std::string>, std::allocator<std::pair<std::string const, int> > >::_M_lower_bound(std::_Rb_tree_node<std::pair<std::string const, int> >*, std::_Rb_tree_node<std::pair<std::string const, int> >*, std::string const&)+0x16
