### PR TITLE
Revision of #4387

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -39,7 +39,7 @@
 
 # This should be incremented after any significant change to the configure
 # script, i.e. any change affecting kaldi.mk or the build system as a whole.
-CONFIGURE_VERSION=11
+CONFIGURE_VERSION=12
 
 # We support bash version 3.2 (Macs still ship with this version as of 2019)
 # and above.

--- a/src/cudamatrix/cu-allocator.cc
+++ b/src/cudamatrix/cu-allocator.cc
@@ -237,7 +237,7 @@ void* CuMemoryAllocator::MallocFromSubregion(SubRegion *subregion,
   block->t = t_;
   allocated_block_map_[block->begin] = block;
   allocated_memory_ += (block->end - block->begin);
-  if (allocated_memory_ > max_allocated_memory_) 
+  if (allocated_memory_ > max_allocated_memory_)
     max_allocated_memory_ = allocated_memory_;
   return block->begin;
 }
@@ -283,36 +283,8 @@ static inline size_t IntegerLog2(size_t i) {
 }
 
 std::string GetFreeGpuMemory(int64* free, int64* total) {
-#ifdef _MSC_VER
   size_t mem_free, mem_total;
   cuMemGetInfo_v2(&mem_free, &mem_total);
-#else
-  // define the function signature type
-  size_t mem_free, mem_total;
-  {
-    // we will load cuMemGetInfo_v2 dynamically from libcuda.so
-    // pre-fill ``safe'' values that will not cause problems
-    mem_free = 1; mem_total = 1;
-    // open libcuda.so
-    void* libcuda = dlopen("libcuda.so", RTLD_LAZY);
-    if (NULL == libcuda) {
-      KALDI_WARN << "cannot open libcuda.so";
-    } else {
-      // define the function signature type
-      // and get the symbol
-      typedef CUresult (*cu_fun_ptr)(size_t*, size_t*);
-      cu_fun_ptr dl_cuMemGetInfo = (cu_fun_ptr)dlsym(libcuda,"cuMemGetInfo_v2");
-      if (NULL == dl_cuMemGetInfo) {
-        KALDI_WARN << "cannot load cuMemGetInfo from libcuda.so";
-      } else {
-        // call the function
-        dl_cuMemGetInfo(&mem_free, &mem_total);
-      }
-      // close the library
-      dlclose(libcuda);
-    }
-  }
-#endif
   // copy the output values outside
   if (NULL != free) *free = mem_free;
   if (NULL != total) *total = mem_total;
@@ -376,8 +348,8 @@ void CuMemoryAllocator::PrintMemoryUsage() const {
             << ", synchronized the GPU " << num_synchronizations_
             << " times out of " << (t_/2) << " frees; "
             << "device memory info: " << GetFreeGpuMemory(NULL, NULL)
-            << "maximum allocated: " << max_allocated_memory_  
-            << "current allocated: " << allocated_memory_; 
+            << "maximum allocated: " << max_allocated_memory_
+            << "current allocated: " << allocated_memory_;
 }
 
 // Note: we just initialize with the default options, but we can change it later

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -113,24 +113,24 @@ void CuDevice::Initialize() {
 
 #if CUDA_VERSION >= 9010
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
-    CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_, 
+    CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_,
             cudaStreamPerThread));
 #endif
-    
-#if CUDA_VERSION >= 9000 
+
+#if CUDA_VERSION >= 9000
 #if CUDA_VERSION >= 11000
