### PR TITLE
[src] Reduce scope of lock in cuda dynamic batcher

### DIFF
--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -28,7 +28,7 @@ CudaOnlinePipelineDynamicBatcher::CudaOnlinePipelineDynamicBatcher(
     CudaOnlinePipelineDynamicBatcherConfig config,
     BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline)
     : config_(config),
-      n_chunks_in_queue_(0),
+      n_chunks_not_done_(0),
       run_batcher_thread_(true),
       cuda_pipeline_(cuda_pipeline),
       max_batch_size_(cuda_pipeline.GetConfig().max_batch_size),
@@ -47,65 +47,73 @@ void CudaOnlinePipelineDynamicBatcher::Push(
     const SubVector<BaseFloat> &wave_samples) {
   std::lock_guard<std::mutex> lk(chunks_m_);
   chunks_.push_back({corr_id, is_first_chunk, is_last_chunk, wave_samples});
-  n_chunks_in_queue_.fetch_add(1);
+  n_chunks_not_done_.fetch_add(1);
 }
 
 void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
   Timer timer;
   double next_timeout_at = timer.Elapsed() + config_.dynamic_batcher_timeout;
   while (run_batcher_thread_) {
-    if (n_chunks_in_queue_.load() >= max_batch_size_ ||
+    if (n_chunks_not_done_.load() >= max_batch_size_ ||
         timer.Elapsed() >= next_timeout_at) {
-      // push batch
-      std::lock_guard<std::mutex> lk(chunks_m_);
       int curr_batch_size = 0;
-      is_corr_id_in_batch_.clear();
-      batch_corr_ids_.clear();
-      batch_is_first_chunk_.clear();
-      batch_is_last_chunk_.clear();
-      batch_wave_samples_.clear();
-      for (auto it = chunks_.begin(); it != chunks_.end();) {
-        CorrelationID corr_id = it->corr_id;
-        bool corr_id_not_in_batch;
-        decltype(is_corr_id_in_batch_.end()) is_corr_id_in_batch_it;
-        std::tie(is_corr_id_in_batch_it, corr_id_not_in_batch) =
-            is_corr_id_in_batch_.insert(corr_id);
-        if (corr_id_not_in_batch) {
-          if (it->is_first_chunk) {
-            if (!cuda_pipeline_.TryInitCorrID(corr_id, 0)) {
-              KALDI_LOG << "All decoding channels are in use. Consider "
-                           "increasing --num-channels";
-              is_corr_id_in_batch_.erase(
-                  is_corr_id_in_batch_it);  // this elt won't be in the batch
-              ++it;  // Ignoring this elt, we'll retry later
-              continue;
+      // create batch
+      {
+        std::lock_guard<std::mutex> lk(chunks_m_);
+        // Following assert would not be valid if we had multiple consumer
+        // threads (equality not verified while DecodeBatch is running)
+        KALDI_ASSERT(n_chunks_not_done_.load() == chunks_.size());
+        is_corr_id_in_batch_.clear();
+        batch_corr_ids_.clear();
+        batch_is_first_chunk_.clear();
+        batch_is_last_chunk_.clear();
+        batch_wave_samples_.clear();
+        for (auto it = chunks_.begin(); it != chunks_.end();) {
+          CorrelationID corr_id = it->corr_id;
+          bool corr_id_not_in_batch;
+          decltype(is_corr_id_in_batch_.end()) is_corr_id_in_batch_it;
+          std::tie(is_corr_id_in_batch_it, corr_id_not_in_batch) =
+              is_corr_id_in_batch_.insert(corr_id);
+          if (corr_id_not_in_batch) {
+            if (it->is_first_chunk) {
+              if (!cuda_pipeline_.TryInitCorrID(corr_id, 0)) {
+                KALDI_LOG << "All decoding channels are in use. Consider "
+                             "increasing --num-channels";
+                is_corr_id_in_batch_.erase(
+                    is_corr_id_in_batch_it);  // this elt won't be in the batch
+                ++it;  // Ignoring this elt, we'll retry later
+                continue;
+              }
             }
+            // first chunk with this corr_id in batch
+            ++curr_batch_size;
+
+            batch_corr_ids_.push_back(it->corr_id);
+            batch_is_first_chunk_.push_back(it->is_first_chunk);
+            batch_is_last_chunk_.push_back(it->is_last_chunk);
+            batch_wave_samples_.push_back(it->wave_samples);
+
+            it = chunks_.erase(it);
+            if (curr_batch_size == max_batch_size_) break;
+          } else {
+            // Ignoring this element, we already have this corr_id in batch
+            ++it;
           }
-          // first chunk with this corr_id in batch
-          ++curr_batch_size;
-
-          batch_corr_ids_.push_back(it->corr_id);
-          batch_is_first_chunk_.push_back(it->is_first_chunk);
-          batch_is_last_chunk_.push_back(it->is_last_chunk);
-          batch_wave_samples_.push_back(it->wave_samples);
-
-          it = chunks_.erase(it);
-          if (curr_batch_size == max_batch_size_) break;
-        } else {
-          // Ignoring this element, we already have this corr_id in batch
-          ++it;
         }
       }
+
+      // Batch created, push batch
       if (curr_batch_size > 0) {
         // KALDI_LOG << "Online Cuda pipeline decoding batch of size "
         //          << curr_batch_size;
         cuda_pipeline_.DecodeBatch(batch_corr_ids_, batch_wave_samples_,
                                    batch_is_first_chunk_, batch_is_last_chunk_);
+        n_chunks_not_done_.fetch_sub(curr_batch_size,
+                                     std::memory_order_release);
       }
       timer.Reset();  // to avoid some kind of overflow..
       next_timeout_at = timer.Elapsed() + config_.dynamic_batcher_timeout;
 
-      n_chunks_in_queue_.store(chunks_.size());
       // process callbacks here
     } else {
       usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
@@ -115,7 +123,7 @@ void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
 
 void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
   // Waiting for the batcher to be done sending work to pipeline
-  while (n_chunks_in_queue_.load() > 0) {
+  while (n_chunks_not_done_.load() > 0) {
     usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
   }
   // Waiting for pipeline to complete

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -61,7 +61,7 @@ class CudaOnlinePipelineDynamicBatcher {
   std::unordered_set<CorrelationID> is_corr_id_in_batch_;
   std::unordered_set<CorrelationID> is_corr_id_in_use_;
   std::mutex chunks_m_;
-  std::atomic<std::uint32_t> n_chunks_in_queue_;  // equals to chunks.size(), lock free
+  std::atomic<std::uint32_t> n_chunks_not_done_;  // chunks not yet computed
   bool run_batcher_thread_;
   std::unique_ptr<std::thread> batcher_thread_;
   BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline_;


### PR DESCRIPTION
Currently, in the cuda dynamic batcher, a lock is held during batch decoding, preventing calls to Push() with new chunks to execute. Reducing the scope of the lock to improve performance.