### PR TITLE
Further reductions on Docker image size

### DIFF
--- a/docker/debian9.8-cpu/Dockerfile
+++ b/docker/debian9.8-cpu/Dockerfile
@@ -35,6 +35,9 @@ RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi.git /opt/kaldi && \
     ./configure --shared && \
     make depend -j $(nproc) && \
     make -j $(nproc) && \
-    find /opt/kaldi  -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \;
+    find /opt/kaldi -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \; && \
+    find /opt/intel -type f -name "*.a" -exec rm {} \; && \
+    find /opt/intel -type f -regex '.*\(_mc.?\|_mic\|_thread\|_ilp64\)\.so' -exec rm {} \; && \
+    rm -rf /opt/kaldi/.git
 WORKDIR /opt/kaldi/
 

--- a/docker/ubuntu16.04-gpu/Dockerfile
+++ b/docker/ubuntu16.04-gpu/Dockerfile
@@ -35,7 +35,10 @@ RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi.git /opt/kaldi && \
     ./configure --shared --use-cuda && \
     make depend -j $(nproc) && \
     make -j $(nproc) && \
-    find /opt/kaldi  -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \;
+    find /opt/kaldi  -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \; && \
+    find /opt/intel -type f -name "*.a" -exec rm {} \; && \
+    find /opt/intel -type f -regex '.*\(_mc.?\|_mic\|_thread\|_ilp64\)\.so' -exec rm {} \; && \
+    rm -rf /opt/kaldi/.git
 
 WORKDIR /opt/kaldi/
 


### PR DESCRIPTION
Signed-off-by: Andres Alvarez <kir4h.gh@gmail.com>

Following the suggestions by @kkm000  in https://github.com/kaldi-asr/kaldi/issues/4228#issuecomment-678452211, some extra deletions for further reduction on the image size. 

We are going down from `5.26GB` to `3.88GB` on the regular one and from `8.21GB` to `6.83GB` on the gpu version

```
kir4h/kaldi                                             gpuv2                           8be3bd9043ff        4 minutes ago       6.83GB
kir4h/kaldi                                             v2                              9ae588678bac        46 minutes ago      3.88GB
kir4h/kaldi                                             gpu                             d2fe407ffe3b        4 days ago          8.21GB
kir4h/kaldi                                             latest                          141039043d6f        4 days ago          5.26GB
kaldiasr/kaldi                                          gpu-latest                      0b92c53f2ef1        3 months ago        14.9GB
kaldiasr/kaldi                                          latest                          b44678467882        3 months ago        11.6GB
```
