### PR TITLE
[src] Elevenize KALDI_DISALLOW_COPY_AND_ASSIGN()

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -121,10 +121,15 @@ void Sleep(double seconds);
           (reinterpret_cast<char*>(&a))[1]=t;} while (0)
 
 
-// Makes copy constructor and operator= private.
+///\brief Declare deleted copy constructor and copy assignment operator=().
+///
+/// Use this macro in the \e public part of a class declaration in a header
+/// file, next to its constructors, so that uncopyability of the type is
+/// clearly readable. Place a semicolon after it.
+///\param type The exact enclosing class name.
 #define KALDI_DISALLOW_COPY_AND_ASSIGN(type)    \
-  type(const type&);                  \
-  void operator = (const type&)
+  type(const type&) = delete;                   \
+  type& operator=(const type&) = delete
 
 template<bool B> class KaldiCompileTimeAssert { };
 template<> class KaldiCompileTimeAssert<true> {


### PR DESCRIPTION
Before C++11 we declared the same members private, usually at the very end of a class declaration. With standardization of the `delete` keyword and adoption of the pattern, it is now idiomatic to make deleted members public. The rationale (which I'm totally with) is that deletion of copy members is part of the public behavior of a type, namely its uncopyability, and should be expressed in and readable from the `public:` section alone.

Google coding style, which we are generally following, does not mention the `DISALLOW_COPY_AND_ASSIGN` macro any more, and [recommends using the `= delete;` construct directly](https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types):

> Every class's **public** interface must make clear which copy and move operations the class supports. This should usually take the form of explicitly declaring and/or deleting the appropriate operations in the **public** section of the declaration.

[Bold mine; the focus on _public_ is very explicit.]

Examples from the guide use the `delete` straight without the macro¹, but I think we should make an exception and continue using the macro, which is more self-explanatory.

clang-tidy gets angry at non-public deleted members, too.

_ _
¹ Which originated at Google as `DISALLOW_EVIL_CONSTRUCTORS` and had been renamed `DISALLOW_COPY_AND_ASSIGN` during my tenure, around 2014, when Google first started releasing parts of its code as OSS.