### PR TITLE
[src] Disable legacy cuda offline binary for jetson devices

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -367,6 +367,7 @@ Either your CUDA is too new or too old."
     echo CUDA = true >> kaldi.mk
     echo CUDATKDIR = $CUDATKDIR >> kaldi.mk
     echo "CUDA_ARCH = $CUDA_ARCH" >> kaldi.mk
+    echo "HOST_ARCH = `uname -m`" >> kaldi.mk
     echo >> kaldi.mk
 
     # 64bit/32bit? We do not support cross compilation with CUDA so, use direct

--- a/src/cudadecoderbin/Makefile
+++ b/src/cudadecoderbin/Makefile
@@ -14,7 +14,12 @@ LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
 EXTRA_LDLIBS += -lrt
 
-BINFILES = batched-wav-nnet3-cuda batched-wav-nnet3-cuda2 batched-wav-nnet3-cuda-online
+BINFILES = batched-wav-nnet3-cuda2 batched-wav-nnet3-cuda-online online2-wav-nnet3-latgen-faster-threaded
+
+# The legacy batched-wav-nnet3-cuda contains some cuda calls not available on Jetson devices
+ifeq ($(HOST_ARCH), x86_64)
+  BINFILES += batched-wav-nnet3-cuda 
+endif
 
 OBJFILES =
 


### PR DESCRIPTION
Related to https://groups.google.com/g/kaldi-help/c/5M8DRRjDP8E/m/wDQ5YAWaAAAJ

Disabling the legacy offline binary for jetson (arm) devices. The "2" version can be used.