### PR TITLE
install tcmalloc

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -1294,24 +1294,18 @@ else
 fi
 
 if $enable_tcmalloc ; then
-  if [ -d ../tools/gperftools ]; then
+  if [ -f ../tools/gperftools/lib/libtcmalloc_minimal.so ]; then
     TCMALLOC_ROOT=$(rel2abs ../tools/gperftools)
-    echo "Checking tcmalloc library in $TCMALLOC_ROOT"
-    if [ -f $TCMALLOC_ROOT/lib/libtcmalloc.so ]; then
-      if [ "$(uname)" == "Linux" ]; then
-        #If profiler is needed, use -ltcmalloc_and_profiler
-        echo "LDLIBS += -Wl,-rpath=$TCMALLOC_ROOT/lib -ltcmalloc" >> kaldi.mk
-      else
-        failure "Now, --enable-tcmalloc option is only supported for Linux"
-      fi
+    echo "Configuring tcmalloc since --enable-tcmalloc"
+    if [ "$(uname)" == "Linux" ]; then
+      echo "LDLIBS += -Wl,-rpath=$TCMALLOC_ROOT/lib -ltcmalloc_minimal" >> kaldi.mk
     else
-      failure "Can't find libtcmalloc.so in ../tools/gperftools,
-               refer to ../tools/extras/install_tcmalloc.sh for instruction."
+      failure "Now, --enable-tcmalloc option is only supported for Linux"
     fi
+    echo "Successfully configured tcmalloc for Linux from $TCMALLOC_ROOT"
   else
-    failure "--enable-tcmalloc switched on, but can't find tcmalloc in 
-             ../tools/gperftools, refer to ../tools/extras/install_tcmalloc.sh 
-             for instruction."
+    failure "Can't find tcmalloc in tools/gperftools. Run" \
+            "'extras/install_tcmalloc.sh' in 'tools/' to install."
   fi
 fi
 

--- a/src/configure
+++ b/src/configure
@@ -97,6 +97,8 @@ Configuration options:
   --android-incdir=DIR  Android include directory
   --enable-kenlm        enable kenlm runtime library installed in "../tools/kenlm"
                         via extras/install_kenlm_query_only.sh, [default=no]
+  --enable-tcmalloc     enable tcmalloc library installed in "../tools/gperftools"
+                        via extras/install_tcmalloc.sh, [default=no]
 
 Following environment variables can be used to override the default toolchain.
   CXX         C++ compiler [default=g++]
@@ -611,6 +613,7 @@ static_fst=false
 static_math=false
 android=false
 enable_kenlm=false
+enable_tcmalloc=false
 
 FSTROOT=`rel2abs ../tools/openfst`
 CUBROOT=`rel2abs ../tools/cub`
@@ -745,6 +748,9 @@ do
     shift ;;
   --enable-kenlm)
     enable_kenlm=true
+    shift ;;
+  --enable-tcmalloc)
+    enable_tcmalloc=true
     shift ;;
   *)  echo "Unknown argument: $1, exiting"; usage; exit 1 ;;
   esac
@@ -1285,6 +1291,28 @@ or try another math library, e.g. --mathlib=OPENBLAS (Kaldi may be slower)."
 else
   failure "Could not detect the platform or we have not yet worked out the
   appropriate configuration for this platform. Please contact the developers."
