### PR TITLE
enable linking from both libs, the heuristic malfunctioned sometimes

### DIFF
--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -13,10 +13,7 @@ CUDA_FLAGS = --compiler-options -fPIC --machine 64 -DHAVE_CUDA \
              -std=c++14 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -lineinfo \
              --verbose -Wno-deprecated-gpu-targets
 
-ifeq ($(shell test -e $(CUDATKDIR)/lib64/libcudart_static.a && echo -n yes),yes)
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-else
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath,$(CUDATKDIR)/lib
-endif
 
 CUDA_LDLIBS += -lcublas -lcusparse -lcudart -lcurand -lcufft -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule


### PR DESCRIPTION
I don't see any reason why adding both library directories should be problematic... and fixes mine and Kirill's problem with CI when the static libs are removed