### PR TITLE
skip_kenlm_module_in_cmake

### DIFF
--- a/cmake/gen_cmake_skeleton.py
+++ b/cmake/gen_cmake_skeleton.py
@@ -26,7 +26,7 @@ def is_bin_dir(d):
     return d.endswith("bin")
 
 def get_files(d):
-    return [name for name in os.listdir(d) if os.path.isfile(os.path.join(d, name))]
+    return [name for name in os.listdir(d) if os.path.isfile(os.path.join(d, name)) and ('kenlm' not in name)]
 
 def is_header(f):
     return f.endswith(".h")

--- a/cmake/gen_cmake_skeleton.py
+++ b/cmake/gen_cmake_skeleton.py
@@ -8,6 +8,7 @@ import argparse
 
 # avoid Python>3 rewrite newline on different platforms
 os.linesep = "\n"
+EXCLUDE_FILES = ['kenlm.h', 'kenlm.cc', 'kenlm-test.cc']
 
 # earily parse, will refernece args globally
 parser = argparse.ArgumentParser()
@@ -26,7 +27,7 @@ def is_bin_dir(d):
     return d.endswith("bin")
 
 def get_files(d):
-    return [name for name in os.listdir(d) if os.path.isfile(os.path.join(d, name)) and ('kenlm' not in name)]
+    return [name for name in os.listdir(d) if os.path.isfile(os.path.join(d, name)) and (name not in EXCLUDE_FILES)]
 
 def is_header(f):
     return f.endswith(".h")


### PR DESCRIPTION
Fixing:
* CMake building failure due to automatic detection of KenLM as a building target(mentioned in https://github.com/kaldi-asr/kaldi/pull/4247)

Code Changes:
* cmake/gen_cmake_skeleton.py: excludes KenLM related source files from CMake building targets

Testing:
* MacOS: Now CMake builds smoothly.

@nshmyrev Nickolay, please help to review and see if this fixes the problem in your building environment. I believe a clean-removal of out-of-tree "build dir", and rebuild with CMake from the beginning should be fine now.