### PR TITLE
[src] missing init in OnlineIvectorExtractionInfo(), fixes #4379

### DIFF
--- a/src/online2/online-ivector-feature.cc
+++ b/src/online2/online-ivector-feature.cc
@@ -97,7 +97,7 @@ void OnlineIvectorExtractionInfo::Check() const {
 
 // The class constructed in this way should never be used.
 OnlineIvectorExtractionInfo::OnlineIvectorExtractionInfo():
-    ivector_period(0), num_gselect(0), min_post(0.0), posterior_scale(0.0),
+    online_cmvn_iextractor(false), ivector_period(0), num_gselect(0), min_post(0.0), posterior_scale(0.0),
     use_most_recent_ivector(true), greedy_ivector_extractor(false),
     max_remembered_frames(0) { }
 


### PR DESCRIPTION
It took me the better part of the week to find out why our models showed performance regression when our code was linked to more recent kaldi builds.  

I learned a lot about constructors, and finally linking against Kaldi on a mac to demonstrate both the bug and a fix.  See also my comments in #4379 why we implicitly use this constructor That Should Never Be Used. 