### PR TITLE
Changes needed to get Kaldi compiled on Win and

### DIFF
--- a/cmake/FindBLAS.cmake
+++ b/cmake/FindBLAS.cmake
@@ -457,9 +457,15 @@ if(BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
         endif()
       endif()
       set(BLAS_mkl_LIB_PATH_SUFFIXES
-          "compiler/lib" "compiler/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
-          "mkl/lib" "mkl/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
-          "lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}")
+          "compiler/lib"
+          "compiler/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "compiler/lib/${BLAS_mkl_ARCH_NAME}"
+          "mkl/lib"
+          "mkl/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "mkl/lib/${BLAS_mkl_ARCH_NAME}"
+          "lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "lib/${BLAS_mkl_ARCH_NAME}"
+      )
 
       foreach(IT ${BLAS_SEARCH_LIBS})
         string(REPLACE " " ";" SEARCH_LIBS ${IT})

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -565,7 +565,6 @@ void BatchedThreadedNnet3CudaOnlinePipeline::FinalizeDecoding(
 void BatchedThreadedNnet3CudaOnlinePipeline::WaitForLatticeCallbacks() {
   while (n_lattice_callbacks_not_done_.load() != 0)
     std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_CALLBACKS_US));
-
 }
 }  // namespace cuda_decoder
 }  // namespace kaldi

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -26,6 +26,7 @@
 #include "feat/feature-window.h"
 #include "lat/lattice-functions.h"
 #include "nnet3/nnet-utils.h"
+#include <numeric>
 
 namespace kaldi {
 namespace cuda_decoder {
@@ -123,7 +124,7 @@ bool BatchedThreadedNnet3CudaOnlinePipeline::TryInitCorrID(
       int waited_for = 0;
       while (waited_for < wait_for) {
         lk.unlock();
-        usleep(KALDI_CUDA_DECODER_WAIT_FOR_AVAILABLE_CHANNEL_US);
+        std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_AVAILABLE_CHANNEL_US));
         waited_for += KALDI_CUDA_DECODER_WAIT_FOR_AVAILABLE_CHANNEL_US;
         lk.lock();
         channel_available = (available_channels_.size() > 0);
@@ -204,7 +205,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeCPUFeatureExtraction(
   }
 
   while (n_compute_features_not_done_.load(std::memory_order_acquire))
-    usleep(KALDI_CUDA_DECODER_WAIT_FOR_CPU_FEATURES_THREADS_US);
+      std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_CPU_FEATURES_THREADS_US));
 
   KALDI_ASSERT(d_all_features_.NumRows() == h_all_features_.NumRows() &&
                d_all_features_.NumCols() == h_all_features_.NumCols());
@@ -563,7 +564,8 @@ void BatchedThreadedNnet3CudaOnlinePipeline::FinalizeDecoding(
 
 void BatchedThreadedNnet3CudaOnlinePipeline::WaitForLatticeCallbacks() {
   while (n_lattice_callbacks_not_done_.load() != 0)
-    usleep(KALDI_CUDA_DECODER_WAIT_FOR_CALLBACKS_US);
+    std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_CALLBACKS_US));
+
 }
 }  // namespace cuda_decoder
 }  // namespace kaldi

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
@@ -146,7 +146,7 @@ void BatchedThreadedNnet3CudaPipeline2::BuildBatchFromCurrentTasks() {
 
 void BatchedThreadedNnet3CudaPipeline2::WaitForAllTasks() {
   while (n_tasks_not_done_.load() != 0) {
-    usleep(KALDI_CUDA_DECODER_WAIT_FOR_TASKS_US);
+    std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_TASKS_US));
   }
 }
 
@@ -179,7 +179,7 @@ void BatchedThreadedNnet3CudaPipeline2::WaitForGroup(const std::string &group) {
   }
 
   while (n_not_done->load(std::memory_order_consume) != 0)
-    usleep(KALDI_CUDA_DECODER_WAIT_FOR_TASKS_US);
+    std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_TASKS_US));
 }
 
 void BatchedThreadedNnet3CudaPipeline2::CreateTask(
@@ -445,7 +445,7 @@ void BatchedThreadedNnet3CudaPipeline2::ComputeTasks() {
     if (current_tasks_.size() < max_batch_size_) AcquireTasks();
     if (current_tasks_.empty()) {
       // If we still have nothing to do, let's sleep a bit
-      usleep(KALDI_CUDA_DECODER_WAIT_FOR_NEW_TASKS_US);
+      std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_WAIT_FOR_NEW_TASKS_US));
       continue;
     }
     BuildBatchFromCurrentTasks();

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -901,7 +901,7 @@ void CudaDecoder::WaitForPartialHypotheses() {
   if (!generate_partial_hypotheses_) return;
   while (n_partial_traceback_threads_not_done_.load(std::memory_order_acquire) >
          0)
-    usleep(200);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
 }
 
 void CudaDecoder::CheckOverflow() {

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -907,7 +907,7 @@ void CudaDecoder::WaitForPartialHypotheses() {
 void CudaDecoder::CheckOverflow() {
   for (LaneId ilane = 0; ilane < nlanes_used_; ++ilane) {
     LaneCounters *lane_counters = h_lanes_counters_.lane(ilane);
-    bool q_overflow = lane_counters->q_overflow;
+    int q_overflow = lane_counters->q_overflow;
     if (q_overflow != OVERFLOW_NONE) {
       // An overflow was prevented in a kernel
       // The algorithm can still go on but quality of the

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -144,8 +144,8 @@ struct CudaDecoderConfig {
 // Forward declaration.
 // Those contains CUDA code. We don't want to include their definition
 // in this header
-class DeviceParams;
-class KernelParams;
+struct DeviceParams;
+struct KernelParams;
 
 class CudaDecoder {
  public:

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -16,8 +16,9 @@
 // limitations under the License.
 
 #include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
+#ifndef WIN32
 #include <unistd.h>
-
+#endif
 // Tries to generate a batch every n us
 #define KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US 100
 
@@ -116,7 +117,7 @@ void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
 
       // process callbacks here
     } else {
-      usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
+        std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US));
     }
   }
 }
@@ -124,7 +125,7 @@ void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
 void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
   // Waiting for the batcher to be done sending work to pipeline
   while (n_chunks_not_done_.load() > 0) {
-    usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
+    std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US));
   }
   // Waiting for pipeline to complete
   cuda_pipeline_.WaitForLatticeCallbacks();

