### PR TITLE
Remove break statement to prevent leaving loop early before finishing processing rest of segments

### DIFF
--- a/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits_mild.py
+++ b/egs/wsj/s5/steps/cleanup/internal/segment_ctm_edits_mild.py
@@ -782,7 +782,6 @@ class Segment(object):
                     self.split_lines_of_utt, cur_start_index,
                     segment.end_index)
                 new_segments.append(new_segment)
-                break
         segments = new_segments
         return segments
 


### PR DESCRIPTION
At this stage of segmentation, it may happen that after previous segment was split, it triggers break statement and rest of segments in the list are discarded.

Consider there are 2 segments in the list 'segments', first one has duration of 17, and second one has 6. The input parameter "hard_max_segment_length" is 15, so first segment needs to be split again. After splitting the first one, the tool reaches StopIteration exception, and then just break out of for loop and left 6-second segment not append to 'new_segments'.

Not sure why was that break statement left there. Please correct me if there are other conditions that need to be considered.