### PR TITLE
Remove intermediate decoding with GMM models

### DIFF
--- a/egs/librispeech/s5/run.sh
+++ b/egs/librispeech/s5/run.sh
@@ -107,16 +107,6 @@ if [ $stage -le 8 ]; then
   # train a monophone system
   steps/train_mono.sh --boost-silence 1.25 --nj 20 --cmd "$train_cmd" \
                       data/train_2kshort data/lang_nosp exp/mono
-
-  # decode using the monophone model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-                     exp/mono exp/mono/graph_nosp_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode.sh --nj 20 --cmd "$decode_cmd" exp/mono/graph_nosp_tgsmall \
-                      data/$test exp/mono/decode_nosp_tgsmall_$test
-    done
-  )&
 fi
 
 if [ $stage -le 9 ]; then
@@ -126,21 +116,6 @@ if [ $stage -le 9 ]; then
   # train a first delta + delta-delta triphone system on a subset of 5000 utterances
   steps/train_deltas.sh --boost-silence 1.25 --cmd "$train_cmd" \
                         2000 10000 data/train_5k data/lang_nosp exp/mono_ali_5k exp/tri1
-
-  # decode using the tri1 model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-                     exp/tri1 exp/tri1/graph_nosp_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode.sh --nj 20 --cmd "$decode_cmd" exp/tri1/graph_nosp_tgsmall \
-                      data/$test exp/tri1/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-                         data/$test exp/tri1/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri1/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
 fi
 
 if [ $stage -le 10 ]; then
@@ -152,21 +127,6 @@ if [ $stage -le 10 ]; then
   steps/train_lda_mllt.sh --cmd "$train_cmd" \
                           --splice-opts "--left-context=3 --right-context=3" 2500 15000 \
                           data/train_10k data/lang_nosp exp/tri1_ali_10k exp/tri2b
-
-  # decode using the LDA+MLLT model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-                     exp/tri2b exp/tri2b/graph_nosp_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode.sh --nj 20 --cmd "$decode_cmd" exp/tri2b/graph_nosp_tgsmall \
-                      data/$test exp/tri2b/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-                         data/$test exp/tri2b/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri2b/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
 fi
 
 if [ $stage -le 11 ]; then
@@ -178,21 +138,6 @@ if [ $stage -le 11 ]; then
   steps/train_sat.sh --cmd "$train_cmd" 2500 15000 \
                      data/train_10k data/lang_nosp exp/tri2b_ali_10k exp/tri3b
 
-  # decode using the tri3b model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-                     exp/tri3b exp/tri3b/graph_nosp_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
-                            exp/tri3b/graph_nosp_tgsmall data/$test \
-                            exp/tri3b/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-                         data/$test exp/tri3b/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri3b/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
 fi
 
 if [ $stage -le 12 ]; then
@@ -205,25 +150,6 @@ if [ $stage -le 12 ]; then
   steps/train_sat.sh  --cmd "$train_cmd" 4200 40000 \
                       data/train_clean_100 data/lang_nosp \
                       exp/tri3b_ali_clean_100 exp/tri4b
-
-  # decode using the tri4b model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-                     exp/tri4b exp/tri4b/graph_nosp_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
-                            exp/tri4b/graph_nosp_tgsmall data/$test \
-                            exp/tri4b/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-                         data/$test exp/tri4b/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri4b/decode_nosp_{tgsmall,tglarge}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,fglarge} \
-        data/$test exp/tri4b/decode_nosp_{tgsmall,fglarge}_$test
-    done
-  )&
 fi
 
 if [ $stage -le 13 ]; then
@@ -244,25 +170,6 @@ if [ $stage -le 13 ]; then
     data/local/lm/lm_tglarge.arpa.gz data/lang data/lang_test_tglarge
   utils/build_const_arpa_lm.sh \
     data/local/lm/lm_fglarge.arpa.gz data/lang data/lang_test_fglarge
-
-  # decode using the tri4b model with pronunciation and silence probabilities
-  (
-    utils/mkgraph.sh \
-      data/lang_test_tgsmall exp/tri4b exp/tri4b/graph_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
-                            exp/tri4b/graph_tgsmall data/$test \
-                            exp/tri4b/decode_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_test_{tgsmall,tgmed} \
-                         data/$test exp/tri4b/decode_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_test_{tgsmall,tglarge} \
-        data/$test exp/tri4b/decode_{tgsmall,tglarge}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_test_{tgsmall,fglarge} \
-        data/$test exp/tri4b/decode_{tgsmall,fglarge}_$test
-    done
-  )&
 fi
 
 if [ $stage -le 14 ] && false; then