+fi
+
+if $enable_tcmalloc ; then
+  if [ -d ../tools/gperftools ]; then
+    TCMALLOC_ROOT=$(rel2abs ../tools/gperftools)
+    echo "Checking tcmalloc library in $TCMALLOC_ROOT"
+    if [ -f $TCMALLOC_ROOT/lib/libtcmalloc.so ]; then
+      if [ "$(uname)" == "Linux" ]; then
+        #If profiler is needed, use -ltcmalloc_and_profiler
+        echo "LDLIBS += -Wl,-rpath=$TCMALLOC_ROOT/lib -ltcmalloc" >> kaldi.mk
+      else
+        failure "Now, --enable-tcmalloc option is only supported for Linux"
+      fi
+    else
+      failure "Can't find libtcmalloc.so in ../tools/gperftools,
+               refer to ../tools/extras/install_tcmalloc.sh for instruction."
+    fi
+  else
+    failure "--enable-tcmalloc switched on, but can't find tcmalloc in 
+             ../tools/gperftools, refer to ../tools/extras/install_tcmalloc.sh 
+             for instruction."
+  fi
 fi
 
 # Append the flags set by environment variables last so they can be used

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -2,6 +2,7 @@
 *.tar.gz
 *.tgz
 *.zip
+*.bak
 
 env.sh
 

--- a/tools/extras/install_tcmalloc.sh
+++ b/tools/extras/install_tcmalloc.sh
@@ -13,7 +13,8 @@
 # So the libunwind is recommanded to be installed. When the deadlock problems
 # happen, the user can try to link with the library libunwind. But there may
 # still be some crash on x64 platform. You can skip the installation about
-# libunwind if you don't need it.
+# libunwind if you don't need it. (Link with "-lunwind" after your installation
+# if you want to include it.)
 #
 # Depending on different platforms which are used by different users, the users
 # also can try differnet malloc libraries such as tbbmalloc and so on. From our
@@ -21,11 +22,11 @@
 
 
 # Make sure we are in the tools/ directory.
-if [ `basename $PWD` == extras ]; then
+if [ $(basename $PWD) == extras ]; then
   cd ..
 fi
 
-! [ `basename $PWD` == tools ] && \
+! [ $(basename $PWD) == tools ] && \
   echo "You must call this script from the tools/ directory" && exit 1;
 
 # prepare libunwind
@@ -54,7 +55,7 @@ fi
 #`pwd` will cause recursive problem.
 tar vxzf libunwind-1.5-rc1.tar.gz
 cd libunwind-1.5-rc1
-./configure --prefix=`pwd`/install || exit 1;
+./configure --prefix=$PWD/install || exit 1;
 make || exit 1;
 make install || exit 1;
 cd ..
@@ -68,17 +69,17 @@ fi
 git clone https://github.com/gperftools/gperftools.git gperftools
 
 # install tcmalloc
-wd=`pwd`
+wd=$PWD
 cd gperftools
 bash autogen.sh
-./configure --prefix=`pwd` || exit 1;
+./configure --prefix=$PWD || exit 1;
 make || exit 1;
 make install || exit 1;
 cd ..
 
 # add path
 (
-  wd=`pwd`
+  wd=$PWD
   echo export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$wd/gperftools/lib
   echo export PATH=$PATH:$wd/gperftools/bin
 ) >> env.sh

