### PR TITLE
fix a issue in copy_trans_dir.sh

### DIFF
--- a/egs/wsj/s5/steps/copy_trans_dir.sh
+++ b/egs/wsj/s5/steps/copy_trans_dir.sh
@@ -58,7 +58,7 @@ done | sort -k1,1 > $dir/trans_out.scp.aug
 
 if [ "$include_original" == "true" ]; then
   cat $dir/trans_tmp.*.scp | awk '{print $0}' | sort -k1,1 > $dir/trans_out.scp.clean
-  cat $dir/trans_out.scp.clean $dir/trans_out.scp.aug | sort -k1,1 > $dir/trans_out.scp
+  cat $dir/trans_out.scp.clean $dir/trans_out.scp.aug | sort -k1,1 > $dir/trans_out.scp.old
 else
   cat $dir/trans_out.scp.aug | sort -k1,1 > $dir/trans_out.scp.old
 fi


### PR DESCRIPTION
File trans_out.scp.old (used in line 66) is undefined if the condition on line 59 falls into the "then" case. I have fixed it.