### PR TITLE
[src] Remove unused class members

### DIFF
--- a/src/chainbin/nnet3-chain-combine2.cc
+++ b/src/chainbin/nnet3-chain-combine2.cc
@@ -20,11 +20,11 @@
 // limitations under the License.
 
 #include "base/kaldi-common.h"
-#include "util/common-utils.h"
-#include "nnet3/nnet-utils.h"
-#include "nnet3/nnet-compute.h"
 #include "nnet3/nnet-chain-diagnostics.h"
 #include "nnet3/nnet-chain-diagnostics2.h"
+#include "nnet3/nnet-compute.h"
+#include "nnet3/nnet-utils.h"
+#include "util/common-utils.h"
 
 
 namespace kaldi {
@@ -35,7 +35,8 @@ namespace nnet3 {
 // make a copy of 'nnet', set test modes on that and evaluate its objective.
 // Note: the object that prob_computer->nnet_ refers to should be 'nnet'.
 double ComputeObjf(bool batchnorm_test_mode, bool dropout_test_mode,
-                   std::vector<std::pair<std::string, NnetChainExample> > &egs, const Nnet &nnet,
+                   std::vector<std::pair<std::string, NnetChainExample> > &egs,
+                   const Nnet &nnet,
                    const chain::ChainTrainingOptions &chain_config,
                    NnetChainModel2 &model,
                    NnetChainComputeProb2 *prob_computer) {
@@ -47,17 +48,15 @@ double ComputeObjf(bool batchnorm_test_mode, bool dropout_test_mode,
       SetDropoutTestMode(true, &nnet_copy);
     NnetComputeProbOptions compute_prob_opts;
     NnetChainComputeProb2 prob_computer_test(compute_prob_opts, chain_config,
-        model, nnet_copy);
+                                             model, nnet_copy);
     return ComputeObjf(false, false, egs, nnet_copy,
                        chain_config, model, &prob_computer_test);
   } else {
     prob_computer->Reset();
-    std::vector<std::pair<std::string, NnetChainExample> >::iterator iter = egs.begin(),
-                                                   end = egs.end();
-    for (; iter != end; ++iter) {
+    for (std::pair<std::string, NnetChainExample>& eg : egs) {
       std::string lang_name = "default";
-      ParseFromQueryString(iter->first, "lang", &lang_name);
-      prob_computer->Compute(lang_name, (*iter).second);
+      ParseFromQueryString(eg.first, "lang", &lang_name);
+      prob_computer->Compute(lang_name, eg.second);
     }
 
     double tot_weight = 0.0;
@@ -74,15 +73,15 @@ double ComputeObjf(bool batchnorm_test_mode, bool dropout_test_mode,
 
 // Updates moving average over num_models nnets, given the average over
 // previous (num_models - 1) nnets, and the new nnet.
-void UpdateNnetMovingAverage(int32 num_models,
-    const Nnet &nnet, Nnet *moving_average_nnet) {
+void UpdateNnetMovingAverage(int32 num_models, const Nnet &nnet,
+                             Nnet *moving_average_nnet) {
   KALDI_ASSERT(NumParameters(nnet) == NumParameters(*moving_average_nnet));
   ScaleNnet((num_models - 1.0) / num_models, moving_average_nnet);
   AddNnet(nnet, 1.0 / num_models, moving_average_nnet);
 }
 
-}
-}
+}  // namespace nnet3
+}  // namespace kaldi
 
 
 int main(int argc, char *argv[]) {
@@ -100,10 +99,11 @@ int main(int argc, char *argv[]) {
         "combining last n models.\n"
         "Inputs and outputs are nnet3 raw nnets.\n"
         "\n"
-        "Usage:  nnet3-chain-combine [options] <den-fst> <raw-nnet-in1> <raw-nnet-in2> ... <raw-nnet-inN> <chain-examples-in> <raw-nnet-out>\n"
-        "\n"
-        "e.g.:\n"
-        " nnet3-combine den.fst 35.raw 36.raw 37.raw 38.raw ark:valid.cegs final.raw\n";
+        "Usage: nnet3-chain-combine [options] <den-fst> <raw-nnet-in1>"
+        " <raw-nnet-in2> ... <raw-nnet-inN> <chain-examples-in>"
+        " <raw-nnet-out>\n"
+        "e.g.:  nnet3-combine den.fst 35.raw 36.raw 37.raw 38.raw"
+        " ark:valid.cegs final.raw\n";
 
     bool binary_write = true;
     int32 max_objective_evaluations = 30;
@@ -111,7 +111,6 @@ int main(int argc, char *argv[]) {
         dropout_test_mode = true;
     std::string use_gpu = "yes";
     chain::ChainTrainingOptions chain_config;
-    NnetChainTraining2Options opts;
 
     ParseOptions po(usage);
     po.Register("binary", &binary_write, "Write output in binary mode");
@@ -119,7 +118,7 @@ int main(int argc, char *argv[]) {
                 "maximum number of objective evaluations in order to figure "
                 "out the best number of models to combine. It helps to speedup "
                 "if the number of models provided to this binary is quite "
-                "large (e.g. several hundred)."); 
+                "large (e.g. several hundred).");
     po.Register("use-gpu", &use_gpu,
                 "yes|no|optional|wait, only has effect if compiled with CUDA");
     po.Register("batchnorm-test-mode", &batchnorm_test_mode,
@@ -130,7 +129,6 @@ int main(int argc, char *argv[]) {
                 "DropoutMaskComponents while evaluating objectives.");
 
     chain_config.Register(&po);
-    opts.Register(&po);
 
     po.Read(argc, argv);
 
@@ -139,7 +137,7 @@ int main(int argc, char *argv[]) {
       exit(1);
     }
 
-#if HAVE_CUDA==1
+#if HAVE_CUDA
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 
@@ -151,11 +149,11 @@ int main(int argc, char *argv[]) {
 
     Nnet nnet;
     ReadKaldiObject(raw_nnet_rxfilename, &nnet);
-    NnetChainModel2 model(opts, &nnet, den_fst_dirname);
+    NnetChainModel2 model(&nnet, den_fst_dirname);
     Nnet moving_average_nnet(nnet), best_nnet(nnet);
     NnetComputeProbOptions compute_prob_opts;
     NnetChainComputeProb2 prob_computer(compute_prob_opts, chain_config,
-        model, moving_average_nnet);
+                                        model, moving_average_nnet);
 
     std::vector<std::pair<std::string, NnetChainExample> > egs;
     egs.reserve(10000);  // reserve a lot of space to minimize the chance of
@@ -165,25 +163,26 @@ int main(int argc, char *argv[]) {
       SequentialNnetChainExampleReader example_reader(
           valid_examples_rspecifier);
       for (; !example_reader.Done(); example_reader.Next())
-        egs.push_back(std::make_pair(example_reader.Key(), example_reader.Value()));
+        egs.push_back(std::make_pair(example_reader.Key(),
+                                     example_reader.Value()));
       KALDI_LOG << "Read " << egs.size() << " examples.";
       KALDI_ASSERT(!egs.empty());
     }
 
     // first evaluates the objective using the last model.
     int32 best_num_to_combine = 1;
-    double
-        init_objf = ComputeObjf(batchnorm_test_mode, dropout_test_mode,
-            egs, moving_average_nnet, chain_config, model, &prob_computer),
-        best_objf = init_objf;
+    double init_objf = ComputeObjf(batchnorm_test_mode, dropout_test_mode, egs,
+                                   moving_average_nnet, chain_config, model,
+                                   &prob_computer);
+    double best_objf = init_objf;
     KALDI_LOG << "objective function using the last model is " << init_objf;
 
     int32 num_nnets = po.NumArgs() - 3;
     // then each time before we re-evaluate the objective function, we will add
     // num_to_add models to the moving average.
-    int32 num_to_add = (num_nnets + max_objective_evaluations - 1) /
-                       max_objective_evaluations;
-    for (int32 n = 1; n < num_nnets; n++) {
+    int32 num_to_add = ((num_nnets + max_objective_evaluations - 1) /
+                        max_objective_evaluations);
+    for (int32 n = 1; n < num_nnets; ++n) {
       std::string this_nnet_rxfilename = po.GetArg(n + 2);
       ReadKaldiObject(this_nnet_rxfilename, &nnet);
       // updates the moving average
@@ -191,8 +190,9 @@ int main(int argc, char *argv[]) {
       // evaluates the objective everytime after adding num_to_add model or
       // all the models to the moving average.
       if ((n - 1) % num_to_add == num_to_add - 1 || n == num_nnets - 1) {
-        double objf = ComputeObjf(batchnorm_test_mode, dropout_test_mode,
-            egs, moving_average_nnet, chain_config, model, &prob_computer);
+        double objf = ComputeObjf(batchnorm_test_mode, dropout_test_mode, egs,
+                                  moving_average_nnet, chain_config, model,
+                                  &prob_computer);
         KALDI_LOG << "Combining last " << n + 1
                   << " models, objective function is " << objf;
         if (objf > best_objf) {
@@ -209,16 +209,15 @@ int main(int argc, char *argv[]) {
     if (HasBatchnorm(nnet))
       RecomputeStats2(egs, chain_config, model, &best_nnet);
 
-#if HAVE_CUDA==1
+#if HAVE_CUDA
     CuDevice::Instantiate().PrintProfile();
 #endif
 
     WriteKaldiObject(best_nnet, nnet_wxfilename, binary_write);
     KALDI_LOG << "Finished combining neural nets, wrote model to "
               << nnet_wxfilename;
-  } catch(const std::exception &e) {
+  } catch (const std::exception &e) {
     std::cerr << e.what() << '\n';
     return -1;
   }
 }
-

--- a/src/chainbin/nnet3-chain-train2.cc
+++ b/src/chainbin/nnet3-chain-train2.cc
@@ -19,9 +19,9 @@
 // limitations under the License.
 
 #include "base/kaldi-common.h"
-#include "util/common-utils.h"
-#include "nnet3/nnet-chain-training2.h"
 #include "cudamatrix/cu-allocator.h"
+#include "nnet3/nnet-chain-training2.h"
+#include "util/common-utils.h"
 
 
 int main(int argc, char *argv[]) {
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
       exit(1);
     }
 
-#if HAVE_CUDA==1
+#if HAVE_CUDA
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
     bool ok;
 
     {
-      NnetChainModel2 model(opts, &nnet, den_fst_dirname);
+      NnetChainModel2 model(&nnet, den_fst_dirname);
       NnetChainTrainer2 trainer(opts, model, &nnet);
 
       SequentialNnetChainExampleReader example_reader(examples_rspecifier);
@@ -97,9 +97,8 @@ int main(int argc, char *argv[]) {
     WriteKaldiObject(nnet, nnet_wxfilename, binary_write);
     KALDI_LOG << "Wrote raw model to " << nnet_wxfilename;
     return (ok ? 0 : 1);
-  } catch(const std::exception &e) {
+  } catch (const std::exception &e) {
     std::cerr << e.what() << '\n';
     return -1;
   }
 }
-

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -368,7 +368,6 @@ class [[deprecated]] BatchedThreadedNnet3CudaPipeline {
   std::unique_ptr<CudaFst> cuda_fst_;
   const TransitionModel *trans_model_;
   const nnet3::AmNnetSimple *am_nnet_;
-  nnet3::DecodableNnetSimpleLoopedInfo *decodable_info_;
   OnlineNnet2FeaturePipelineInfo *feature_info_;
 
   std::mutex tasks_mutex_;         // protects tasks_front_ and

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -760,7 +760,6 @@ class CudaDecoder {
   // channel.
   std::vector<std::mutex> channel_lock_;
 
-  bool worker_threads_running_;
   // For each channel, set by PrepareForGetRawLattice
   // argmin cost, list of the tokens within
   // [best_cost;best_cost+lattice_beam] and if we've reached a final
@@ -869,7 +868,7 @@ class CudaDecoder {
   std::vector<ChannelId> lanes2channels_todo_;
   std::atomic<int> n_acoustic_h2h_copies_todo_;
   std::atomic<int> n_extra_prev_tokens_h2h_copies_todo_;
-  std::atomic<int> n_d2h_copies_ready_;
+  //TODO(hugovbraun): unused: std::atomic<int> n_d2h_copies_ready_;
   std::atomic<int> n_infotoken_h2h_copies_todo_;
   int32 n_h2h_task_not_done_;
   int32 n_init_decoding_h2h_task_not_done_;
@@ -880,7 +879,7 @@ class CudaDecoder {
   std::condition_variable n_h2h_main_task_todo_cv_;
   std::condition_variable h2h_done_;
   std::condition_variable init_decoding_h2h_done_;
-  std::atomic<bool> active_wait_;
+  //TODO(hugovbraun): unused: std::atomic<bool> active_wait_;
 
   // Used for sync on partial hypotheses tasks
   std::atomic<std::int32_t> n_partial_traceback_threads_todo_;

--- a/src/cudadecoder/lattice-postprocessor.h
+++ b/src/cudadecoder/lattice-postprocessor.h
@@ -76,9 +76,7 @@ class LatticePostprocessor {
   const TransitionModel *tmodel_;
   std::shared_ptr<const WordBoundaryInfo> word_info_;
   BaseFloat decoder_frame_shift_;
-  // Params for align words
-  int32 max_states_;
-  // Params for ScaleLattice
+  // Params for ScaleLattice.
   bool use_lattice_scale_;
   std::vector<std::vector<double> > lattice_scales_;
 

--- a/src/cudafeat/feature-online-batched-cmvn-cuda.cc
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda.cc
@@ -26,7 +26,6 @@ CudaOnlineBatchedCmvn::CudaOnlineBatchedCmvn(
     int32_t stats_coarsening_factor)
     : opts_(opts),
       cmvn_state_(cmvn_state),
-      feat_dim_(feat_dim),
       chunk_size_(chunk_size),
       num_channels_(num_channels),
       stats_coarsening_factor_(stats_coarsening_factor) {
@@ -39,8 +38,6 @@ CudaOnlineBatchedCmvn::CudaOnlineBatchedCmvn(
 
   stats_fragments_.Resize(num_channels_, feat_dim * num_fragments_ * 2);
 }
-
-CudaOnlineBatchedCmvn::~CudaOnlineBatchedCmvn() {}
 
 // Computes a chunk of features for each channel included in channels
 void CudaOnlineBatchedCmvn::ComputeFeaturesBatched(

--- a/src/cudafeat/feature-online-batched-cmvn-cuda.h
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda.h
@@ -27,11 +27,10 @@ namespace kaldi {
 class CudaOnlineBatchedCmvn {
  public:
   CudaOnlineBatchedCmvn(const OnlineCmvnOptions &opts,
-                        const CudaOnlineCmvnState &cmvn_state, int32_t feat_dim,
+                        const CudaOnlineCmvnState &cmvn_state,
+                        int32_t feat_dim,
                         int32_t chunk_size, int32_t num_channels,
                         int32_t stats_coarsening_factor);
-
-  ~CudaOnlineBatchedCmvn();
 
   // Computes a chunk of features for each channel included in lanes
   void ComputeFeaturesBatched(int32_t num_lanes, const LaneDesc *lanes,
@@ -42,7 +41,6 @@ class CudaOnlineBatchedCmvn {
   const OnlineCmvnOptions &opts_;
   const CudaOnlineCmvnState cmvn_state_;
 
-  int32_t feat_dim_;
   int32_t chunk_size_;
   int32_t num_channels_;
 

--- a/src/cudafeat/feature-online-cmvn-cuda.cu
+++ b/src/cudafeat/feature-online-cmvn-cuda.cu
@@ -35,7 +35,7 @@ __host__ __device__ inline float2 operator+(const float2 &a, const float2 &b) {
 
 #if __CUDA_ARCH__ == 750
 __launch_bounds__ (1024, 1)
-#else 
+#else
 __launch_bounds__ (1024, 2)
 #endif
 __global__ void compute_cmvn_stats_kernel(const float *data, int32_t ldd,
@@ -87,7 +87,7 @@ __global__ void apply_cmvn_kernel(
 
   for (int c = threadIdx.x; c < num_cols; c += blockDim.x) {
     float2 frame_stats =
-        reinterpret_cast<const float2* __restrict__>(&stats[r * lds])[c];
+        reinterpret_cast<const float2 __restrict__*>(&stats[r * lds])[c];
 
     float val = feat_in[r * ldi + c];
 
@@ -100,7 +100,7 @@ __global__ void apply_cmvn_kernel(
 
       // stats at the start row of the window that must be removed
       float2 ostats =
-          reinterpret_cast<const float2* __restrict__>(&stats[o * lds])[c];
+          reinterpret_cast<const float2 __restrict__*>(&stats[o * lds])[c];
 
       // remove start of the window stats
       frame_stats = frame_stats - ostats;

--- a/src/cudafeat/online-batched-feature-pipeline-cuda.h
+++ b/src/cudafeat/online-batched-feature-pipeline-cuda.h
@@ -121,7 +121,6 @@ class OnlineBatchedFeaturePipelineCuda {
 
   // channel array for stashing sample count
   int32_t *current_samples_stash_;
-  ChannelId *channels_;
 
   // Host and Device array of lane descriptions
   LaneDesc *h_lanes_, *lanes_;

--- a/src/cudamatrix/cu-sp-matrix.cc
+++ b/src/cudamatrix/cu-sp-matrix.cc
@@ -111,13 +111,9 @@ void CuSpMatrix<Real>::AddVec2(const Real alpha, const CuVectorBase<Real> &v) {
   if (CuDevice::Instantiate().Enabled()) {
     if (this->num_rows_ == 0) return;
     CuTimer tim;
-    size_t nr = this->num_rows_;
-    dim3 dimBlock(CU2DBLOCK, CU2DBLOCK);
-    dim3 dimGrid(n_blocks(nr, CU2DBLOCK), n_blocks(nr, CU2DBLOCK));
-
-    CUBLAS_SAFE_CALL(cublas_spr(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER, this->num_rows_, alpha, v.Data(),
+    CUBLAS_SAFE_CALL(cublas_spr(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER,
+                                this->num_rows_, alpha, v.Data(),
                                 1, this->Data()));
-    
     CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddVec2", tim);
   } else
 #endif
@@ -151,7 +147,7 @@ void CuSpMatrix<Real>::AddMat2(const Real alpha, const CuMatrixBase<Real> &M,
     cublas_syrk(GetCublasHandle(), CUBLAS_FILL_MODE_UPPER, trans, this_dim, m_other_dim, alpha, M.Data(),
                 M.Stride(), beta, tmp_mat.Data(), tmp_mat.Stride());
     this->CopyFromMat(tmp_mat, kTakeLower);
-    
+
     CuDevice::Instantiate().AccuProfile("CuSpMatrix::AddMat2", tim);
   } else
 #endif

--- a/src/matrix/numpy-array.cc
+++ b/src/matrix/numpy-array.cc
@@ -19,12 +19,11 @@
 
 #include "matrix/numpy-array.h"
 
-#include "base/kaldi-utils.h"
-
 #include <functional>  // for std::multiplies
 #include <numeric>     // for std::accumulate
 
 #include "base/kaldi-error.h"
+#include "base/kaldi-utils.h"
 
 namespace {
 
@@ -37,16 +36,9 @@ constexpr bool kIsLittleEndian = false;
 constexpr bool kIsLittleEndian = true;
 #endif
 
-template <bool is_little_endian>
+template <bool isLittleEndian>
 struct EndianString {
-  // for little endian
-  static constexpr const char* value = "<";
-};
-
-template <>
-struct EndianString<false> {
-  // for big endian
-  static constexpr const char* value = ">";
+  static constexpr const char* value = isLittleEndian ? "<" : ">";
 };
 
 template <typename>

--- a/src/nnet3/nnet-chain-diagnostics2.h
+++ b/src/nnet3/nnet-chain-diagnostics2.h
@@ -1,7 +1,7 @@
 // nnet3/nnet-chain-diagnostics.h
 
 // Copyright    2015  Johns Hopkins University (author: Daniel Povey)
-//                2019    Idiap Research Institute (author: Srikanth Madikeri)
+//              2019  Idiap Research Institute (author: Srikanth Madikeri)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -48,14 +48,14 @@ class NnetChainComputeProb2 {
  public:
   // does not store a reference to 'config' but does store one to 'nnet'.
   NnetChainComputeProb2(const NnetComputeProbOptions &nnet_config,
-                       const chain::ChainTrainingOptions &chain_config,
-                       NnetChainModel2 &model,
-                       const Nnet &nnet);
+                        const chain::ChainTrainingOptions &chain_config,
+                        NnetChainModel2 &model,
+                        const Nnet &nnet);
 
   NnetChainComputeProb2(const NnetComputeProbOptions &nnet_config,
-                       const chain::ChainTrainingOptions &chain_config,
-                       NnetChainModel2 &model,
-                       Nnet *nnet);
+                        const chain::ChainTrainingOptions &chain_config,
+                        NnetChainModel2 &model,
+                        Nnet *nnet);
 
   // Reset the likelihood stats, and the derivative stats (if computed).
   void Reset();
@@ -71,9 +71,9 @@ class NnetChainComputeProb2 {
   // or NULL if there is no such info.
   const ChainObjectiveInfo *GetObjective(const std::string &output_name) const;
 
-  // This function returns the total objective over all output nodes recorded here, and
-  // outputs to 'tot_weight' the total weight (typically the number of frames)
-  // corresponding to it.
+  // This function returns the total objective over all output nodes recorded
+  // here, and outputs to 'tot_weight' the total weight (typically the number
+  // of frames) corresponding to it.
   double GetTotalObjective(double *tot_weight) const;
 
   // if config.compute_deriv == true, returns a reference to the
@@ -95,25 +95,25 @@ class NnetChainComputeProb2 {
   int32 num_minibatches_processed_;  // this is only for diagnostics
 
   unordered_map<std::string, ChainObjectiveInfo, StringHasher> objf_info_;
-
 };
 
-void RecomputeStats2(const std::string &lang_name, std::vector<NnetChainExample> &egs,
-                    const chain::ChainTrainingOptions &chain_config_in,
-                    NnetChainModel2 &model,
-                    Nnet *nnet);
+void RecomputeStats2(const std::string &lang_name,
+                     std::vector<NnetChainExample> &egs,
+                     const chain::ChainTrainingOptions &chain_config_in,
+                     NnetChainModel2 &model,
+                     Nnet *nnet);
 
-void RecomputeStats2(std::vector<std::pair<std::string, NnetChainExample> > &egs,
-                    const chain::ChainTrainingOptions &chain_config_in,
-                    NnetChainModel2 &model,
-                    Nnet *nnet);
+void RecomputeStats2(std::vector<std::pair<std::string, NnetChainExample>> &egs,
+                     const chain::ChainTrainingOptions &chain_config_in,
+                     NnetChainModel2 &model,
+                     Nnet *nnet);
 
 void RecomputeStats2(std::vector<NnetChainExample> &egs,
-                    const chain::ChainTrainingOptions &chain_config_in,
-                    NnetChainModel2 &model,
-                    Nnet *nnet);
-} // namespace nnet3
-} // namespace kaldi
+                     const chain::ChainTrainingOptions &chain_config_in,
+                     NnetChainModel2 &model,
+                     Nnet *nnet);
+
+}  // namespace nnet3
+}  // namespace kaldi
 
 #endif // KALDI_NNET3_NNET_CHAIN_DIAGNOSTICS2_H_
-

--- a/src/nnet3/nnet-chain-training2.cc
+++ b/src/nnet3/nnet-chain-training2.cc
@@ -310,18 +310,6 @@ NnetChainTrainer2::~NnetChainTrainer2() {
   delete delta_nnet_;
 }
 
-NnetChainModel2::NnetChainModel2(const NnetChainTraining2Options& /* unused */,
-                                 Nnet *nnet, const std::string &den_fst_dir)
-    : nnet(nnet), den_fst_dir_(den_fst_dir) {}
-
-NnetChainModel2::~NnetChainModel2() {}
-
-/* fst::StdVectorFst* NnetChainModel2::GetDenFstForLang( */
-/*        const std::string &language_name) { */
-/*   LanguageInfo *info = GetInfoForLang(language_name); */
-/*   return &(info->den_fst); */
-/* } */
-
 const chain::DenominatorGraph *NnetChainModel2::GetDenGraphForLang(
     const std::string &lang) {
   const LanguageInfo *info = GetInfoForLang(lang);
@@ -349,7 +337,7 @@ const NnetChainModel2::LanguageInfo *NnetChainModel2::GetInfoForLang(
     ReadFstKaldi(den_fst_filename, &den_fst);
     std::string output = "output-" + lang;
     lang_info_.emplace(lang,
-                       LanguageInfo{lang, den_fst, nnet->OutputDim(output)});
+                       LanguageInfo{lang, den_fst, nnet_->OutputDim(output)});
   }
   // Use .at(), not operator[](), because the [] requires a default constructor.
   // The .at() throws if the element isn't found, which works in lieu of an

--- a/src/nnet3/nnet-chain-training2.h
+++ b/src/nnet3/nnet-chain-training2.h
@@ -1,7 +1,7 @@
 // nnet3/nnet-chain-training.h
 
 // Copyright    2015  Johns Hopkins University (author: Daniel Povey)
-//                2019    Idiap Research Institute (author: Srikanth Madikeri)
+//              2019  Idiap Research Institute (author: Srikanth Madikeri)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -23,7 +23,6 @@
 
 #include "chain/chain-den-graph.h"
 #include "chain/chain-training.h"
-#include "nnet3/nnet-chain-example.h"
 #include "nnet3/nnet-chain-example.h"
 #include "nnet3/nnet-chain-training.h"
 #include "nnet3/nnet-computation.h"
@@ -53,7 +52,7 @@ struct NnetChainTraining2Options {
 class NnetChainModel2 {
  public:
   /**
-     Constructor to which you pass the model directory and the den-fst
+     Constructor to which you pass the model and the den-fst
      directory.  There is no requirement that all these directories be distinct.
 
      For each language called "lang" the following files should exist:
@@ -71,13 +70,9 @@ class NnetChainModel2 {
 
       **/
 
-  NnetChainModel2(const NnetChainTraining2Options &opts,
-                  Nnet *nnet,
-                  const std::string &den_fst_dir);
+  NnetChainModel2(Nnet *nnet, const std::string &den_fst_dir)
+      : nnet_(nnet), den_fst_dir_(den_fst_dir) {}
 
-  ~NnetChainModel2();
-
-  /* fst::StdVectorFst *GetDenFstForLang(const std::string &language_name); */
   const chain::DenominatorGraph *GetDenGraphForLang(const std::string &lang);
 
  private:
@@ -101,7 +96,7 @@ class NnetChainModel2 {
   // contents from disk) if it does not already exist.
   const LanguageInfo *GetInfoForLang(const std::string &lang);
 
-  Nnet *nnet;
+  Nnet *nnet_;
   // Directory where denominator FSTs are located.
   std::string den_fst_dir_;
 

--- a/src/online2/online-nnet2-decoding-threaded.cc
+++ b/src/online2/online-nnet2-decoding-threaded.cc
@@ -28,8 +28,7 @@ namespace kaldi {
 ThreadSynchronizer::ThreadSynchronizer():
     abort_(false),
     producer_waiting_(false),
-    consumer_waiting_(false),
-    num_errors_(0) {
+    consumer_waiting_(false) {
   producer_semaphore_.Signal();
   consumer_semaphore_.Signal();
 }

--- a/src/online2/online-nnet2-decoding-threaded.h
+++ b/src/online2/online-nnet2-decoding-threaded.h
@@ -104,10 +104,6 @@ class ThreadSynchronizer {
                         // held); else undefined.  Used for validation of input.
   Semaphore producer_semaphore_;  // The producer thread waits on this semaphore
   Semaphore consumer_semaphore_;  // The consumer thread waits on this semaphore
-  int32 num_errors_;  // Rumber of times the threads alternated doing Lock() and
-                      // UnlockFailure().  This should not happen at all; but
-                      // it's more user-friendly to simply warn a few times; and then
-                      // only after a number of errors, to fail.
   KALDI_DISALLOW_COPY_AND_ASSIGN(ThreadSynchronizer);
 };
 

--- a/src/online2/online-nnet3-wake-word-faster-decoder.h
+++ b/src/online2/online-nnet3-wake-word-faster-decoder.h
@@ -30,12 +30,9 @@
 
 namespace kaldi {
 
-// Extends the definition of FasterDecoder's options to include additional
-// parameters.
+/// Extends the FasterDecoder's options with additional parameters
+/// (currently none).
 struct OnlineWakeWordFasterDecoderOpts : public FasterDecoderOptions {
-
-  OnlineWakeWordFasterDecoderOpts() {}
-
   void Register(OptionsItf *opts, bool full) {
     FasterDecoderOptions::Register(opts, full);
   }
@@ -52,9 +49,8 @@ struct OnlineWakeWordFasterDecoderOpts : public FasterDecoderOptions {
 class OnlineWakeWordFasterDecoder : public FasterDecoder {
  public:
   OnlineWakeWordFasterDecoder(const fst::Fst<fst::StdArc> &fst,
-                              const OnlineWakeWordFasterDecoderOpts &opts,
-                              const TransitionModel &trans_model)
-      : FasterDecoder(fst, opts), opts_(opts), trans_model_(trans_model) {}
+                              const OnlineWakeWordFasterDecoderOpts &opts)
+      : FasterDecoder(fst, opts), opts_(opts) {}
 
   // Makes a linear graph, by tracing back from the last "immortal" token
   // to the previous one
@@ -69,7 +65,6 @@ class OnlineWakeWordFasterDecoder : public FasterDecoder {
   // and then (possibly multiple times) AdvanceDecoding().
   void InitDecoding();
 
-  
  private:
   // Returns a linear fst by tracing back the last N frames, beginning
   // from the best current token
@@ -84,7 +79,6 @@ class OnlineWakeWordFasterDecoder : public FasterDecoder {
   void UpdateImmortalToken();
 
   const OnlineWakeWordFasterDecoderOpts opts_;
-  const TransitionModel &trans_model_; // needed for trans-id -> phone conversion
   Token *immortal_tok_;      // "immortal" token means it's an ancestor of ...
   Token *prev_immortal_tok_; // ... all currently active tokens
   KALDI_DISALLOW_COPY_AND_ASSIGN(OnlineWakeWordFasterDecoder);

--- a/src/online2bin/online2-wav-nnet3-wake-word-decoder-faster.cc
+++ b/src/online2bin/online2-wav-nnet3-wake-word-decoder-faster.cc
@@ -183,8 +183,8 @@ int main(int argc, char *argv[]) {
             decodable_info, feature_pipeline.InputFeature(),
             feature_pipeline.IvectorFeature());
 
-        OnlineWakeWordFasterDecoder decoder(*decode_fst, decoder_opts,
-                                            trans_model);
+        OnlineWakeWordFasterDecoder decoder(*decode_fst, decoder_opts);
+
         OnlineTimer decoding_timer(utt);
 
         BaseFloat samp_freq = wave_data.SampFreq();

--- a/src/rnnlm/rnnlm-training.cc
+++ b/src/rnnlm/rnnlm-training.cc
@@ -34,7 +34,6 @@ RnnlmTrainer::RnnlmTrainer(bool train_embedding,
                            nnet3::Nnet *rnnlm):
     train_embedding_(train_embedding),
     core_config_(core_config),
-    embedding_config_(embedding_config),
     objective_config_(objective_config),
     rnnlm_(rnnlm),
     core_trainer_(NULL),

--- a/src/rnnlm/rnnlm-training.h
+++ b/src/rnnlm/rnnlm-training.h
@@ -31,10 +31,10 @@ namespace kaldi {
 namespace rnnlm {
 
 /*
-  The class RnnlmTrainer is for training an RNNLM (one individual training job, not
-  the top-level logic about learning rate schedules, parameter averaging, and the
-  like); it contains the most of the logic that the command-line program rnnlm-train
-  implements.
+  The class RnnlmTrainer is for training an RNNLM (one individual training job,
+  not the top-level logic about learning rate schedules, parameter averaging,
+  and the like); it contains the most of the logic that the command-line program
+  rnnlm-train implements.
 */
 
 class RnnlmTrainer {
@@ -61,7 +61,7 @@ class RnnlmTrainer {
                              If word_feature_mat is NULL, this
                              is the word-embedding matrix of dimension
                              vocab-size by embedding-dim; otherwise it is the
-                             feature-embedding matrix of dimension feature-dim by
+                             feature-embedding matrix of dimension feature-dim
                              by embedding-dim, and we have to multiply it by
                              word_feature_mat to get the word embedding matrix.
       @param [in,out] rnnlm  The RNNLM to be trained.  The class will retain
@@ -69,7 +69,7 @@ class RnnlmTrainer {
   */
   RnnlmTrainer(bool train_embedding,
                const RnnlmCoreTrainerOptions &core_config,
-               const RnnlmEmbeddingTrainerOptions &embedding_config,
+               const RnnlmEmbeddingTrainerOptions & embedding_config,
                const RnnlmObjectiveOptions &objective_config,
                const CuSparseMatrix<BaseFloat> *word_feature_mat,
                CuMatrix<BaseFloat> *embedding_mat,
@@ -113,7 +113,7 @@ class RnnlmTrainer {
   /// w.r.t. the word-embedding for this minibatch (of dimension
   /// previus_minibatch_.vocab_size by embedding_mat_.NumCols()).
   /// You can think of it as the backprop for the function 'GetWordEmbedding()'.
-  ///   @param [in] word_embedding_deriv   The derivative w.r.t. the embeddings of
+  ///  @param [in] word_embedding_deriv  The derivative w.r.t. the embeddings of
   ///                       just the words used in this minibatch
   ///                       (i.e. the minibatch-level word-embedding matrix,
   ///                       possibly using a subset of words).  This is an input
@@ -127,7 +127,6 @@ class RnnlmTrainer {
 
   bool train_embedding_;  // true if we are training the embedding.
   const RnnlmCoreTrainerOptions &core_config_;
-  const RnnlmEmbeddingTrainerOptions &embedding_config_;
   const RnnlmObjectiveOptions &objective_config_;
 
   // The neural net we are training (not owned here)


### PR DESCRIPTION
I'm trying to take care of compiler warnings about unused class data members. In a few cases, it's obvious. In most cases, however, the variables should probably have been used. This is WIP; I did not completely remove everything. In some cases, I commented out the variables and their initialization; in some, I did but left in constructor parameters that used to initialize them. It should be one way or another—either completely remove them, including extra constructor arguments, or figure out why are they unused, restore them and fix the bigger problem. `embedding_config_` in rnnlm-training.* is especially suspicious.

@danpovey, @hugovbraun, need your help with that. PTAL at the parts of code you know, and let me know which way should I proceed with them. Please mark only those than need to be changed; let's by default assume that the changes which are not commented on are good to go.