### PR TITLE
[src] Initialize CuDevice member; cleanup cu-common.{h,cc}

### DIFF
--- a/src/cudamatrix/cu-common.cc
+++ b/src/cudamatrix/cu-common.cc
@@ -18,22 +18,17 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_CUDAMATRIX_COMMON_H_
-#define KALDI_CUDAMATRIX_COMMON_H_
+#if HAVE_CUDA
 
-// This file contains some #includes, forward declarations
-// and typedefs that are needed by all the main header
-// files in this directory.
-#include <mutex>
-#include "base/kaldi-common.h"
-#include "matrix/kaldi-blas.h"
-#include "cudamatrix/cu-device.h"
 #include "cudamatrix/cu-common.h"
+
+#include <cuda.h>
+
+#include "base/kaldi-common.h"
 #include "cudamatrix/cu-matrixdim.h"
+#include "matrix/kaldi-blas.h"
 
 namespace kaldi {
-
-#if HAVE_CUDA == 1
 
 #ifdef USE_NVTX
 NvtxTracer::NvtxTracer(const char* name) {
@@ -91,6 +86,7 @@ void GetBlockSizesForSimpleMatrixOperation(int32 num_rows,
 }
 
 const char* cublasGetStatusString(cublasStatus_t status) {
+  // Defined in CUDA include file: cublas.h or cublas_api.h
   switch(status) {
     case CUBLAS_STATUS_SUCCESS:           return "CUBLAS_STATUS_SUCCESS";
     case CUBLAS_STATUS_NOT_INITIALIZED:   return "CUBLAS_STATUS_NOT_INITIALIZED";
@@ -108,6 +104,7 @@ const char* cublasGetStatusString(cublasStatus_t status) {
 
 const char* cusparseGetStatusString(cusparseStatus_t status) {
   // detail info come from http://docs.nvidia.com/cuda/cusparse/index.html#cusparsestatust
+  // Defined in CUDA include file: cusparse.h
   switch(status) {
     case CUSPARSE_STATUS_SUCCESS:                   return "CUSPARSE_STATUS_SUCCESS";
     case CUSPARSE_STATUS_NOT_INITIALIZED:           return "CUSPARSE_STATUS_NOT_INITIALIZED";
@@ -129,6 +126,7 @@ const char* cusparseGetStatusString(cusparseStatus_t status) {
 
 const char* curandGetStatusString(curandStatus_t status) {
   // detail info come from http://docs.nvidia.com/cuda/curand/group__HOST.html
+  // Defined in CUDA include file: curand.h
   switch(status) {
     case CURAND_STATUS_SUCCESS:                     return "CURAND_STATUS_SUCCESS";
     case CURAND_STATUS_VERSION_MISMATCH:            return "CURAND_STATUS_VERSION_MISMATCH";
@@ -146,9 +144,7 @@ const char* curandGetStatusString(curandStatus_t status) {
   }
   return "CURAND_STATUS_UNKNOWN_ERROR";
 }
-#endif
 
-} // namespace
+}  // namespace kaldi
 
-
-#endif  // KALDI_CUDAMATRIX_COMMON_H_
+#endif  // HAVE_CUDA

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -22,6 +22,8 @@
 #ifndef KALDI_CUDAMATRIX_CU_COMMON_H_
 #define KALDI_CUDAMATRIX_CU_COMMON_H_
 
+#if HAVE_CUDA
+
 #include <iostream>
 #include <sstream>
 
@@ -29,7 +31,6 @@
 #include "cudamatrix/cu-matrixdim.h" // for CU1DBLOCK and CU2DBLOCK
 #include "matrix/matrix-common.h"
 
-#if HAVE_CUDA == 1
 #include <cublas_v2.h>
 #include <cuda_runtime_api.h>
 #include <curand.h>
@@ -136,12 +137,11 @@ const char* cusparseGetStatusString(cusparseStatus_t status);
 
 /** This is analogous to the CUDA function cudaGetErrorString(). **/
 const char* curandGetStatusString(curandStatus_t status);
-}
 
-#else
-namespace kaldi {
+}  // namespace kaldi
+
+#else  // HAVE CUDA
 #define NVTX_RANGE(name)
-};
 #endif  // HAVE_CUDA
 
 namespace kaldi {
@@ -159,7 +159,6 @@ template<typename Real> class CuTpMatrix;
 template<typename Real> class CuSparseMatrix;
 
 template<typename Real> class CuBlockMatrix; // this has no non-CU counterpart.
-
 
 }  // namespace kaldi
 

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -22,14 +22,14 @@
 #ifndef KALDI_CUDAMATRIX_CU_COMMON_H_
 #define KALDI_CUDAMATRIX_CU_COMMON_H_
 
-#if HAVE_CUDA
-
 #include <iostream>
 #include <sstream>
 
 #include "base/kaldi-error.h"
 #include "cudamatrix/cu-matrixdim.h" // for CU1DBLOCK and CU2DBLOCK
 #include "matrix/matrix-common.h"
+
+#if HAVE_CUDA
 
 #include <cublas_v2.h>
 #include <cuda_runtime_api.h>

--- a/src/cudamatrix/cu-device.cc
+++ b/src/cudamatrix/cu-device.cc
@@ -598,6 +598,7 @@ CuDevice::CuDevice():
     device_id_copy_(-1),
     cublas_handle_(NULL),
     cusparse_handle_(NULL),
+    curand_handle_(NULL),
     cusolverdn_handle_(NULL) {
 }
 


### PR DESCRIPTION
* Initialize `CuDevice::curand_handle_` to `NULL` in constructor
* Remove stray include guards from cu-common.cc
* Rearrange `#include`s per coding guidelines
* Exclude more `#include`s if !HAVE_CUDA in cu-common.{cc,h}