--- a/tools/extras/install_tcmalloc.sh
+++ b/tools/extras/install_tcmalloc.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright 2021 Hang Lyu
+#
+# This script attempts to install tcmalloc and libunwind.
+# The tcmalloc provides the more efficient way to malloc so that it can speed
+# up the code, especially for the decoding code which contains massive memory
+# allocation operations.
+#
+# At the same time, the tcmalloc also provides some profilers which can help
+# the user to analysis the performance of the code. However, there may have 
+# some deadlock problems when you use the profilers with default build-in glibc.
+# So the libunwind is recommanded to be installed. When the deadlock problems
+# happen, the user can try to link with the library libunwind. But there may
+# still be some crash on x64 platform. You can skip the installation about
+# libunwind if you don't need it.
+#
+# Depending on different platforms which are used by different users, the users
+# also can try differnet malloc libraries such as tbbmalloc and so on. From our
+# test, the tcmalloc is most efficient on our platform.
+
+
+# Make sure we are in the tools/ directory.
+if [ `basename $PWD` == extras ]; then
+  cd ..
+fi
+
+! [ `basename $PWD` == tools ] && \
+  echo "You must call this script from the tools/ directory" && exit 1;
+
+# prepare libunwind
+echo "****() Installing libunwind"
+if [ ! -e libunwind-1.5-rc1.tar.gz ]; then
+  echo "Trying to download libunwind via wget"
+
+  if ! which wget >&/dev/null; then
+    echo "This script requires you to first install wget"
+    echo "You can also just download libunwind-1.5-rc1.tar.gz from"
+    echo "http://download-mirror.savannah.gnu.org/releases/libunwind/libunwind-1.5-rc1.tar.gz"
+    exit 1;
+  fi
+
+  wget http://download.savannah.nongnu.org/releases/libunwind/libunwind-1.5-rc1.tar.gz || exit 1;
+
+  if [ ! -f libunwind-1.5-rc1.tar.gz ]; then
+    echo "Download of libunwind failed!"
+    echo "Aborting script. Please download and install libunwind manually!"
+    exit 1;
+  fi
+fi
+
+# install libunwind
+# The installation directory can be changed. But be careful, set the prefix as 
+#`pwd` will cause recursive problem.
+tar vxzf libunwind-1.5-rc1.tar.gz
+cd libunwind-1.5-rc1
+./configure --prefix=`pwd`/install || exit 1;
+make || exit 1;
+make install || exit 1;
+cd ..
+
+# prepare tcmalloc
+if [ -d gperftools ]; then
+  echo "$0: Assuming gperftools is already installed Please delete the directory"
+  echo "./gperftools if you need to reinstall."
+  mv gproftools gproftools_backup
+fi
+git clone https://github.com/gperftools/gperftools.git gperftools
+
+# install tcmalloc
+wd=`pwd`
+cd gperftools
+bash autogen.sh
+./configure --prefix=`pwd` || exit 1;
+make || exit 1;
+make install || exit 1;
+cd ..
+
+# add path
+(
+  wd=`pwd`
+  echo export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$wd/gperftools/lib
+  echo export PATH=$PATH:$wd/gperftools/bin
+) >> env.sh
+
+

--- a/tools/extras/install_tcmalloc.sh
+++ b/tools/extras/install_tcmalloc.sh
@@ -54,11 +54,12 @@ fi
 # The installation directory can be changed. But be careful, set the prefix as 
 #`pwd` will cause recursive problem.
 tar vxzf libunwind-1.5-rc1.tar.gz
+(
 cd libunwind-1.5-rc1
 ./configure --prefix=$PWD/install || exit 1;
 make || exit 1;
 make install || exit 1;
-cd ..
+)
 
 # prepare tcmalloc
 if [ -d gperftools ]; then

--- a/tools/extras/install_tcmalloc.sh
+++ b/tools/extras/install_tcmalloc.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 #
 # Copyright 2021 Hang Lyu
+#           2021 kkm
 #
-# This script attempts to install tcmalloc and libunwind.
+# This script attempts to install tcmalloc.
 # The tcmalloc provides the more efficient way to malloc so that it can speed
 # up the code, especially for the decoding code which contains massive memory
 # allocation operations.
 #
 # At the same time, the tcmalloc also provides some profilers which can help
-# the user to analysis the performance of the code. However, there may have 
-# some deadlock problems when you use the profilers with default build-in glibc.
-# So the libunwind is recommanded to be installed. When the deadlock problems
-# happen, the user can try to link with the library libunwind. But there may
-# still be some crash on x64 platform. You can skip the installation about
-# libunwind if you don't need it. (Link with "-lunwind" after your installation
-# if you want to include it.)
+# the user to analysis the performance of the code. 
+# However, there may have some deadlock problems when you use the profilers with
+# default build-in glibc. So the libunwind is recommanded to be installed. When
+# the deadlock problems happen, the user can try to link with the library
+# libunwind. But there may still be some crash on x64 platform. (Link with
+# "-lunwind" after your installation if you want to include it.)
+# As very rare end users will need it and we believe the users who need it must
+# be qualified to reconfigure and build as much of toolset as they want, we skip
+# the installation around libunwind.
 #
 # Depending on different platforms which are used by different users, the users
