### PR TITLE
fix fail Kaldi install on CPU: CUDA error

### DIFF
--- a/src/makefiles/default_rules.mk
+++ b/src/makefiles/default_rules.mk
@@ -148,10 +148,10 @@ endif
 depend:
 	rm -f .depend.mk
 ifneq ($(CC_DEP_COMMAND),)
-	$(CC_DEP_COMMAND) >> .depend.mk
+	-$(CC_DEP_COMMAND) >> .depend.mk
 endif
 ifneq ($(NVCC_DEP_COMMAND),)
-	$(NVCC_DEP_COMMAND) >> .depend.mk
+	-$(NVCC_DEP_COMMAND) >> .depend.mk
 endif
 
 # removing automatic making of "depend" as it's quite slow.


### PR DESCRIPTION
fix fail Kaldi install on CPU: CUDA support is required to compile this library on issue #4518 