### PR TITLE
Add DockerImage for Debian 10

### DIFF
--- a/docker/debian10-cpu/Dockerfile
+++ b/docker/debian10-cpu/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:10
+LABEL maintainer="rick@scriptix.io"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        g++ \
+        make \
+        automake \
+        autoconf \
+        bzip2 \
+        unzip \
+        wget \
+        sox \
+        libtool \
+        git \
+        subversion \
+        python2.7 \
+        python3 \
+        zlib1g-dev \
+        ca-certificates \
+        gfortran \
+        patch \
+        ffmpeg \
+	vim && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN git clone --depth 1 https://github.com/kaldi-asr/kaldi.git /opt/kaldi #EOL
+RUN    cd /opt/kaldi/tools && \
+       ./extras/install_mkl.sh && \
+       make -j $(nproc) && \
+       cd /opt/kaldi/src && \
+       ./configure --shared && \
+       make depend -j $(nproc) && \
+       make -j $(nproc) && \
+       find /opt/kaldi -type f \( -name "*.o" -o -name "*.la" -o -name "*.a" \) -exec rm {} \; && \
+       find /opt/intel -type f -name "*.a" -exec rm {} \; && \
+       find /opt/intel -type f -regex '.*\(_mc.?\|_mic\|_thread\|_ilp64\)\.so' -exec rm {} \; && \
+       rm -rf /opt/kaldi/.git
+WORKDIR /opt/kaldi/


### PR DESCRIPTION
Debian 9 has been EOL for a while now, this PR adds a Dockerfile for Debian 10 which will EOL in 2022.

This Dockerfile is essentially the same as the Debian 9 image with the following exceptions:
  * Base image is `debian:10`
  * Default Python is `python3`
