### PR TITLE
[src] Compile cudadecoder binaries on Windows

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -21,10 +21,14 @@
 #ifndef KALDI_BASE_KALDI_UTILS_H_
 #define KALDI_BASE_KALDI_UTILS_H_ 1
 
-#if defined(_MSC_VER)
-# define WIN32_LEAN_AND_MEAN
-# define NOMINMAX
-# include <windows.h>
+#if _MSC_VER
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX 1
+#endif
+#include <windows.h>
 #endif
 
 #ifdef _MSC_VER
@@ -88,7 +92,7 @@ inline int MachineIsLittleEndian() {
 // This function kaldi::Sleep() provides a portable way
 // to sleep for a possibly fractional
 // number of seconds.  On Windows it's only accurate to microseconds.
-void Sleep(float seconds);
+void Sleep(double seconds);
 }
 
 #define KALDI_SWAP8(a) do { \

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
+#ifndef KALDI_CUDADECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_
+#define KALDI_CUDADECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_
 
-#ifndef KALDI_CUDA_DECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_
-#define KALDI_CUDA_DECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_
+#if HAVE_CUDA
 
 #define KALDI_CUDA_DECODER_MIN_NCHANNELS_FACTOR 2
 
@@ -427,5 +427,5 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
 }  // end namespace cuda_decoder
 }  // end namespace kaldi.
 
-#endif  // KALDI_CUDA_DECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_
 #endif  // HAVE_CUDA
+#endif  // KALDI_CUDADECODER_BATCHED_THREADED_CUDA_ONLINE_PIPELINE_H_

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
@@ -15,9 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !HAVE_CUDA
+#error CUDA support must be configured to compile this library.
+#endif
+
 #define SLEEP_BACKOFF_NS 500
 #define SLEEP_BACKOFF_S ((double)SLEEP_BACKOFF_NS / 1e9)
-#if HAVE_CUDA == 1
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-pipeline.h"
 #include <nvToolsExt.h>
