### PR TITLE
fix typo in data_prep for egs/sprakbanken_swe

### DIFF
--- a/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
+++ b/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
@@ -45,7 +45,7 @@ if [ ! -f $dir/download/sve.16khz.0467-3.tar.gz ]; then
     ( wget --tries 100 http://www.nb.no/sbfil/talegjenkjenning/16kHz/sve.16khz.0467-3.tar.gz --directory-prefix=$dir/download )
 fi
 
-if [ ! -f $dir/download/sve.16khz.0467-1.tar.gz ]; then 
+if [ ! -f $dir/download/sve.16khz.0468.tar.gz ]; then 
     ( wget --tries 100 http://www.nb.no/sbfil/talegjenkjenning/16kHz/sve.16khz.0468.tar.gz --directory-prefix=$dir/download )
 fi    
 


### PR DESCRIPTION
The bash script that retrieves audio data for the sprakbanken_swe example performed an incorrect file presence check.