### PR TITLE
[scipts/rnnlm] Fix bug of check unused file in backward lm rescore

### DIFF
--- a/scripts/rnnlm/lmrescore_nbest_back.sh
+++ b/scripts/rnnlm/lmrescore_nbest_back.sh
@@ -61,7 +61,7 @@ elif [ ! -f $oldlm ]; then
     exit 1;
 fi
 
-for f in $rnndir/final.raw $data/feats.scp $indir/lat.1.gz; do
+for f in $rnndir/final.raw $indir/lat.1.gz; do
   [ ! -f $f ] && echo "$0: expected file $f to exist." && exit 1;
 done
 


### PR DESCRIPTION
Not need to check is `$data/feats.scp` exist