### PR TITLE
fix generate vs project error in windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 
 # Please keep sorted alphabetically, and start each with a letter which
 # is different from the first one in the last word one the row above it.
-SUBDIRS := base bin chain chainbin cudamatrix decoder		\
+SUBDIRS = base bin chain chainbin cudamatrix decoder		\
            feat featbin fgmmbin fstbin fstext			\
            gmm gmmbin hmm                               	\
            ivector ivectorbin kws kwsbin	        	\


### PR DESCRIPTION
when using generate_solution.pl to build windows library,  line 975 comand is mainly to generate all kaldi subdir project, but failed. It should match "SUBDIRS = " string.