--- a/src/cudadecoder/thread-pool-light.h
+++ b/src/cudadecoder/thread-pool-light.h
@@ -99,7 +99,7 @@ class ThreadPoolLightWorker {
         (curr_task_.func_ptr)(curr_task_.obj_ptr, curr_task_.arg1,
                               curr_task_.arg2);
       } else {
-        usleep(1000);  // TODO
+          std::this_thread::sleep_for(std::chrono::microseconds(1000));  // TODO
       }
     }
   }
@@ -159,7 +159,7 @@ class ThreadPoolLight {
   void Push(const ThreadPoolLightTask &task) {
     // Could try another curr_iworker_
     while (!TryPush(task))
-      usleep(KALDI_CUDA_DECODER_THREAD_POOL_QUEUE_FULL_WAIT_FOR_US);
+      std::this_thread::sleep_for(std::chrono::microseconds(KALDI_CUDA_DECODER_THREAD_POOL_QUEUE_FULL_WAIT_FOR_US));
   }
 };
 

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #include <queue>
+#include <chrono>
 #if HAVE_CUDA == 1
 
 #include <cuda.h>
@@ -214,7 +215,9 @@ int main(int argc, char *argv[]) {
       auto chunk = streams.top();
       streams.pop();
       double wait_for = chunk.send_next_chunk_at - timer.Elapsed();
-      if (wait_for > 0) usleep(wait_for * 1e6);
+      if (wait_for > 0) 
+          std::this_thread::sleep_for(std::chrono::microseconds(int64(wait_for * 1e6)));
+          
 
       SubVector<BaseFloat> data(chunk.wav->Data(), 0);
 

--- a/src/cudadecoderbin/cuda-bin-tools.h
+++ b/src/cudadecoderbin/cuda-bin-tools.h
@@ -18,6 +18,7 @@
 #include <iomanip>
 #include <iostream>
 #include <vector>
+#include <numeric>
 #include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
 #include "cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h"
 #include "cudadecoder/cuda-pipeline-common.h"

--- a/src/fstbin/fstdeterminizestar.cc
+++ b/src/fstbin/fstdeterminizestar.cc
@@ -129,7 +129,7 @@ int main(int argc, char *argv[]) {
             // of scope anyway.
           }
           fst_writer.Write(key, fst);
-        } catch (const std::runtime_error &e) {
+        } catch (const std::runtime_error &) {
           KALDI_WARN << "Error during determinization for key " << key;
         }
       }

--- a/src/latbin/lattice-expand.cc
+++ b/src/latbin/lattice-expand.cc
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
               << (n_arcs_in/den) << " to " << (n_arcs_out/den) << " arcs, over "
               << n_done << " utterances.";
     KALDI_LOG << "Overall, " << static_cast<BaseFloat>(n_expanded)/n_done * 100
-              << "\% percentage of lattices get expanded.";
+              << "% percentage of lattices get expanded.";
     KALDI_LOG << "Processed " << n_done << " lattices with " << n_err
               << " failures.";
     return (n_done != 0 ? 0 : 1);

--- a/src/nnet/nnet-sentence-averaging-component.h
+++ b/src/nnet/nnet-sentence-averaging-component.h
@@ -89,7 +89,7 @@ class SimpleSentenceAveragingComponent : public Component {
           // from now 'only_summing_' is 'bool':
           try {
             ReadBasicType(is, binary, &only_summing_);
-          } catch(const std::exception &e) {
+          } catch(const std::exception &) {
             KALDI_WARN << "ERROR was handled by exception!";
             BaseFloat dummy_float;
             ReadBasicType(is, binary, &dummy_float);

--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -2312,7 +2312,7 @@ void MaxChangeStats::Print(const Nnet &nnet) const {
                   << ", per-component max-change was enforced "
                   << ((100.0 * num_max_change_per_component_applied[i]) /
                       num_minibatches_processed)
-                  << " \% of the time.";
+                  << " % of the time.";
       i++;
     }
   }
@@ -2320,7 +2320,7 @@ void MaxChangeStats::Print(const Nnet &nnet) const {
     KALDI_LOG << "The global max-change was enforced "
               << ((100.0 * num_max_change_global_applied) /
                   num_minibatches_processed)
-              << " \% of the time.";
+              << " % of the time.";
 }
 
 

--- a/src/util/kaldi-table-test.cc
+++ b/src/util/kaldi-table-test.cc
@@ -1065,7 +1065,7 @@ void UnitTestTableNumpyArray() {
   writer.Write(key1, NumpyArray<BaseFloat>(v));
   writer.Write(key2, NumpyArray<BaseFloat>(m));
   writer.Close();
-  usleep(200);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
 
   const char* rspecifier = "scp:numpy_array.scp";
   {


### PR DESCRIPTION
*usleep does not exist on windows and this_thread::sleep is platform-independent way how to do this.
*the new Intel OneAPI (rebranded MKL and Compiler) changed a bit the directory structure. Also should be backward compatible.
*Will be grateful if someone will test on linux...

Signed-off-by: Jan "Yenda" Trmal <yenda@kalditek.com>