### PR TITLE
[src] Dynamic batcher for cuda online pipeline

### DIFF
--- a/src/cudadecoder/Makefile
+++ b/src/cudadecoder/Makefile
@@ -18,7 +18,7 @@ OBJFILES = cuda-decoder.o cuda-decoder-kernels.o cuda-fst.o \
 	   batched-threaded-nnet3-cuda-pipeline.o \
 	   batched-threaded-nnet3-cuda-pipeline2.o \
 	   batched-static-nnet3.o batched-static-nnet3-kernels.o \
-	   decodable-cumatrix.o
+	   cuda-online-pipeline-dynamic-batcher.o decodable-cumatrix.o
 
 LIBNAME = kaldi-cudadecoder
 

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -123,6 +123,9 @@ struct BatchedThreadedNnet3CudaOnlinePipelineConfig {
 class BatchedThreadedNnet3CudaOnlinePipeline {
  public:
   using CorrelationID = uint64_t;
+  typedef std::function<void(const string &, bool, bool)> BestPathCallback;
+  typedef std::function<void(CompactLattice &)> LatticeCallback;
+
   BatchedThreadedNnet3CudaOnlinePipeline(
       const BatchedThreadedNnet3CudaOnlinePipelineConfig &config,
       const fst::Fst<fst::StdArc> &decode_fst,
@@ -131,6 +134,8 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
         max_batch_size_(config.max_batch_size),
         trans_model_(&trans_model),
         am_nnet_(&am_nnet),
+        partial_hypotheses_(NULL),
+        end_points_(NULL),
         word_syms_(NULL) {
     config_.compute_opts.CheckAndFixConfigs(am_nnet_->GetNnet().Modulus());
     config_.CheckAndFixConfigs();
@@ -138,6 +143,10 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
     thread_pool_.reset(new ThreadPoolLight(num_worker_threads));
 
     Initialize(decode_fst);
+  }
+
+  const BatchedThreadedNnet3CudaOnlinePipelineConfig &GetConfig() {
+    return config_;
   }
 
   // Called when a new utterance will be decoded w/ correlation id corr_id
@@ -148,11 +157,13 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // up to wait_for seconds)
   bool TryInitCorrID(CorrelationID corr_id, int wait_for = 0);
 
+  void SetBestPathCallback(CorrelationID corr_id,
+                           const BestPathCallback &callback);
+
   // Set the callback function to call with the final lattice for a given
   // corr_id
-  void SetLatticeCallback(
-      CorrelationID corr_id,
-      const std::function<void(CompactLattice &)> &callback);
+  void SetLatticeCallback(CorrelationID corr_id,
+                          const LatticeCallback &callback);
 
   // Chunk of one utterance. We receive batches of those chunks through
   // DecodeBatch
@@ -250,7 +261,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // CPU function
   void ComputeOneFeature(int element);
   static void ComputeOneFeatureWrapper(void *obj, uint64_t element,
-                                       uint64_t ignored) {
+                                       void *ignored) {
     static_cast<BatchedThreadedNnet3CudaOnlinePipeline *>(obj)
         ->ComputeOneFeature(element);
   }
@@ -264,20 +275,22 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
 
   void RunDecoder(const std::vector<int> &channels);
 
-  void BuildLatticesAndRunCallbacks(const std::vector<CorrelationID> &corr_ids,
-                                    const std::vector<int> &channels,
-                                    const std::vector<bool> &is_last_chunk);
+  void RunCallbacksAndFinalize(const std::vector<CorrelationID> &corr_ids,
+                               const std::vector<int> &channels,
+                               const std::vector<bool> &is_last_chunk);
 
   // If an utterance is done, we call FinalizeDecoding async on
   // the threadpool
   // it will call the utterance's callback when done
-  void FinalizeDecoding(int32 ichannel, CorrelationID corr_id);
+  void FinalizeDecoding(int32 ichannel, const LatticeCallback *callback);
   // static wrapper for thread pool
   static void FinalizeDecodingWrapper(void *obj, uint64_t ichannel64,
-                                      uint64_t corr_id) {
+                                      void *callback_ptr) {
     int32 ichannel = static_cast<int32>(ichannel64);
+    const LatticeCallback *callback =
+        static_cast<const LatticeCallback *>(callback_ptr);
     static_cast<BatchedThreadedNnet3CudaOnlinePipeline *>(obj)
-        ->FinalizeDecoding(ichannel, corr_id);
+        ->FinalizeDecoding(ichannel, callback);
   }
   // Data members
 
@@ -295,10 +308,22 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // corr_id -> decoder channel map
   std::unordered_map<CorrelationID, int32> corr_id2channel_;
 
-  // channels -> callbacks
-  // the callback is called once the final lattice is ready
-  std::vector<std::unique_ptr<std::function<void(CompactLattice &)>>>
-      channels_callbacks_;
+  // Where to store partial_hypotheses_ and end_points_ if available
+  std::vector<const std::string *> *partial_hypotheses_;
+  std::vector<bool> *end_points_;
+
+  // Used when none were provided by the API but we still need to generate
+  // partial hyp and endp
+  std::vector<const std::string *> partial_hypotheses_buf_;
+  std::vector<bool> end_points_buf_;
+
+  // The callback is called once the final lattice is ready
+  std::unordered_map<CorrelationID, const LatticeCallback> lattice_callbacks_;
+  // Used for both final and partial best paths
+  std::unordered_map<CorrelationID, const BestPathCallback>
+      best_path_callbacks_;
+  // Lock for callbacks
+  std::mutex map_callbacks_m_;
 
   // New channels in the current batch. We've just received
   // their first batch
@@ -313,6 +338,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // their last chunk
   std::vector<int> list_channels_last_chunk_;
   std::vector<CorrelationID> list_corr_id_last_chunk_;
+  std::vector<LatticeCallback *> list_lattice_callbacks_last_chunk_;
 
   // Number of frames already computed in channel (before
   // curr_batch_)

--- a/src/cudadecoder/cuda-decoder-common.h
+++ b/src/cudadecoder/cuda-decoder-common.h
@@ -573,19 +573,22 @@ enum QUEUE_ID { MAIN_Q = 0, AUX_Q = 1 };
 struct PartialPathArc {
   int32 token_idx;
   int32 arc_idx;
+  int32 substring_end;
+  int32 olabel;
+
+  PartialPathArc(int32 _token_idx = -1, int32 _arc_idx = -1,
+                 int32 _substring_end = -1)
+      : token_idx(_token_idx),
+        arc_idx(_arc_idx),
+        substring_end(_substring_end),
+        olabel(-1) {}
 };
 
 // Partial hypothesis formatted and meant to be used by user
 struct PartialHypothesis {
-  std::vector<int> arc_idx;
-  std::vector<int> olabel;
   std::string out_str;
 
-  void clear() {
-    arc_idx.clear();
-    olabel.clear();
-    out_str.clear();
-  }
+  void clear() { out_str.clear(); }
 };
 
 }  // end namespace cuda_decoder

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -460,7 +460,9 @@ class CudaDecoder {
 
   // Used to generate the partial hypotheses
   // Called by the worker threads async
-  void BuildPartialHypothesisOutput(ChannelId ichannel);
+  void BuildPartialHypothesisOutput(
+      ChannelId ichannel,
+      std::stack<std::pair<int, PartialPathArc *>> *traceback_buffer_);
   void GeneratePartialPath(LaneId ilane, ChannelId ichannel);
 
   void EndpointDetected(LaneId ilane, ChannelId ichannel);

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -1,0 +1,126 @@
+// cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Hugo Braun
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
+#include <unistd.h>
+
+// Tries to generate a batch every n us
+#define KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US 100
+
+namespace kaldi {
+namespace cuda_decoder {
+
+CudaOnlinePipelineDynamicBatcher::CudaOnlinePipelineDynamicBatcher(
+    CudaOnlinePipelineDynamicBatcherConfig config,
+    BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline)
+    : config_(config),
+      n_chunks_in_queue_(0),
+      run_batcher_thread_(true),
+      cuda_pipeline_(cuda_pipeline),
+      max_batch_size_(cuda_pipeline.GetConfig().max_batch_size),
+      num_channels_(cuda_pipeline.GetConfig().num_channels) {
+  batcher_thread_.reset(new std::thread(
+      &CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop, this));
+}
+
+CudaOnlinePipelineDynamicBatcher::~CudaOnlinePipelineDynamicBatcher() {
+  run_batcher_thread_ = false;
+  batcher_thread_->join();
+}
+
+void CudaOnlinePipelineDynamicBatcher::Push(
+    CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
+    const SubVector<BaseFloat> &wave_samples) {
+  std::lock_guard<std::mutex> lk(chunks_m_);
+  chunks_.push_back({corr_id, is_first_chunk, is_last_chunk, wave_samples});
+  n_chunks_in_queue_.fetch_add(1);
+}
+
+void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
+  Timer timer;
+  double next_timeout_at = timer.Elapsed() + config_.dynamic_batcher_timeout;
+  while (run_batcher_thread_) {
+    if (n_chunks_in_queue_.load() >= max_batch_size_ ||
+        timer.Elapsed() >= next_timeout_at) {
+      // push batch
+      std::lock_guard<std::mutex> lk(chunks_m_);
+      int curr_batch_size = 0;
+      is_corr_id_in_batch_.clear();
+      batch_corr_ids_.clear();
+      batch_is_first_chunk_.clear();
+      batch_is_last_chunk_.clear();
+      batch_wave_samples_.clear();
+      for (auto it = chunks_.begin(); it != chunks_.end();) {
+        CorrelationID corr_id = it->corr_id;
+        bool corr_id_not_in_batch;
+        decltype(is_corr_id_in_batch_.end()) is_corr_id_in_batch_it;
+        std::tie(is_corr_id_in_batch_it, corr_id_not_in_batch) =
+            is_corr_id_in_batch_.insert(corr_id);
+        if (corr_id_not_in_batch) {
+          if (it->is_first_chunk) {
+            if (!cuda_pipeline_.TryInitCorrID(corr_id, 0)) {
+              KALDI_LOG << "All decoding channels are in use. Consider "
+                           "increasing --num-channels";
+              is_corr_id_in_batch_.erase(
+                  is_corr_id_in_batch_it);  // this elt won't be in the batch
+              ++it;  // Ignoring this elt, we'll retry later
+              continue;
+            }
+          }
+          // first chunk with this corr_id in batch
+          ++curr_batch_size;
+
+          batch_corr_ids_.push_back(it->corr_id);
+          batch_is_first_chunk_.push_back(it->is_first_chunk);
+          batch_is_last_chunk_.push_back(it->is_last_chunk);
+          batch_wave_samples_.push_back(it->wave_samples);
+
+          it = chunks_.erase(it);
+          if (curr_batch_size == max_batch_size_) break;
+        } else {
+          // Ignoring this element, we already have this corr_id in batch
+          ++it;
+        }
+      }
+      if (curr_batch_size > 0) {
+        // KALDI_LOG << "Online Cuda pipeline decoding batch of size "
+        //          << curr_batch_size;
+        cuda_pipeline_.DecodeBatch(batch_corr_ids_, batch_wave_samples_,
+                                   batch_is_first_chunk_, batch_is_last_chunk_);
+      }
+      timer.Reset();  // to avoid some kind of overflow..
+      next_timeout_at = timer.Elapsed() + config_.dynamic_batcher_timeout;
+
+      n_chunks_in_queue_.store(chunks_.size());
+      // process callbacks here
+    } else {
+      usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
+    }
+  }
+}
+
+void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
+  // Waiting for the batcher to be done sending work to pipeline
+  while (n_chunks_in_queue_.load() > 0) {
+    usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
+  }
+  // Waiting for pipeline to complete
+  cuda_pipeline_.WaitForLatticeCallbacks();
+}
+
+}  // namespace cuda_decoder
+}  // end namespace kaldi.

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -1,0 +1,85 @@
+// cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Hugo Braun
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unordered_map>
+#if HAVE_CUDA == 1
+
+#ifndef KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
+#define KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
+
+#include <atomic>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
+
+namespace kaldi {
+namespace cuda_decoder {
+
+struct CudaOnlinePipelineDynamicBatcherConfig {
+  double dynamic_batcher_timeout = 2e-3;
+};
+
+class CudaOnlinePipelineDynamicBatcher {
+ public:
+  CudaOnlinePipelineDynamicBatcher(
+      CudaOnlinePipelineDynamicBatcherConfig config,
+      BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline);
+  typedef BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID CorrelationID;
+
+  virtual ~CudaOnlinePipelineDynamicBatcher();
+  void Push(CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
+            const SubVector<BaseFloat> &wave_samples);
+
+  void WaitForCompletion();
+
+ private:
+  CudaOnlinePipelineDynamicBatcherConfig config_;
+  struct Chunk {
+    CorrelationID corr_id;
+    bool is_first_chunk;
+    bool is_last_chunk;
+    SubVector<BaseFloat> wave_samples;
+  };
+
+  void BatcherThreadLoop();
+  std::list<Chunk> chunks_;
+  std::unordered_set<CorrelationID> is_corr_id_in_batch_;
+  std::unordered_set<CorrelationID> is_corr_id_in_use_;
+  std::mutex chunks_m_;
+  std::atomic_int32_t n_chunks_in_queue_;  // equals to chunks.size(), lock free
+  bool run_batcher_thread_;
+  std::unique_ptr<std::thread> batcher_thread_;
+  BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline_;
+
+  std::vector<CorrelationID> batch_corr_ids_;
+  std::vector<bool> batch_is_first_chunk_;
+  std::vector<bool> batch_is_last_chunk_;
+  std::vector<SubVector<BaseFloat>> batch_wave_samples_;
+
+  std::vector<const std::string *> partial_hypotheses_;
+  std::vector<bool> end_points_;
+
+  int max_batch_size_;
+  int num_channels_;
+};
+
+}  // end namespace cuda_decoder
+}  // end namespace kaldi.
+
+#endif  // KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
+#endif  // HAVE_CUDA

--- a/src/cudadecoder/thread-pool-light.h
+++ b/src/cudadecoder/thread-pool-light.h
@@ -29,10 +29,10 @@ namespace kaldi {
 namespace cuda_decoder {
 
 struct ThreadPoolLightTask {
-  void (*func_ptr)(void *, uint64_t, uint64_t);
+  void (*func_ptr)(void *, uint64_t, void *);
   void *obj_ptr;
   uint64_t arg1;
-  uint64_t arg2;
+  void *arg2;
 };
 
 template <int QUEUE_SIZE>

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <queue>
 #if HAVE_CUDA == 1
 
 #include <cuda.h>
@@ -22,7 +23,8 @@
 #include <nvToolsExt.h>
 #include <iomanip>
 #include <sstream>
-#include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
+#include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
+#include "cudadecoderbin/cuda-bin-tools.h"
 #include "cudamatrix/cu-allocator.h"
 #include "fstext/fstext-lib.h"
 #include "lat/lattice-functions.h"
@@ -39,35 +41,26 @@ using namespace cuda_decoder;
 // BatchedThreadedNnet3CudaOnlinePipeline
 //
 
-// Prints some statistics based on latencies stored in latencies
-void PrintLatencyStats(std::vector<double> &latencies) {
-  if (latencies.empty()) return;
-  double total = std::accumulate(latencies.begin(), latencies.end(), 0.);
-  double avg = total / latencies.size();
-  std::sort(latencies.begin(), latencies.end());
+struct Stream {
+  std::shared_ptr<WaveData> wav;
+  BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID corr_id;
+  int offset;
+  double send_next_chunk_at;
+  double *latency_ptr;
 
-  double nresultsf = static_cast<double>(latencies.size());
-  size_t per90i = static_cast<size_t>(std::floor(90. * nresultsf / 100.));
-  size_t per95i = static_cast<size_t>(std::floor(95. * nresultsf / 100.));
-  size_t per99i = static_cast<size_t>(std::floor(99. * nresultsf / 100.));
+  Stream(const std::shared_ptr<WaveData> &_wav,
+         BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID _corr_id,
+         double _send_next_chunk_at, double *_latency_ptr)
+      : wav(_wav),
+        corr_id(_corr_id),
+        offset(0),
+        send_next_chunk_at(_send_next_chunk_at),
+        latency_ptr(_latency_ptr) {}
 
-  double lat_90 = latencies[per90i];
-  double lat_95 = latencies[per95i];
-  double lat_99 = latencies[per99i];
-
-  KALDI_LOG << "Latencies (s):\tAvg\t\t90%\t\t95%\t\t99%";
-  KALDI_LOG << std::fixed << std::setprecision(3) << "\t\t\t" << avg << "\t\t"
-            << lat_90 << "\t\t" << lat_95 << "\t\t" << lat_99;
-}
-
-// time with arbitrary reference
-double inline gettime_monotonic() {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  double time = ts.tv_sec;
-  time += (double)(ts.tv_nsec) / 1e9;
-  return time;
-}
+  bool operator<(const Stream &other) const {
+    return (send_next_chunk_at > other.send_next_chunk_at);
+  }
+};
 
 int main(int argc, char *argv[]) {
   try {
@@ -77,374 +70,193 @@ int main(int argc, char *argv[]) {
     typedef kaldi::int32 int32;
     typedef kaldi::int64 int64;
 
-    const char *usage =
-        "Reads in wav file(s) and simulates online "
-        "decoding with "
-        "neural nets\n"
-        "(nnet3 setup).  Note: some configuration values "
-        "and inputs "
-        "are\n"
-        "set via config files whose filenames are passed "
-        "as "
-        "options\n"
-        "\n"
-        "Usage: batched-wav-nnet3-cuda [options] "
-        "<nnet3-in> "
-        "<fst-in> "
-        "<wav-rspecifier> <lattice-wspecifier>\n";
+    CudaOnlineBinaryOptions opts;
+    int errno;
+    if ((errno = SetUpAndReadCmdLineOptions(argc, argv, &opts))) return errno;
 
-    std::string word_syms_rxfilename;
-
-    bool write_lattice = true;
-    int num_todo = -1;
-    int niterations = 3;
-    int num_streaming_channels = 2000;
-    bool print_partial_hypotheses = false;
-    bool print_endpoints = false;
-    ParseOptions po(usage);
-    po.Register("write-lattice", &write_lattice,
-                "Output lattice to a file. Setting to "
-                "false is useful when "
-                "benchmarking");
-    po.Register("print-partial-hypotheses", &print_partial_hypotheses,
-                "Prints the partial hypotheses");
-    po.Register("print-endpoints", &print_endpoints,
-                "Prints the detected endpoints");
-    po.Register("word-symbol-table", &word_syms_rxfilename,
-                "Symbol table for words [for debug output]");
-    po.Register("file-limit", &num_todo,
-                "Limits the number of files that are processed by "
-                "this driver. "
-                "After N files are processed the remaining files "
-                "are ignored. "
-                "Useful for profiling");
-    po.Register("iterations", &niterations,
-                "Number of times to decode the corpus. Output will "
-                "be written "
-                "only once.");
-    po.Register("num-parallel-streaming-channels", &num_streaming_channels,
-                "Number of channels streaming in parallel");
-
-    // Multi-threaded CPU and batched GPU decoder
-    BatchedThreadedNnet3CudaOnlinePipelineConfig batched_decoder_config;
-    CuDevice::RegisterDeviceOptions(&po);
-    RegisterCuAllocatorOptions(&po);
-    batched_decoder_config.Register(&po);
-
-    po.Read(argc, argv);
-    batched_decoder_config.num_channels = std::max(
-        batched_decoder_config.num_channels, 2 * num_streaming_channels);
-
-    if (po.NumArgs() != 4) {
-      po.PrintUsage();
-      return 1;
-    }
-
-    g_cuda_allocator.SetOptions(g_allocator_options);
-    CuDevice::Instantiate().SelectGpuId("yes");
-    CuDevice::Instantiate().AllowMultithreading();
-
-    std::string nnet3_rxfilename = po.GetArg(1), fst_rxfilename = po.GetArg(2),
-                wav_rspecifier = po.GetArg(3), clat_wspecifier = po.GetArg(4);
     TransitionModel trans_model;
     nnet3::AmNnetSimple am_nnet;
-
-    // read transition model and nnet
-    bool binary;
-    Input ki(nnet3_rxfilename, &binary);
-    trans_model.Read(ki.Stream(), binary);
-    am_nnet.Read(ki.Stream(), binary);
-    SetBatchnormTestMode(true, &(am_nnet.GetNnet()));
-    SetDropoutTestMode(true, &(am_nnet.GetNnet()));
-    nnet3::CollapseModel(nnet3::CollapseModelConfig(), &(am_nnet.GetNnet()));
-
-    CompactLatticeWriter clat_writer(clat_wspecifier);
-    std::mutex clat_writer_m;
-
-    fst::Fst<fst::StdArc> *decode_fst =
-        fst::ReadFstKaldiGeneric(fst_rxfilename);
-
+    fst::Fst<fst::StdArc> *decode_fst;
+    fst::SymbolTable *word_syms;
+    ReadModels(opts, &trans_model, &am_nnet, &decode_fst, &word_syms);
     BatchedThreadedNnet3CudaOnlinePipeline cuda_pipeline(
-        batched_decoder_config, *decode_fst, am_nnet, trans_model);
-
+        opts.batched_decoder_config, *decode_fst, am_nnet, trans_model);
     delete decode_fst;
+    if (word_syms) cuda_pipeline.SetSymbolTable(*word_syms);
 
-    fst::SymbolTable *word_syms = NULL;
-    if (word_syms_rxfilename != "") {
-      if (!(word_syms = fst::SymbolTable::ReadText(word_syms_rxfilename)))
-        KALDI_ERR << "Could not read symbol "
-                     "table from file "
-                  << word_syms_rxfilename;
-      else {
-        cuda_pipeline.SetSymbolTable(*word_syms);
-      }
+    CompactLatticeWriter clat_writer(opts.clat_wspecifier);
+    std::mutex clat_writer_m;
+    if (!opts.write_lattice) {
+      KALDI_LOG << "If you want to write lattices to disk, please set "
+                   "--write-lattice=true";
     }
-
-    int32 num_task_submitted = 0, num_err = 0;
-    double tot_like = 0.0;
-    int64 num_frames = 0;
-    double total_audio_not_starved = 0;
-    double total_compute_time_not_starved = 0;
 
     int chunk_length = cuda_pipeline.GetNSampsPerChunk();
     double chunk_seconds = cuda_pipeline.GetSecondsPerChunk();
     double seconds_per_sample = chunk_seconds / chunk_length;
 
-    // pre-loading data
-    // we don't want to measure I/O
-    double total_audio = 0;
-    SequentialTableReader<WaveHolder> wav_reader(wav_rspecifier);
     std::vector<std::shared_ptr<WaveData>> all_wav;
     std::vector<std::string> all_wav_keys;
-    {
-      std::cout << "Loading eval dataset..." << std::flush;
-      for (; !wav_reader.Done(); wav_reader.Next()) {
-        std::string utt = wav_reader.Key();
-        std::shared_ptr<WaveData> wave_data = std::make_shared<WaveData>();
-        wave_data->Swap(&wav_reader.Value());
-        all_wav.push_back(wave_data);
-        all_wav_keys.push_back(utt);
-        total_audio += wave_data->Duration();
-      }
-      std::cout << "done" << std::endl;
-    }
-    total_audio *= niterations;
+    ReadDataset(opts, &all_wav, &all_wav_keys);
 
-    struct Stream {
-      std::shared_ptr<WaveData> wav;
-      BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID corr_id;
-      int offset;
-      double send_next_chunk_at;
-      double *latency_ptr;
-
-      Stream(const std::shared_ptr<WaveData> &_wav,
-             BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID _corr_id,
-             double *_latency_ptr)
-          : wav(_wav), corr_id(_corr_id), offset(0), latency_ptr(_latency_ptr) {
-        send_next_chunk_at = gettime_monotonic();
-      }
-
-      bool operator<(const Stream &other) {
-        return (send_next_chunk_at < other.send_next_chunk_at);
-      }
-    };
-    nvtxRangePush("Global Timer");
-    // starting timer here so we
-    // can measure throughput
-    // without allocation
-    // overheads
-    // using kaldi timer, which starts counting in the
-    // constructor
-    Timer timer;
-    double this_iteration_timer = timer.Elapsed();
-    std::vector<double> iteration_timer;
-    std::vector<std::unique_ptr<Stream>> curr_tasks, next_tasks;
-    curr_tasks.reserve(num_streaming_channels);
-    next_tasks.reserve(num_streaming_channels);
-    size_t all_wav_i = 0;
-    size_t all_wav_max = all_wav.size() * niterations;
-    std::vector<double> latencies(all_wav_max);
     BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID correlation_id_cnt =
         0;
-    // Batch sent to online pipeline
-    std::vector<BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID>
-        batch_corr_ids;
-    std::vector<bool> batch_is_first_chunk;
-    std::vector<bool> batch_is_last_chunk;
-    // Used when use_online_ivectors_
-    std::vector<SubVector<BaseFloat>> batch_wave_samples;
 
-    // Partial hypotheses
-    std::vector<const std::string *> partial_hypotheses;
-    std::vector<const std::string *> *partial_hypotheses_ptr =
-        print_partial_hypotheses ? &partial_hypotheses : NULL;
+    CudaOnlinePipelineDynamicBatcherConfig dynamic_batcher_config;
+    CudaOnlinePipelineDynamicBatcher dynamic_batcher(dynamic_batcher_config,
+                                                     cuda_pipeline);
 
-    // Endpointing
-    std::vector<bool> end_points;
-    std::vector<bool> *end_points_ptr = print_endpoints ? &end_points : NULL;
+    // Streaming code
+    // Wav reader index
+    size_t all_wav_i = 0;
+    size_t all_wav_max = all_wav.size() * opts.niterations;
+    std::vector<double> latencies(all_wav_max);
 
-    double batch_valid_at = gettime_monotonic();
-    bool pipeline_starved_warning_printed = false;
+    // We will start all utterances at a random position within the first second
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+
+    std::priority_queue<Stream> streams;
+    nvtxRangePush("Global Timer");
+    Timer timer;
+
+    // Initial set of streams will start randomly within the first second of
+    // streaming That's to simulate something more realistic than a large spike
+    // of all channels starting at the same time
+    bool add_random_offset = true;
+    KALDI_LOG << "Inferencing...";
     while (true) {
-      int this_iteration_total_samples = 0;
-      batch_valid_at = 0.;
-      while (curr_tasks.size() < num_streaming_channels &&
-             all_wav_i < all_wav_max) {
-        // Creating new tasks
+      while (streams.size() < opts.num_streaming_channels) {
+        int wav_i = all_wav_i++;
+        if (wav_i >= all_wav_max) {
+          break;
+        }
         uint64_t corr_id = correlation_id_cnt++;
-        size_t all_wav_i_modulo = all_wav_i % (all_wav.size());
-        double *latency_ptr = &latencies[all_wav_i];
-        std::unique_ptr<Stream> ptr(
-            new Stream(all_wav[all_wav_i_modulo], corr_id, latency_ptr));
-        curr_tasks.emplace_back(std::move(ptr));
+        size_t all_wav_i_modulo = wav_i % (all_wav.size());
+        double *latency_ptr = &latencies[corr_id];
 
-        // If no channels are available, we will wait up
-        // to INT_MAX microseconds for a channel to
-        // become available. The reason why we can in
-        // theory have no channel available is because a
-        // channel is still in used when the last chunk
-        // has been processed but the lattice is still
-        // being generated This is why we set
-        // batched_decoder_config.num_channels strictly
-        // higher than num_streaming_channels
-        // If we want to ensure that we are never using
-        // more channels than num_streaming_channels, we
-        // can call WaitForLatticeCallbacks after each
-        // DecodeBatch. That way, we know TryInitCorrID
-        // will always have a channel available right
-        // away if batched_decoder_config.num_channels
-        // >= num_streaming_channels
-        KALDI_ASSERT(cuda_pipeline.TryInitCorrID(corr_id, INT_MAX));
-        const std::string &utt = all_wav_keys[all_wav_i_modulo];
-        size_t iteration = all_wav_i / all_wav.size();
-        std::string key =
-            (iteration == 0) ? utt : (std::to_string(iteration) + "-" + utt);
-        cuda_pipeline.SetLatticeCallback(
-            corr_id, [&clat_writer, &clat_writer_m, key, write_lattice,
-                      latency_ptr](CompactLattice &clat) {
-              if (write_lattice) {
-                std::lock_guard<std::mutex> lk(clat_writer_m);
-                clat_writer.Write(key, clat);
+        // The "speaker" start talking at stream_will_start_at
+        double stream_will_start_at = timer.Elapsed();  // "now"
+        if (add_random_offset) stream_will_start_at += dis(gen);
+        // The "speaker" will speak for stream_duration seconds
+        double stream_duration = all_wav[all_wav_i_modulo]->Duration();
+        // The first chunk will be available whenever the first chunk was
+        // "spoken" e.g. if the first chunk is made of 0.5s for audio, we have
+        // to wait 0.5s after stream_will_start_at
+        double first_chunk_available_at =
+            stream_will_start_at + std::min(stream_duration, chunk_seconds);
+
+        // stream_will_stop_at is used for latency computation
+        // We started streaming at t0=stream_will_start_at, so the audio will be
+        // done streaming at t1=stream_will_start_at+duration We will get
+        // the result at t2, we then have latency=t2-t1
+        double stream_will_stop_at = stream_will_start_at + stream_duration;
+        // tmp storing in lat_ptr
+        // we'll do lat_ptr = now - lat_ptr in callback
+        *latency_ptr = stream_will_stop_at;
+
+        // Defining the callback for results
+        cuda_pipeline.SetBestPathCallback(
+            corr_id,
+            [latency_ptr, &timer, &opts, corr_id](
+                const std::string &str, bool partial, bool endpoint_detected) {
+              if (partial && opts.print_partial_hypotheses)
+                KALDI_LOG << "corr_id #" << corr_id << " [partial] : " << str;
+
+              if (endpoint_detected && opts.print_endpoints)
+                KALDI_LOG << "corr_id #" << corr_id << " [endpoint detected]";
+
+              if (!partial) {
+                // *latency_ptr currently contains t1="stream_will_start_at +
+                // duration" where stream_will_start_at is when this stream
+                // started and duration is the duration of this audio file so t1
+                // is the time when the virtual user is done talking
+                // timer.Elapsed() now contains t2, i.e. when the result is
+                // ready latency = t2 - t1
+                if (!opts.generate_lattice) {
+                  // If we need to gen a lattice, latency will take the lattice
+                  // gen into account
+                  *latency_ptr = timer.Elapsed() - *latency_ptr;
+                }
+                if (opts.print_hypotheses)
+                  KALDI_LOG << "corr_id #" << corr_id << " : " << str;
               }
-              double now = gettime_monotonic();
-              *latency_ptr = now - *latency_ptr;
             });
-        ++all_wav_i;
-        ++num_task_submitted;
-      }
-      // If still empty, done
-      if (curr_tasks.empty()) break;
 
-      std::sort(curr_tasks.begin(), curr_tasks.end());
-
-      for (size_t itask = 0; itask < curr_tasks.size(); ++itask) {
-        Stream &task = *(curr_tasks[itask]);
-
-        SubVector<BaseFloat> data(task.wav->Data(), 0);
-        int32 samp_offset = task.offset;
-        int32 nsamp = data.Dim();
-        int32 samp_remaining = nsamp - samp_offset;
-        int32 num_samp =
-            chunk_length < samp_remaining ? chunk_length : samp_remaining;
-        bool is_last_chunk = (chunk_length >= samp_remaining);
-        SubVector<BaseFloat> wave_part(data, samp_offset, num_samp);
-        bool is_first_chunk = (samp_offset == 0);
-
-        task.offset += num_samp;
-        batch_valid_at = std::max(task.send_next_chunk_at, batch_valid_at);
-        this_iteration_total_samples += num_samp;
-
-        batch_corr_ids.push_back(task.corr_id);
-        batch_is_first_chunk.push_back(is_first_chunk);
-        batch_is_last_chunk.push_back(is_last_chunk);
-        batch_wave_samples.push_back(wave_part);
-
-        if (!is_last_chunk) {
-          next_tasks.push_back(std::move(curr_tasks[itask]));
-        } else {
-          *task.latency_ptr = task.send_next_chunk_at;
+        if (opts.generate_lattice) {
+          // Setting a callback will indicate the pipeline to generate a
+          // lattice
+          int iter = all_wav_i / all_wav.size();
+          std::string key = all_wav_keys[all_wav_i_modulo];
+          if (opts.niterations > 1) key += std::to_string(iter);
+          cuda_pipeline.SetLatticeCallback(
+              corr_id, [&opts, &clat_writer, &clat_writer_m, key, latency_ptr,
+                        &timer](CompactLattice &clat) {
+                *latency_ptr = timer.Elapsed() - *latency_ptr;
+                if (opts.write_lattice) {
+                  std::lock_guard<std::mutex> lk(clat_writer_m);
+                  clat_writer.Write(key, clat);
+                }
+              });
         }
 
-        task.send_next_chunk_at += chunk_seconds;
-        if (batch_corr_ids.size() == batched_decoder_config.max_batch_size ||
-            (itask == (curr_tasks.size() - 1))) {
-          // Wait for batch to be valid
-          double now = gettime_monotonic();
-          double wait_for = batch_valid_at - now;
-          if (wait_for > 0) usleep(wait_for * 1e6);
-
-          cuda_pipeline.DecodeBatch(batch_corr_ids, batch_wave_samples,
-                                    batch_is_first_chunk, batch_is_last_chunk,
-                                    partial_hypotheses_ptr, end_points_ptr);
-          if (print_partial_hypotheses || print_endpoints) {
-            KALDI_LOG << "========== BEGIN CHUNK ==========";
-            for (size_t i = 0; i < batch_corr_ids.size(); ++i) {
-              std::ostringstream oss;
-              bool something_to_print = (print_partial_hypotheses ||
-                                         (print_endpoints && end_points[i]));
-              if (!something_to_print) continue;
-
-              oss << "CORR_ID #" << batch_corr_ids[i];
-              if (print_endpoints) {
-                oss << (end_points[i] ? " [ENDPOINT]" : "\t\t");
-              }
-              if (print_partial_hypotheses)
-                oss << "\t: " << *partial_hypotheses[i];
-              KALDI_LOG << oss.str();
-            }
-            KALDI_LOG << "=========== END CHUNK ===========";
-          }
-          batch_corr_ids.clear();
-          batch_is_first_chunk.clear();
-          batch_is_last_chunk.clear();
-          batch_wave_samples.clear();
-        }
+        // Adding that stream to our simulation stream pool
+        streams.emplace(all_wav[all_wav_i_modulo], corr_id,
+                        first_chunk_available_at, latency_ptr);
       }
-      bool pipeline_starved = (curr_tasks.size() < num_streaming_channels);
-      if (pipeline_starved && !pipeline_starved_warning_printed) {
-        std::cout << "\nNote: Streaming the end of the "
-                     "last "
-                     "utterances. "
-                     "Not enough unprocessed "
-                     "utterances available to stream "
-                  << num_streaming_channels
-                  << " channels in parallel. The "
-                     "pipeline is starved. Will now "
-                     "stream partial batches while "
-                     "still limiting I/O at realtime "
-                     "speed. RTFX will drop. \n"
-                  << std::endl;
-        pipeline_starved_warning_printed = true;
-      }
-      double curr_timer = timer.Elapsed();
-      double diff = curr_timer - this_iteration_timer;
-      this_iteration_timer = curr_timer;
-      double this_iteration_total_seconds =
-          this_iteration_total_samples * seconds_per_sample;
-      if (!pipeline_starved) {
-        total_audio_not_starved += this_iteration_total_seconds;
-        total_compute_time_not_starved += diff;
-      }
-      double this_iteration_rtfx = this_iteration_total_seconds / diff;
-      if (pipeline_starved) std::cout << "STARVED: ";
-      std::cout << "Number of active streaming channels: " << std::setw(5)
-                << curr_tasks.size() << "\tInstant RTFX: " << std::setw(6)
-                << std::fixed << std::setprecision(1) << this_iteration_rtfx
-                << std::endl;
+      add_random_offset = false;  // the next streams will just start whenever a
+                                  // spot is available
 
-      curr_tasks.swap(next_tasks);
-      next_tasks.clear();
+      // If we reach this, we're just done with all streams
+      if (streams.empty()) break;
+
+      auto chunk = streams.top();
+      streams.pop();
+      double wait_for = chunk.send_next_chunk_at - timer.Elapsed();
+      if (wait_for > 0) usleep(wait_for * 1e6);
+
+      SubVector<BaseFloat> data(chunk.wav->Data(), 0);
+
+      // Current chunk
+      int32 total_num_samp = data.Dim();
+      int this_chunk_num_samp =
+          std::min(total_num_samp - chunk.offset, chunk_length);
+      bool is_last_chunk =
+          ((chunk.offset + this_chunk_num_samp) == total_num_samp);
+      bool is_first_chunk = (chunk.offset == 0);
+      SubVector<BaseFloat> wave_part(data, chunk.offset, this_chunk_num_samp);
+
+      // Giving current chunk to the dynamic batcher for processing
+      dynamic_batcher.Push(chunk.corr_id, is_first_chunk, is_last_chunk,
+                           wave_part);
+
+      // Current chunk was sent, done
+      chunk.offset += this_chunk_num_samp;
+
+      // Streaming simulation:
+      // We need to know the duration of the next chunk
+      // The next time we will "wake up" the stream will be at
+      // send_next_chunk_at with send_next_chunk_at = send_current_chunk_at +
+      // next_chunk_duration
+      int next_chunk_num_samp =
+          std::min(total_num_samp - chunk.offset, chunk_length);
+      double next_chunk_seconds = next_chunk_num_samp * seconds_per_sample;
+      chunk.send_next_chunk_at += next_chunk_seconds;
+
+      // If there is a next chunk, add it to the list of streams tasks
+      if (!is_last_chunk) streams.push(chunk);
     }
-    cuda_pipeline.WaitForLatticeCallbacks();
+
+    dynamic_batcher.WaitForCompletion();
+    KALDI_LOG << "Done.";
     nvtxRangePop();
 
-    KALDI_LOG << "Decoded " << num_task_submitted << " utterances, " << num_err
-              << " with errors.";
-    KALDI_LOG << "Overall likelihood per frame was " << (tot_like / num_frames)
-              << " per frame over " << num_frames << " frames.";
-
-    KALDI_LOG << "NON-STARVED:";
-    KALDI_LOG << "\tThis section only concerns the part of the "
-                 "computation "
-                 "where we had enough active utterances to simulate "
-              << num_streaming_channels << " parallel clients. ";
-    KALDI_LOG << "\tIt corresponds to the throughput an online instance "
-                 "can handle with all channels in use.";
-    KALDI_LOG << "\tTotal Compute Time: " << total_compute_time_not_starved;
-    KALDI_LOG << "\tTotal Audio Decoded: " << total_audio_not_starved;
-    KALDI_LOG << "\tRealTimeX: "
-              << total_audio_not_starved / total_compute_time_not_starved;
-
-    KALDI_LOG << "OVERALL:";
-    KALDI_LOG << "\tTotal Utterances Decoded: " << num_task_submitted;
-    KALDI_LOG << "\tTotal Audio Decoded: " << total_audio << " seconds";
     KALDI_LOG << "\tLatency stats:";
     PrintLatencyStats(latencies);
-
     delete word_syms;  // will delete if non-NULL.
 
     clat_writer.Close();
-
     cudaDeviceSynchronize();
 
     return 0;

--- a/src/cudadecoderbin/cuda-bin-tools.h
+++ b/src/cudadecoderbin/cuda-bin-tools.h
@@ -1,0 +1,185 @@
+// cudadecoderbin/cuda-bin-tools.h
+//
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+// Hugo Braun
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
+#include "fstext/fstext-lib.h"
+#include "nnet3/am-nnet-simple.h"
+#include "nnet3/nnet-utils.h"
+
+#ifndef KALDI_CUDA_DECODER_BIN_CUDA_BIN_TOOLS_H_
+#define KALDI_CUDA_DECODER_BIN_CUDA_BIN_TOOLS_H_
+
+namespace kaldi {
+namespace cuda_decoder {
+
+// Prints some statistics based on latencies stored in latencies
+void PrintLatencyStats(std::vector<double> &latencies) {
+  if (latencies.empty()) return;
+  double total = std::accumulate(latencies.begin(), latencies.end(), 0.);
+  double avg = total / latencies.size();
+  std::sort(latencies.begin(), latencies.end());
+
+  double nresultsf = static_cast<double>(latencies.size());
+  size_t per90i = static_cast<size_t>(std::floor(90. * nresultsf / 100.));
+  size_t per95i = static_cast<size_t>(std::floor(95. * nresultsf / 100.));
+  size_t per99i = static_cast<size_t>(std::floor(99. * nresultsf / 100.));
+
+  double lat_90 = latencies[per90i];
+  double lat_95 = latencies[per95i];
+  double lat_99 = latencies[per99i];
+
+  KALDI_LOG << "Latencies (s):\tAvg\t\t90%\t\t95%\t\t99%";
+  KALDI_LOG << std::fixed << std::setprecision(3) << "\t\t\t" << avg << "\t\t"
+            << lat_90 << "\t\t" << lat_95 << "\t\t" << lat_99;
+}
+
+struct CudaOnlineBinaryOptions {
+  bool write_lattice = false;
+  int num_todo = -1;
+  int niterations = 1;
+  int num_streaming_channels = 2000;
+  bool print_partial_hypotheses = false;
+  bool print_hypotheses = false;
+  bool print_endpoints = false;
+  bool generate_lattice = false;
+  std::string word_syms_rxfilename, nnet3_rxfilename, fst_rxfilename,
+      wav_rspecifier, clat_wspecifier;
+  BatchedThreadedNnet3CudaOnlinePipelineConfig batched_decoder_config;
+};
+
+int SetUpAndReadCmdLineOptions(int argc, char *argv[],
+                               CudaOnlineBinaryOptions *opts_ptr) {
+  CudaOnlineBinaryOptions &opts = *opts_ptr;
+  const char *usage =
+      "Reads in wav file(s) and simulates online "
+      "decoding with "
+      "neural nets\n"
+      "(nnet3 setup).  Note: some configuration values "
+      "and inputs "
+      "are\n"
+      "set via config files whose filenames are passed "
+      "as "
+      "options\n"
+      "\n"
+      "Usage: batched-wav-nnet3-cuda [options] "
+      "<nnet3-in> "
+      "<fst-in> "
+      "<wav-rspecifier> <lattice-wspecifier>\n";
+
+  ParseOptions po(usage);
+  po.Register("print-hypotheses", &opts.print_hypotheses,
+              "Prints the final hypotheses");
+  po.Register("print-partial-hypotheses", &opts.print_partial_hypotheses,
+              "Prints the partial hypotheses");
+  po.Register("print-endpoints", &opts.print_endpoints,
+              "Prints the detected endpoints");
+  po.Register("word-symbol-table", &opts.word_syms_rxfilename,
+              "Symbol table for words [for debug output]");
+  po.Register("file-limit", &opts.num_todo,
+              "Limits the number of files that are processed by "
+              "this driver. "
+              "After N files are processed the remaining files "
+              "are ignored. "
+              "Useful for profiling");
+  po.Register("iterations", &opts.niterations,
+              "Number of times to decode the corpus. Output will "
+              "be written "
+              "only once.");
+  po.Register("num-parallel-streaming-channels", &opts.num_streaming_channels,
+              "Number of channels streaming in parallel");
+  po.Register("generate-lattice", &opts.generate_lattice,
+              "Generate full lattices");
+  po.Register("write-lattice", &opts.write_lattice, "Output lattice to a file");
+
+  g_cuda_allocator.SetOptions(g_allocator_options);
+  CuDevice::Instantiate().SelectGpuId("yes");
+  CuDevice::Instantiate().AllowMultithreading();
+
+  CuDevice::RegisterDeviceOptions(&po);
+  RegisterCuAllocatorOptions(&po);
+  opts.batched_decoder_config.Register(&po);
+
+  po.Read(argc, argv);
+  opts.batched_decoder_config.num_channels =
+      std::max(opts.batched_decoder_config.num_channels,
+               2 * opts.num_streaming_channels);
+
+  opts.nnet3_rxfilename = po.GetArg(1);
+  opts.fst_rxfilename = po.GetArg(2);
+  opts.wav_rspecifier = po.GetArg(3);
+  opts.clat_wspecifier = po.GetArg(4);
+
+  if (opts.write_lattice) opts.generate_lattice = true;
+  if (po.NumArgs() != 4) {
+    po.PrintUsage();
+    return 1;
+  }
+  return 0;
+}
+
+void ReadModels(const CudaOnlineBinaryOptions &opts,
+                TransitionModel *trans_model, nnet3::AmNnetSimple *am_nnet,
+                fst::Fst<fst::StdArc> **decode_fst,
+                fst::SymbolTable **word_syms) {
+  // read transition model and nnet
+  bool binary;
+  Input ki(opts.nnet3_rxfilename, &binary);
+  trans_model->Read(ki.Stream(), binary);
+  am_nnet->Read(ki.Stream(), binary);
+  SetBatchnormTestMode(true, &(am_nnet->GetNnet()));
+  SetDropoutTestMode(true, &(am_nnet->GetNnet()));
+  nnet3::CollapseModel(nnet3::CollapseModelConfig(), &(am_nnet->GetNnet()));
+
+  *decode_fst = fst::ReadFstKaldiGeneric(opts.fst_rxfilename);
+
+  if (!opts.word_syms_rxfilename.empty()) {
+    if (!(*word_syms = fst::SymbolTable::ReadText(opts.word_syms_rxfilename)))
+      KALDI_ERR << "Could not read symbol "
+                   "table from file "
+                << opts.word_syms_rxfilename;
+  }
+}
+
+void ReadDataset(const CudaOnlineBinaryOptions &opts,
+                 std::vector<std::shared_ptr<WaveData>> *all_wav,
+                 std::vector<std::string> *all_wav_keys) {
+  // pre-loading data
+  // we don't want to measure I/O
+  SequentialTableReader<WaveHolder> wav_reader(opts.wav_rspecifier);
+  size_t file_count = 0;
+  {
+    std::cout << "Loading eval dataset..." << std::flush;
+    for (; !wav_reader.Done(); wav_reader.Next()) {
+      if (file_count++ == opts.num_todo) break;
+      std::string utt = wav_reader.Key();
+      std::shared_ptr<WaveData> wave_data = std::make_shared<WaveData>();
+      wave_data->Swap(&wav_reader.Value());
+      all_wav->push_back(wave_data);
+      all_wav_keys->push_back(utt);
+      // total_audio += wave_data->Duration();
+    }
+    std::cout << "done" << std::endl;
+  }
+}
+
+}  // namespace cuda_decoder
+}  // namespace kaldi
+
+#endif


### PR DESCRIPTION
Still a draft but getting close.

Adding a dynamic batcher for the cuda online pipeline. The dynamic batcher takes care of automatically creating the batches for the pipeline. It allows the user to just call dynamic_batcher.Push(new chunk) with whatever chunk is ready, from whichever audio channel. The batcher will take care of the rest.

```dynamic_batcher.Push(CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk, SubVector<Basefloat> wave_part);```

With corr_id a unique uint64_t identifier for each channel. Results are returned using callbacks:

```
cuda_pipeline.SetBestPathCallback()
cuda_pipeline.SetLatticeCallback()
```

And that's all. The rest is handled by the batcher and the pipeline.

The best path callback also returns partial hypotheses and endpointing. Both callbacks are optional (but you should of course define at least one).
If the lattice callback is not set, the lattice will not be generated, reducing the pressure on the CPU. Please note that recent GPUs come with a fairly large amount of memory (~40GB), which might allow some users to skip the lattice rescoring and just use larger FSTs instead.

The online example binary has been rewritten to use the new batcher and simplify understanding of how it works. I'll add comments on methodology in the file. 
For now, the important thing to know is that we've chosen the most comprehensive definition of latency, which is "time between speaker is done talking and the callback with the result is running". 
If we start streaming a speaker at t1, and that speaker corresponds to an audio file of duration d, then we consider the speaker as done talking at t2=t1+d. We then get the final result back at t3. Latency is t3-t2. It includes all possible reason for delay (delay due to dynamic batching, processing of all chunks, context flush, final result generation, etc.). Except network, which is outside the scope of this work for now.

Here are some latency numbers in single GPU measured with the eg model "librispeech" on librispeech/test_clean:

```
=== 3500 parallel users ===
V100
Latencies (s):	Avg		90%		95%		99%
 		0.117		0.161		0.172		0.206
Ampere GPU
Latencies (s):	Avg		90%		95%		99%
 		0.069		0.093		0.101		0.118

=== 7000 parallel users ===
Ampere GPU
Latencies (s):	Avg		90%		95%		99%
		0.225		0.312		0.355		0.437
```