@@ -965,5 +968,3 @@ void BatchedThreadedNnet3CudaPipeline::ExecuteWorker(int threadId) {
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
-
-#endif  // HAVE_CUDA == 1

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -48,7 +48,7 @@ namespace cuda_decoder {
  */
 // configuration options common to the BatchedThreadedNnet3CudaPipeline and
 // BatchedThreadedNnet3CudaPipeline
-struct BatchedThreadedNnet3CudaPipelineConfig {
+struct [[deprecated]] BatchedThreadedNnet3CudaPipelineConfig {
   BatchedThreadedNnet3CudaPipelineConfig()
       : max_batch_size(200),
         num_channels(-1),
@@ -136,7 +136,7 @@ struct BatchedThreadedNnet3CudaPipelineConfig {
  * decoding. For examples of how to use this decoder see cudadecoder/README and
  * cudadecoderbin/batched-wav-nnet3-cuda.cc
  */
-class BatchedThreadedNnet3CudaPipeline {
+class [[deprecated]] BatchedThreadedNnet3CudaPipeline {
  public:
   BatchedThreadedNnet3CudaPipeline(
       const BatchedThreadedNnet3CudaPipelineConfig &config)

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
-
 #ifndef KALDI_CUDA_DECODER_BATCHED_THREADED_NNET3_CUDA_PIPELINE2_H_
 #define KALDI_CUDA_DECODER_BATCHED_THREADED_NNET3_CUDA_PIPELINE2_H_
+
+#if HAVE_CUDA
 
 #include <atomic>
 #include <thread>
@@ -241,5 +241,5 @@ class BatchedThreadedNnet3CudaPipeline2 {
 }  // end namespace cuda_decoder
 }  // namespace kaldi
 
-#endif  // KALDI_CUDA_DECODER_BATCHED_THREADED_CUDA_DECODER_H_
 #endif  // HAVE_CUDA
+#endif  // KALDI_CUDA_DECODER_BATCHED_THREADED_CUDA_DECODER_H_

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -15,8 +15,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_CUDA_DECODER_CUDA_DECODER_H_
-#define KALDI_CUDA_DECODER_CUDA_DECODER_H_
+#ifndef KALDI_CUDADECODER_CUDA_DECODER_H_
+#define KALDI_CUDADECODER_CUDA_DECODER_H_
+
+#if HAVE_CUDA
+
+#include <cuda_runtime_api.h>
+
+#include <cfloat>
+#include <mutex>
+#include <tuple>
+#include <vector>
 
 #include "cudadecoder/cuda-decodable-itf.h"
 #include "cudadecoder/cuda-decoder-common.h"
@@ -24,12 +33,6 @@
 #include "cudadecoder/thread-pool-light.h"
 #include "nnet3/decodable-online-looped.h"
 #include "online2/online-endpoint.h"
-
-#include <cuda_runtime_api.h>
-#include <cfloat>
-#include <mutex>
-#include <tuple>
-#include <vector>
 
 namespace kaldi {
 namespace cuda_decoder {
@@ -144,8 +147,8 @@ struct CudaDecoderConfig {
 // Forward declaration.
 // Those contains CUDA code. We don't want to include their definition
 // in this header
-class DeviceParams;
-class KernelParams;
+struct DeviceParams;
+struct KernelParams;
 
 class CudaDecoder {
  public:
@@ -933,4 +936,5 @@ class CudaDecoder {
 }  // end namespace cuda_decoder
 }  // namespace kaldi
 
-#endif  // KALDI_CUDA_DECODER_CUDA_DECODER_H_
+#endif  // HAVE_CUDA
+#endif  // KALDI_CUDADECODER_CUDA_DECODER_H_

--- a/src/cudadecoder/cuda-fst.cc
+++ b/src/cudadecoder/cuda-fst.cc
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
+#if !HAVE_CUDA
+#error CUDA support must be configured to compile this library.
+#endif
 
 #include "cudadecoder/cuda-fst.h"
 
@@ -205,5 +207,3 @@ void CudaFst::Finalize() {
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
-
-#endif  // HAVE_CUDA == 1

--- a/src/cudadecoder/thread-pool-light.h
+++ b/src/cudadecoder/thread-pool-light.h
@@ -15,18 +15,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_CUDA_DECODER_THREAD_POOL_LIGHT_H_
-#define KALDI_CUDA_DECODER_THREAD_POOL_LIGHT_H_
-
-#define KALDI_CUDA_DECODER_THREAD_POOL_QUEUE_FULL_WAIT_FOR_US 1000
+#ifndef KALDI_CUDADECODER_THREAD_POOL_LIGHT_H_
+#define KALDI_CUDADECODER_THREAD_POOL_LIGHT_H_
 
 #include <atomic>
 #include <thread>
 #include <vector>
+
 #include "util/stl-utils.h"
 
 namespace kaldi {
 namespace cuda_decoder {
+
+const double kSleepForWorkerAvailable = 1e-3;
 
 struct ThreadPoolLightTask {
   void (*func_ptr)(void *, uint64_t, void *);
@@ -99,7 +100,7 @@ class ThreadPoolLightWorker {
         (curr_task_.func_ptr)(curr_task_.obj_ptr, curr_task_.arg1,
                               curr_task_.arg2);
       } else {
-        usleep(1000);  // TODO
+        Sleep(1e-3f);  // TODO
       }
     }
   }
@@ -159,11 +160,11 @@ class ThreadPoolLight {
   void Push(const ThreadPoolLightTask &task) {
     // Could try another curr_iworker_
     while (!TryPush(task))
-      usleep(KALDI_CUDA_DECODER_THREAD_POOL_QUEUE_FULL_WAIT_FOR_US);
+      Sleep(kSleepForWorkerAvailable);
   }
 };
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
 
-#endif  // KALDI_CUDA_DECODER_THREAD_POOL_H_
+#endif  // KALDI_CUDADECODER_THREAD_POOL_H_

--- a/src/cudadecoder/thread-pool.h
+++ b/src/cudadecoder/thread-pool.h
@@ -47,13 +47,13 @@ namespace kaldi {
 namespace cuda_decoder {
 
 // C++ indexes enum 0,1,2...
-enum ThreadPoolPriority {
+enum [[deprecated]] ThreadPoolPriority {
   THREAD_POOL_LOW_PRIORITY,
   THREAD_POOL_NORMAL_PRIORITY,
   THREAD_POOL_HIGH_PRIORITY
 };
 
-class ThreadPool {
+class [[deprecated]] ThreadPool {
  public:
   ThreadPool(size_t);
   template <class F, class... Args>

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -15,14 +15,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary for the online pipeline BatchedThreadedNnet3CudaOnlinePipeline.
+// Can serve both as a benchmarking tool and an example on how to call
+// BatchedThreadedNnet3CudaOnlinePipeline.
+
+#if !HAVE_CUDA
+#error CUDA support must be configured to compile this binary.
+#endif
+
+#include <algorithm>
+#include <iomanip>
 #include <queue>
-#if HAVE_CUDA == 1
+#include <sstream>
 
 #include <cuda.h>
 #include <cuda_profiler_api.h>
 #include <nvToolsExt.h>
-#include <iomanip>
-#include <sstream>
+
 #include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
 #include "cudadecoderbin/cuda-bin-tools.h"
 #include "cudamatrix/cu-allocator.h"
@@ -33,29 +42,27 @@
 #include "util/kaldi-thread.h"
 
 using namespace kaldi;
-using namespace cuda_decoder;
+using namespace kaldi::cuda_decoder;
+using namespace fst;
+using CorrelationID = CudaOnlinePipelineDynamicBatcher::CorrelationID;
 
-//
-// Binary for the online pipeline BatchedThreadedNnet3CudaOnlinePipeline
-// Can serve both as a benchmarking tool and an example on how to call
-// BatchedThreadedNnet3CudaOnlinePipeline
-//
+typedef kaldi::int32 int32;
+typedef kaldi::int64 int64;
 
 struct Stream {
   std::shared_ptr<WaveData> wav;
-  BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID corr_id;
+  CorrelationID corr_id;
   int offset;
   double send_next_chunk_at;
   double *latency_ptr;
 
-  Stream(const std::shared_ptr<WaveData> &_wav,
-         BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID _corr_id,
-         double _send_next_chunk_at, double *_latency_ptr)
-      : wav(_wav),
-        corr_id(_corr_id),
-        offset(0),
-        send_next_chunk_at(_send_next_chunk_at),
-        latency_ptr(_latency_ptr) {}
+  Stream(const std::shared_ptr<WaveData> &wav, CorrelationID corr_id,
+         double send_next_chunk_at, double *latency_ptr)
+    : wav(wav),
+      corr_id(corr_id),
+      offset(0),
+      send_next_chunk_at(send_next_chunk_at),
+      latency_ptr(latency_ptr) {}
 
   bool operator<(const Stream &other) const {
     return (send_next_chunk_at > other.send_next_chunk_at);
@@ -64,15 +71,8 @@ struct Stream {
 
 int main(int argc, char *argv[]) {
   try {
-    using namespace kaldi;
-    using namespace fst;
-
-    typedef kaldi::int32 int32;
-    typedef kaldi::int64 int64;
-
     CudaOnlineBinaryOptions opts;
-    int errno;
-    if ((errno = SetUpAndReadCmdLineOptions(argc, argv, &opts))) return errno;
+    if (SetUpAndReadCmdLineOptions(argc, argv, &opts) != 0) return 1;
 
     TransitionModel trans_model;
     nnet3::AmNnetSimple am_nnet;
@@ -80,15 +80,15 @@ int main(int argc, char *argv[]) {
     fst::SymbolTable *word_syms;
     ReadModels(opts, &trans_model, &am_nnet, &decode_fst, &word_syms);
     BatchedThreadedNnet3CudaOnlinePipeline cuda_pipeline(
-        opts.batched_decoder_config, *decode_fst, am_nnet, trans_model);
+      opts.batched_decoder_config, *decode_fst, am_nnet, trans_model);
     delete decode_fst;
     if (word_syms) cuda_pipeline.SetSymbolTable(*word_syms);
 
     CompactLatticeWriter clat_writer(opts.clat_wspecifier);
     std::mutex clat_writer_m;
     if (!opts.write_lattice) {
-      KALDI_LOG << "If you want to write lattices to disk, please set "
-                   "--write-lattice=true";
+      KALDI_LOG << ("If you want to write lattices to disk, please set "
+                    "--write-lattice=true");
     }
 
     int chunk_length = cuda_pipeline.GetNSampsPerChunk();
@@ -98,21 +98,28 @@ int main(int argc, char *argv[]) {
     std::vector<std::shared_ptr<WaveData>> all_wav;
     std::vector<std::string> all_wav_keys;
     ReadDataset(opts, &all_wav, &all_wav_keys);
+    KALDI_ASSERT(all_wav.size() > 0);
+    KALDI_ASSERT(all_wav.size() == all_wav_keys.size());
+    KALDI_LOG << "Loaded " << all_wav.size() << "files.";
+    for (int i=0; i < all_wav.size(); ++i) {
+      if (all_wav[i]->Data().NumRows() <= 0) {
+        KALDI_ERR << "Bad file, 0 channels at index [" << i << "], id="
+                  << all_wav_keys[i];
+      }
+    }
 
-    BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID correlation_id_cnt =
-        0;
+    CorrelationID correlation_id_cnt = 0;
 
     CudaOnlinePipelineDynamicBatcherConfig dynamic_batcher_config;
     CudaOnlinePipelineDynamicBatcher dynamic_batcher(dynamic_batcher_config,
                                                      cuda_pipeline);
-
     // Streaming code
     // Wav reader index
     size_t all_wav_i = 0;
     size_t all_wav_max = all_wav.size() * opts.niterations;
     std::vector<double> latencies(all_wav_max);
 
-    // We will start all utterances at a random position within the first second
+    // Start all utterances at a random position within the first second.
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_real_distribution<> dis(0.0, 1.0);
@@ -122,8 +129,8 @@ int main(int argc, char *argv[]) {
     Timer timer;
 
     // Initial set of streams will start randomly within the first second of
-    // streaming That's to simulate something more realistic than a large spike
-    // of all channels starting at the same time
+    // streaming. That's to simulate something more realistic than a large
+    // spike of all channels starting at the same time.
     bool add_random_offset = true;
     KALDI_LOG << "Inferencing...";
     while (true) {
@@ -136,47 +143,49 @@ int main(int argc, char *argv[]) {
         size_t all_wav_i_modulo = wav_i % (all_wav.size());
         double *latency_ptr = &latencies[corr_id];
 
-        // The "speaker" start talking at stream_will_start_at
+        // Utterance starts at stream_will_start_at.
         double stream_will_start_at = timer.Elapsed();  // "now"
         if (add_random_offset) stream_will_start_at += dis(gen);
-        // The "speaker" will speak for stream_duration seconds
+        // Utterance continues for stream_duration seconds.
         double stream_duration = all_wav[all_wav_i_modulo]->Duration();
         // The first chunk will be available whenever the first chunk was
         // "spoken" e.g. if the first chunk is made of 0.5s for audio, we have
         // to wait 0.5s after stream_will_start_at
         double first_chunk_available_at =
-            stream_will_start_at + std::min(stream_duration, chunk_seconds);
+          stream_will_start_at + std::min(stream_duration, chunk_seconds);
 
-        // stream_will_stop_at is used for latency computation
-        // We started streaming at t0=stream_will_start_at, so the audio will be
-        // done streaming at t1=stream_will_start_at+duration We will get
-        // the result at t2, we then have latency=t2-t1
+        // stream_will_stop_at is used for latency computation.
+        // Streaming starts at t0 = stream_will_start_at and ends at
+        // t1 = stream_will_start_at + duration. We will get the result at t2,
+        // therefore the latency = t2 - t1.
         double stream_will_stop_at = stream_will_start_at + stream_duration;
         // tmp storing in lat_ptr
         // we'll do lat_ptr = now - lat_ptr in callback
         *latency_ptr = stream_will_stop_at;
 
-        // Defining the callback for results
+        // Define the callback for results.
         cuda_pipeline.SetBestPathCallback(
-            corr_id,
-            [latency_ptr, &timer, &opts, corr_id](
-                const std::string &str, bool partial, bool endpoint_detected) {
-              if (partial && opts.print_partial_hypotheses)
+          corr_id,
+          [&, latency_ptr, corr_id](const std::string &str, bool partial,
+                                    bool endpoint_detected) {
+              if (partial && opts.print_partial_hypotheses) {
                 KALDI_LOG << "corr_id #" << corr_id << " [partial] : " << str;
+              }
 
-              if (endpoint_detected && opts.print_endpoints)
+              if (endpoint_detected && opts.print_endpoints) {
                 KALDI_LOG << "corr_id #" << corr_id << " [endpoint detected]";
+              }
 
               if (!partial) {
                 // *latency_ptr currently contains t1="stream_will_start_at +
-                // duration" where stream_will_start_at is when this stream
-                // started and duration is the duration of this audio file so t1
-                // is the time when the virtual user is done talking
-                // timer.Elapsed() now contains t2, i.e. when the result is
-                // ready latency = t2 - t1
+                // duration" where stream_will_start_at is the time when this
+                // stream has started and 'duration' is the duration of this
+                // audio file, so t1 is the time when the virtual user is done
+                // talking. timer.Elapsed() now contains t2, i.e. when the
+                // result is ready, the latency = t2 - t1.
                 if (!opts.generate_lattice) {
-                  // If we need to gen a lattice, latency will take the lattice
-                  // gen into account
+                  // If generating a lattice, latency will include the time
+                  // spent generating it.
                   *latency_ptr = timer.Elapsed() - *latency_ptr;
                 }
                 if (opts.print_hypotheses)
@@ -191,39 +200,40 @@ int main(int argc, char *argv[]) {
           std::string key = all_wav_keys[all_wav_i_modulo];
           if (iter > 0) key += std::to_string(iter);
           cuda_pipeline.SetLatticeCallback(
-              corr_id, [&opts, &clat_writer, &clat_writer_m, key, latency_ptr,
-                        &timer](CompactLattice &clat) {
-                *latency_ptr = timer.Elapsed() - *latency_ptr;
-                if (opts.write_lattice) {
-                  std::lock_guard<std::mutex> lk(clat_writer_m);
-                  clat_writer.Write(key, clat);
-                }
-              });
+            corr_id,
+            [&, key, latency_ptr](CompactLattice &clat) {
+              *latency_ptr = timer.Elapsed() - *latency_ptr;
+              if (opts.write_lattice) {
+                std::lock_guard<std::mutex> lk(clat_writer_m);
+                clat_writer.Write(key, clat);
+              }
+            });
         }
 
         // Adding that stream to our simulation stream pool
         streams.emplace(all_wav[all_wav_i_modulo], corr_id,
                         first_chunk_available_at, latency_ptr);
       }
-      add_random_offset = false;  // the next streams will just start whenever a
-                                  // spot is available
+      // The next streams will just start whenever a spot is available.
+      add_random_offset = false;
 
       // If we reach this, we're just done with all streams
       if (streams.empty()) break;
 
-      auto chunk = streams.top();
+      Stream chunk = streams.top();
       streams.pop();
       double wait_for = chunk.send_next_chunk_at - timer.Elapsed();
-      if (wait_for > 0) usleep(wait_for * 1e6);
+      if (wait_for > 0) kaldi::Sleep(wait_for);
 
+      KALDI_ASSERT(chunk.wav->Data().NumRows() > 0);
       SubVector<BaseFloat> data(chunk.wav->Data(), 0);
 
       // Current chunk
       int32 total_num_samp = data.Dim();
       int this_chunk_num_samp =
-          std::min(total_num_samp - chunk.offset, chunk_length);
+        std::min(total_num_samp - chunk.offset, chunk_length);
       bool is_last_chunk =
-          ((chunk.offset + this_chunk_num_samp) == total_num_samp);
+        ((chunk.offset + this_chunk_num_samp) == total_num_samp);
       bool is_first_chunk = (chunk.offset == 0);
       SubVector<BaseFloat> wave_part(data, chunk.offset, this_chunk_num_samp);
 
@@ -240,7 +250,7 @@ int main(int argc, char *argv[]) {
       // send_next_chunk_at with send_next_chunk_at = send_current_chunk_at +
       // next_chunk_duration
       int next_chunk_num_samp =
-          std::min(total_num_samp - chunk.offset, chunk_length);
+        std::min(total_num_samp - chunk.offset, chunk_length);
       double next_chunk_seconds = next_chunk_num_samp * seconds_per_sample;
       chunk.send_next_chunk_at += next_chunk_seconds;
 
@@ -252,9 +262,9 @@ int main(int argc, char *argv[]) {
     KALDI_LOG << "Done.";
     nvtxRangePop();
 
-    KALDI_LOG << "\tLatency stats:";
+    KALDI_LOG << "Latency stats:";
     PrintLatencyStats(latencies);
-    delete word_syms;  // will delete if non-NULL.
+    delete word_syms;
 
     clat_writer.Close();
     cudaDeviceSynchronize();
@@ -265,5 +275,3 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 }  // main()
-
-#endif  // if HAVE_CUDA == 1

--- a/src/cudafeat/feature-online-batched-spectral-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-spectral-cuda-kernels.cu
@@ -15,12 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
-#include <nvToolsExt.h>
-#include <cub/cub.cuh>
-#endif
-
 #include "cudafeat/feature-online-batched-spectral-cuda-kernels.h"
+
+#include <cub/cub.cuh>
+#include <nvToolsExt.h>
+
 #include "cudafeat/lane-desc.h"
 #include "cudamatrix/cu-rand.h"
 

--- a/src/cudafeat/feature-spectral-cuda.cu
+++ b/src/cudafeat/feature-spectral-cuda.cu
@@ -15,12 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
+#include "cudafeat/feature-spectral-cuda.h"
+
 #include <nvToolsExt.h>
 #include <cub/cub.cuh>
-#endif
 
-#include "cudafeat/feature-spectral-cuda.h"
 #include "cudamatrix/cu-rand.h"
 
 // Each thread block processes a unique frame

--- a/src/cudafeat/feature-window-cuda.cu
+++ b/src/cudafeat/feature-window-cuda.cu
@@ -15,10 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HAVE_CUDA == 1
-#include <nvToolsExt.h>
-#endif
 #include "cudafeat/feature-window-cuda.h"
+
+#include <nvToolsExt.h>
+
 #include "matrix/matrix-functions.h"
 
 namespace kaldi {
@@ -28,10 +28,10 @@ CudaFeatureWindowFunction::CudaFeatureWindowFunction(
   nvtxRangePushA("CudaFeatureWindowFunction::CudaFeatureWindowFunction");
   int32 frame_length = opts.WindowSize();
 
-  // Create CPU feature window
+  // Create CPU feature window.
   FeatureWindowFunction feature_window(opts);
 
-  // Copy into GPU memory
+  // Copy into GPU memory.
   cu_window.Resize(frame_length, kUndefined);
   cu_window.CopyFromVec(feature_window.window);
   nvtxRangePop();

--- a/src/cudafeat/online-batched-feature-pipeline-cuda.cc
+++ b/src/cudafeat/online-batched-feature-pipeline-cuda.cc
@@ -16,11 +16,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if HAVE_CUDA
+
 #include "cudafeat/online-batched-feature-pipeline-cuda.h"
 
-#if HAVE_CUDA == 1
 #include <nvToolsExt.h>
-#endif
 
 namespace kaldi {
 
@@ -197,3 +197,5 @@ void OnlineBatchedFeaturePipelineCuda::ComputeFeaturesBatched(
 }
 
 }  // namespace kaldi
+
+#endif  // HAVE_CUDA

--- a/src/cudafeat/online-ivector-feature-cuda.cc
+++ b/src/cudafeat/online-ivector-feature-cuda.cc
@@ -67,7 +67,7 @@ void IvectorExtractorFastCuda::GetIvector(const CuMatrixBase<BaseFloat> &feats,
 
       // create submatrix which removes last column
       CuSubMatrix<BaseFloat> cu_lda(cu_lda_, 0, lda_rows, 0, lda_cols - 1);
-  
+
       // Add offset
       lda_feats_normalized.CopyRowsFromVec(offset_);
       lda_feats_normalized.AddMatMat(1.0, spliced_feats_normalized, kNoTrans,
@@ -75,7 +75,7 @@ void IvectorExtractorFastCuda::GetIvector(const CuMatrixBase<BaseFloat> &feats,
 
     } else {
       KALDI_ERR << "Dimension mismatch: source features have dimension "
-                << spliced_feats_normalized.NumCols() << " and LDA #cols is " 
+                << spliced_feats_normalized.NumCols() << " and LDA #cols is "
                 << lda_cols;
     }
   }
@@ -97,14 +97,14 @@ void IvectorExtractorFastCuda::GetIvector(const CuMatrixBase<BaseFloat> &feats,
 
       // create submatrix which removes last column
       CuSubMatrix<BaseFloat> cu_lda(cu_lda_, 0, lda_rows, 0, lda_cols - 1);
-      
+
       // Add offset
       lda_feats.CopyRowsFromVec(offset_);
       lda_feats.AddMatMat(1.0, spliced_feats, kNoTrans, cu_lda, kTrans, 1.0);
 
     } else {
       KALDI_ERR << "Dimension mismatch: source features have dimension "
-                << spliced_feats.NumCols() << " and LDA #cols is " 
+                << spliced_feats.NumCols() << " and LDA #cols is "
                 << lda_cols;
     }
   }

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -19,22 +19,22 @@
 // limitations under the License.
 
 
-
 #ifndef KALDI_CUDAMATRIX_CU_COMMON_H_
 #define KALDI_CUDAMATRIX_CU_COMMON_H_
-#include "cudamatrix/cu-matrixdim.h" // for CU1DBLOCK and CU2DBLOCK
 
 #include <iostream>
 #include <sstream>
+
 #include "base/kaldi-error.h"
+#include "cudamatrix/cu-matrixdim.h" // for CU1DBLOCK and CU2DBLOCK
 #include "matrix/matrix-common.h"
 
 #if HAVE_CUDA == 1
 #include <cublas_v2.h>
-#include <cusparse.h>
-#include <curand.h>
 #include <cuda_runtime_api.h>
-#include "nvToolsExt.h"
+#include <curand.h>
+#include <cusparse.h>
+#include <nvToolsExt.h>
 
 #define CU_SAFE_CALL(fun) \
 { \
@@ -142,7 +142,7 @@ const char* curandGetStatusString(curandStatus_t status);
 namespace kaldi {
 #define NVTX_RANGE(name)
 };
-#endif // HAVE_CUDA
+#endif  // HAVE_CUDA
 
 namespace kaldi {
 // Some forward declarations, needed for friend declarations.
@@ -161,7 +161,6 @@ template<typename Real> class CuSparseMatrix;
 template<typename Real> class CuBlockMatrix; // this has no non-CU counterpart.
 
 
-}
+}  // namespace kaldi
 
-
-#endif
+#endif  // KALDI_CUDAMATRIX_CU_COMMON_H_

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -16,4 +16,4 @@ CUDA_FLAGS = --compiler-options -fPIC --machine 64 -DHAVE_CUDA \
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64/stubs -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib/stubs -L$(CUDATKDIR)/lib -Wl,-rpath,$(CUDATKDIR)/lib
 
-CUDA_LDLIBS += -lcuda -lcublas -lcusparse -lcudart -lcurand -lcufft -lnvToolsExt #LDLIBS : The .so libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcuda -lcublas -lcusparse -lcusolver -lcudart -lcurand -lcufft -lnvToolsExt

--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -2312,7 +2312,7 @@ void MaxChangeStats::Print(const Nnet &nnet) const {
                   << ", per-component max-change was enforced "
                   << ((100.0 * num_max_change_per_component_applied[i]) /
                       num_minibatches_processed)
-                  << " \% of the time.";
+                  << " % of the time.";
       i++;
     }
   }
@@ -2320,7 +2320,7 @@ void MaxChangeStats::Print(const Nnet &nnet) const {
     KALDI_LOG << "The global max-change was enforced "
               << ((100.0 * num_max_change_global_applied) /
                   num_minibatches_processed)
-              << " \% of the time.";
+              << " % of the time.";
 }
 
 

--- a/src/util/kaldi-table-test.cc
+++ b/src/util/kaldi-table-test.cc
@@ -1065,7 +1065,7 @@ void UnitTestTableNumpyArray() {
   writer.Write(key1, NumpyArray<BaseFloat>(v));
   writer.Write(key2, NumpyArray<BaseFloat>(m));
   writer.Close();
-  usleep(200);
+  Sleep(200e-6);
 
   const char* rspecifier = "scp:numpy_array.scp";
   {
@@ -1124,8 +1124,7 @@ void UnitTestTableNumpyArray() {
 }
 
 
-
-}  // end namespace kaldi.
+}  // namespace kaldi
 
 int main() {
   using namespace kaldi;


### PR DESCRIPTION
* Make `BatchedThreadedNnet3CudaOnlinePipeline::CorrelationID`  public for binaries in src/cudadecoderbin to compile (fallout from #4490 -- our CI runs w/o CUDA).
* Replace Win32-specific `Sleep()` with portable C++ `std::chrono`  classes in src/base/kaldi-utils.*. Change `Sleep(float)` arg type to `double` because this is what these classes take and return when converting to/from time in seconds.
* Use C++ `double` constants for timers instead of sesquipedalian macros. Express time invariably in seconds.
* Move includes under `HAVE_CUDA` conditionals in files without code that would make no sense without CUDA. Check for `HAVE_CUDA` always after include guards for consistency.
* Issue an `#error` if attempting to compile CUDA-dependent code with `HAVE_CUDA` not set (not yet all files, only these I had to touch).
* Add, reword some and reformat commentary and help strings in src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc

Accidental touch-paint fixes:
* Replace `usleep()` with `kaldi::Sleep()` in src/util/kaldi-table-test.cc.
* Fix escape non-sequence `\%` where `%` was intended in strings in src/nnet3/nnet-utils.cc.

@hugovbraun, PTAL.