### PR TITLE
Fix make depend without cuda

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h"
 
@@ -619,3 +617,5 @@ void BatchedThreadedNnet3CudaOnlinePipeline::WaitForLatticeCallbacks() {
 
 }  // namespace cuda_decoder
 }  // namespace kaldi
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #define SLEEP_BACKOFF_NS 500
 #define SLEEP_BACKOFF_S ((double)SLEEP_BACKOFF_NS / 1e9)
@@ -968,3 +966,5 @@ void BatchedThreadedNnet3CudaPipeline::ExecuteWorker(int threadId) {
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline2.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support is required to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-pipeline2.h"
 
@@ -479,3 +477,5 @@ void BatchedThreadedNnet3CudaPipeline2::SetLatticePostprocessor(
 
 }  // namespace cuda_decoder
 }  // namespace kaldi
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #include "cudadecoder/cuda-decoder.h"
 
@@ -2078,3 +2076,5 @@ void CudaDecoder::SetThreadPoolAndStartCPUWorkers(ThreadPoolLight *thread_pool,
 
 }  // namespace cuda_decoder
 }  // namespace kaldi
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoder/cuda-fst.cc
+++ b/src/cudadecoder/cuda-fst.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #include "cudadecoder/cuda-fst.h"
 
@@ -207,3 +205,5 @@ void CudaFst::Finalize() {
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this library.
-#endif
+#if HAVE_CUDA == 1
 
 #include "cudadecoder/cuda-online-pipeline-dynamic-batcher.h"
 
@@ -169,3 +167,5 @@ void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
 
 }  // namespace cuda_decoder
 }  // namespace kaldi
+
+#endif /* HAVE_CUDA == 1 */

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda-online.cc
@@ -19,9 +19,7 @@
 // Can serve both as a benchmarking tool and an example on how to call
 // BatchedThreadedNnet3CudaOnlinePipeline.
 
-#if !HAVE_CUDA
-#error CUDA support must be configured to compile this binary.
-#endif
+#if HAVE_CUDA == 1
 
 #include <algorithm>
 #include <iomanip>
@@ -275,3 +273,5 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 }  // main()
+
+#endif  // if HAVE_CUDA == 1

--- a/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
+++ b/src/cudadecoderbin/batched-wav-nnet3-cuda2.cc
@@ -15,8 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <atomic>
 #if HAVE_CUDA == 1
+
+#include <atomic>
 
 #include <cuda.h>
 #include <cuda_profiler_api.h>


### PR DESCRIPTION
Currently `make depend` without cuda is broken. Originally broken in 5de039aeaacb90241d0362f113eeb88c5c46943d 

```
shmyrev@kappa ~/t/kaldi/src/cudadecoderbin $ make depend
rm -f .depend.mk
g++ -M -std=c++14 -I.. -isystem /home/shmyrev/t/kaldi/tools/openfst-1.7.2/include -O1  -Wall -Wno-sign-compare -Wno-unused-local-typedefs -Wno-deprecated-declarations -Winit-self -DKALDI_DOUBLEPRECISION=0 -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_ATLAS -I/home/shmyrev/t/kaldi/tools/ATLAS_headers/include -msse -msse2 -pthread -g batched-wav-nnet3-cuda2.cc batched-wav-nnet3-cuda.cc batched-wav-nnet3-cuda-online.cc >> .depend.mk
batched-wav-nnet3-cuda-online.cc:23:2: error: #error CUDA support must be configured to compile this binary.
   23 | #error CUDA support must be configured to compile this binary.
      |  ^~~~~
batched-wav-nnet3-cuda-online.cc:31:10: fatal error: cuda.h: No such file or directory
   31 | #include <cuda.h>
      |          ^~~~~~~~
compilation terminated.
../makefiles/default_rules.mk:149: recipe for target 'depend' failed
make: *** [depend] Error 1
```