@@ -300,25 +207,6 @@ if [ $stage -le 16 ]; then
   # create a larger SAT model, trained on the 460 hours of data.
   steps/train_sat.sh  --cmd "$train_cmd" 5000 100000 \
                       data/train_clean_460 data/lang exp/tri4b_ali_clean_460 exp/tri5b
-
-  # decode using the tri5b model
-  (
-    utils/mkgraph.sh data/lang_test_tgsmall \
-                     exp/tri5b exp/tri5b/graph_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
-      steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
-                            exp/tri5b/graph_tgsmall data/$test \
-                            exp/tri5b/decode_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_test_{tgsmall,tgmed} \
-                         data/$test exp/tri5b/decode_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_test_{tgsmall,tglarge} \
-        data/$test exp/tri5b/decode_{tgsmall,tglarge}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_test_{tgsmall,fglarge} \
-        data/$test exp/tri5b/decode_{tgsmall,fglarge}_$test
-    done
-  )&
 fi
 
 
@@ -354,10 +242,9 @@ if [ $stage -le 18 ]; then
                        7000 150000 data/train_960 data/lang exp/tri5b_ali_960 exp/tri6b
 
   # decode using the tri6b model
-  (
-    utils/mkgraph.sh data/lang_test_tgsmall \
-                     exp/tri6b exp/tri6b/graph_tgsmall
-    for test in test_clean test_other dev_clean dev_other; do
+  utils/mkgraph.sh data/lang_test_tgsmall \
+                   exp/tri6b exp/tri6b/graph_tgsmall
+  for test in test_clean test_other dev_clean dev_other; do
       steps/decode_fmllr.sh --nj 20 --cmd "$decode_cmd" \
                             exp/tri6b/graph_tgsmall data/$test exp/tri6b/decode_tgsmall_$test
       steps/lmrescore.sh --cmd "$decode_cmd" data/lang_test_{tgsmall,tgmed} \
@@ -368,8 +255,7 @@ if [ $stage -le 18 ]; then
       steps/lmrescore_const_arpa.sh \
         --cmd "$decode_cmd" data/lang_test_{tgsmall,fglarge} \
         data/$test exp/tri6b/decode_{tgsmall,fglarge}_$test
-    done
-  )&
+  done
 fi
 
 
@@ -421,6 +307,3 @@ fi
 # ## The following is an older version of the online-nnet2 recipe, without "multi-splice".  It's faster
 # ## to train but slightly worse.
 # # local/online/run_nnet2.sh
-
-# Wait for decodings in the background
-wait

