### PR TITLE
[src] fix typo string -> std::string

### DIFF
--- a/src/fstext/pre-determinize-inl.h
+++ b/src/fstext/pre-determinize-inl.h
@@ -236,7 +236,7 @@ inline bool HasBannedPrefixPlusDigits(SymbolTable *symTable, std::string prefix,
   const char *prefix_ptr = prefix.c_str();
   size_t prefix_len = strlen(prefix_ptr);  // allowed to be zero but not encouraged.
   for (SymbolTableIterator siter(*symTable); !siter.Done(); siter.Next()) {
-    const string &sym = siter.Symbol();
+    const std::string &sym = siter.Symbol();
     if (!strncmp(prefix_ptr, sym.c_str(), prefix_len)) {  // has prefix.
       if (isdigit(sym[prefix_len])) {  // we don't allow prefix followed by a digit, as a symbol.
         // Has at least one digit.


### PR DESCRIPTION
fix the typo