### PR TITLE
fix tab grep bug in prepare_rnnlm_dir.sh

### DIFF
--- a/scripts/rnnlm/prepare_rnnlm_dir.sh
+++ b/scripts/rnnlm/prepare_rnnlm_dir.sh
@@ -140,7 +140,7 @@ if [ $stage -le 6 ]; then
     feat_dim=$(tail -n 1 $dir/config/features.txt | awk '{print $1 + 1;}')
 
     first_element_opt=
-    if grep -q '0\tconstant' $dir/config/features.txt; then
+    if grep -q '0'$'\t''constant' $dir/config/features.txt; then
       first_element_opt="--first-element 1.0"
     fi
     # we'll probably make the stddev configurable soon, or maybe just remove it.


### PR DESCRIPTION
In grep command, '\t' is not a right way to match 'tab' symbol. Use "$'\t'" to do it.