### PR TITLE
[src] Fix leaking CudaFst object's device memory

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -90,9 +90,8 @@ void BatchedThreadedNnet3CudaOnlinePipeline::AllocateAndInitializeData(
     feature_pipelines_.resize(config_.num_channels);
   }
 
-  // Decoder
-  cuda_fst_ = std::make_shared<CudaFst>();
-  cuda_fst_->Initialize(decode_fst, trans_model_);
+  // Decoder.
+  cuda_fst_ = std::make_unique<CudaFst>(decode_fst, trans_model_);
   cuda_decoder_.reset(new CudaDecoder(*cuda_fst_, config_.decoder_opts,
                                       max_batch_size_, config_.num_channels));
   if (config_.num_decoder_copy_threads > 0) {

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -413,7 +413,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
   // HCLG graph : CudaFst object is a host object, but contains
   // data stored in
   // GPU memory
-  std::shared_ptr<CudaFst> cuda_fst_;
+  std::unique_ptr<CudaFst> cuda_fst_;
   std::unique_ptr<CudaDecoder> cuda_decoder_;
 
   std::unique_ptr<ThreadPoolLight> thread_pool_;

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.cc
@@ -23,8 +23,13 @@
 #define SLEEP_BACKOFF_S ((double)SLEEP_BACKOFF_NS / 1e9)
 
 #include "cudadecoder/batched-threaded-nnet3-cuda-pipeline.h"
+
+#include <memory>
+
 #include <nvToolsExt.h>
+
 #include "base/kaldi-utils.h"
+#include "cudadecoder/cuda-fst.h"
 
 // This pipeline is deprecated and will be removed. Please switch to
 // batched-threaded-nnet3-cuda-pipeline2
@@ -45,7 +50,7 @@ void BatchedThreadedNnet3CudaPipeline::Initialize(
 
   am_nnet_ = &am_nnet;
   trans_model_ = &trans_model;
-  cuda_fst_.Initialize(decode_fst, trans_model_);
+  cuda_fst_ = std::make_unique<CudaFst>(decode_fst, trans_model_);
 
   feature_info_ = new OnlineNnet2FeaturePipelineInfo(config_.feature_opts);
   feature_info_->ivector_extractor_info.use_most_recent_ivector = true;
@@ -93,7 +98,7 @@ void BatchedThreadedNnet3CudaPipeline::Finalize() {
     thread_contexts_[i].join();
   }
 
-  cuda_fst_.Finalize();
+  cuda_fst_.reset();
 
   delete feature_info_;
   delete work_pool_;
@@ -819,7 +824,7 @@ void BatchedThreadedNnet3CudaPipeline::ExecuteWorker(int threadId) {
             << " num_channels=" << config_.num_channels;
   // Data structures that are reusable across decodes but unique to each
   // thread
-  CudaDecoder cuda_decoder(cuda_fst_, config_.decoder_opts,
+  CudaDecoder cuda_decoder(*cuda_fst_, config_.decoder_opts,
                            config_.max_batch_size, config_.num_channels);
   nnet3::NnetBatchComputer computer(config_.compute_opts, am_nnet_->GetNnet(),
                                     am_nnet_->Priors());
@@ -916,7 +921,7 @@ void BatchedThreadedNnet3CudaPipeline::ExecuteWorker(int threadId) {
         // outs, and cleans up data structures
         PostDecodeProcessing(cuda_decoder, channel_state, decodables, tasks);
 
-      } catch (CudaDecoderException e) {
+      } catch (CudaDecoderException &e) {
         // Code to catch errors.  Most errors are
         // unrecoverable but a user can mark them
         // recoverable which will cancel the entire

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -19,6 +19,7 @@
 #define KALDI_CUDA_DECODER_BATCHED_THREADED_NNET3_CUDA_PIPELINE_H_
 
 #include <atomic>
+#include <memory>
 #include <thread>
 
 #include "cudadecoder/cuda-decoder.h"
@@ -364,7 +365,7 @@ class [[deprecated]] BatchedThreadedNnet3CudaPipeline {
 
   BatchedThreadedNnet3CudaPipelineConfig config_;
 
-  CudaFst cuda_fst_;
+  std::unique_ptr<CudaFst> cuda_fst_;
   const TransitionModel *trans_model_;
   const nnet3::AmNnetSimple *am_nnet_;
   nnet3::DecodableNnetSimpleLoopedInfo *decodable_info_;

--- a/src/cudadecoder/cuda-fst.cc
+++ b/src/cudadecoder/cuda-fst.cc
@@ -27,137 +27,12 @@
 namespace kaldi {
 namespace cuda_decoder {
 
-void CudaFst::ComputeOffsets(const fst::Fst<StdArc> &fst) {
-  // count states since Fst doesn't provide this functionality
-  num_states_ = 0;
-  for (fst::StateIterator<fst::Fst<StdArc> > iter(fst); !iter.Done();
-       iter.Next())
-    ++num_states_;
-
-  // allocate and initialize offset arrays
-  h_final_.resize(num_states_);
-  h_e_offsets_.resize(num_states_ + 1);
-  h_ne_offsets_.resize(num_states_ + 1);
-
-  // iterate through states and arcs and count number of arcs per state
-  e_count_ = 0;
-  ne_count_ = 0;
-
-  // Init first offsets
-  h_ne_offsets_[0] = 0;
-  h_e_offsets_[0] = 0;
-  for (int i = 0; i < num_states_; i++) {
-    h_final_[i] = fst.Final(i).Value();
-    // count emiting and non_emitting arcs
-    for (fst::ArcIterator<fst::Fst<StdArc> > aiter(fst, i); !aiter.Done();
-         aiter.Next()) {
-      StdArc arc = aiter.Value();
-      int32 ilabel = arc.ilabel;
-      if (ilabel != 0) {  // emitting
-        e_count_++;
-      } else {  // non-emitting
-        ne_count_++;
-      }
-    }
-    h_ne_offsets_[i + 1] = ne_count_;
-    h_e_offsets_[i + 1] = e_count_;
-  }
-
-  // We put the emitting arcs before the nonemitting arcs in the arc list
-  // adding offset to the non emitting arcs
-  // we go to num_states_+1 to take into account the last offset
-  for (int i = 0; i < num_states_ + 1; i++)
-    h_ne_offsets_[i] += e_count_;  // e_arcs before
-
-  arc_count_ = e_count_ + ne_count_;
-}
-
-void CudaFst::AllocateData(const fst::Fst<StdArc> &fst) {
-  d_e_offsets_ = static_cast<unsigned int *>(CuDevice::Instantiate().Malloc(
-      (num_states_ + 1) * sizeof(*d_e_offsets_)));
-  d_ne_offsets_ = static_cast<unsigned int *>(CuDevice::Instantiate().Malloc(
-      (num_states_ + 1) * sizeof(*d_ne_offsets_)));
-  d_final_ = static_cast<float *>(
-      CuDevice::Instantiate().Malloc((num_states_) * sizeof(*d_final_)));
-
-  h_arc_weights_.resize(arc_count_);
-  h_arc_nextstate_.resize(arc_count_);
-  // ilabels (id indexing)
-  h_arc_id_ilabels_.resize(arc_count_);
-  h_arc_olabels_.resize(arc_count_);
-
-  d_arc_weights_ = static_cast<float *>(
-      CuDevice::Instantiate().Malloc(arc_count_ * sizeof(*d_arc_weights_)));
-  d_arc_nextstates_ = static_cast<StateId *>(
-      CuDevice::Instantiate().Malloc(arc_count_ * sizeof(*d_arc_nextstates_)));
-
-  // Only the ilabels for the e_arc are needed on the device
-  d_arc_pdf_ilabels_ = static_cast<int32 *>(
-      CuDevice::Instantiate().Malloc(e_count_ * sizeof(*d_arc_pdf_ilabels_)));
-}
-
-void CudaFst::PopulateArcs(const fst::Fst<StdArc> &fst) {
-  // now populate arc data
-  int e_idx = 0;
-  int ne_idx = e_count_;  // starts where e_offsets_ ends
-  for (int i = 0; i < num_states_; i++) {
-    for (fst::ArcIterator<fst::Fst<StdArc> > aiter(fst, i); !aiter.Done();
-         aiter.Next()) {
-      StdArc arc = aiter.Value();
-      int idx;
-      if (arc.ilabel != 0) {  // emitting
-        idx = e_idx++;
-      } else {
-        idx = ne_idx++;
-      }
-      h_arc_weights_[idx] = arc.weight.Value();
-      h_arc_nextstate_[idx] = arc.nextstate;
-      h_arc_id_ilabels_[idx] = arc.ilabel;
-      // For now we consider id indexing == pdf indexing
-      // If the two are differents, we'll call ApplyTransModelOnIlabels with a
-      // TransitionModel
-      h_arc_pdf_ilabels_[idx] = arc.ilabel;
-      h_arc_olabels_[idx] = arc.olabel;
-    }
-  }
-}
-
-void CudaFst::ApplyTransitionModelOnIlabels(
-    const TransitionModel &trans_model) {
-  // Converting ilabel here, to avoid reindexing when reading nnet3 output
-  // We only need to convert the emitting arcs
-  // The emitting arcs are the first e_count_ arcs
-  for (int iarc = 0; iarc < e_count_; ++iarc)
-    h_arc_pdf_ilabels_[iarc] =
-        trans_model.TransitionIdToPdf(h_arc_id_ilabels_[iarc]);
-}
-
-void CudaFst::CopyDataToDevice() {
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
-      d_e_offsets_, &h_e_offsets_[0], (num_states_ + 1) * sizeof(*d_e_offsets_),
-      cudaMemcpyHostToDevice));
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
-      d_ne_offsets_, &h_ne_offsets_[0],
-      (num_states_ + 1) * sizeof(*d_ne_offsets_), cudaMemcpyHostToDevice));
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(d_final_, &h_final_[0],
-                                                num_states_ * sizeof(*d_final_),
-                                                cudaMemcpyHostToDevice));
-
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(
-      cudaMemcpy(d_arc_weights_, &h_arc_weights_[0],
-                 arc_count_ * sizeof(*d_arc_weights_), cudaMemcpyHostToDevice));
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
-      d_arc_nextstates_, &h_arc_nextstate_[0],
-      arc_count_ * sizeof(*d_arc_nextstates_), cudaMemcpyHostToDevice));
-  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
-      d_arc_pdf_ilabels_, &h_arc_pdf_ilabels_[0],
-      e_count_ * sizeof(*d_arc_pdf_ilabels_), cudaMemcpyHostToDevice));
-}
-
-void CudaFst::Initialize(const fst::Fst<StdArc> &fst,
-                         const TransitionModel *trans_model) {
+CudaFst::CudaFst(const fst::StdFst &fst,
+                 const TransitionModel *trans_model /* = nullptr */) {
   nvtxRangePushA("CudaFst constructor");
+
   start_ = fst.Start();
+  KALDI_ASSERT(start_ != fst::kNoStateId);
 
   ComputeOffsets(fst);
   AllocateData(fst);
@@ -181,29 +56,137 @@ void CudaFst::Initialize(const fst::Fst<StdArc> &fst,
   cudaDeviceSynchronize();
   KALDI_DECODER_CUDA_CHECK_ERROR();
   h_arc_pdf_ilabels_.clear();  // we don't need those on host
+
   nvtxRangePop();
 }
 
-void CudaFst::Finalize() {
-  nvtxRangePushA("CudaFst destructor");
+void CudaFst::ComputeOffsets(const fst::StdFst &fst) {
+  // count states since Fst doesn't provide this functionality
+  num_states_ = 0;
+  for (fst::StateIterator<fst::StdFst> iter(fst); !iter.Done(); iter.Next()) {
+    ++num_states_;
+  }
 
-  // Making sure that Initialize was called before Finalize
-  KALDI_ASSERT(d_e_offsets_ &&
-               "Please call CudaFst::Initialize() before calling Finalize()");
-  KALDI_ASSERT(d_ne_offsets_);
-  KALDI_ASSERT(d_final_);
-  KALDI_ASSERT(d_arc_weights_);
-  KALDI_ASSERT(d_arc_nextstates_);
-  KALDI_ASSERT(d_arc_pdf_ilabels_);
+  // allocate and initialize offset arrays
+  h_final_.resize(num_states_);
+  h_e_offsets_.resize(num_states_ + 1);
+  h_ne_offsets_.resize(num_states_ + 1);
 
-  CuDevice::Instantiate().Free(d_e_offsets_);
-  CuDevice::Instantiate().Free(d_ne_offsets_);
-  CuDevice::Instantiate().Free(d_final_);
-  CuDevice::Instantiate().Free(d_arc_weights_);
-  CuDevice::Instantiate().Free(d_arc_nextstates_);
-  CuDevice::Instantiate().Free(d_arc_pdf_ilabels_);
-  nvtxRangePop();
+  // iterate through states and arcs and count number of arcs per state
+  e_count_ = 0;
+  ne_count_ = 0;
+
+  // Init first offsets
+  h_ne_offsets_[0] = 0;
+  h_e_offsets_[0] = 0;
+  for (uint32 i = 0; i < num_states_; ++i) {
+    h_final_[i] = fst.Final(i).Value();
+    // count emiting and non_emitting arcs
+    for (fst::ArcIterator<fst::StdFst> aiter(fst, i); !aiter.Done();
+         aiter.Next()) {
+      Arc arc = aiter.Value();
+      Label ilabel = arc.ilabel;
+      if (ilabel != 0) {  // emitting
+        e_count_++;
+      } else {  // non-emitting
+        ne_count_++;
+      }
+    }
+    h_ne_offsets_[i + 1] = ne_count_;
+    h_e_offsets_[i + 1] = e_count_;
+  }
+
+  // We put the emitting arcs before the nonemitting arcs in the arc list
+  // adding offset to the non emitting arcs
+  // we go to num_states_+1 to take into account the last offset
+  for (uint32 i = 0; i < num_states_ + 1; ++i)
+    h_ne_offsets_[i] += e_count_;  // e_arcs before
+
+  arc_count_ = e_count_ + ne_count_;
 }
 
-}  // end namespace cuda_decoder
-}  // end namespace kaldi
+void CudaFst::AllocateData(const fst::StdFst &fst) {
+  d_e_offsets_.reset(static_cast<uint32*>(CuDevice::Instantiate().Malloc(
+      (num_states_ + 1) * sizeof(*d_e_offsets_))));
+  d_ne_offsets_.reset(static_cast<uint32*>(CuDevice::Instantiate().Malloc(
+      (num_states_ + 1) * sizeof(*d_ne_offsets_))));
+  d_final_.reset(static_cast<float*>(CuDevice::Instantiate().Malloc(
+      (num_states_) * sizeof(*d_final_))));
+
+  h_arc_weights_.resize(arc_count_);
+  h_arc_nextstate_.resize(arc_count_);
+  // ilabels (id indexing)
+  h_arc_id_ilabels_.resize(arc_count_);
+  h_arc_olabels_.resize(arc_count_);
+
+  d_arc_weights_.reset(static_cast<CostType*>(CuDevice::Instantiate().Malloc(
+      arc_count_ * sizeof(*d_arc_weights_))));
+  d_arc_nextstates_.reset(static_cast<StateId*>(CuDevice::Instantiate().Malloc(
+      arc_count_ * sizeof(*d_arc_nextstates_))));
+
+  // Only the ilabels for the e_arc are needed on the device
+  d_arc_pdf_ilabels_.reset(static_cast<int32*>(CuDevice::Instantiate().Malloc(
+      e_count_ * sizeof(*d_arc_pdf_ilabels_))));
+}
+
+void CudaFst::PopulateArcs(const fst::StdFst &fst) {
+  // now populate arc data
+  uint32 e_idx = 0;
+  uint32 ne_idx = e_count_;  // starts where e_offsets_ ends
+  for (uint32 i = 0; i < num_states_; ++i) {
+    for (fst::ArcIterator<fst::StdFst> aiter(fst, i); !aiter.Done();
+         aiter.Next()) {
+      Arc arc = aiter.Value();
+      uint32 idx;
+      if (arc.ilabel != 0) {  // emitting
+        idx = e_idx++;
+      } else {
+        idx = ne_idx++;
+      }
+      h_arc_weights_[idx] = arc.weight.Value();
+      h_arc_nextstate_[idx] = arc.nextstate;
+      h_arc_id_ilabels_[idx] = arc.ilabel;
+      // For now we consider id indexing == pdf indexing
+      // If the two are differents, we'll call ApplyTransModelOnIlabels with a
+      // TransitionModel
+      h_arc_pdf_ilabels_[idx] = arc.ilabel;
+      h_arc_olabels_[idx] = arc.olabel;
+    }
+  }
+}
+
+void CudaFst::ApplyTransitionModelOnIlabels(
+    const TransitionModel &trans_model) {
+  // Converting ilabel here, to avoid reindexing when reading nnet3 output
+  // We only need to convert the emitting arcs
+  // The emitting arcs are the first e_count_ arcs
+  for (uint32 iarc = 0; iarc < e_count_; ++iarc) {
+    h_arc_pdf_ilabels_[iarc] =
+        trans_model.TransitionIdToPdf(h_arc_id_ilabels_[iarc]);
+  }
+}
+
+void CudaFst::CopyDataToDevice() {
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
+      d_e_offsets_.get(), &h_e_offsets_[0],
+      (num_states_ + 1) * sizeof(*d_e_offsets_),
+      cudaMemcpyHostToDevice));
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
+      d_ne_offsets_.get(), &h_ne_offsets_[0],
+      (num_states_ + 1) * sizeof(*d_ne_offsets_), cudaMemcpyHostToDevice));
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(d_final_.get(), &h_final_[0],
+                                                num_states_ * sizeof(*d_final_),
+                                                cudaMemcpyHostToDevice));
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(
+      cudaMemcpy(d_arc_weights_.get(), &h_arc_weights_[0],
+                 arc_count_ * sizeof(*d_arc_weights_), cudaMemcpyHostToDevice));
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
+      d_arc_nextstates_.get(), &h_arc_nextstate_[0],
+      arc_count_ * sizeof(*d_arc_nextstates_), cudaMemcpyHostToDevice));
+  KALDI_DECODER_CUDA_API_CHECK_ERROR(cudaMemcpy(
+      d_arc_pdf_ilabels_.get(), &h_arc_pdf_ilabels_[0],
+      e_count_ * sizeof(*d_arc_pdf_ilabels_), cudaMemcpyHostToDevice));
+}
+
+}  // namespace cuda_decoder
+}  // namespace kaldi

