### PR TITLE
[src] Removing extra binary in cudadecoderbin makefile

### DIFF
--- a/src/cudadecoderbin/Makefile
+++ b/src/cudadecoderbin/Makefile
@@ -14,7 +14,7 @@ LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
 EXTRA_LDLIBS += -lrt
 
-BINFILES = batched-wav-nnet3-cuda2 batched-wav-nnet3-cuda-online online2-wav-nnet3-latgen-faster-threaded
+BINFILES = batched-wav-nnet3-cuda2 batched-wav-nnet3-cuda-online
 
 # The legacy batched-wav-nnet3-cuda contains some cuda calls not available on Jetson devices
 ifeq ($(HOST_ARCH), x86_64)


### PR DESCRIPTION
Removing an extra binary from the Makefile that doesn't exist in the main branch.