### PR TITLE
fix cast type in rnnlm-lattice-rescoring

### DIFF
--- a/src/rnnlm/rnnlm-lattice-rescoring.cc
+++ b/src/rnnlm/rnnlm-lattice-rescoring.cc
@@ -94,7 +94,7 @@ bool KaldiRnnlmDeterministicFst::GetArc(StateId s, Label ilabel,
   }
 
   std::pair<const std::vector<Label>, StateId> wseq_state_pair(
-      word_seq, static_cast<Label>(state_to_wseq_.size()));
+      word_seq, static_cast<StateId>(state_to_wseq_.size()));
 
   // Attemps to insert the current <wseq_state_pair>. If the pair already exists
   // then it returns false.


### PR DESCRIPTION
Fix a simple cast type mistake in rnnlm-lattice-rescoring. It's no harm, as both StateId and Label are int32 for StdArc.