### PR TITLE
Set 8 frames per chunk by default

### DIFF
--- a/src/nnet3/decodable-simple-looped.h
+++ b/src/nnet3/decodable-simple-looped.h
@@ -54,7 +54,7 @@ struct NnetSimpleLoopedComputationOptions {
   NnetSimpleLoopedComputationOptions():
       extra_left_context_initial(0),
       frame_subsampling_factor(1),
-      frames_per_chunk(20),
+      frames_per_chunk(24),
       acoustic_scale(0.1),
       debug_computation(false) { }
 


### PR DESCRIPTION
By default we use 20 frames per chunk which results in tensor size 7 for chain models with subsampling 3. With 24 frames per chunk we get tensors of size 8, which ends in slightly faster matrix multiplication.