-# also can try differnet malloc libraries such as tbbmalloc and so on. From our
-# test, the tcmalloc is most efficient on our platform.
+# also can try differnet malloc libraries such as tbbmalloc, ptmalloc and so on.
+# From our test, the tcmalloc is most efficient on our platform.
 
+set -e
 
 # Make sure we are in the tools/ directory.
 if [ $(basename $PWD) == extras ]; then
@@ -29,60 +33,20 @@ fi
 ! [ $(basename $PWD) == tools ] && \
   echo "You must call this script from the tools/ directory" && exit 1;
 
-# prepare libunwind
-echo "****() Installing libunwind"
-if [ ! -e libunwind-1.5-rc1.tar.gz ]; then
-  echo "Trying to download libunwind via wget"
-
-  if ! which wget >&/dev/null; then
-    echo "This script requires you to first install wget"
-    echo "You can also just download libunwind-1.5-rc1.tar.gz from"
-    echo "http://download-mirror.savannah.gnu.org/releases/libunwind/libunwind-1.5-rc1.tar.gz"
-    exit 1;
-  fi
-
-  wget http://download.savannah.nongnu.org/releases/libunwind/libunwind-1.5-rc1.tar.gz || exit 1;
-
-  if [ ! -f libunwind-1.5-rc1.tar.gz ]; then
-    echo "Download of libunwind failed!"
-    echo "Aborting script. Please download and install libunwind manually!"
-    exit 1;
-  fi
-fi
-
-# install libunwind
-# The installation directory can be changed. But be careful, set the prefix as 
-#`pwd` will cause recursive problem.
-tar vxzf libunwind-1.5-rc1.tar.gz
-(
-cd libunwind-1.5-rc1
-./configure --prefix=$PWD/install || exit 1;
-make || exit 1;
-make install || exit 1;
-)
-
 # prepare tcmalloc
 if [ -d gperftools ]; then
-  echo "$0: Assuming gperftools is already installed Please delete the directory"
-  echo "./gperftools if you need to reinstall."
-  mv gproftools gproftools_backup
+  echo "$0: existing 'gperftools' subdirectory is renamed 'gperftools.bak'"
+  mv -f gpreftools gpreftools.bak
 fi
-git clone https://github.com/gperftools/gperftools.git gperftools
+
+wget https://github.com/gperftools/gperftools/releases/download/gperftools-2.9.1/gperftools-2.9.1.tar.gz &&
+  tar xzf gperftools-2.9.1.tar.gz &&
+  mv gperftools-2.9.1 gperftools
 
 # install tcmalloc
-wd=$PWD
-cd gperftools
-bash autogen.sh
-./configure --prefix=$PWD || exit 1;
-make || exit 1;
-make install || exit 1;
-cd ..
-
-# add path
 (
-  wd=$PWD
-  echo export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$wd/gperftools/lib
-  echo export PATH=$PATH:$wd/gperftools/bin
-) >> env.sh
-
-
+  cd gperftools &&
+  ./configure --prefix=$PWD --enable-minimal --disable-debugalloc --disable-static &&
+  make &&
+  make install
+)


### PR DESCRIPTION
This is a PR for installing the ``tcmalloc'' library to speed up the decoding-like codes.

@huangruizhe  , hi ruizhe, when you are free, could you please try to run the PR on the grid of CLSP. You can run the tools/extras/install_tcmalloc.sh to install it and include the ``--enable-tcmalloc'' option when you execute ``configure'' command. It's ok for me when I test on my local grid.

After that, may be you can use ``decoder/lattice-simple-decoder or simple-decoder'' (which use the build-in data structure such as unordered_map rather than kaldi's hash-lish) to test the speedup on any dataset. From my experience, it will speed up the former  on a lot and the latter a little bit. Thanks.