### PR TITLE
[scripts] Correctly symlink lda.mat in chain2 [#4357]

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain2/compute_preconditioning_matrix.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/compute_preconditioning_matrix.sh
@@ -76,7 +76,8 @@ if [ $stage -le 2 ]; then
         $ldafolder/lda.mat $ldafolder/lda_stats || exit 1
 
     rm $ldafolder/lda_stats
-    ln -sf $ldafolder/lda.mat $ldafolder/configs/lda.mat
+    # lda.mat is in $ldafolder, i.e. one up from $ldafolder/config.
+    ln -sf ../lda.mat $ldafolder/configs/lda.mat
 fi
 
 echo "$0: Finished computing LDA transform"


### PR DESCRIPTION
_Of course_ `ln -sfr $ldafolder/lda.mat $ldafolder/configs/lda.mat` would have been much more readable, but _of course_ macOS `ln` does not have `-r`, so do it the ugly way.

FYI, AWS's gonna deploy macOS servers any day now.

Fixes #4357