### PR TITLE
Multiple changes to chain2/train.sh

### DIFF
--- a/egs/mini_librispeech/s5/local/chain2/tuning/run_tdnn_1a.sh
+++ b/egs/mini_librispeech/s5/local/chain2/tuning/run_tdnn_1a.sh
@@ -325,7 +325,7 @@ fi
 if [ $stage -le 22 ]; then
   echo "$0: about to train model"
   steps/chain2/train.sh \
-    --stage $train_stage --cmd "$cuda_cmd" \
+    --stage $train_stage --cmd "$train_cmd" \
     --xent-regularize $xent_regularize --leaky-hmm-coefficient 0.1 \
     --max-param-change 2.0 \
     --num-jobs-initial 2 --num-jobs-final 5 \

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -315,7 +315,7 @@ if [ $stage -le $num_iters ]; then
    fi
 fi
 
-if ! $multilingual_eg -a [ ! -f $dir/final.mdl ]; then
+if [[ ! $multilingual_eg ]] && [[ ! -f $dir/final.mdl ]]; then
   echo "$0: $dir/final.mdl does not exist."
   # we don't want to clean up if the training didn't succeed.
   exit 1;

--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -110,8 +110,7 @@ if [ $stage -le -2 ]; then
 fi
 
 
-# won't work at Idiap
-#if [ "$use_gpu" != "no" ]; then gpu_cmd_opt="--gpu 1"; else gpu_cmd_opt=""; fi
+if [ "$use_gpu" != "no" ]; then gpu_cmd_opt="--gpu 1"; else gpu_cmd_opt=""; fi
 
 num_iters=$(wc -l <$dir/schedule.txt)
 


### PR DESCRIPTION
chain2/train.sh has been changed as follows

- gpu_cmd_opt is set to '--gpu 1' when use_gpu is not no
- regression fix: the final.mdl check had an issue for monolingual scripts after the fix for multilingual models

In addition, in the mini_librispeech recipe, train.sh is called with $train_cmd.

Srikanth