### PR TITLE
fix compilation failure on  std::atomic_int32_t with gcc/++<7.0

### DIFF
--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -61,7 +61,7 @@ class CudaOnlinePipelineDynamicBatcher {
   std::unordered_set<CorrelationID> is_corr_id_in_batch_;
   std::unordered_set<CorrelationID> is_corr_id_in_use_;
   std::mutex chunks_m_;
-  std::atomic_int32_t n_chunks_in_queue_;  // equals to chunks.size(), lock free
+  std::atomic<std::uint32_t> n_chunks_in_queue_;  // equals to chunks.size(), lock free
   bool run_batcher_thread_;
   std::unique_ptr<std::thread> batcher_thread_;
   BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline_;


### PR DESCRIPTION
The error msg is:

../cudadecoder/cuda-online-pipeline-dynamic-batcher.h:64:8: error: ‘atomic_int32_t’ in namespace ‘std’ does not name a type
   std::atomic_int32_t n_chunks_in_queue_;  // equals to chunks.size(), lock free

I see it was recently introduced in https://github.com/kaldi-asr/kaldi/commit/cc79575e2a7e028728a6f5b444ede9214e13881c.

It is suggested from the Internet to use std::atomic<std::uint32_t> instead. I tried and the compilation was passed.