### PR TITLE
Fix the problem that Smith-Waterman alignment might miss (1, 1) in align_ctm_ref.py (#4227)

### DIFF
--- a/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
+++ b/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
@@ -498,7 +498,7 @@ def ctm_line_to_string(ctm_line):
 
 
 def test_alignment(align_full_hyp):
-    hyp = "CGCCAT"
+    hyp = "GCCAT"
     ref = "AGCACACA"
 
     verbose = 3

--- a/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
+++ b/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
@@ -288,9 +288,8 @@ def smith_waterman_alignment(ref, hyp, similarity_score_function,
                     or (prev_ref_index, prev_hyp_index) == (0, 0)):
                 score = H[ref_index][hyp_index]
                 if score != 0:
-                    ref_word = ref[ref_index-1]
-                    hyp_word = hyp[hyp_index-1]
-                    assert ref_word != eps_symbol and hyp_word != eps_symbol
+                    ref_word = ref[ref_index-1] if ref_index > 0 else eps_symbol
+                    hyp_word = hyp[hyp_index-1] if hyp_index > 0 else eps_symbol
                     output.append((ref_word, hyp_word, prev_ref_index,
                         prev_hyp_index, ref_index, hyp_index))
 

--- a/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
+++ b/egs/wsj/s5/steps/cleanup/internal/align_ctm_ref.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 # Copyright 2016    Vimal Manohar
+#           2020    Dongji Gao
 # Apache 2.0.
 
 """This module aligns a hypothesis (CTM or text) with a reference to
@@ -283,11 +284,18 @@ def smith_waterman_alignment(ref, hyp, similarity_score_function,
            or (align_full_hyp and hyp_index > 0)):
         try:
             prev_ref_index, prev_hyp_index = bp[ref_index][hyp_index]
-
             if ((prev_ref_index, prev_hyp_index) == (ref_index, hyp_index)
                     or (prev_ref_index, prev_hyp_index) == (0, 0)):
-                ref_index, hyp_index = (prev_ref_index, prev_hyp_index)
                 score = H[ref_index][hyp_index]
+                if score != 0:
+                    ref_word = ref[ref_index-1]
+                    hyp_word = hyp[hyp_index-1]
+                    assert ref_word != eps_symbol and hyp_word != eps_symbol
+                    output.append((ref_word, hyp_word, prev_ref_index,
+                        prev_hyp_index, ref_index, hyp_index))
+
+                    ref_index, hyp_index = (prev_ref_index, prev_hyp_index)
+                    score = H[ref_index][hyp_index]
                 break
 
             if (ref_index == prev_ref_index + 1
@@ -313,6 +321,7 @@ def smith_waterman_alignment(ref, hyp, similarity_score_function,
                      prev_ref_index, prev_hyp_index, ref_index, hyp_index))
             else:
                 raise RuntimeError
+
 
             ref_index, hyp_index = (prev_ref_index, prev_hyp_index)
             score = H[ref_index][hyp_index]
@@ -489,7 +498,7 @@ def ctm_line_to_string(ctm_line):
 
 
 def test_alignment(align_full_hyp):
-    hyp = "GCCAT"
+    hyp = "CGCCAT"
     ref = "AGCACACA"
 
     verbose = 3


### PR DESCRIPTION
Fix the problem that the Smith-Waterman alignment might miss (1, 1) during backtracing if they match