-    cublas_compute_type_ = CUBLAS_COMPUTE_32F; 
+    cublas_compute_type_ = CUBLAS_COMPUTE_32F;
     cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     // Enable tensor cores in CUBLAS
     // Note if the device does not support tensor cores this will fall back to normal math mode
     if (device_options_.use_tf32_compute) {
         // Use TF32 compute for Ampere Tensor Cores
-        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32;
         cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
     if (device_options_.use_tensor_cores) {
         // Use FP16 compute for pre-Ampere Tensor Cores
-        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+        cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F;
         cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
@@ -288,27 +288,27 @@ void CuDevice::FinalizeActiveGpu() {
     // Initialize CUBLAS.
     CUBLAS_SAFE_CALL(cublasCreate(&cublas_handle_));
     CUBLAS_SAFE_CALL(cublasSetStream(cublas_handle_, cudaStreamPerThread));
-    
-#if CUDA_VERSION >= 9010 
+
+#if CUDA_VERSION >= 9010
     CUSOLVER_SAFE_CALL(cusolverDnCreate(&cusolverdn_handle_));
     CUSOLVER_SAFE_CALL(cusolverDnSetStream(cusolverdn_handle_,
             cudaStreamPerThread));
 #endif
 
-#if CUDA_VERSION >= 9000 
+#if CUDA_VERSION >= 9000
 #if CUDA_VERSION >= 11000
-    cublas_compute_type_ = CUBLAS_COMPUTE_32F; 
+    cublas_compute_type_ = CUBLAS_COMPUTE_32F;
     cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT;
     // Enable tensor cores in CUBLAS
     // Note if the device does not support tensor cores this will fall back to normal math mode
     if ((properties_.major >= 8) && (device_options_.use_tf32_compute)) {
       // Use TF32 compute for Ampere Tensor Cores
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32; 
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_TF32;
       cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
     if (device_options_.use_tensor_cores) {
       // Use FP16 compute for pre-Ampere Tensor Cores
-      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F; 
+      cublas_compute_type_ = CUBLAS_COMPUTE_32F_FAST_16F;
       cublas_gemm_algo_ = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
     }
 #else
@@ -318,11 +318,11 @@ void CuDevice::FinalizeActiveGpu() {
     }
 #endif
 #endif
-    
+
     // Initialize the cuSPARSE library
     CUSPARSE_SAFE_CALL(cusparseCreate(&cusparse_handle_));
     CUSPARSE_SAFE_CALL(cusparseSetStream(cusparse_handle_, cudaStreamPerThread));
-    
+
     // Initialize the generator,
     CURAND_SAFE_CALL(curandCreateGenerator(
           &curand_handle_, CURAND_RNG_PSEUDO_DEFAULT));
@@ -569,28 +569,7 @@ void CuDevice::PrintProfile() {
 void CuDevice::DeviceGetName(char* name, int32 len, int32 dev) {
   // prefill with something reasonable
   strncpy(name,"Unknown GPU",len);
-#ifdef _MSC_VER
   cuDeviceGetName(name, len, dev);
-#else
-  // open libcuda.so
-  void* libcuda = dlopen("libcuda.so",RTLD_LAZY);
-  if (NULL == libcuda) {
-    KALDI_WARN << "cannot open libcuda.so";
-  } else {
-    // define the function signature type
-    typedef CUresult (*cu_fun_ptr)(char*,int,CUdevice);
-    // get the symbol
-    cu_fun_ptr cuDeviceGetName_ptr = (cu_fun_ptr)dlsym(libcuda,"cuDeviceGetName");
-    if (NULL == cuDeviceGetName_ptr) {
-      KALDI_WARN << "cannot load cuDeviceGetName from libcuda.so";
-    } else {
-      // call the function
-      cuDeviceGetName_ptr(name, len, dev);
-    }
-    // close the library
-    dlclose(libcuda);
-  }
-#endif
 }
 
 
@@ -641,7 +620,7 @@ CuDevice::~CuDevice() {
 // Each thread has its own copy of the CuDevice object.
 // Note: this was declared "static".
 thread_local CuDevice CuDevice::this_thread_device_;
-  
+
 CuDevice::CuDeviceOptions CuDevice::device_options_;
 
 // define and initialize the static members of the CuDevice object.

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -13,7 +13,7 @@ CUDA_FLAGS = --compiler-options -fPIC --machine 64 -DHAVE_CUDA \
              -std=c++14 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -lineinfo \
              --verbose -Wno-deprecated-gpu-targets
 
-CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-CUDA_LDFLAGS += -L$(CUDATKDIR)/lib -Wl,-rpath,$(CUDATKDIR)/lib
+CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64/stubs -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
+CUDA_LDFLAGS += -L$(CUDATKDIR)/lib/stubs -L$(CUDATKDIR)/lib -Wl,-rpath,$(CUDATKDIR)/lib
 
-CUDA_LDLIBS += -lcublas -lcusparse -lcudart -lcurand -lcufft -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcuda -lcublas -lcusparse -lcudart -lcurand -lcufft -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule


### PR DESCRIPTION
This is a revision of #4387 reverted by #4396, with fixes to the Makefile fragments to correctly link the CUDA driver symbols.
Since the NVIDIA driver and CUDA toolkit may be installed separately (e.g., during `docker build`, the container images have the CUDA toolkit only but not the driver), NVIDIA ships a symbol-only stub libraries for the driver to allow compilation of CUDA programs that uses the driver API directly.
Those symbol-only stub libraries are located under `$(CUDATKDIR)/lib64/stubs`, and at runtime they are resolved to actual driver-provided files (e.g., in containers launched via `nvidia-docker` with GPU assignments).