### PR TITLE
[src] Unpin host memory, fix race in cuda-online-pipeline

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -27,6 +27,7 @@
 
 #include <nvToolsExt.h>
 
+#include "cudamatrix/cu-common.h"
 #include "feat/feature-window.h"
 #include "lat/lattice-functions.h"
 #include "nnet3/nnet-utils.h"
@@ -37,6 +38,22 @@ namespace cuda_decoder {
 const double kSleepForCallBack = 10e-3;
 const double kSleepForCpuFeatures = 1e-3;
 const double kSleepForChannelAvailable = 1e-3;
+
+BatchedThreadedNnet3CudaOnlinePipeline::~BatchedThreadedNnet3CudaOnlinePipeline(
+) {
+  // The destructor races with callback completion. Even if all callbacks have
+  // finished, the counter may (non-deterministically) lag behind by a few ms.
+  // Deleting the object when all callbacks had been called is UB: the variable
+  // n_lattice_callbacks_not_done_ is accessed after a callback has returned.
+  WaitForLatticeCallbacks();
+  KALDI_ASSERT(n_lattice_callbacks_not_done_ == 0);
+  KALDI_ASSERT(available_channels_.empty() ||
+               available_channels_.size() == config_.num_channels);
+
+  if (h_all_waveform_.SizeInBytes() > 0) {
+    CU_SAFE_CALL(::cudaHostUnregister(h_all_waveform_.Data()));
+  }
+}
 
 void BatchedThreadedNnet3CudaOnlinePipeline::Initialize(
     const fst::Fst<fst::StdArc> &decode_fst) {
@@ -611,7 +628,8 @@ void BatchedThreadedNnet3CudaOnlinePipeline::FinalizeDecoding(
   n_lattice_callbacks_not_done_.fetch_sub(1, std::memory_order_release);
 }
 
-void BatchedThreadedNnet3CudaOnlinePipeline::WaitForLatticeCallbacks() {
+void BatchedThreadedNnet3CudaOnlinePipeline::WaitForLatticeCallbacks()
+    noexcept {
   while (n_lattice_callbacks_not_done_.load() != 0)
     Sleep(kSleepForCallBack);
 }


### PR DESCRIPTION
* Unpin memory of h_all_waveform_, deallocated but left pinned upon
  instance destruction.
* Add a destructor to the class, and invoke WaitForLatticeCallbacks()
  to prevent a short race between the destorying of this instance and
  completion of callback threads, which decrement the pending callback
  count _after_ the callback has returned and been deleted.
* Add assertions to the destructor.

@galv, @hugovbraun, PTAL.