### PR TITLE
[src] Using C++14 for CUDA

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -339,16 +339,20 @@ Either your CUDA is too new or too old."
       GCC_VER=$($COMPILER -dumpversion)
       GCC_VER_NUM=$(echo $GCC_VER | sed 's/\./ /g' | xargs printf "%d%02d%02d")
       case $CUDA_VERSION in
-        7_*)
-          MIN_UNSUPPORTED_GCC_VER="5.0"
-          MIN_UNSUPPORTED_GCC_VER_NUM=50000;
-          CUSOLVER=false
-        ;;
-        8_*)
-          MIN_UNSUPPORTED_GCC_VER="6.0"
-          MIN_UNSUPPORTED_GCC_VER_NUM=60000;
-          CUSOLVER=false
-        ;;
+        # Disabling CUDA 7 and CUDA 8 because we now use C++14 to compile CUDA code
+        # It is still possible to use those cuda versions by switching back to C++11
+        # in src/makefiles/cuda_64bit.mk and use CUB <= 1.8.0 (see tools/)
+        # https://github.com/kaldi-asr/kaldi/pull/4242
+        #7_*)
+        #  MIN_UNSUPPORTED_GCC_VER="5.0"
+        #  MIN_UNSUPPORTED_GCC_VER_NUM=50000;
+        #  CUSOLVER=false
+        #;;
+        #8_*)
+        #  MIN_UNSUPPORTED_GCC_VER="6.0"
+        #  MIN_UNSUPPORTED_GCC_VER_NUM=60000;
+        #  CUSOLVER=false
+        #;;
         9_0)
           MIN_UNSUPPORTED_GCC_VER="7.0"
           MIN_UNSUPPORTED_GCC_VER_NUM=70000;
@@ -383,10 +387,9 @@ Either your CUDA is too new or too old."
       case `uname -m` in
         x86_64|ppc64le)
           case $CUDA_VERSION in
-            5_5) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35" ;;
-            6_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50" ;;
-            7_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52" ;;
-            8_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61" ;;
+            # Disabling CUDA 7 and 8. See a few lines above for details.		   
+            #7_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52" ;;
+            #8_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61" ;;
             9_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70" ;;
             10_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75" ;;
             11_*) CUDA_ARCH="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80" ;;
@@ -395,8 +398,9 @@ Either your CUDA is too new or too old."
         ;;
         aarch64)
           case $CUDA_VERSION in
-            7_*)     CUDA_ARCH="-gencode arch=compute_53,code=sm_53" ;;
-            8_*|9_*) CUDA_ARCH="-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62" ;;
+            #7_*)     CUDA_ARCH="-gencode arch=compute_53,code=sm_53" ;;
+            #8_*)     CUDA_ARCH="-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62" ;;
+            9_*)    CUDA_ARCH="-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62" ;;
             10_*)    CUDA_ARCH="-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62 -gencode arch=compute_72,code=sm_72" ;;
             *) echo "Unsupported CUDA_VERSION (CUDA_VERSION=$CUDA_VERSION), please report it to Kaldi mailing list, together with 'nvcc -h' or 'ptxas -h' which lists allowed -gencode values..."; exit 1 ;;
           esac

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -10,8 +10,8 @@ CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include -fPIC -pthread -isystem $(OPENFST
 CUDA_INCLUDE= -I$(CUDATKDIR)/include -I$(CUBROOT)
 CUDA_FLAGS = --machine 64 -DHAVE_CUDA \
              -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
-             -std=c++11 -DCUDA_API_PER_THREAD_DEFAULT_STREAM  -lineinfo \
-             --verbose -Xcompiler "$(CXXFLAGS)"
+             -std=c++14 -DCUDA_API_PER_THREAD_DEFAULT_STREAM  -lineinfo \
+             --verbose -Wno-deprecated-gpu-targets
 
 ifeq ($(shell test -e $(CUDATKDIR)/lib64/libcudart_static.a && echo -n yes),yes)
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64


### PR DESCRIPTION
Using C++14 for cuda instead of C++11. Required by CUB. The CXXFLAGS are still using c++11.