### PR TITLE
Fix condition for copying default transition model in chain2 training

### DIFF
--- a/egs/wsj/s5/steps/nnet3/chain2/train.sh
+++ b/egs/wsj/s5/steps/nnet3/chain2/train.sh
@@ -130,7 +130,7 @@ if [ $stage -le -1 ]; then
   if [ $num_langs -eq 1 ]; then
       echo "$0: Num langs is 1"
       cp $dir/init/default.raw $dir/0.raw
-      if [ ! -f $dir/init/default_trans.mdl ]; then
+      if [ ! -f $dir/0_trans.mdl ]; then
           cp $dir/init/default_trans.mdl $dir/0_trans.mdl 
       fi
   else


### PR DESCRIPTION
A recent PR (https://github.com/kaldi-asr/kaldi/pull/4413) fixed an issue, but introduced another one.  As is, the condition does not make sense ("if the file '$dir/init/default_trans.mdl' does NOT exist, copy that file to another"). I propose to change it so that the copy only happens if the target does not exist yet.