### PR TITLE
Remove unused stats in batched-wav-nnet3-cuda2

### DIFF
--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -127,8 +127,6 @@ int main(int argc, char *argv[]) {
     }
 
     int32 num_task_submitted = 0, num_err = 0;
-    double tot_like = 0.0;
-    int64 num_frames = 0;
     double total_audio = 0;
 
     nvtxRangePush("Global Timer");
@@ -177,8 +175,6 @@ int main(int argc, char *argv[]) {
 
     KALDI_LOG << "Decoded " << num_task_submitted << " utterances, " << num_err
               << " with errors.";
-    KALDI_LOG << "Overall likelihood per frame was " << (tot_like / num_frames)
-              << " per frame over " << num_frames << " frames.";
 
     KALDI_LOG << "Overall: "
               << " Aggregate Total Time: " << total_time


### PR DESCRIPTION
Fix for #4390

We were printing values that were not actually computed. Removing them for now. It seems like a very aggregated value anyway (likelihood per frame across all utterances) - not sure if there is much information left in that single value.