### PR TITLE
fix scripts/rnnlm/prepare_rnnlm_dir.sh

### DIFF
--- a/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r2/local/rnnlm/prepare_rnnlm_data.sh
@@ -17,7 +17,7 @@ mkdir -p $dir
 rnnlm/validate_data_dir.py $data_dir/data/
 
 # get unigram counts
-rnnlm/get_unigram_counts.sh $data_dir/data/
+rnnlm/ensure_counts_present.sh $data_dir/data/
 
 # get vocab
 mkdir -p $data_dir/vocab

--- a/egs/tedlium/s5_r3/local/rnnlm/prepare_rnnlm_data.sh
+++ b/egs/tedlium/s5_r3/local/rnnlm/prepare_rnnlm_data.sh
@@ -17,7 +17,7 @@ mkdir -p $dir
 rnnlm/validate_data_dir.py $data_dir/data/
 
 # get unigram counts
-rnnlm/get_unigram_counts.sh $data_dir/data/
+rnnlm/ensure_counts_present.sh $data_dir/data/
 
 # get vocab
 mkdir -p $data_dir/vocab

--- a/scripts/rnnlm/prepare_rnnlm_dir.sh
+++ b/scripts/rnnlm/prepare_rnnlm_dir.sh
@@ -72,7 +72,7 @@ fi
 if [ $stage -le 2 ]; then
   if [ ! -f $text_dir/dev.counts ] || [ $text_dir/dev.counts -ot $text_dir/dev.txt ]; then
     echo "$0: preparing unigram counts in $text_dir"
-    rnnlm/get_unigram_counts.sh $text_dir
+    rnnlm/ensure_counts_present.sh $text_dir
   fi
 fi
 


### PR DESCRIPTION
rnnlm/get_unigram_counts.sh is absent.
Actually, we use rnnlm/ensure_counts_present.sh to generate the '.counts' files, so replace corresponding commands.