### PR TITLE
[src] Use static_assert for KALDI_COMPILE_TIME_ASSERT

### DIFF
--- a/src/base/kaldi-utils.h
+++ b/src/base/kaldi-utils.h
@@ -131,21 +131,19 @@ void Sleep(double seconds);
   type(const type&) = delete;                   \
   type& operator=(const type&) = delete
 
-template<bool B> class KaldiCompileTimeAssert { };
-template<> class KaldiCompileTimeAssert<true> {
- public:
-  static inline void Check() { }
-};
-
-#define KALDI_COMPILE_TIME_ASSERT(b) KaldiCompileTimeAssert<(b)>::Check()
+#if __cplusplus >= 201703L
+#define KALDI_COMPILE_TIME_ASSERT static_assert
+#else
+#define KALDI_COMPILE_TIME_ASSERT(b) static_assert((b), #b)
+#endif
 
 #define KALDI_ASSERT_IS_INTEGER_TYPE(I) \
-  KaldiCompileTimeAssert<std::numeric_limits<I>::is_specialized \
-                 && std::numeric_limits<I>::is_integer>::Check()
+  KALDI_COMPILE_TIME_ASSERT(std::numeric_limits<I>::is_specialized \
+                            && std::numeric_limits<I>::is_integer)
 
 #define KALDI_ASSERT_IS_FLOATING_TYPE(F) \
-  KaldiCompileTimeAssert<std::numeric_limits<F>::is_specialized \
-                && !std::numeric_limits<F>::is_integer>::Check()
+  KALDI_COMPILE_TIME_ASSERT(std::numeric_limits<F>::is_specialized \
+                            && !std::numeric_limits<F>::is_integer)
 
 #if defined(_MSC_VER)
 #define KALDI_STRCASECMP _stricmp


### PR DESCRIPTION
Remove `template<bool B> class KaldiCompileTimeAssert` because `static_assert` is now a language declaration. Before C++17 a second argument for the message is required (lame, lame!), which is, lacking anything better, is obtained by stringizing the function-like macro argument. For C++17, the second argument is optional, and the semantics is identical.