### PR TITLE
Fix the backoff logic bug in GetProbForWord

### DIFF
--- a/src/rnnlm/sampling-lm-estimate.cc
+++ b/src/rnnlm/sampling-lm-estimate.cc
@@ -539,7 +539,7 @@ BaseFloat SamplingLmEstimator::GetProbForWord(
   // compute the probability from lowest to highest order.
   KALDI_ASSERT(word > 0 && word < static_cast<int32>(unigram_probs_.size()));
   BaseFloat ans = unigram_probs_[word];
-  for (size_t i = 0; i < states.size(); i++) {
+  for (size_t i = states.size() - 1; i >= 0; i--) {
     const HistoryState *state = states[i];
     ans *= state->backoff_count / state->total_count;
     Count c;

--- a/src/rnnlm/sampling-lm-estimate.cc
+++ b/src/rnnlm/sampling-lm-estimate.cc
@@ -539,7 +539,7 @@ BaseFloat SamplingLmEstimator::GetProbForWord(
   // compute the probability from lowest to highest order.
   KALDI_ASSERT(word > 0 && word < static_cast<int32>(unigram_probs_.size()));
   BaseFloat ans = unigram_probs_[word];
-  for (int32 i = states.size() - 1; i >= 0; i--) {
+  for (int32 i = states.size() - 1; i >= 0; --i) {
     const HistoryState *state = states[i];
     ans *= state->backoff_count / state->total_count;
     Count c;

--- a/src/rnnlm/sampling-lm-estimate.cc
+++ b/src/rnnlm/sampling-lm-estimate.cc
@@ -539,7 +539,7 @@ BaseFloat SamplingLmEstimator::GetProbForWord(
   // compute the probability from lowest to highest order.
   KALDI_ASSERT(word > 0 && word < static_cast<int32>(unigram_probs_.size()));
   BaseFloat ans = unigram_probs_[word];
-  for (size_t i = states.size() - 1; i >= 0; i--) {
+  for (int32 i = states.size() - 1; i >= 0; i--) {
     const HistoryState *state = states[i];
     ans *= state->backoff_count / state->total_count;
     Count c;


### PR DESCRIPTION
Fix the bug in GetProbForWord.
When we construct the 'backoff' history states, we erase the 'head' word from the history word sequence gradually. So the function argument--"states" is arranged from the high order to low order. So we should iterate it from the end.
I use a 4-gram case as the example, as the 3-gram (normal case) only push one element into the 'states' argument so it will not trigger any problem. 
Say we are dealing with ‘(w1, w2, w3, w4)’，the history of it is '(w1, w2, w3)'. There are two backoff history states will be pushed into the 'states' variable. states[0] = (w2, w3), state[1] = (w3).
In original code, we will compute "ans = P(w4) * bow(w2, w3) + P(w4|w2, w3) * bow(w3) + P(w4|w3)".
I think the correct one should be "ans = P(w4) * bow (w3) + P(w4|w3) * bow(w2, w3) + P(w4|w2, w3)" as the new code.