--- a/src/cudadecoder/cuda-fst.h
+++ b/src/cudadecoder/cuda-fst.h
@@ -15,8 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_CUDA_DECODER_CUDA_FST_H_
-#define KALDI_CUDA_DECODER_CUDA_FST_H_
+#ifndef KALDI_CUDADECODER_CUDA_FST_H_
+#define KALDI_CUDADECODER_CUDA_FST_H_
+
+#if HAVE_CUDA
+
+#include <vector>
+
+#include "base/kaldi-utils.h"
 #include "cudadecoder/cuda-decoder-common.h"
 #include "cudamatrix/cu-device.h"
 #include "lat/kaldi-lattice.h"
@@ -25,11 +31,7 @@
 namespace kaldi {
 namespace cuda_decoder {
 
-typedef fst::StdArc StdArc;
-typedef StdArc::Weight StdWeight;
-typedef StdArc::Label Label;
-
-// FST in both device and host memory
+//
 // Converting the OpenFst format to the CSR Compressed Sparse Row (CSR) Matrix
 // format.
 // https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
@@ -41,37 +43,66 @@ typedef StdArc::Label Label;
 // Emitting arcs and non-emitting arcs are stored as separate matrices for
 // efficiency
 // We then copy the FST to the device (while keeping its original copy on host)
+
+///\brief Represent the HCLG FST in both device and host memory.
+///
+/// The standard Kaldi's representation of the HCLG machine in fst::StdFst is
+/// converted to the Compressed Sparse Row (CSR), a.k.a. [Yale format matrix](
+/// https://en.wikipedia.org/w/index.php?title=Sparse_matrix&oldid=1023781875#Compressed_sparse_row_%28CSR%2C_CRS_or_Yale_format%29),
+/// where states correcpond to rows and arcs to columns. This format allows
+/// storing the FST in a compact form, and leads to clean memory accesses.
+///
+/// For instance, when loading the arcs from a given source, we can load all
+/// arcs information (destination, weight, etc.) with coalesced reads. Emitting
+/// and non-emitting arcs are stored as separate matrices for efficiency.
+///
+/// The object stores this representation in both host and device memory for
+/// its lifetime.
+
 class CudaFst {
  public:
-  CudaFst()
-      : d_e_offsets_(nullptr),
-        d_ne_offsets_(nullptr),
-        d_arc_weights_(nullptr),
-        d_arc_nextstates_(nullptr),
-        d_arc_pdf_ilabels_(nullptr),
-        d_final_(nullptr){};
-  // Creates a CSR representation of the FST,
-  // then copies it to the GPU
-  // If a TransitionModel is passed, we'll use it to convert the ilabels id
-  // indexes into pdf indexes
-  // If no TransitionModel is passed, we'll assume TransitionModel == identity
-  // Important: The CudaDecodable won't apply the TransitionModel. If you use a
-  // TransitionModel, you need to apply it now
-  void Initialize(const fst::Fst<StdArc> &fst,
-                  const TransitionModel *trans_model = NULL);
-  void Finalize();
+  typedef fst::StdArc Arc;
+  typedef Arc::Weight Weight;
+  typedef Arc::Label Label;
+  typedef Arc::StateId StateId;
 
-  inline uint32_t NumStates() const { return num_states_; }
-  inline StateId Start() const { return start_; }
+  ///\brief Creates a CSR representation of the FST, then copies it to the GPU.
+  ///
+  /// If a non-null \p trans_model is passed, we'll use it to convert the
+  /// ilabel ID indexes into PDF indexes. Otherwise we assume
+  /// TransitionModel == identity.
+  ///
+  ///\warning The CudaDecodable won't apply the TransitionModel. If you use a
+  ///  TransitionModel, you need to apply it now.
+  CudaFst(const fst::StdFst &fst,
+          const TransitionModel *trans_model = nullptr);
+
+  KALDI_DISALLOW_COPY_AND_ASSIGN(CudaFst);
+
+  uint32_t NumStates() const { return num_states_; }
+  StateId Start() const { return start_; }
 
  private:
+  // TODO(kkm): The typedef and the deleter for unique_ptr to device memory
+  // should better be integerated into cu-device or cu-allocator. This
+  // is currently a proof-of-concept only.
+  template<typename T>
+  struct CuDeleter {
+    constexpr CuDeleter() noexcept = default;
+    void operator()(T* ptr) const { CuDevice::Instantiate().Free(ptr); }
+  };
+  /// A uniquely owned, movable pointer to device-allocated memory.
+  template<typename T>
+  using unique_device_ptr = std::unique_ptr<T, CuDeleter<T>>;
+
+
   friend class CudaDecoder;
   // Counts arcs and computes offsets of the fst passed in
-  void ComputeOffsets(const fst::Fst<StdArc> &fst);
+  void ComputeOffsets(const fst::StdFst &fst);
   // Allocates memory to store FST
-  void AllocateData(const fst::Fst<StdArc> &fst);
+  void AllocateData(const fst::StdFst &fst);
   // Populate the arcs data (arc.destination, arc.weights, etc.)
-  void PopulateArcs(const fst::Fst<StdArc> &fst);
+  void PopulateArcs(const fst::StdFst &fst);
   // Converting the id ilabels into pdf ilabels using the transition model
   // It allows the CudaDecoder to read the acoustic model loglikelihoods at the
   // right indexes
@@ -79,21 +110,21 @@ class CudaFst {
   // Copies fst to device into the pre-allocated datastructures
   void CopyDataToDevice();
   // Total number of states
-  unsigned int num_states_;
+  uint32 num_states_;
   // Starting state of the FST
   // Computation should start from state start_
   StateId start_;
   // Number of emitting, non-emitting, and total number of arcs
-  unsigned int e_count_, ne_count_, arc_count_;
+  uint32 e_count_, ne_count_, arc_count_;
   // This data structure is similar to a CSR matrix format
   // with 2 offsets matrices (one emitting one non-emitting).
   // Offset arrays are num_states_+1 in size (last state needs
   // its +1 arc_offset)
-  // Arc values for state i are stored in the range of [offset[i],offset[i+1][
-  unsigned int *d_e_offsets_;  // Emitting offset arrays
-  std::vector<unsigned int> h_e_offsets_;
-  unsigned int *d_ne_offsets_;  // Non-emitting offset arrays
-  std::vector<unsigned int> h_ne_offsets_;
+  // Arc values for state i are stored in the range of [offset[i],offset[i+1]]
+  unique_device_ptr<uint32> d_e_offsets_;  // Emitting offset arrays
+  std::vector<uint32> h_e_offsets_;
+  unique_device_ptr<uint32> d_ne_offsets_;  // Non-emitting offset arrays
+  std::vector<uint32> h_ne_offsets_;
   // These are the values for each arc.
   // Arcs belonging to state i are found in the range of [offsets[i],
   // offsets[i+1][
@@ -101,16 +132,16 @@ class CudaFst {
   // (emitting/nonemitting)
   // The ilabels arrays are of size e_count_, not arc_count_
   std::vector<CostType> h_arc_weights_;
-  CostType *d_arc_weights_;
+  unique_device_ptr<CostType> d_arc_weights_;
   std::vector<StateId> h_arc_nextstate_;
-  StateId *d_arc_nextstates_;
+  unique_device_ptr<StateId> d_arc_nextstates_;
   std::vector<int32> h_arc_id_ilabels_;
-  int32 *d_arc_pdf_ilabels_;
+  unique_device_ptr<int32> d_arc_pdf_ilabels_;
   std::vector<int32> h_arc_olabels_;
   // Final costs
   // final cost of state i is h_final_[i]
   std::vector<CostType> h_final_;
-  CostType *d_final_;
+  unique_device_ptr<CostType> d_final_;
 
   // ilabels (pdf indexing)
   // only populate during CSR generation, cleared after (not needed on host)
@@ -119,4 +150,6 @@ class CudaFst {
 
 }  // end namespace cuda_decoder
 }  // end namespace kaldi
-#endif  // KALDI_CUDA_DECODER_CUDA_FST_H_
+
+#endif  // HAVE_CUDA
+#endif  // KALDI_CUDADECODER_CUDA_FST_H_


### PR DESCRIPTION
`BatchedThreadedNnet3CudaOnlinePipeline` never freed a `CudaFst` object which it initialized. Freeing it caused an error returned from `::cudaFree` (with our allocator disabled).

The root cause of this problem was copying of the `CudaFst` in `CudaDecoder`'s constructor. I rewrote it so that `CudaDecoder` only stores a reference to a `CudaFst` instance, and the object itself is uniquely owned by the pipeline (as `CudaDecoder` already is). 

This allowed folding of separate `CudaFst::Initialize` and `CudaFst::Finalize` methods into its respective constructor and destructor.

Then I added a proof-of-concept `unique_device_ptr`, a specialization of `std::unique_ptr` for device-allocated memory. The type is declared privately in, and only used by `CudaFst`. The `CudaFst::Finalize` had been removed entirely, and the memory is freed in the object's destructor, as members are destroyed. The specialized smart pointer is defined as 

```c++
  template<typename T>
  struct CuDeleter {
    constexpr CuDeleter() noexcept = default;
    void operator()(T* ptr) const { CuDevice::Instantiate().Free(ptr); }
  };

  /// A uniquely owned, movable pointer to device-allocated memory.
  template<typename T>
  using unique_device_ptr = std::unique_ptr<T, CuDeleter<T>>;
```

Technically this does not provide any safety against e.g. dereferencing the device pointer on host, only controls the allocation lifetime. But my two-day leak hunting safari suggests that this thing alone is quite useful.

I think we can also minimize ugly alloc size computation by adding members to CuDevice, Malloc-like, but templated on an element type and taking the number of elements as an argument, and returning `unique_device_ptr`. (A raw pointer is detachable with unique_device_ptr::release(), but that's explicit and more readable).

@danpovey, @jtrmal, please comment on this approach.

My hands are itchy for a single-member `device_memptr` structure, not mutually implicitly convertible with a regular pointer. How many different ::cudaXXX() functions which take pointers do we use? No more than a dozen, I think. We could wrap them so that they take raw pointers for host, `device_memptr`s for device memory. And if the thing also knew it was pinned and unregistered itself on destruction of the wrapper, I'd jump over the moon. In short, I want to make writing incorrect CUDA host-side code as hard as possible. :)

Other minor cleanup:
* Match the types in `CudaFst` to those in `monsterstruct DeviceParams` (like `int` vs `int32`), and use explicitly sized integer types generally.
* Use safe pointers for `KernelParams` and `DeviceParams` instead of new/delete.
* Move definitions of Arc, Weight, Label and StateId into `CudaFst` and out of the namespace scope, where they probably ended up by mistake.
* Doxygenate some comments, very non-systematically, rather only those I had to touch.

@hugovbraun, @galv, PTAL.