### PR TITLE
[src] fix passing std::ostream by ref

### DIFF
--- a/src/lat/kaldi-lattice.cc
+++ b/src/lat/kaldi-lattice.cc
@@ -78,7 +78,7 @@ bool WriteCompactLattice(std::ostream &os, bool binary,
     fst::FstPrinter<CompactLatticeArc> printer(t, t.InputSymbols(),
                                                t.OutputSymbols(),
                                                NULL, acceptor, write_one, "\t");
-    printer.Print(&os, "<unknown>");
+    printer.Print(os, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will
@@ -403,7 +403,7 @@ bool WriteLattice(std::ostream &os, bool binary, const Lattice &t) {
     fst::FstPrinter<LatticeArc> printer(t, t.InputSymbols(),
                                         t.OutputSymbols(),
                                         NULL, acceptor, write_one, "\t");
-    printer.Print(&os, "<unknown>");
+    printer.Print(os, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will


### PR DESCRIPTION
openfst expecting that by ref:
```c++
// /include/fst/script/print-impl.h
template <class Arc>
class FstPrinter {
 public:
  using StateId = typename Arc::StateId;
  using Label = typename Arc::Label;
  using Weight = typename Arc::Weight;
  ...

  // Prints FST to an output stream.
  void Print(std::ostream &ostrm, const std::string &dest) {
      ...
  }
```