### PR TITLE
[scripts] Fix to support <end-time> of segments be -1 in utils/validate_data_dir.sh

### DIFF
--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -179,7 +179,7 @@ if [ -f $data/wav.scp ]; then
     check_sorted_and_uniq $data/segments
     # We have a segments file -> interpret wav file as "recording-ids" not utterance-ids.
     ! cat $data/segments | \
-      awk '{if (NF != 4 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
+      awk '{if (NF != 4 || ( $4 > 0 && $4 <= $3 ) ) { print "Bad line in segments file", $0; exit(1); }}' && \
       echo "$0: badly formatted segments file" && exit 1;
 
     segments_len=`cat $data/segments | wc -l`


### PR DESCRIPTION
extract-segments support <end-time> be -1, which means the segment runs till the end of the WAV file
but utils/validate_data_dir.sh does not support that.