### PR TITLE
Fix compilation error on gcc 5.4.0, vector->std::vector

### DIFF
--- a/src/online2bin/online2-wav-nnet3-wake-word-decoder-faster.cc
+++ b/src/online2bin/online2-wav-nnet3-wake-word-decoder-faster.cc
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
             std::vector<int32> word_ids;
             decoder.FinishTraceBack(&out_fst);
             fst::GetLinearSymbolSequence(out_fst,
-                                         static_cast<vector<int32> *>(0),
+                                         static_cast<std::vector<int32> *>(0),
                                          &word_ids,
                                          static_cast<LatticeArc::Weight*>(0));
             PrintPartialResult(word_ids, word_syms, partial_res || word_ids.size());
@@ -239,7 +239,7 @@ int main(int argc, char *argv[]) {
             std::vector<int32> word_ids;
             if (decoder.PartialTraceback(&out_fst)) {
               fst::GetLinearSymbolSequence(out_fst,
-                                           static_cast<vector<int32> *>(0),
+                                           static_cast<std::vector<int32> *>(0),
                                            &word_ids,
                                            static_cast<LatticeArc::Weight*>(0));
               PrintPartialResult(word_ids, word_syms, false);


### PR DESCRIPTION
Similar fix to #1479