### PR TITLE
fixed relative path to openfst in install_opengram.sh

### DIFF
--- a/tools/extras/install_opengrm.sh
+++ b/tools/extras/install_opengrm.sh
@@ -31,6 +31,6 @@ fi
 tar -xovzf ngram-1.3.7.tar.gz|| exit 1
 
 cd ngram-1.3.7
-OPENFSTPREFIX=`pwd`/../openfst
+OPENFSTPREFIX=`pwd`/../../openfst
 LDFLAGS="-L${OPENFSTPREFIX}/lib" CXXFLAGS="-I${OPENFSTPREFIX}/include" ./configure --prefix ${OPENFSTPREFIX}
 make; make install


### PR DESCRIPTION
running `./install_opengram.sh` leads to error "configure: error: fst/fst.h header not found"