### PR TITLE
Clapack support

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -1025,7 +1025,28 @@ elif [ "`uname`" == "Darwin" ]; then
   OSX_VER_NUM=$(echo $OSX_VER | sed 's/\./ /g' | xargs printf "%d%02d")
   echo "Configuring for OS X version $OSX_VER ..."
   if [ $OSX_VER_NUM -ge 1005 ]; then
-    cat makefiles/darwin.mk >> kaldi.mk
+    if [ "$MATHLIB" == "CLAPACK" ]; then
+      if [ -z "$CLAPACKROOT" ]; then
+          failure "Must specify the location of CLAPACK with --clapack-root option (and it must exist)"
+      fi
+      if [ ! -f ../tools/CLAPACK/clapack.h ]; then
+          failure "could not find file ../tools/CLAPACK/clapack.h"
+      fi
+      if [ ! -d "$CLAPACKROOT" ]; then
+          failure "The directory $CLAPACKROOT does not exist"
+      fi
+      # Also check for cblas.h and f2c.h
+      echo "Using CLAPACK libs from $CLAPACKROOT as the linear algebra library."
+      echo "CLAPACKROOT = $CLAPACKROOT" >> kaldi.mk
+      if [ ! -f makefiles/darwin_clapack.mk ]; then
+          failure "makefiles/darwin_clapack.mk not found."
+      fi
+      cat makefiles/darwin_clapack.mk >> kaldi.mk
+      echo "Warning (CLAPACK): this part of the configure process is not properly tested and may not work."
+      echo "Successfully configured for Darwin with CLAPACK libs from $CLAPACKROOT"
+    else
+      cat makefiles/darwin.mk >> kaldi.mk
+    fi
   else
     failure "Mac OS X version '$OSX_VER' is not supported."
   fi
@@ -1143,6 +1164,7 @@ elif [ "`uname`" == "Linux" ]; then
     if [[ "$TARGET_ARCH" == arm* ]]; then
       cat makefiles/linux_clapack_arm.mk >> kaldi.mk
     else
+      echo "CLAPACKROOT = $CLAPACKROOT" >> kaldi.mk
       cat makefiles/linux_clapack.mk >> kaldi.mk
     fi
     echo "Warning (CLAPACK): this part of the configure process is not properly tested and may not work."

--- a/src/makefiles/darwin_clapack.mk
+++ b/src/makefiles/darwin_clapack.mk
@@ -1,0 +1,50 @@
+# Darwin (macOS) configuration
+
+ifndef DEBUG_LEVEL
+$(error DEBUG_LEVEL not defined.)
+endif
+ifndef DOUBLE_PRECISION
+$(error DOUBLE_PRECISION not defined.)
+endif
+ifndef OPENFSTINC
+$(error OPENFSTINC not defined.)
+endif
+ifndef OPENFSTLIBS
+$(error OPENFSTLIBS not defined.)
+endif
+
+CLAPACKLIBS = $(CLAPACKROOT)/CLAPACK-3.2.1/lapack.a $(CLAPACKROOT)/CLAPACK-3.2.1/libcblaswr.a \
+	      $(CLAPACKROOT)/CBLAS/lib/cblas.a \
+	      $(CLAPACKROOT)/f2c_BLAS-3.8.0/blas.a $(CLAPACKROOT)/libf2c/libf2c.a
+
+CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+           -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
+           -Wno-deprecated-declarations -Winit-self \
+           -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
+           -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK -I../../tools/CLAPACK \
+           -msse -msse2 -pthread \
+           -g
+
+ifeq ($(KALDI_FLAVOR), dynamic)
+CXXFLAGS += -fPIC
+endif
+
+ifeq ($(DEBUG_LEVEL), 0)
+CXXFLAGS += -DNDEBUG
+endif
+ifeq ($(DEBUG_LEVEL), 2)
+CXXFLAGS += -O0 -DKALDI_PARANOID
+endif
+
+# Compiler specific flags
+COMPILER = $(shell $(CXX) -v 2>&1)
+ifeq ($(findstring clang,$(COMPILER)),clang)
+# Suppress annoying clang warnings that are perfectly valid per spec.
+CXXFLAGS += -Wno-mismatched-tags
+else ifeq ($(findstring GCC,$(COMPILER)),GCC)
+# Allow implicit conversions between vectors.
+CXXFLAGS += -flax-vector-conversions
+endif
+
+LDFLAGS = $(EXTRA_LDFLAGS) $(OPENFSTLDFLAGS) -g
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(CLAPACKLIBS) -lm -lpthread -ldl

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -13,6 +13,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
+CLAPACKLIBS = $(CLAPACKROOT)/CLAPACK-3.2.1/lapack.a $(CLAPACKROOT)/CLAPACK-3.2.1/libcblaswr.a \
+	      $(CLAPACKROOT)/CBLAS/lib/cblas.a \
+	      $(CLAPACKROOT)/f2c_BLAS-3.8.0/blas.a $(CLAPACKROOT)/libf2c/libf2c.a
+
 CXXFLAGS = -std=c++11 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
@@ -40,4 +44,4 @@ CXXFLAGS += -Wno-mismatched-tags
 endif
 
 LDFLAGS = $(EXTRA_LDFLAGS) $(OPENFSTLDFLAGS) -rdynamic
-LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(ATLASLIBS) -lm -lpthread -ldl
+LDLIBS = $(EXTRA_LDLIBS) $(OPENFSTLIBS) $(CLAPACKLIBS) -lm -lpthread -ldl


### PR DESCRIPTION
Hi,
While porting Kaldi to Web Assembly, we, at Inria, faced the issue of interfacing Kaldi with CLAPACK. To successfully compile Kaldi with CLAPACK, CBLAS and (reference) BLAS, we ended up making some minor modifications the source code of the matrix library.

In this PR, we are submitting the changes we made to some of the build scripts in Kaldi so that it can be built against our version of CLAPACK, which is available at https://gitlab.inria.fr/kaldi.web/clapack-wasm.

What do you think?

PS: We also reorganized and bound the online decoder in `online2bin/online2-tcp-nnet3-decode-faster.cc` with javascript. The end result is running at https://kaldi-web.loria.fr, which runs the online decoder in a web browser. Would you like a separate PR to add these changes?