--- a/egs/mini_librispeech/s5/RESULTS
+++ b/egs/mini_librispeech/s5/RESULTS
@@ -6,17 +6,9 @@ for x in exp/chain*/*/decode*; do [ -d $x ] && [[ $x =~ "$1" ]] && grep WER $x/w
 exit 0
 
 # Results on on dev_clean_2
-%WER 49.18 [ 9903 / 20138, 439 ins, 2332 del, 7132 sub ] exp/mono/decode_nosp_tgsmall_dev_clean_2/wer_8_0.0
-%WER 20.42 [ 4113 / 20138, 469 ins, 545 del, 3099 sub ] exp/tri1/decode_nosp_tglarge_dev_clean_2/wer_14_0.0
-%WER 24.56 [ 4945 / 20138, 447 ins, 792 del, 3706 sub ] exp/tri1/decode_nosp_tgmed_dev_clean_2/wer_14_0.0
-%WER 27.37 [ 5512 / 20138, 425 ins, 969 del, 4118 sub ] exp/tri1/decode_nosp_tgsmall_dev_clean_2/wer_14_0.0
-%WER 18.59 [ 3743 / 20138, 435 ins, 517 del, 2791 sub ] exp/tri2b/decode_nosp_tglarge_dev_clean_2/wer_15_0.0
-%WER 22.06 [ 4443 / 20138, 400 ins, 748 del, 3295 sub ] exp/tri2b/decode_nosp_tgmed_dev_clean_2/wer_15_0.0
-%WER 24.32 [ 4898 / 20138, 413 ins, 899 del, 3586 sub ] exp/tri2b/decode_nosp_tgsmall_dev_clean_2/wer_15_0.0
 %WER 13.45 [ 2708 / 20138, 358 ins, 330 del, 2020 sub ] exp/tri3b/decode_nosp_tglarge_dev_clean_2/wer_17_0.0
 %WER 16.25 [ 3273 / 20138, 332 ins, 485 del, 2456 sub ] exp/tri3b/decode_nosp_tgmed_dev_clean_2/wer_16_0.0
 %WER 18.10 [ 3645 / 20138, 332 ins, 603 del, 2710 sub ] exp/tri3b/decode_nosp_tgsmall_dev_clean_2/wer_16_0.0
-
 
 %WER 18.58 [ 3742 / 20138, 366 ins, 763 del, 2613 sub ] exp/chain/tdnn1a_sp/decode_tgsmall_dev_clean_2/wer_10_0.0
 %WER 13.35 [ 2689 / 20138, 318 ins, 491 del, 1880 sub ] exp/chain/tdnn1a_sp/decode_tglarge_dev_clean_2/wer_9_0.5

--- a/egs/mini_librispeech/s5/run.sh
+++ b/egs/mini_librispeech/s5/run.sh
@@ -67,15 +67,6 @@ if [ $stage -le 3 ]; then
   # TODO(galv): Is this too many jobs for a smaller dataset?
   steps/train_mono.sh --boost-silence 1.25 --nj 5 --cmd "$train_cmd" \
     data/train_500short data/lang_nosp exp/mono
-  # TODO: Understand why we use lang_nosp here...
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-      exp/mono exp/mono/graph_nosp_tgsmall
-    for test in dev_clean_2; do
-      steps/decode.sh --nj 10 --cmd "$decode_cmd" exp/mono/graph_nosp_tgsmall \
-        data/$test exp/mono/decode_nosp_tgsmall_$test
-    done
-  )&
 
   steps/align_si.sh --boost-silence 1.25 --nj 5 --cmd "$train_cmd" \
     data/train_clean_5 data/lang_nosp exp/mono exp/mono_ali_train_clean_5
@@ -85,21 +76,6 @@ fi
 if [ $stage -le 4 ]; then
   steps/train_deltas.sh --boost-silence 1.25 --cmd "$train_cmd" \
     2000 10000 data/train_clean_5 data/lang_nosp exp/mono_ali_train_clean_5 exp/tri1
-
-  # decode using the tri1 model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-      exp/tri1 exp/tri1/graph_nosp_tgsmall
-    for test in dev_clean_2; do
-      steps/decode.sh --nj 5 --cmd "$decode_cmd" exp/tri1/graph_nosp_tgsmall \
-      data/$test exp/tri1/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-        data/$test exp/tri1/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri1/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
 
   steps/align_si.sh --nj 5 --cmd "$train_cmd" \
     data/train_clean_5 data/lang_nosp exp/tri1 exp/tri1_ali_train_clean_5
@@ -111,21 +87,6 @@ if [ $stage -le 5 ]; then
     --splice-opts "--left-context=3 --right-context=3" 2500 15000 \
     data/train_clean_5 data/lang_nosp exp/tri1_ali_train_clean_5 exp/tri2b
 
-  # decode using the LDA+MLLT model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-      exp/tri2b exp/tri2b/graph_nosp_tgsmall
-    for test in dev_clean_2; do
-      steps/decode.sh --nj 10 --cmd "$decode_cmd" exp/tri2b/graph_nosp_tgsmall \
-        data/$test exp/tri2b/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-        data/$test exp/tri2b/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri2b/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
-
   # Align utts using the tri2b model
   steps/align_si.sh  --nj 5 --cmd "$train_cmd" --use-graphs true \
     data/train_clean_5 data/lang_nosp exp/tri2b exp/tri2b_ali_train_clean_5
@@ -135,22 +96,6 @@ fi
 if [ $stage -le 6 ]; then
   steps/train_sat.sh --cmd "$train_cmd" 2500 15000 \
     data/train_clean_5 data/lang_nosp exp/tri2b_ali_train_clean_5 exp/tri3b
-
-  # decode using the tri3b model
-  (
-    utils/mkgraph.sh data/lang_nosp_test_tgsmall \
-      exp/tri3b exp/tri3b/graph_nosp_tgsmall
-    for test in dev_clean_2; do
-      steps/decode_fmllr.sh --nj 10 --cmd "$decode_cmd" \
-        exp/tri3b/graph_nosp_tgsmall data/$test \
-        exp/tri3b/decode_nosp_tgsmall_$test
-      steps/lmrescore.sh --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tgmed} \
-        data/$test exp/tri3b/decode_nosp_{tgsmall,tgmed}_$test
-      steps/lmrescore_const_arpa.sh \
-        --cmd "$decode_cmd" data/lang_nosp_test_{tgsmall,tglarge} \
-        data/$test exp/tri3b/decode_nosp_{tgsmall,tglarge}_$test
-    done
-  )&
 fi
 
 # Now we compute the pronunciation and silence probabilities from training data,
@@ -200,6 +145,3 @@ if [ $stage -le 9 ]; then
 fi
 
 # local/grammar/simple_demo.sh
-
-# Don't finish until all background decoding jobs are finished.
-wait


### PR DESCRIPTION
Since we advertise mini_librispeech/librispeech as pattern to follow it is important to keep them modern.

Intermediate GMM decodings are not very relevant these days anyway but they take a lot of time in training and essentially create bad patterns newbies follow.

This patch removes intermediate decodings, keeping only the last one.

