### PR TITLE
[src] Assert matrix size before memcpy into it

### DIFF
--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -15,16 +15,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <unordered_map>
-#if HAVE_CUDA == 1
+#ifndef KALDI_CUDADECODER_CUDA_ONLINE_PIPELINE_DYNAMIC_BATCHER_H_
+#define KALDI_CUDADECODER_CUDA_ONLINE_PIPELINE_DYNAMIC_BATCHER_H_
 
-#ifndef KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
-#define KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
+#if HAVE_CUDA
 
 #include <atomic>
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <unordered_map>
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
 
@@ -86,6 +86,7 @@ class CudaOnlinePipelineDynamicBatcher {
       is_first_chunk.push_back(is_first);
       is_last_chunk.push_back(is_last);
       int nsamples = samples.Dim();
+      KALDI_ASSERT(nsamples <= h_all_waveform.NumCols());
       const BaseFloat *wave_src = samples.Data();
       BaseFloat *wave_dst = h_all_waveform.RowData(idx);
       std::memcpy(wave_dst, wave_src, nsamples * sizeof(BaseFloat));
@@ -132,8 +133,8 @@ class CudaOnlinePipelineDynamicBatcher {
   std::unique_ptr<Batch> curr_batch_, next_batch_;
 };
 
-}  // end namespace cuda_decoder
-}  // end namespace kaldi.
+}  // namespace cuda_decoder
+}  // namespace kaldi
 
-#endif  // KALDI_CUDA_DECODER_DYNAMIC_BATCHER_H_
 #endif  // HAVE_CUDA
+#endif  // KALDI_CUDADECODER_CUDA_ONLINE_PIPELINE_DYNAMIC_BATCHER_H_


### PR DESCRIPTION
* `KALDI_ASSERT` enough space in a matrix column before `memcpy()`ing into it.
* [chore] rearrange the include guard to make including the file invariant w.r.t. `HAVE_CUDA` defined, and rename the guard preprocessor variable to the coding conventions.

The pipeline object has an accessor that returns the correct number of samples per chunk, but I slapped together a quick POC code that had no reference to the pipeline at the point I called `Push()`, computed the wrong size, and the "quick" part turned into a day-long bug hunting. The OED has both _slow_ and _stupid_ as antonyms to _quick_ for a good reason...  :-0

/cc @hugovbraun