### PR TITLE
[src] Removing exceptions-related warnings in cudadecoder

### DIFF
--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -313,7 +313,7 @@ void CudaDecoder::InitDeviceParams() {
   h_device_params_->fst_zero = StdWeight::Zero().Value();
 }
 
-CudaDecoder::~CudaDecoder() {
+CudaDecoder::~CudaDecoder() noexcept(false) {
   // Stopping h2h tasks
   h2h_threads_running_ = false;
   n_h2h_main_task_todo_cv_.notify_all();

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -206,7 +206,7 @@ class CudaDecoder {
   CudaDecoder(const CudaFst &fst, const CudaDecoderConfig &config,
               int32 nchannels)
       : CudaDecoder(fst, config, nchannels, nchannels) {}
-  virtual ~CudaDecoder();
+  virtual ~CudaDecoder() noexcept(false);
 
   // InitDecoding initializes the decoding, and should only be used if you
   // intend to call AdvanceDecoding() on the channels listed in channels


### PR DESCRIPTION
Throwing exceptions in destructors requires explicit opt in with c++11