### PR TITLE
[src] Fix up the legacy dlopen-based CUDA driver calls

### DIFF
--- a/src/cudamatrix/cu-allocator.cc
+++ b/src/cudamatrix/cu-allocator.cc
@@ -237,7 +237,7 @@ void* CuMemoryAllocator::MallocFromSubregion(SubRegion *subregion,
   block->t = t_;
   allocated_block_map_[block->begin] = block;
   allocated_memory_ += (block->end - block->begin);
-  if (allocated_memory_ > max_allocated_memory_) 
+  if (allocated_memory_ > max_allocated_memory_)
     max_allocated_memory_ = allocated_memory_;
   return block->begin;
 }
@@ -283,36 +283,8 @@ static inline size_t IntegerLog2(size_t i) {
 }
 
 std::string GetFreeGpuMemory(int64* free, int64* total) {
-#ifdef _MSC_VER
   size_t mem_free, mem_total;
   cuMemGetInfo_v2(&mem_free, &mem_total);
-#else
-  // define the function signature type
-  size_t mem_free, mem_total;
-  {
-    // we will load cuMemGetInfo_v2 dynamically from libcuda.so
-    // pre-fill ``safe'' values that will not cause problems
-    mem_free = 1; mem_total = 1;
-    // open libcuda.so
-    void* libcuda = dlopen("libcuda.so", RTLD_LAZY);
-    if (NULL == libcuda) {
-      KALDI_WARN << "cannot open libcuda.so";
-    } else {
-      // define the function signature type
-      // and get the symbol
-      typedef CUresult (*cu_fun_ptr)(size_t*, size_t*);
-      cu_fun_ptr dl_cuMemGetInfo = (cu_fun_ptr)dlsym(libcuda,"cuMemGetInfo_v2");
-      if (NULL == dl_cuMemGetInfo) {
-        KALDI_WARN << "cannot load cuMemGetInfo from libcuda.so";
-      } else {
-        // call the function
-        dl_cuMemGetInfo(&mem_free, &mem_total);
-      }
-      // close the library
-      dlclose(libcuda);
-    }
-  }
-#endif
   // copy the output values outside
   if (NULL != free) *free = mem_free;
   if (NULL != total) *total = mem_total;
@@ -376,8 +348,8 @@ void CuMemoryAllocator::PrintMemoryUsage() const {
             << ", synchronized the GPU " << num_synchronizations_
             << " times out of " << (t_/2) << " frees; "
             << "device memory info: " << GetFreeGpuMemory(NULL, NULL)
-            << "maximum allocated: " << max_allocated_memory_  
-            << "current allocated: " << allocated_memory_; 
+            << "maximum allocated: " << max_allocated_memory_
+            << "current allocated: " << allocated_memory_;
 }
 
 // Note: we just initialize with the default options, but we can change it later

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -113,15 +113,15 @@ void CuDevice::Initialize() {
 
 #if CUDA_VERSION >= 9010
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
-    CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_, 
+    CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_,
             cudaStreamPerThread));
 #endif
-    
-#if CUDA_VERSION >= 9000 
+
+#if CUDA_VERSION >= 9000
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_,
             CUBLAS_TENSOR_OP_MATH));
     }
 #endif
@@ -270,27 +270,27 @@ void CuDevice::FinalizeActiveGpu() {
     // Initialize CUBLAS.
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
-    
-#if CUDA_VERSION >= 9010 
+
+#if CUDA_VERSION >= 9010
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
     CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_,
             cudaStreamPerThread));
 #endif
 
-#if CUDA_VERSION >= 9000 
+#if CUDA_VERSION >= 9000
     if (device_options_.use_tensor_cores) {
       // Enable tensor cores in CUBLAS
       // Note if the device does not support tensor cores this will fall back to normal math mode
-      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_, 
+      CUBLAS_SAFE_CALL(cublasSetMathMode(cublas_handle_,
             CUBLAS_TENSOR_OP_MATH));
     }
 #endif
 
-    
+
     // Initialize the cuSPARSE library
     CUSPARSE_SAFE_CALL(cusparseCreate(&cusparse_handle_));
     CUSPARSE_SAFE_CALL(cusparseSetStream(cusparse_handle_, cudaStreamPerThread));
-    
+
     // Initialize the generator,
     CURAND_SAFE_CALL(curandCreateGenerator(
           &curand_handle_, CURAND_RNG_PSEUDO_DEFAULT));
@@ -539,28 +539,7 @@ void CuDevice::PrintProfile() {
 void CuDevice::DeviceGetName(char* name, int32 len, int32 dev) {
   // prefill with something reasonable
   strncpy(name,"Unknown GPU",len);
-#ifdef _MSC_VER
   cuDeviceGetName(name, len, dev);
-#else
-  // open libcuda.so
-  void* libcuda = dlopen("libcuda.so",RTLD_LAZY);
-  if (NULL == libcuda) {
-    KALDI_WARN << "cannot open libcuda.so";
-  } else {
-    // define the function signature type
-    typedef CUresult (*cu_fun_ptr)(char*,int,CUdevice);
-    // get the symbol
-    cu_fun_ptr cuDeviceGetName_ptr = (cu_fun_ptr)dlsym(libcuda,"cuDeviceGetName");
-    if (NULL == cuDeviceGetName_ptr) {
-      KALDI_WARN << "cannot load cuDeviceGetName from libcuda.so";
-    } else {
-      // call the function
-      cuDeviceGetName_ptr(name, len, dev);
-    }
-    // close the library
-    dlclose(libcuda);
-  }
-#endif
 }
 
 
@@ -611,7 +590,7 @@ CuDevice::~CuDevice() {
 // Each thread has its own copy of the CuDevice object.
 // Note: this was declared "static".
 thread_local CuDevice CuDevice::this_thread_device_;
-  
+
 CuDevice::CuDeviceOptions CuDevice::device_options_;
 
 // define and initialize the static members of the CuDevice object.


### PR DESCRIPTION
fixes #4370

* Use the plain extern library functions which are linked at the build time, instead of `dlopen()` to
  load the entire driver library at runtime just to get the device name and memory size.
  - Since there are no other places that use `dlopen()` for CUDA driver calls in the codebase,
    I see no technical reason to stick on it.
  - Using `dlopen()` causes issues with environments with non-standard library configurations.
* Also my editor has removed some trailing whitespaces.
