### PR TITLE
Add a few fixes for undefined behaviour

### DIFF
--- a/src/base/kaldi-math.cc
+++ b/src/base/kaldi-math.cc
@@ -66,7 +66,7 @@ RandomState::RandomState() {
   // without calling rand() in between, they would give you the same sequence
   // offset by one (if we didn't have the "+ 27437" in the code).  27437 is just
   // a randomly chosen prime number.
-  seed = Rand() + 27437;
+  seed = unsigned(Rand()) + 27437;
 }
 
 bool WithProb(BaseFloat prob, struct RandomState* state) {

--- a/src/decoder/lattice-incremental-decoder.h
+++ b/src/decoder/lattice-incremental-decoder.h
@@ -28,7 +28,7 @@
 #include "lat/determinize-lattice-pruned.h"
 #include "lat/kaldi-lattice.h"
 #include "decoder/grammar-fst.h"
-#include "lattice-faster-decoder.h"
+#include "decoder/lattice-faster-decoder.h"
 
 namespace kaldi {
 /**

--- a/src/fstext/determinize-star-inl.h
+++ b/src/fstext/determinize-star-inl.h
@@ -292,7 +292,7 @@ template<class F> class DeterminizerStar {
       for (typename std::vector<Element>::const_iterator iter = subset->begin();
            iter != subset->end(); ++iter) {
         hash *= factor;
-        hash += iter->state + 103333 * iter->string;
+        hash += iter->state + size_t(103333) * iter->string;
         factor *= 23531;  // these numbers are primes.
       }
       return hash;

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -1328,6 +1328,9 @@ void MatrixBase<Real>::MulColsVec(const VectorBase<Real> &scale) {
 
 template<typename Real>
 void MatrixBase<Real>::SetZero() {
+  // Avoid calling memset on NULL, that's undefined behaviour.
+  if(data_ == NULL) return;
+
   if (num_cols_ == stride_)
     memset(data_, 0, sizeof(Real)*num_rows_*num_cols_);
   else


### PR DESCRIPTION
In building and running Kaldi, I found a few cases of undefined behaviour being triggered. Running with a UB sanitizer, these caused my runs to fail. Two of them have to do with signed plus unsigned integer arithmetic overflowing signed integers, and one of them is memset(NULL, 0). The last change here is an include change to match the style used everywhere else in Kaldi (this also caused a failure in my use of Kaldi). 