### PR TITLE
Delete *.{a,la,o} files to reduce Docker image size

### DIFF
--- a/docker/debian9.8-cpu/Dockerfile
+++ b/docker/debian9.8-cpu/Dockerfile
@@ -25,17 +25,16 @@ RUN apt-get update && \
 	vim && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/python2.7 /usr/bin/python 
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
 
 RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi.git /opt/kaldi && \
-    cd /opt/kaldi && \
     cd /opt/kaldi/tools && \
     ./extras/install_mkl.sh && \
     make -j $(nproc) && \
     cd /opt/kaldi/src && \
     ./configure --shared && \
     make depend -j $(nproc) && \
-    make -j $(nproc)
-
+    make -j $(nproc) && \
+    find /opt/kaldi  -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \;
 WORKDIR /opt/kaldi/
 

--- a/docker/ubuntu16.04-gpu/Dockerfile
+++ b/docker/ubuntu16.04-gpu/Dockerfile
@@ -25,17 +25,17 @@ RUN apt-get update && \
 	vim && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/python2.7 /usr/bin/python 
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
 
 RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi.git /opt/kaldi && \
-    cd /opt/kaldi && \
     cd /opt/kaldi/tools && \
     ./extras/install_mkl.sh && \
     make -j $(nproc) && \
     cd /opt/kaldi/src && \
     ./configure --shared --use-cuda && \
     make depend -j $(nproc) && \
-    make -j $(nproc)
+    make -j $(nproc) && \
+    find /opt/kaldi  -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \;
 
 WORKDIR /opt/kaldi/
 


### PR DESCRIPTION
This PR partially fixes #4151 by applying some of the suggestions mentioned by @kkm000 in https://github.com/kaldi-asr/kaldi/issues/4151#issuecomment-658701919. There are other suggestions from his list we could apply(uninstalling building packages, removing the `.git` folder...) but this is a good start.

By just removing `*.o`, `*.a` and `*.la` images are reduced around 6GB:

```console
kir4h/kaldi                                             gpu                             d2fe407ffe3b        3 hours ago         8.21GB
kir4h/kaldi                                             latest                          141039043d6f        5 hours ago         5.26GB
kaldiasr/kaldi                                          gpu-latest                      0b92c53f2ef1        3 months ago        14.9GB
kaldiasr/kaldi                                          latest                          b44678467882        3 months ago        11.6GB
```

I have done a basic testing and I think nothing is broken but if there something else I can check please let me know.