### PR TITLE
Fix #4501

### DIFF
--- a/src/cudadecoder/batched-static-nnet3.cc
+++ b/src/cudadecoder/batched-static-nnet3.cc
@@ -92,9 +92,9 @@ void BatchedStaticNnet3::Allocate() {
 }
 
 void BatchedStaticNnet3::Deallocate() {
-  cudaFreeHost(h_batch_slot_assignement_);
-  cudaFreeHost(d_batch_slot_assignement_);
-  cudaEventDestroy(batch_slot_assignement_copy_evt_);
+  CU_SAFE_CALL(cudaFreeHost(h_batch_slot_assignement_));
+  CU_SAFE_CALL(cudaFree(d_batch_slot_assignement_));
+  CU_SAFE_CALL(cudaEventDestroy(batch_slot_assignement_copy_evt_));
 }
 
 void BatchedStaticNnet3::CompileNnet3() {

--- a/src/cudadecoder/cuda-decoder-common.h
+++ b/src/cudadecoder/cuda-decoder-common.h
@@ -251,12 +251,12 @@ class HostMatrix {
     KALDI_ASSERT(nrows_ > 0);
     KALDI_ASSERT(ncols_ > 0);
     KALDI_ASSERT(!data_);
-    cudaMallocHost((void **)&data_, (size_t)nrows_ * ncols_ * sizeof(*data_));
+    CU_SAFE_CALL(cudaMallocHost((void **)&data_, (size_t)nrows_ * ncols_ * sizeof(*data_)));
     KALDI_ASSERT(data_);
   }
   void Free() {
     KALDI_ASSERT(data_);
-    cudaFreeHost(data_);
+    CU_SAFE_CALL(cudaFreeHost(data_));
   }
 
  protected:

--- a/src/cudadecoder/cuda-pipeline-common.h
+++ b/src/cudadecoder/cuda-pipeline-common.h
@@ -143,7 +143,7 @@ struct HostDeviceVector {
 
   virtual ~HostDeviceVector() {
     Deallocate();
-    cudaEventDestroy(evt);
+    CU_SAFE_CALL(cudaEventDestroy(evt));
   }
 
   void Reallocate(const size_t new_size) {
@@ -169,11 +169,11 @@ struct HostDeviceVector {
   }
   void Deallocate() {
     if (d_data) {
-      cudaFree(d_data);
+      CU_SAFE_CALL(cudaFree(d_data));
       d_data = NULL;
     }
     if (h_data) {
-      cudaFreeHost(h_data);
+      CU_SAFE_CALL(cudaFreeHost(h_data));
       h_data = NULL;
     }
   }

--- a/src/cudafeat/feature-spectral-cuda.cu
+++ b/src/cudafeat/feature-spectral-cuda.cu
@@ -407,9 +407,9 @@ CudaSpectralFeatures::CudaSpectralFeatures(const CudaSpectralFeatureOptions &opt
   stride_ = cu_windows_.Stride();
   tmp_stride_ = tmp_window_.Stride();
 
-  cufftPlanMany(&plan_, 1, &padded_length_, NULL, 1, stride_, NULL, 1,
-                tmp_stride_ / 2, CUFFT_R2C, fft_size_);
-  cufftSetStream(plan_, cudaStreamPerThread);
+  CUFFT_SAFE_CALL(cufftPlanMany(&plan_, 1, &padded_length_, NULL, 1, stride_, NULL, 1,
+                                tmp_stride_ / 2, CUFFT_R2C, fft_size_));
+  CUFFT_SAFE_CALL(cufftSetStream(plan_, cudaStreamPerThread));
   cumfcc_opts_ = opts;
 }
 
@@ -563,6 +563,6 @@ CudaSpectralFeatures::~CudaSpectralFeatures() {
   CuDevice::Instantiate().Free(vecs_);
   CuDevice::Instantiate().Free(offsets_);
   CuDevice::Instantiate().Free(sizes_);
-  cufftDestroy(plan_);
+  CUFFT_SAFE_CALL(cufftDestroy(plan_));
 }
 }  // namespace kaldi

--- a/src/cudafeat/online-batched-feature-pipeline-cuda.cc
+++ b/src/cudafeat/online-batched-feature-pipeline-cuda.cc
@@ -94,7 +94,7 @@ OnlineBatchedFeaturePipelineCuda::OnlineBatchedFeaturePipelineCuda(
   current_samples_stash_ = new int32_t[num_channels_];
 
   // allocated pinned memory for storing channel desc
-  cudaMallocHost(&h_lanes_, sizeof(LaneDesc) * max_lanes_);
+  CU_SAFE_CALL(cudaMallocHost(&h_lanes_, sizeof(LaneDesc) * max_lanes_));
 
   // allocate device memory
   lanes_ =
@@ -108,13 +108,13 @@ OnlineBatchedFeaturePipelineCuda::~OnlineBatchedFeaturePipelineCuda() {
   if (cmvn_ != NULL) delete cmvn_;
   if (ivector_ != NULL) delete ivector_;
 
-  cudaFreeHost(h_lanes_);
+  CU_SAFE_CALL(cudaFreeHost(h_lanes_));
 
   delete[] current_samples_stash_;
 
   CuDevice::Instantiate().Free(lanes_);
 
-  cudaEventDestroy(event_);
+  CU_SAFE_CALL(cudaEventDestroy(event_));
 }
 
 void OnlineBatchedFeaturePipelineCuda::ComputeFeaturesBatched(

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -48,7 +48,7 @@
 { \
   int32 ret; \
   if ((ret = (fun)) != CUFFT_SUCCESS) { \
-    KALDI_ERR << "cublasResult " << ret << " returned from '" << #fun << "'"; \
+    KALDI_ERR << "cufftResult " << ret << " returned from '" << #fun << "'"; \
   } \
 }
 


### PR DESCRIPTION
cudaFreeHost() was called instead of cudaFree() on
d_batch_slot_assignment_, which is a pointer to device memory, causing
an error.

This hadn't been noticd before because people usually destroyed the
BatchedThreadedNnet3CudaPipeline2 only when terminating the program.

Testing: I manualy applid the change described in
https://github.com/kaldi-asr/kaldi/issues/4501#issue-863211097

No unit test.

Additionally, add several defensive CU_SAFE_CALL guards that weren't
there before.