### PR TITLE
add -std=c++11 to solve make sctk error

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -124,7 +124,7 @@ sctk/.compiled: sctk
 
 # The GitHub archive unpacks into SCTK-{40-character-long-hash}/
 sctk: sctk-$(SCTK_GITHASH).tar.gz
-	tar --exclude '*NONE*html' -xmaf sctk-$(SCTK_GITHASH).tar.gz
+	tar zxvf sctk-$(SCTK_GITHASH).tar.gz
 	rm -rf sctk-$(SCTK_GITHASH) sctk
 	mv SCTK-$(SCTK_GITHASH)* sctk-$(SCTK_GITHASH)
 	ln -s sctk-$(SCTK_GITHASH) sctk

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -107,7 +107,7 @@ openfst_cleaned:
 
 SCTK_CXFLAGS = -w -march=native
 SCTK_MKENV = CFLAGS="$(CFLAGS) $(SCTK_CXFLAGS)" \
-             CXXFLAGS="$(CXXFLAGS) $(SCTK_CXFLAGS)" \
+             CXXFLAGS="$(CXXFLAGS) -std=c++11 $(SCTK_CXFLAGS)" \
 
 # Keep the existing target 'sclite' to avoid breaking the users who might have
 # scripted it in.


### PR DESCRIPTION
solve this problem:
make sctk, show error 
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
#error This file requires compiler and library support