### PR TITLE
[src] Fix configuring static MKL

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -292,7 +292,11 @@ configure_mkl_libraries() {
   for file in $mkl_libs; do
     local libfile=$mkllibdir/lib$file.$suffix
     check_exists $libfile
-    linkline+=" -l$file"
+    if ! $static; then
+      linkline+=" -l$file"
+    else
+      linkline+=" $libfile"
+    fi
   done
   linkline+=$link_post
 


### PR DESCRIPTION
Unfortunately, https://github.com/kaldi-asr/kaldi/pull/4185 broke static MKL compilation. Originally link lines for static MKL contained `/opt/intel/mkl/lib/intel64/libmkl_core.a` and this has been changed to `-lmkl`. For static compilation, the search path is not set, so this fails. `(Message: ***configure failed: Cannot validate the MKL switches ***)`

This PR fixes this problem and restores the link line to the Intel recommended version for static MKL installation. shared MKL is unaffected.
