### PR TITLE
chain2 small fix: no groups-per-minibatch option

### DIFF
--- a/egs/babel/s5d/local/chain2/run_tdnn.sh
+++ b/egs/babel/s5d/local/chain2/run_tdnn.sh
@@ -297,7 +297,7 @@ if [ $stage -le 18 ]; then
     --initial-effective-lrate $initial_effective_lrate \
     --final-effective-lrate $final_effective_lrate \
     --max-param-change $max_param_change \
-    --groups-per-minibatch 128 \
+    --minibatch-size 128 \
     --l2-regularize 0.00005 \
     --num-jobs-initial $num_jobs_initial --num-jobs-final $num_jobs_final \
      $common_egs_dir $dir

--- a/egs/babel_multilang/s5/local/chain2/run_tdnn.sh
+++ b/egs/babel_multilang/s5/local/chain2/run_tdnn.sh
@@ -420,7 +420,7 @@ if [ $stage -le 18 ]; then
     --initial-effective-lrate $initial_effective_lrate \
     --final-effective-lrate $final_effective_lrate \
     --max-param-change $max_param_change \
-    --groups-per-minibatch 128 \
+    --minibatch-size 128 \
     --srand 1 \
     --shuffle-buffer-size 5000 \
     --l2-regularize 5e-5 \

--- a/egs/mini_librispeech/s5/local/chain2/tuning/run_tdnn_1a.sh
+++ b/egs/mini_librispeech/s5/local/chain2/tuning/run_tdnn_1a.sh
@@ -329,7 +329,7 @@ if [ $stage -le 22 ]; then
     --xent-regularize $xent_regularize --leaky-hmm-coefficient 0.1 \
     --max-param-change 2.0 \
     --num-jobs-initial 2 --num-jobs-final 5 \
-    --groups-per-minibatch 256,128,64 \
+    --minibatch-size 256,128,64 \
      $dir/egs $dir || exit 1;
 fi
 

--- a/egs/swbd/s5c/local/chain2/tuning/run_tdnn_7k.sh
+++ b/egs/swbd/s5c/local/chain2/tuning/run_tdnn_7k.sh
@@ -297,7 +297,7 @@ if [ $stage -le 19 ]; then
     --initial-effective-lrate $initial_effective_lrate \
     --final-effective-lrate $final_effective_lrate \
     --max-param-change $max_param_change \
-    --groups-per-minibatch 128 \
+    --minibatch-size 128 \
     --l2-regularize 0.00005 \
     --num-jobs-initial $num_jobs_initial --num-jobs-final $num_jobs_final \
      $common_egs_dir $dir

--- a/egs/wsj/s5/local/chain2/tuning/run_tdnn_1i.sh
+++ b/egs/wsj/s5/local/chain2/tuning/run_tdnn_1i.sh
@@ -363,7 +363,7 @@ if [ $stage -le 22 ]; then
     --initial-effective-lrate 0.0005 \
     --final-effective-lrate 0.00005 \
     --num-epochs 10 \
-    --groups-per-minibatch 128,64 \
+    --minibatch-size 128,64 \
      $dir/egs $dir || exit 1;
 fi
 

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -38,7 +38,7 @@ num_jobs_initial=1
 num_jobs_final=1
 initial_effective_lrate=0.001
 final_effective_lrate=0.0001
-minibatch_size=32  # This is how you set the minibatch size. 
+groups_per_minibatch=32  # This is how you set the minibatch size. 
 
 max_iters_combine=80
 max_models_combine=20
@@ -232,7 +232,7 @@ while [ $x -lt $num_iters ]; do
              $l2_regularize_opt \
              --srand=$srand \
              "nnet3-copy --learning-rate=$lrate $dir/${x}.raw - |" $den_fst_dir \
-             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$minibatch_size ark:- ark:-|" \
+             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$groups_per_minibatch ark:- ark:-|" \
              ${model_out_prefix}.$j.raw || touch $dir/.error &
   done
   wait

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -38,7 +38,7 @@ num_jobs_initial=1
 num_jobs_final=1
 initial_effective_lrate=0.001
 final_effective_lrate=0.0001
-groups_per_minibatch=32  # This is how you set the minibatch size. 
+minibatch_size=32  # This is how you set the minibatch size. 
 
 max_iters_combine=80
 max_models_combine=20
@@ -232,7 +232,7 @@ while [ $x -lt $num_iters ]; do
              $l2_regularize_opt \
              --srand=$srand \
              "nnet3-copy --learning-rate=$lrate $dir/${x}.raw - |" $den_fst_dir \
-             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$groups_per_minibatch ark:- ark:-|" \
+             "ark:nnet3-chain-copy-egs $egs_opts --frame-shift=$frame_shift scp:$egs_dir/train.$scp_index.scp ark:- | nnet3-chain-shuffle-egs --buffer-size=$shuffle_buffer_size --srand=$x ark:- ark:- | nnet3-chain-merge-egs $multilingual_eg_opts --minibatch-size=$minibatch_size ark:- ark:-|" \
              ${model_out_prefix}.$j.raw || touch $dir/.error &
   done
   wait


### PR DESCRIPTION
In normal local/chain2/*.sh, the "groups-per-minibatch" option is passed to steps/chain2/train.sh. But the train.sh doesn't have corresponding option. I found it is same as "minibatch" which is used in command "nnet3-chain-merge-egs". So replace the "minibatch" with "groups_per_minibatch"