### PR TITLE
Fixed usage message of validate_lang.pl

### DIFF
--- a/egs/wsj/s5/utils/validate_lang.pl
+++ b/egs/wsj/s5/utils/validate_lang.pl
@@ -123,7 +123,7 @@ if (@ARGV != 1) {
   print "Usage: $0 [options] <lang_directory>\n";
   print "e.g.:  $0 data/lang\n";
   print "Options:\n";
-  print " --skip-det-check                         (this flag causes it to skip a deterministic fst check).\n";
+  print " --skip-generate-words-check              (this flag causes it to skip a check of generated word sequences).\n";
   print " --skip-determinization-check             (this flag causes it to skip a time consuming check).\n";
   print " --skip-disambig-check                    (this flag causes it to skip a disambig check in phone bigram models).\n";
   exit(1);


### PR DESCRIPTION
The usage message of validate_lang.pl mentioned --skip-det-check which was not used.  The --skip-generate-words-check option was added to the usage message.