### PR TITLE
[src] making the cuda dynamic batcher long stream friendly

### DIFF
--- a/src/cudadecoder/batched-static-nnet3.cc
+++ b/src/cudadecoder/batched-static-nnet3.cc
@@ -18,6 +18,7 @@
 #if HAVE_CUDA == 1
 
 #include "cudadecoder/batched-static-nnet3.h"
+
 #include "nnet3/nnet-utils.h"
 
 namespace kaldi {
@@ -299,11 +300,14 @@ void BatchedStaticNnet3::RunBatch(
     CuMatrix<BaseFloat> *d_all_log_posteriors,
     std::vector<std::vector<std::pair<int, BaseFloat *>>>
         *all_frames_log_posteriors_ptrs) {
-  KALDI_ASSERT(d_features.size() == channels.size());
-  KALDI_ASSERT(is_last_chunk.size() == channels.size());
-  KALDI_ASSERT(is_first_chunk.size() == channels.size());
+  // Using >= to avoid having to recompute d_features
+  // In some cases the ptrs in d_features and d_ivectors are always the same,
+  // but the number of active channels vary
+  KALDI_ASSERT(d_features.size() >= channels.size());
+  KALDI_ASSERT(is_last_chunk.size() >= channels.size());
+  KALDI_ASSERT(is_first_chunk.size() >= channels.size());
   if (has_ivector_) {
-    KALDI_ASSERT(d_ivectors.size() == channels.size());
+    KALDI_ASSERT(d_ivectors.size() >= channels.size());
   }
   // Initializing the new channels
   for (size_t i = 0; i < is_first_chunk.size(); ++i) {

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -22,7 +22,9 @@
 #define KALDI_CUDA_DECODER_WAIT_FOR_AVAILABLE_CHANNEL_US 1000
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
+
 #include <nvToolsExt.h>
+
 #include "feat/feature-window.h"
 #include "lat/lattice-functions.h"
 #include "nnet3/nnet-utils.h"
@@ -57,6 +59,10 @@ void BatchedThreadedNnet3CudaOnlinePipeline::AllocateAndInitializeData(
     h_all_ivectors_.Resize(max_batch_size_, ivector_dim_, kSetZero,
                            kStrideEqualNumCols);
   }
+
+  // Set d_features_ptrs_, d_ivectors_ptrs_, features_frame_stride_
+  // to be used with DecodeBatch
+  SetFeaturesPtrs();
 
   d_all_log_posteriors_.Resize(max_batch_size_ * output_frames_per_chunk_,
                                trans_model_->NumPdfs(), kUndefined);
@@ -158,11 +164,8 @@ bool BatchedThreadedNnet3CudaOnlinePipeline::TryInitCorrID(
   return true;
 }  // namespace cuda_decoder
 
-void BatchedThreadedNnet3CudaOnlinePipeline::ComputeGPUFeatureExtraction(
-    const std::vector<int> &channels,
-    const std::vector<SubVector<BaseFloat>> &wave_samples,
-    const std::vector<bool> &is_first_chunk,
-    const std::vector<bool> &is_last_chunk) {
+void BatchedThreadedNnet3CudaOnlinePipeline::CompactWavesToMatrix(
+    const std::vector<SubVector<BaseFloat>> &wave_samples) {
   for (int i = 0; i < wave_samples.size(); ++i) {
     const SubVector<BaseFloat> &src = wave_samples[i];
     int size = src.Dim();
@@ -171,10 +174,18 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeGPUFeatureExtraction(
     BaseFloat *wave_dst = h_all_waveform_.RowData(i);
     std::memcpy(wave_dst, wave_src, size * sizeof(BaseFloat));
   }
+}
+
+void BatchedThreadedNnet3CudaOnlinePipeline::ComputeGPUFeatureExtraction(
+    const std::vector<int> &channels, const Matrix<BaseFloat> &h_all_waveform,
+    const std::vector<int> &n_samples_valid,
+    const std::vector<bool> &is_first_chunk,
+    const std::vector<bool> &is_last_chunk) {
   // CopyFromMat syncs, avoiding it
-  KALDI_ASSERT(d_all_waveform_.SizeInBytes() == h_all_waveform_.SizeInBytes());
-  cudaMemcpyAsync(d_all_waveform_.Data(), h_all_waveform_.Data(),
-                  h_all_waveform_.SizeInBytes(), cudaMemcpyHostToDevice,
+  KALDI_ASSERT(d_all_waveform_.SizeInBytes() == h_all_waveform.SizeInBytes());
+  // Note : we could have smaller copies using the actual channels.size()
+  cudaMemcpyAsync(d_all_waveform_.Data(), h_all_waveform.Data(),
+                  h_all_waveform.SizeInBytes(), cudaMemcpyHostToDevice,
                   cudaStreamPerThread);
 
   KALDI_ASSERT(channels.size() == is_last_chunk.size());
@@ -182,18 +193,20 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeGPUFeatureExtraction(
 
   KALDI_ASSERT(gpu_feature_pipeline_);
   gpu_feature_pipeline_->ComputeFeaturesBatched(
-      channels.size(), channels, n_samples_valid_, is_first_chunk,
-      is_last_chunk, model_frequency_, d_all_waveform_, &d_all_features_,
-      &d_all_ivectors_, &n_input_frames_valid_);
+      channels.size(), channels, n_samples_valid, is_first_chunk, is_last_chunk,
+      model_frequency_, d_all_waveform_, &d_all_features_, &d_all_ivectors_,
+      &n_input_frames_valid_);
 }
 
 void BatchedThreadedNnet3CudaOnlinePipeline::ComputeCPUFeatureExtraction(
-    const std::vector<int> &channels,
-    const std::vector<SubVector<BaseFloat>> &wave_samples,
+    const std::vector<int> &channels, const Matrix<BaseFloat> &h_all_waveform,
+    const std::vector<int> &n_samples_valid,
     const std::vector<bool> &is_last_chunk) {
   // Will be used by worker threads to grab work
+
   fe_threads_channels_ = &channels;
-  fe_threads_wave_samples_ = &wave_samples;
+  fe_threads_h_all_waveform_ = &h_all_waveform;
+  fe_threads_n_samples_valid_ = &n_samples_valid;
 
   n_compute_features_not_done_.store(channels.size());
 
@@ -222,15 +235,79 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeCPUFeatureExtraction(
 
 void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
     const std::vector<CorrelationID> &corr_ids,
+    const Matrix<BaseFloat> &h_all_waveform,
+    const std::vector<int> &n_samples_valid,
+    const std::vector<bool> &is_first_chunk,
+    const std::vector<bool> &is_last_chunk,
+    std::vector<const std::string *> *in_partial_hypotheses,
+    std::vector<bool> *in_end_points) {
+  KALDI_ASSERT(corr_ids.size() > 0);
+  KALDI_ASSERT(corr_ids.size() <= h_all_waveform.NumRows());
+  KALDI_ASSERT(corr_ids.size() == is_last_chunk.size());
+  ListIChannelsInBatch(corr_ids, &channels_);
+
+  // Feature extraction
+  if (config_.use_gpu_feature_extraction) {
+    ComputeGPUFeatureExtraction(channels_, h_all_waveform, n_samples_valid,
+                                is_first_chunk, is_last_chunk);
+  } else {
+    ComputeCPUFeatureExtraction(channels_, h_all_waveform, n_samples_valid,
+                                is_last_chunk);
+  }
+
+  // Calling DecodeBatch with computed features
+  DecodeBatch(corr_ids, d_features_ptrs_, features_frame_stride_,
+              n_input_frames_valid_, d_ivectors_ptrs_, is_first_chunk,
+              is_last_chunk, &channels_, in_partial_hypotheses, in_end_points);
+}
+
+void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
+    const std::vector<CorrelationID> &corr_ids,
     const std::vector<SubVector<BaseFloat>> &wave_samples,
     const std::vector<bool> &is_first_chunk,
     const std::vector<bool> &is_last_chunk,
     std::vector<const std::string *> *in_partial_hypotheses,
     std::vector<bool> *in_end_points) {
-  nvtxRangePushA("DecodeBatch");
   KALDI_ASSERT(corr_ids.size() > 0);
   KALDI_ASSERT(corr_ids.size() == wave_samples.size());
   KALDI_ASSERT(corr_ids.size() == is_last_chunk.size());
+  ListIChannelsInBatch(corr_ids, &channels_);
+
+  // Compact in h_all_waveform_ to use the main DecodeBatch version
+  CompactWavesToMatrix(wave_samples);
+
+  DecodeBatch(corr_ids, h_all_waveform_, n_samples_valid_, is_first_chunk,
+              is_last_chunk, in_partial_hypotheses, in_end_points);
+}
+
+void BatchedThreadedNnet3CudaOnlinePipeline::SetFeaturesPtrs() {
+  d_features_ptrs_.clear();
+  d_ivectors_ptrs_.clear();
+  for (int i = 0; i < max_batch_size_; ++i) {
+    d_features_ptrs_.push_back(d_all_features_.Data() +
+                               i * input_frames_per_chunk_ *
+                                   d_all_features_.Stride());
+    if (use_ivectors_) {
+      d_ivectors_ptrs_.push_back(d_all_ivectors_.Data() + i * ivector_dim_);
+    }
+  }
+  features_frame_stride_ = d_all_features_.Stride();
+}
+
+void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
+    const std::vector<CorrelationID> &corr_ids,
+    const std::vector<BaseFloat *> &d_features, const int features_frame_stride,
+    const std::vector<int> &n_input_frames_valid,
+    const std::vector<BaseFloat *> &d_ivectors,
+    const std::vector<bool> &is_first_chunk,
+    const std::vector<bool> &is_last_chunk, std::vector<int> *channels,
+    std::vector<const std::string *> *in_partial_hypotheses,
+    std::vector<bool> *in_end_points) {
+  nvtxRangePushA("DecodeBatch");
+  if (!channels) {
+    channels = &channels_;
+    ListIChannelsInBatch(corr_ids, channels);
+  }
 
   partial_hypotheses_ = in_partial_hypotheses;
   end_points_ = in_end_points;
@@ -241,43 +318,6 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
       if (!partial_hypotheses_) partial_hypotheses_ = &partial_hypotheses_buf_;
       if (!end_points_) end_points_ = &end_points_buf_;
     }
-  }
-
-  ListIChannelsInBatch(corr_ids, &channels_);
-
-  if (config_.use_gpu_feature_extraction)
-    ComputeGPUFeatureExtraction(channels_, wave_samples, is_first_chunk,
-                                is_last_chunk);
-  else
-    ComputeCPUFeatureExtraction(channels_, wave_samples, is_last_chunk);
-
-  d_features_ptrs_.clear();
-  d_ivectors_ptrs_.clear();
-  for (int i = 0; i < channels_.size(); ++i) {
-    d_features_ptrs_.push_back(d_all_features_.Data() +
-                               i * input_frames_per_chunk_ *
-                                   d_all_features_.Stride());
-    if (use_ivectors_) {
-      d_ivectors_ptrs_.push_back(d_all_ivectors_.Data() + i * ivector_dim_);
-    }
-  }
-  int features_frame_stride = d_all_features_.Stride();
-  DecodeBatch(corr_ids, d_features_ptrs_, features_frame_stride,
-              n_input_frames_valid_, d_ivectors_ptrs_, is_first_chunk,
-              is_last_chunk, &channels_);
-}
-
-void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
-    const std::vector<CorrelationID> &corr_ids,
-    const std::vector<BaseFloat *> &d_features, const int features_frame_stride,
-    const std::vector<int> &n_input_frames_valid,
-    const std::vector<BaseFloat *> &d_ivectors,
-    const std::vector<bool> &is_first_chunk,
-    const std::vector<bool> &is_last_chunk, std::vector<int> *channels) {
-  nvtxRangePushA("DecodeBatch");
-  if (!channels) {
-    channels = &channels_;
-    ListIChannelsInBatch(corr_ids, channels);
   }
 
   list_channels_first_chunk_.clear();
@@ -323,8 +363,10 @@ void BatchedThreadedNnet3CudaOnlinePipeline::DecodeBatch(
 }
 
 void BatchedThreadedNnet3CudaOnlinePipeline::ComputeOneFeature(int element) {
-  const SubVector<BaseFloat> &wave_samples =
-      (*fe_threads_wave_samples_)[element];
+  const int nsamples = (*fe_threads_n_samples_valid_)[element];
+  const SubVector<BaseFloat> wave_samples(
+      (*fe_threads_h_all_waveform_).RowData(element), nsamples);
+
   const int ichannel = (*fe_threads_channels_)[element];
   OnlineNnet2FeaturePipeline &feature_pipeline = *feature_pipelines_[ichannel];
   // KALDI_ASSERT("Mismatch sample frequency/model frequency" &&
@@ -335,6 +377,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeOneFeature(int element) {
       "this.GetNSampsPerChunk()" &&
       wave_samples.Dim() <= samples_per_chunk_);
   int32 start_iframe = feature_pipeline.NumFramesReady();
+
   feature_pipeline.AcceptWaveform(model_frequency_, wave_samples);
 
   // All frames should be ready here
@@ -359,7 +402,7 @@ void BatchedThreadedNnet3CudaOnlinePipeline::ComputeOneFeature(int element) {
   n_input_frames_valid_[element] = nframes;
 
   n_compute_features_not_done_.fetch_sub(1, std::memory_order_release);
-}
+}  // namespace cuda_decoder
 
 void BatchedThreadedNnet3CudaOnlinePipeline::RunCallbacksAndFinalize(
     const std::vector<CorrelationID> &corr_ids,

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -193,28 +193,34 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
       std::vector<const std::string *> *partial_hypotheses = nullptr,
       std::vector<bool> *end_point = nullptr);
 
+  void CompactWavesToMatrix(
+      const std::vector<SubVector<BaseFloat>> &wave_samples);
+
   // Version providing directly the features. Only runs nnet3 & decoder
   // Used when we want to provide the final ivectors (offline case)
   // channels can be provided if they are known (internal use)
-  void DecodeBatch(const std::vector<CorrelationID> &corr_ids,
-                   const std::vector<BaseFloat *> &d_features,
-                   const int features_frame_stride,
-                   const std::vector<int> &n_input_frames_valid,
-                   const std::vector<BaseFloat *> &d_ivectors,
-                   const std::vector<bool> &is_first_chunk,
-                   const std::vector<bool> &is_last_chunk,
-                   std::vector<int> *channels = NULL);
-
-  void ComputeGPUFeatureExtraction(
-      const std::vector<int> &channels,
-      const std::vector<SubVector<BaseFloat>> &wave_samples,
+  void DecodeBatch(
+      const std::vector<CorrelationID> &corr_ids,
+      const std::vector<BaseFloat *> &d_features,
+      const int features_frame_stride,
+      const std::vector<int> &n_input_frames_valid,
+      const std::vector<BaseFloat *> &d_ivectors,
       const std::vector<bool> &is_first_chunk,
-      const std::vector<bool> &is_last_chunk);
+      const std::vector<bool> &is_last_chunk, std::vector<int> *channels = NULL,
+      std::vector<const std::string *> *partial_hypotheses = nullptr,
+      std::vector<bool> *end_point = nullptr);
 
-  void ComputeCPUFeatureExtraction(
-      const std::vector<int> &channels,
-      const std::vector<SubVector<BaseFloat>> &wave_samples,
-      const std::vector<bool> &is_last_chunk);
+  // "Advanced user" version of DecodeBatch
+  // Can be changed without notice and break backward compatibility
+  // Accepts a compact Matrix of wave samples
+  void DecodeBatch(
+      const std::vector<CorrelationID> &corr_ids,
+      const Matrix<BaseFloat> &h_all_waveform,
+      const std::vector<int> &n_samples_valid,
+      const std::vector<bool> &is_first_chunk,
+      const std::vector<bool> &is_last_chunk,
+      std::vector<const std::string *> *in_partial_hypotheses = nullptr,
+      std::vector<bool> *in_end_points = nullptr);
 
   // Maximum number of samples per chunk
   int32 GetNSampsPerChunk() const { return samples_per_chunk_; }
@@ -256,19 +262,29 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // Filling  curr_batch_ichannels_
   void ListIChannelsInBatch(const std::vector<CorrelationID> &corr_ids,
                             std::vector<int> *channels);
-  void CPUFeatureExtraction(
-      const std::vector<int> &channels,
-      const std::vector<SubVector<BaseFloat>> &wave_samples);
+
+  void ComputeGPUFeatureExtraction(const std::vector<int> &channels,
+                                   const Matrix<BaseFloat> &h_all_waveform,
+                                   const std::vector<int> &n_samples_valid,
+                                   const std::vector<bool> &is_first_chunk,
+                                   const std::vector<bool> &is_last_chunk);
+
+  void ComputeCPUFeatureExtraction(const std::vector<int> &channels,
+                                   const Matrix<BaseFloat> &h_all_waveform,
+                                   const std::vector<int> &n_samples_valid,
+                                   const std::vector<bool> &is_last_chunk);
 
   // Compute features and ivectors for the chunk
   // curr_batch[element]
   // CPU function
   void ComputeOneFeature(int element);
+
   static void ComputeOneFeatureWrapper(void *obj, uint64_t element,
                                        void *ignored) {
     static_cast<BatchedThreadedNnet3CudaOnlinePipeline *>(obj)
         ->ComputeOneFeature(element);
   }
+
   void RunNnet3(const std::vector<int> &channels,
                 const std::vector<BaseFloat *> &d_features,
                 const int feature_stride,
@@ -282,6 +298,9 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   void RunCallbacksAndFinalize(const std::vector<CorrelationID> &corr_ids,
                                const std::vector<int> &channels,
                                const std::vector<bool> &is_last_chunk);
+
+  // Set d_features_ptrs_ and d_ivectors_ptrs_ using channels_
+  void SetFeaturesPtrs();
 
   // If an utterance is done, we call FinalizeDecoding async on
   // the threadpool
@@ -376,11 +395,13 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // Current assignement buffers, when DecodeBatch is running
   std::vector<int> channels_;
   std::vector<BaseFloat *> d_features_ptrs_;
+  int features_frame_stride_;  // stride of d_features_ptrs_
   std::vector<BaseFloat *> d_ivectors_ptrs_;
 
   // Used by CPU FE threads. Could be merged with channels_
   const std::vector<int> *fe_threads_channels_;
-  const std::vector<SubVector<BaseFloat>> *fe_threads_wave_samples_;
+  const Matrix<BaseFloat> *fe_threads_h_all_waveform_;
+  const std::vector<int> *fe_threads_n_samples_valid_;
 
   std::unique_ptr<OnlineBatchedFeaturePipelineCuda> gpu_feature_pipeline_;
   std::unique_ptr<BatchedStaticNnet3> cuda_nnet3_;

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
@@ -22,6 +22,7 @@
 #define KALDI_CUDA_DECODER_WAIT_FOR_NEW_TASKS_US 100
 
 #include <nvToolsExt.h>
+
 #include "cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h"
 
 namespace kaldi {

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
+
 #include <unistd.h>
 
 // Tries to generate a batch every n us
@@ -28,11 +29,17 @@ CudaOnlinePipelineDynamicBatcher::CudaOnlinePipelineDynamicBatcher(
     CudaOnlinePipelineDynamicBatcherConfig config,
     BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline)
     : config_(config),
-      n_chunks_not_done_(0),
       run_batcher_thread_(true),
       cuda_pipeline_(cuda_pipeline),
+      n_chunks_not_done_(0),
       max_batch_size_(cuda_pipeline.GetConfig().max_batch_size),
       num_channels_(cuda_pipeline.GetConfig().num_channels) {
+  curr_batch_.reset(
+      new Batch(max_batch_size_, cuda_pipeline.GetNSampsPerChunk()));
+
+  next_batch_.reset(
+      new Batch(max_batch_size_, cuda_pipeline.GetNSampsPerChunk()));
+
   batcher_thread_.reset(new std::thread(
       &CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop, this));
 }
@@ -44,10 +51,76 @@ CudaOnlinePipelineDynamicBatcher::~CudaOnlinePipelineDynamicBatcher() {
 
 void CudaOnlinePipelineDynamicBatcher::Push(
     CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
-    const SubVector<BaseFloat> &wave_samples) {
-  std::lock_guard<std::mutex> lk(chunks_m_);
-  chunks_.push_back({corr_id, is_first_chunk, is_last_chunk, wave_samples});
-  n_chunks_not_done_.fetch_add(1);
+    const SubVector<BaseFloat> &wave_samples_subv) {
+  std::lock_guard<std::mutex> lk(next_batch_and_backlog_m_);
+
+  // Try to add the chunk is the batch right away
+  if (!TryAddChunkToNextBatchDeepCopy(corr_id, is_first_chunk, is_last_chunk,
+                                      wave_samples_subv)) {
+    // If we cannot add the chunk to the next batch,
+    // put it in the backlog
+    Vector<BaseFloat> wave_samples(wave_samples_subv);  // deep copy
+    backlog_.push_back(
+        {corr_id, is_first_chunk, is_last_chunk, std::move(wave_samples)});
+  }
+  n_chunks_not_done_.fetch_add(1, std::memory_order_release);
+}
+
+bool CudaOnlinePipelineDynamicBatcher::TryAddChunkToNextBatchDeepCopy(
+    CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
+    const VectorBase<BaseFloat> &wave_samples) {
+  // Assuming the thread executing this owns next_batch_and_backlog_m_
+
+  if (next_batch_->Size() == max_batch_size_) {
+    return false;
+  }  // batch is full
+
+  bool corr_id_not_in_batch;
+  decltype(next_batch_->is_corr_id_in_batch.end()) is_corr_id_in_batch_it;
+  std::tie(is_corr_id_in_batch_it, corr_id_not_in_batch) =
+      next_batch_->is_corr_id_in_batch.insert(corr_id);
+  if (!corr_id_not_in_batch) {
+    // We already have that corr_id in batch
+    // not adding it for now
+    return false;
+  }
+
+  if (is_first_chunk) {
+    // Initialize this stream
+    if (!cuda_pipeline_.TryInitCorrID(corr_id, 0)) {
+      KALDI_LOG << "All decoding channels are in use. Consider "
+                   "increasing --num-channels";
+      next_batch_->is_corr_id_in_batch.erase(
+          is_corr_id_in_batch_it);  // this elt won't be in the batch
+      return false;
+    }
+  }
+
+  // If everything looks good, skipping the backlog_ and adding directly to the
+  // next batch
+  // Deep copy of wave_samples
+  next_batch_->PushBack(corr_id, is_first_chunk, is_last_chunk, wave_samples);
+
+  return true;
+}
+
+void CudaOnlinePipelineDynamicBatcher::FillNextBatchWithBacklog() {
+  // Assuming this thread owns next_batch_and_backlog_m_
+
+  for (auto it = backlog_.begin(); it != backlog_.end(); /* nothing */) {
+    if (next_batch_->Size() == max_batch_size_) break;
+
+    if (TryAddChunkToNextBatchDeepCopy(it->corr_id, it->is_first_chunk,
+                                       it->is_last_chunk, it->wave_samples)) {
+      // This chunk made it into the batch
+      // Removing it from the backlog
+      it = backlog_.erase(it);
+    } else {
+      // Cannot add chunk to batch
+      // Will retry later
+      ++it;
+    }
+  }
 }
 
 void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
@@ -56,70 +129,38 @@ void CudaOnlinePipelineDynamicBatcher::BatcherThreadLoop() {
   while (run_batcher_thread_) {
     if (n_chunks_not_done_.load() >= max_batch_size_ ||
         timer.Elapsed() >= next_timeout_at) {
-      int curr_batch_size = 0;
-      // create batch
+      // Time to run the batch
       {
-        std::lock_guard<std::mutex> lk(chunks_m_);
-        // Following assert would not be valid if we had multiple consumer
-        // threads (equality not verified while DecodeBatch is running)
-        KALDI_ASSERT(n_chunks_not_done_.load() == chunks_.size());
-        is_corr_id_in_batch_.clear();
-        batch_corr_ids_.clear();
-        batch_is_first_chunk_.clear();
-        batch_is_last_chunk_.clear();
-        batch_wave_samples_.clear();
-        for (auto it = chunks_.begin(); it != chunks_.end();) {
-          CorrelationID corr_id = it->corr_id;
-          bool corr_id_not_in_batch;
-          decltype(is_corr_id_in_batch_.end()) is_corr_id_in_batch_it;
-          std::tie(is_corr_id_in_batch_it, corr_id_not_in_batch) =
-              is_corr_id_in_batch_.insert(corr_id);
-          if (corr_id_not_in_batch) {
-            if (it->is_first_chunk) {
-              if (!cuda_pipeline_.TryInitCorrID(corr_id, 0)) {
-                KALDI_LOG << "All decoding channels are in use. Consider "
-                             "increasing --num-channels";
-                is_corr_id_in_batch_.erase(
-                    is_corr_id_in_batch_it);  // this elt won't be in the batch
-                ++it;  // Ignoring this elt, we'll retry later
-                continue;
-              }
-            }
-            // first chunk with this corr_id in batch
-            ++curr_batch_size;
-
-            batch_corr_ids_.push_back(it->corr_id);
-            batch_is_first_chunk_.push_back(it->is_first_chunk);
-            batch_is_last_chunk_.push_back(it->is_last_chunk);
-            batch_wave_samples_.push_back(it->wave_samples);
-
-            it = chunks_.erase(it);
-            if (curr_batch_size == max_batch_size_) break;
-          } else {
-            // Ignoring this element, we already have this corr_id in batch
-            ++it;
-          }
-        }
-      }
+        // lock protects next_batch_, backlog_
+        std::lock_guard<std::mutex> lk(next_batch_and_backlog_m_);
+        std::swap(curr_batch_, next_batch_);
+        // We will soon run curr_batch_
+        // Before releasing the lock, we'll add the backlog to next_batch_
+        // Once the lock is released, Push(..) will start adding things in
+        // next_batch_
+        // We want to preserve FIFO property, so considering the backlog first
+        FillNextBatchWithBacklog();
+      }  // lock_guard
 
       // Batch created, push batch
-      if (curr_batch_size > 0) {
-        // KALDI_LOG << "Online Cuda pipeline decoding batch of size "
-        //          << curr_batch_size;
-        cuda_pipeline_.DecodeBatch(batch_corr_ids_, batch_wave_samples_,
-                                   batch_is_first_chunk_, batch_is_last_chunk_);
-        n_chunks_not_done_.fetch_sub(curr_batch_size,
+      if (curr_batch_->Size() > 0) {
+        cuda_pipeline_.DecodeBatch(
+            curr_batch_->corr_ids, curr_batch_->h_all_waveform,
+            curr_batch_->n_samples_valid, curr_batch_->is_first_chunk,
+            curr_batch_->is_last_chunk);
+        n_chunks_not_done_.fetch_sub(curr_batch_->Size(),
                                      std::memory_order_release);
+
+        curr_batch_->Clear();
       }
+
       timer.Reset();  // to avoid some kind of overflow..
       next_timeout_at = timer.Elapsed() + config_.dynamic_batcher_timeout;
-
-      // process callbacks here
     } else {
       usleep(KALDI_CUDA_DECODER_DYNAMIC_BATCHER_LOOP_US);
     }
   }
-}
+}  // namespace cuda_decoder
 
 void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
   // Waiting for the batcher to be done sending work to pipeline

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+
 #include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
 
 namespace kaldi {
@@ -35,47 +36,99 @@ struct CudaOnlinePipelineDynamicBatcherConfig {
 };
 
 class CudaOnlinePipelineDynamicBatcher {
+  typedef BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID CorrelationID;
+
+  // Batches created by this Batcher
+  struct Batch {
+    std::vector<CorrelationID> corr_ids;
+    std::vector<bool> is_first_chunk;
+    std::vector<bool> is_last_chunk;
+    Matrix<BaseFloat> h_all_waveform;
+    std::vector<int> n_samples_valid;
+    std::unordered_set<CorrelationID> is_corr_id_in_batch;
+
+    Batch(int max_batch_size, int max_samps_per_chunk) {
+      h_all_waveform.Resize(max_batch_size, max_samps_per_chunk, kUndefined,
+                            kStrideEqualNumCols);
+      // TODO use cudaHostRegister, check cudaDevAttrHostRegisterSupported
+    }
+
+    void Clear() {
+      corr_ids.clear();
+      is_first_chunk.clear();
+      is_last_chunk.clear();
+      n_samples_valid.clear();
+      is_corr_id_in_batch.clear();
+    }
+
+    // Adding chunk to the batch. Deep copy of samples
+    void PushBack(CorrelationID corr_id, bool is_first, bool is_last,
+                  const VectorBase<BaseFloat> &samples) {
+      size_t idx = corr_ids.size();
+      KALDI_ASSERT(idx < h_all_waveform.NumRows());
+      corr_ids.push_back(corr_id);
+      is_first_chunk.push_back(is_first);
+      is_last_chunk.push_back(is_last);
+      int nsamples = samples.Dim();
+      const BaseFloat *wave_src = samples.Data();
+      BaseFloat *wave_dst = h_all_waveform.RowData(idx);
+      std::memcpy(wave_dst, wave_src, nsamples * sizeof(BaseFloat));
+      n_samples_valid.push_back(nsamples);
+    }
+
+    size_t Size() { return corr_ids.size(); }
+  };
+
  public:
   CudaOnlinePipelineDynamicBatcher(
       CudaOnlinePipelineDynamicBatcherConfig config,
       BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline);
-  typedef BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID CorrelationID;
 
   virtual ~CudaOnlinePipelineDynamicBatcher();
+
+  // Push a new chunk to the dynamic batcher
+  // the wave_samples will be deep copied,
+  // the caller can safely reuse or free wave_samples's storage after Push's
+  // return
   void Push(CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
             const SubVector<BaseFloat> &wave_samples);
-
   void WaitForCompletion();
 
  private:
+  // Either add to next_batch_ or to backlog_
+  bool TryAddChunkToNextBatchDeepCopy(
+      CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
+      const VectorBase<BaseFloat> &wave_samples);
+
+  // When we start building a fresh (empty) batch,
+  // we'll first add what we can from the backlog_
+  // (FIFO)
+  void FillNextBatchWithBacklog();
+
   CudaOnlinePipelineDynamicBatcherConfig config_;
   struct Chunk {
     CorrelationID corr_id;
     bool is_first_chunk;
     bool is_last_chunk;
-    SubVector<BaseFloat> wave_samples;
+    Vector<BaseFloat> wave_samples;  // deep copy, owns data
   };
 
   void BatcherThreadLoop();
-  std::list<Chunk> chunks_;
-  std::unordered_set<CorrelationID> is_corr_id_in_batch_;
-  std::unordered_set<CorrelationID> is_corr_id_in_use_;
-  std::mutex chunks_m_;
-  std::atomic<std::uint32_t> n_chunks_not_done_;  // chunks not yet computed
+  std::list<Chunk> backlog_;
+  // Protects both next_batch_ and backlog_
+  std::mutex next_batch_and_backlog_m_;
   bool run_batcher_thread_;
   std::unique_ptr<std::thread> batcher_thread_;
   BatchedThreadedNnet3CudaOnlinePipeline &cuda_pipeline_;
 
-  std::vector<CorrelationID> batch_corr_ids_;
-  std::vector<bool> batch_is_first_chunk_;
-  std::vector<bool> batch_is_last_chunk_;
-  std::vector<SubVector<BaseFloat>> batch_wave_samples_;
-
   std::vector<const std::string *> partial_hypotheses_;
   std::vector<bool> end_points_;
+  std::atomic<std::uint32_t> n_chunks_not_done_;
 
   int max_batch_size_;
   int num_channels_;
+
+  std::unique_ptr<Batch> curr_batch_, next_batch_;
 };
 
 }  // end namespace cuda_decoder


### PR DESCRIPTION
The function Push(..) of the dynamic batcher now guarantees that a deep copy of the samples will be done. So that the caller doesn't have to deal with lifetime/deallocation of the samples. 
Taking the opportunity to also improve performance of the set "batcher + pipeline".

A "TODO' is intentionally left in the code. A line can be added to improve performance of the H2D copy, but I'll take care of it in a future commit.