### PR TITLE
Adding TF32 tensor core support

### DIFF
--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -118,12 +118,32 @@ void CuDevice::Initialize() {
 #endif
     
 #if CUDA_VERSION >= 9000 
+#if CUDA_VERSION >= 11000
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-            CUBLAS_TENSOR_OP_MATH));
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    } else {
+      // Enable TF32 compute mode in CUBLAS by default for tensor core acceleration
+      // Note if the device does not support tensor cores this will fall back to normal math mode
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TF32_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
+#else
+    if (device_options_.use_tensor_cores) {
+      // Enable tensor cores in CUBLAS
+      // Note if the device does not support tensor cores this will fall back to normal math mode
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUDA_R_32F; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    }
+#endif
 #endif
 
     // Initialize the cuSPARSE library
@@ -278,12 +298,32 @@ void CuDevice::FinalizeActiveGpu() {
 #endif
 
 #if CUDA_VERSION >= 9000 
+#if CUDA_VERSION >= 11000
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-            CUBLAS_TENSOR_OP_MATH));
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    } else {
+      // Enable TF32 compute mode in CUBLAS by default for tensor core acceleration
+      // Note if the device does not support tensor cores this will fall back to normal math mode
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TF32_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
+#else
+    if (device_options_.use_tensor_cores) {
+      // Enable tensor cores in CUBLAS
+      // Note if the device does not support tensor cores this will fall back to normal math mode
+      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      //       CUBLAS_TENSOR_OP_MATH));
+      cublas_compute_type_ = CUDA_R_32F; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    }
+#endif
 #endif
 
     

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -119,6 +119,8 @@ void CuDevice::Initialize() {
     
 #if CUDA_VERSION >= 9000 
 #if CUDA_VERSION >= 11000
+    cublas_compute_type_ = CUBLAS_COMPUTE_32F; 
+    cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     // Enable tensor cores in CUBLAS
     // Note if the device does not support tensor cores this will fall back to normal math mode
     if (device_options_.use_tf32_compute) {
@@ -132,6 +134,8 @@ void CuDevice::Initialize() {
         cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
+    cublas_compute_type_ = CUDA_R_32F; 
+    cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
@@ -297,19 +301,23 @@ void CuDevice::FinalizeActiveGpu() {
 
 #if CUDA_VERSION >= 9000 
 #if CUDA_VERSION >= 11000
+    cublas_compute_type_ = CUBLAS_COMPUTE_32F; 
+    cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     // Enable tensor cores in CUBLAS
     // Note if the device does not support tensor cores this will fall back to normal math mode
     if ((properties_.major >= 8) && (device_options_.use_tf32_compute)) {
-        // Use TF32 compute for Ampere Tensor Cores
-        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
-        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+      // Use TF32 compute for Ampere Tensor Cores
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
     if (device_options_.use_tensor_cores) {
-        // Use FP16 compute for pre-Ampere Tensor Cores
-        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
-        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+      // Use FP16 compute for pre-Ampere Tensor Cores
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
+    cublas_compute_type_ = CUDA_R_32F; 
+    cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -119,27 +119,22 @@ void CuDevice::Initialize() {
     
 #if CUDA_VERSION >= 9000 
 #if CUDA_VERSION >= 11000
+    // Enable tensor cores in CUBLAS
+    // Note if the device does not support tensor cores this will fall back to normal math mode
+    if (device_options_.use_tf32_compute) {
+        // Use TF32 compute for Ampere Tensor Cores
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    }
     if (device_options_.use_tensor_cores) {
-      // Enable tensor cores in CUBLAS
-      // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TENSOR_OP_MATH));
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
-      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
-    } else {
-      // Enable TF32 compute mode in CUBLAS by default for tensor core acceleration
-      // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TF32_TENSOR_OP_MATH));
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
-      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+        // Use FP16 compute for pre-Ampere Tensor Cores
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TENSOR_OP_MATH));
       cublas_compute_type_ = CUDA_R_32F; 
       cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
@@ -287,6 +282,9 @@ void CuDevice::FinalizeActiveGpu() {
     device_id_copy_ = device_id;
     initialized_ = true;  // Prevent Initialize() from being called on this,
                           // the main thread.
+
+    CU_SAFE_CALL(cudaGetDeviceProperties(&properties_, device_id));
+
     // Initialize CUBLAS.
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
@@ -299,33 +297,27 @@ void CuDevice::FinalizeActiveGpu() {
 
 #if CUDA_VERSION >= 9000 
 #if CUDA_VERSION >= 11000
+    // Enable tensor cores in CUBLAS
+    // Note if the device does not support tensor cores this will fall back to normal math mode
+    if ((properties_.major >= 8) && (device_options_.use_tf32_compute)) {
+        // Use TF32 compute for Ampere Tensor Cores
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+    }
     if (device_options_.use_tensor_cores) {
-      // Enable tensor cores in CUBLAS
-      // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TENSOR_OP_MATH));
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
-      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
-    } else {
-      // Enable TF32 compute mode in CUBLAS by default for tensor core acceleration
-      // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TF32_TENSOR_OP_MATH));
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
-      cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+        // Use FP16 compute for pre-Ampere Tensor Cores
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+        cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      // CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
-      //       CUBLAS_TENSOR_OP_MATH));
       cublas_compute_type_ = CUDA_R_32F; 
       cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #endif
 #endif
-
     
     // Initialize the cuSPARSE library
     CUSPARSE_SAFE_CALL(cusparseCreate(&cusparse_handle_));
@@ -342,8 +334,6 @@ void CuDevice::FinalizeActiveGpu() {
     // Notify the user which GPU is being userd.
     char name[128];
     DeviceGetName(name,128, device_id);
-
-    CU_SAFE_CALL(cudaGetDeviceProperties(&properties_, device_id));
 
     KALDI_LOG << "The active GPU is [" << device_id << "]: " << name << "\t"
               << GetFreeGpuMemory(&free_memory_at_startup_, NULL) << " version "

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -238,12 +238,20 @@ class CuDevice {
 
   struct CuDeviceOptions {
     bool use_tensor_cores; // Enable tensor cores
-    CuDeviceOptions () : use_tensor_cores(false) {};
+    bool use_tf32_compute; // Switch to TF32 compute mode
+    CuDeviceOptions () : use_tensor_cores(false), use_tf32_compute(false) {};
     void Register(OptionsItf *po) {
       po->Register("cuda-use-tensor-cores", &use_tensor_cores, 
           "Enable FP16 tensor math. "
           "This is higher performance but less accuracy. "
           "This is only recommended for inference.");
+#if CUDA_VERSION >= 11000
+      po->Register("cuda-use-tf32-compute", &use_tf32_compute, 
+          "Enable TF32 tensor math. "
+          "This is higher performance and keeps the same "
+          "dynamic range as FP32 with slightly lower precision."
+          "This is recommended for training over FP16.");
+#endif
     }
   };
 

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -101,6 +101,13 @@ class CuDevice {
     return cusolverdn_handle_; 
   }
 
+#if CUDA_VERSION >= 11000
+  inline cublasComputeType_t GetCublasComputeType() { return cublas_compute_type_; }
+#else
+  inline cudaDataType_t GetCublasComputeType() { return cublas_compute_type_; }
+#endif
+  inline cublasGemmAlgo_t GetCublasGemmAlgo() { return cublas_gemm_algo_; }
+
   inline void SeedGpu() {
     if (CuDevice::Instantiate().Enabled()) {
       // To get same random sequence, call srand() before the method is invoked,
@@ -331,6 +338,13 @@ class CuDevice {
   cusparseHandle_t cusparse_handle_;
   curandGenerator_t curand_handle_;
   cusolverDnHandle_t cusolverdn_handle_;
+
+#if CUDA_VERSION >= 11000
+  cublasComputeType_t cublas_compute_type_;
+#else
+  cudaDataType_t cublas_compute_type_;
+#endif
+  cublasGemmAlgo_t cublas_gemm_algo_;
 }; // class CuDevice
 
 

--- a/src/cudamatrix/cublas-wrappers.h
+++ b/src/cudamatrix/cublas-wrappers.h
@@ -23,6 +23,8 @@
 // Do not include this file directly.  It is to be included
 // by .cc files in this directory.
 
+#include "cudamatrix/cu-device.h"
+
 namespace kaldi {
 #if HAVE_CUDA == 1
 
@@ -31,7 +33,10 @@ inline cublasStatus_t cublas_gemm(
     cublasOperation_t transb, int m, int n,int k, float alpha,
     const float *A, int lda, const float *B, int ldb, float beta,
     float *C, int ldc) {
-  return cublasSgemm_v2(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc);
+  // return cublasSgemm_v2(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc);
+  return cublasGemmEx(handle,transa,transb,m,n,k,&alpha,A,CUDA_R_32F,lda,B,CUDA_R_32F,ldb,&beta,
+                      C,CUDA_R_32F,ldc,CuDevice::Instantiate().GetCublasComputeType(),
+                      CuDevice::Instantiate().GetCublasGemmAlgo());
 }
 inline cublasStatus_t cublas_gemm(
     cublasHandle_t handle, cublasOperation_t transa,
@@ -54,7 +59,10 @@ inline cublasStatus_t cublas_gemmBatched(
     cublasOperation_t transb, int m, int n, int k, float alpha,
     const float *A[], int lda, const float *B[], int ldb, float beta,
     float *C[], int ldc, int batchCount) {
-  return cublasSgemmBatched(handle, transa, transb, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc, batchCount);
+  // return cublasSgemmBatched(handle, transa, transb, m, n, k, &alpha, A, lda, B, ldb, &beta, C, ldc, batchCount);
+  return cublasGemmBatchedEx(handle, transa, transb, m, n, k, &alpha, (void* const*)A, CUDA_R_32F,  lda,
+                             (void* const*)B, CUDA_R_32F, ldb, &beta, (void* const*)C, CUDA_R_32F, ldc, batchCount,
+                             CuDevice::Instantiate().GetCublasComputeType(), CuDevice::Instantiate().GetCublasGemmAlgo());
 }
 inline cublasStatus_t cublas_gemmBatched(
     cublasHandle_t handle, cublasOperation_t transa,

--- a/src/cudamatrix/cublas-wrappers.h
+++ b/src/cudamatrix/cublas-wrappers.h
@@ -33,7 +33,6 @@ inline cublasStatus_t cublas_gemm(
     cublasOperation_t transb, int m, int n,int k, float alpha,
     const float *A, int lda, const float *B, int ldb, float beta,
     float *C, int ldc) {
-  // return cublasSgemm_v2(handle,transa,transb,m,n,k,&alpha,A,lda,B,ldb,&beta,C,ldc);
   return cublasGemmEx(handle,transa,transb,m,n,k,&alpha,A,CUDA_R_32F,lda,B,CUDA_R_32F,ldb,&beta,
                       C,CUDA_R_32F,ldc,CuDevice::Instantiate().GetCublasComputeType(),
                       CuDevice::Instantiate().GetCublasGemmAlgo());


### PR DESCRIPTION
This PR adds [TF32](https://blogs.nvidia.com/blog/2020/05/14/tensorfloat-32-precision-format/) support to `cudamatrix`. TF32 is a compute type with the same dynamic range as single precision and is much more suitable to training, especially in cases where half precision training results in NaN errors due to the lower dynamic range. TF32 support needs CUDA 11+ and Ampere+ GPU architecture, provides up to 8x higher matrix multiply throughput without any significant loss in accuracy. TF32 tensor cores are enabled using the flag `--cuda-use-tf32-compute`.

This PR also updates the use of some deprecated CUDA API for enabling tensor core support.