### PR TITLE
[src] Cuda decoder hashmap reset fix, endpointing_ init

### DIFF
--- a/src/cudadecoder/cuda-decoder-kernels-utils.h
+++ b/src/cudadecoder/cuda-decoder-kernels-utils.h
@@ -22,7 +22,7 @@
 #define KALDI_CUDA_DECODER_HASHMAP_NO_KEY -1
 #define KALDI_CUDA_DECODER_HASHMAP_NO_VAL                 \
   {                                                       \
-    KALDI_CUDA_DECODER_HASHMAP_NO_KEY, 0, ULONG_MAX \
+    KALDI_CUDA_DECODER_HASHMAP_NO_KEY, 0, ULLONG_MAX \
   }
 
 #include "util/stl-utils.h"

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -35,6 +35,7 @@ CudaDecoder::CudaDecoder(const CudaFst &fst, const CudaDecoderConfig &config,
                          int32 nlanes, int32 nchannels)
     : word_syms_(NULL),
       generate_partial_hypotheses_(false),
+      endpointing_(false),
       partial_traceback_(false),
       frame_shift_seconds_(FLT_MAX),
       fst_(fst),

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -860,8 +860,8 @@ class CudaDecoder {
   std::atomic<bool> active_wait_;
 
   // Used for sync on partial hypotheses tasks
-  std::atomic<std::uint32_t> n_partial_traceback_threads_todo_;
-  std::atomic<std::uint32_t> n_partial_traceback_threads_not_done_;
+  std::atomic<std::int32_t> n_partial_traceback_threads_todo_;
+  std::atomic<std::int32_t> n_partial_traceback_threads_not_done_;
 
   bool h2h_threads_running_;
   // Using the output from GetBestPath, we add the best tokens (as


### PR DESCRIPTION
Fixing a bug that appears with some compilers, where "unsigned long" is 32bits. Using the max constant for unsigned long long instead. 

Also fixing two "silent" bugs: One init missing, some unsigned values which can become negative.