### PR TITLE
Sprakbanken swe fix

### DIFF
--- a/egs/sprakbanken_swe/s5/cmd.sh
+++ b/egs/sprakbanken_swe/s5/cmd.sh
@@ -10,6 +10,6 @@
 # conf/queue.conf in http://kaldi-asr.org/doc/queue.html for more information,
 # or search for the string 'default_config' in utils/queue.pl or utils/slurm.pl.
 
-export train_cmd="queue.pl --mem 2G"
-export decode_cmd="queue.pl --mem 4G"
-export mkgraph_cmd="queue.pl --mem 8G"
+export train_cmd="run.pl"
+export decode_cmd="run.pl"
+export mkgraph_cmd="run.pl"

--- a/egs/sprakbanken_swe/s5/conf/decode.config
+++ b/egs/sprakbanken_swe/s5/conf/decode.config
@@ -1,0 +1,1 @@
+decode_dnn.config

--- a/egs/sprakbanken_swe/s5/local/score.sh
+++ b/egs/sprakbanken_swe/s5/local/score.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Copyright 2012-2014  Johns Hopkins University (Author: Daniel Povey, Yenda Trmal)
+# Apache 2.0
+
+# See the script steps/scoring/score_kaldi_cer.sh in case you need to evalutate CER
+
+[ -f ./path.sh ] && . ./path.sh
+
+# begin configuration section.
+cmd=run.pl
+stage=0
+decode_mbr=false
+stats=true
+beam=6
+word_ins_penalty=0.0,0.5,1.0
+min_lmwt=7
+max_lmwt=17
+iter=final
+#end configuration section.
+
+echo "$0 $@"  # Print the command line for logging
+[ -f ./path.sh ] && . ./path.sh
+. parse_options.sh || exit 1;
+
+if [ $# -ne 3 ]; then
+  echo "Usage: local/score.sh [--cmd (run.pl|queue.pl...)] <data-dir> <lang-dir|graph-dir> <decode-dir>"
+  echo " Options:"
+  echo "    --cmd (run.pl|queue.pl...)      # specify how to run the sub-processes."
+  echo "    --stage (0|1|2)                 # start scoring script from part-way through."
+  echo "    --decode_mbr (true/false)       # maximum bayes risk decoding (confusion network)."
+  echo "    --min_lmwt <int>                # minumum LM-weight for lattice rescoring "
+  echo "    --max_lmwt <int>                # maximum LM-weight for lattice rescoring "
+  exit 1;
+fi
+
+data=$1
+lang_or_graph=$2
+dir=$3
+
+symtab=$lang_or_graph/words.txt
+
+for f in $symtab $dir/lat.1.gz $data/text; do
+  [ ! -f $f ] && echo "score.sh: no such file $f" && exit 1;
+done
+
+
+ref_filtering_cmd="cat"
+[ -x local/wer_output_filter ] && ref_filtering_cmd="local/wer_output_filter"
+[ -x local/wer_ref_filter ] && ref_filtering_cmd="local/wer_ref_filter"
+hyp_filtering_cmd="cat"
+[ -x local/wer_output_filter ] && hyp_filtering_cmd="local/wer_output_filter"
+[ -x local/wer_hyp_filter ] && hyp_filtering_cmd="local/wer_hyp_filter"
+
+
+if $decode_mbr ; then
+  echo "$0: scoring with MBR, word insertion penalty=$word_ins_penalty"
+else
+  echo "$0: scoring with word insertion penalty=$word_ins_penalty"
+fi
+
+
+mkdir -p $dir/scoring_kaldi
+cat $data/text | $ref_filtering_cmd > $dir/scoring_kaldi/test_filt.txt || exit 1;
+if [ $stage -le 0 ]; then
+
+  for wip in $(echo $word_ins_penalty | sed 's/,/ /g'); do
+    mkdir -p $dir/scoring_kaldi/penalty_$wip/log
+
+    if $decode_mbr ; then
+      $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring_kaldi/penalty_$wip/log/best_path.LMWT.log \
+        acwt=\`perl -e \"print 1.0/LMWT\"\`\; \
+        lattice-scale --inv-acoustic-scale=LMWT "ark:gunzip -c $dir/lat.*.gz|" ark:- \| \
+        lattice-add-penalty --word-ins-penalty=$wip ark:- ark:- \| \
+        lattice-prune --beam=$beam ark:- ark:- \| \
+        lattice-mbr-decode  --word-symbol-table=$symtab \
+        ark:- ark,t:- \| \
+        utils/int2sym.pl -f 2- $symtab \| \
+        $hyp_filtering_cmd '>' $dir/scoring_kaldi/penalty_$wip/LMWT.txt || exit 1;
+
+    else
+      $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring_kaldi/penalty_$wip/log/best_path.LMWT.log \
+        lattice-scale --inv-acoustic-scale=LMWT "ark:gunzip -c $dir/lat.*.gz|" ark:- \| \
+        lattice-add-penalty --word-ins-penalty=$wip ark:- ark:- \| \
+        lattice-best-path --word-symbol-table=$symtab ark:- ark,t:- \| \
+        utils/int2sym.pl -f 2- $symtab \| \
+        $hyp_filtering_cmd '>' $dir/scoring_kaldi/penalty_$wip/LMWT.txt || exit 1;
+    fi
+
+    $cmd LMWT=$min_lmwt:$max_lmwt $dir/scoring_kaldi/penalty_$wip/log/score.LMWT.log \
+      cat $dir/scoring_kaldi/penalty_$wip/LMWT.txt \| \
+      compute-wer --text --mode=present \
+      ark:$dir/scoring_kaldi/test_filt.txt  ark,p:- ">&" $dir/wer_LMWT_$wip || exit 1;
+
+  done
+fi
+
+
+
+if [ $stage -le 1 ]; then
+
+  for wip in $(echo $word_ins_penalty | sed 's/,/ /g'); do
+    for lmwt in $(seq $min_lmwt $max_lmwt); do
+      # adding /dev/null to the command list below forces grep to output the filename
+      grep WER $dir/wer_${lmwt}_${wip} /dev/null
+    done
+  done | utils/best_wer.sh  >& $dir/scoring_kaldi/best_wer || exit 1
+
+  best_wer_file=$(awk '{print $NF}' $dir/scoring_kaldi/best_wer)
+  best_wip=$(echo $best_wer_file | awk -F_ '{print $NF}')
+  best_lmwt=$(echo $best_wer_file | awk -F_ '{N=NF-1; print $N}')
+
+  if [ -z "$best_lmwt" ]; then
+    echo "$0: we could not get the details of the best WER from the file $dir/wer_*.  Probably something went wrong."
+    exit 1;
+  fi
+
+  if $stats; then
+    mkdir -p $dir/scoring_kaldi/wer_details
+    echo $best_lmwt > $dir/scoring_kaldi/wer_details/lmwt # record best language model weight
+    echo $best_wip > $dir/scoring_kaldi/wer_details/wip # record best word insertion penalty
+
+    $cmd $dir/scoring_kaldi/log/stats1.log \
+      cat $dir/scoring_kaldi/penalty_$best_wip/$best_lmwt.txt \| \
+      align-text --special-symbol="'***'" ark:$dir/scoring_kaldi/test_filt.txt ark:- ark,t:- \|  \
+      utils/scoring/wer_per_utt_details.pl --special-symbol "'***'" \| tee $dir/scoring_kaldi/wer_details/per_utt \|\
+       utils/scoring/wer_per_spk_details.pl $data/utt2spk \> $dir/scoring_kaldi/wer_details/per_spk || exit 1;
+
+    $cmd $dir/scoring_kaldi/log/stats2.log \
+      cat $dir/scoring_kaldi/wer_details/per_utt \| \
+      utils/scoring/wer_ops_details.pl --special-symbol "'***'" \| \
+      sort -b -i -k 1,1 -k 4,4rn -k 2,2 -k 3,3 \> $dir/scoring_kaldi/wer_details/ops || exit 1;
+
+    $cmd $dir/scoring_kaldi/log/wer_bootci.log \
+      compute-wer-bootci --mode=present \
+        ark:$dir/scoring_kaldi/test_filt.txt ark:$dir/scoring_kaldi/penalty_$best_wip/$best_lmwt.txt \
+        '>' $dir/scoring_kaldi/wer_details/wer_bootci || exit 1;
+
+  fi
+fi
+
+# If we got here, the scoring was successful.
+# As a  small aid to prevent confusion, we remove all wer_{?,??} files;
+# these originate from the previous version of the scoring files
+# i keep both statement here because it could lead to confusion about
+# the capabilities of the script (we don't do cer in the script)
+rm $dir/wer_{?,??} 2>/dev/null
+rm $dir/cer_{?,??} 2>/dev/null
+
+exit 0;

--- a/egs/sprakbanken_swe/s5/local/sprak2kaldi.py
+++ b/egs/sprakbanken_swe/s5/local/sprak2kaldi.py
@@ -77,6 +77,11 @@ def create_parallel_file_list(session, sndlist, txtlist):
         if not os.path.exists(oldsound): 
             continue
 
+        # Giampiero Salvi: at least one file only has header but no samples check this
+        # 0468 sv test/Stasjon20/191299/adb_0468/speech/scr0468/20/04682001/r4680013/u0013872.wav
+        if os.stat(oldsound).st_size == 1024:
+            continue
+        
         # create file and write the transcription
         txtout = session.create_filename(recnum+1, "txt")
         txtline = os.path.join(session.sessiondir, txtout)

--- a/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
+++ b/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
@@ -18,6 +18,8 @@ utils=`pwd`/utils
 
 . ./path.sh
 
+if false; then
+
 # Checks if python3 is available on the system and install python3 in userspace if not
 # This recipe currently relies on version 3 because python3 uses utf8 as internal 
 # string representation
@@ -56,11 +58,19 @@ if [ ! -d $dir/download/0468 ]; then
     tar -xzf $dir/download/sve.16khz.0467-1.tar.gz -C $dir/download/0467-1
     tar -xzf $dir/download/sve.16khz.0467-2.tar.gz -C $dir/download/0467-2
     tar -xzf $dir/download/sve.16khz.0467-3.tar.gz -C $dir/download/0467-3
-    tar -xzf $dir/download/sve.16khz.0468.tar.gz -C $dir/download/0468    
+    make -p $dir/download/0468
+    tar -xzf $dir/download/sve.16khz.0468.tar.gz -C $dir/download/0468
 
+    echo "Correcting file names."
+    mv $dir/download/0467-1/'0467 sv train 1' $dir/download/0467-1/0467_sv_train_1 
+    mv $dir/download/0467-2/'0467 sv train 2' $dir/download/0467-2/0467_sv_train_2 
+    mv $dir/download/0467-3/'0467 sv train 3' $dir/download/0467-3/0467_sv_train_3 
+    mv $dir/download/0468/'0468 sv test' $dir/download/0468/0468_sv_test 
      
     echo "Corpus unpacked succesfully."
 fi
+
+fi # <- remove this
 
 sph2pipe=$(which sph2pipe) || sph2pipe=$KALDI_ROOT/tools/sph2pipe_v2.5/sph2pipe
 if [ ! -x $sph2pipe ]; then

--- a/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
+++ b/egs/sprakbanken_swe/s5/local/sprak_data_prep.sh
@@ -18,8 +18,6 @@ utils=`pwd`/utils
 
 . ./path.sh
 
-if false; then
-
 # Checks if python3 is available on the system and install python3 in userspace if not
 # This recipe currently relies on version 3 because python3 uses utf8 as internal 
 # string representation
@@ -58,7 +56,7 @@ if [ ! -d $dir/download/0468 ]; then
     tar -xzf $dir/download/sve.16khz.0467-1.tar.gz -C $dir/download/0467-1
     tar -xzf $dir/download/sve.16khz.0467-2.tar.gz -C $dir/download/0467-2
     tar -xzf $dir/download/sve.16khz.0467-3.tar.gz -C $dir/download/0467-3
-    make -p $dir/download/0468
+    mkdir -p $dir/download/0468
     tar -xzf $dir/download/sve.16khz.0468.tar.gz -C $dir/download/0468
 
     echo "Correcting file names."
@@ -69,8 +67,6 @@ if [ ! -d $dir/download/0468 ]; then
      
     echo "Corpus unpacked succesfully."
 fi
-
-fi # <- remove this
 
 sph2pipe=$(which sph2pipe) || sph2pipe=$KALDI_ROOT/tools/sph2pipe_v2.5/sph2pipe
 if [ ! -x $sph2pipe ]; then


### PR DESCRIPTION
The changes in this branch make the sprakbanken_swe recipe run. This is still not the version that was used to obtain the results reported in the RESULTS file. It obtains on average about 5 percent points lower accuracy that what reported. This may be due to a large number of missing words in the dictionary, mostly due to misspelling in the transcriptions of the data set. Also, the scripts seem to optimize insertion penalty and language weight to the same test data that is used for the final results, which is not correct.