### PR TITLE
#4574 Create Minimal Dependency Lattice Tools

### DIFF
--- a/src/cudadecoder/lattice-postprocessor.h
+++ b/src/cudadecoder/lattice-postprocessor.h
@@ -25,6 +25,7 @@
 #include "cudadecoder/cuda-pipeline-common.h"
 #include "cudamatrix/cu-device.h"
 #include "fstext/fstext-lib.h"
+#include "hmm/transition-model.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/sausages.h"
 #include "lat/word-align-lattice.h"

--- a/src/decoder/decodable-matrix.cc
+++ b/src/decoder/decodable-matrix.cc
@@ -22,10 +22,12 @@
 namespace kaldi {
 
 DecodableMatrixMapped::DecodableMatrixMapped(
-    const TransitionModel &tm,
+    const TransitionInformation &tm,
     const MatrixBase<BaseFloat> &likes,
     int32 frame_offset):
-    trans_model_(tm), likes_(&likes), likes_to_delete_(NULL),
+    trans_model_(tm),
+    tid_to_pdf_(trans_model_.TransitionIdToPdfArray()),
+    likes_(&likes), likes_to_delete_(NULL),
     frame_offset_(frame_offset) {
   stride_ = likes.Stride();
   raw_data_ = likes.Data() - (stride_ * frame_offset);
@@ -37,9 +39,11 @@ DecodableMatrixMapped::DecodableMatrixMapped(
 }
 
 DecodableMatrixMapped::DecodableMatrixMapped(
-    const TransitionModel &tm, const Matrix<BaseFloat> *likes,
+    const TransitionInformation &tm, const Matrix<BaseFloat> *likes,
     int32 frame_offset):
-    trans_model_(tm), likes_(likes), likes_to_delete_(likes),
+    trans_model_(tm),
+    tid_to_pdf_(trans_model_.TransitionIdToPdfArray()),
+    likes_(likes), likes_to_delete_(likes),
     frame_offset_(frame_offset) {
   stride_ = likes->Stride();
   raw_data_ = likes->Data() - (stride_ * frame_offset_);
@@ -51,7 +55,7 @@ DecodableMatrixMapped::DecodableMatrixMapped(
 
 
 BaseFloat DecodableMatrixMapped::LogLikelihood(int32 frame, int32 tid) {
-  int32 pdf_id = trans_model_.TransitionIdToPdfFast(tid);
+  int32 pdf_id = tid_to_pdf_[tid];
 #ifdef KALDI_PARANOID
   return (*likes_)(frame - frame_offset_, pdf_id);
 #else

--- a/src/decoder/decodable-matrix.cc
+++ b/src/decoder/decodable-matrix.cc
@@ -55,6 +55,7 @@ DecodableMatrixMapped::DecodableMatrixMapped(
 
 
 BaseFloat DecodableMatrixMapped::LogLikelihood(int32 frame, int32 tid) {
+  KALDI_PARANOID_ASSERT(tid >= 1 && tid < tid_to_pdf_.size());
   int32 pdf_id = tid_to_pdf_[tid];
 #ifdef KALDI_PARANOID
   return (*likes_)(frame - frame_offset_, pdf_id);

--- a/src/decoder/decodable-matrix.h
+++ b/src/decoder/decodable-matrix.h
@@ -34,9 +34,10 @@ namespace kaldi {
 class DecodableMatrixScaledMapped: public DecodableInterface {
  public:
   // This constructor creates an object that will not delete "likes" when done.
-  DecodableMatrixScaledMapped(const TransitionModel &tm,
+  DecodableMatrixScaledMapped(const TransitionInformation &tm,
                               const Matrix<BaseFloat> &likes,
                               BaseFloat scale): trans_model_(tm), likes_(&likes),
+                                                tid_to_pdf_(trans_model_.TransitionIdToPdfArray()),
                                                 scale_(scale), delete_likes_(false) {
     if (likes.NumCols() != tm.NumPdfs())
       KALDI_ERR << "DecodableMatrixScaledMapped: mismatch, matrix has "
@@ -46,10 +47,11 @@ class DecodableMatrixScaledMapped: public DecodableInterface {
 
   // This constructor creates an object that will delete "likes"
   // when done.
-  DecodableMatrixScaledMapped(const TransitionModel &tm,
+  DecodableMatrixScaledMapped(const TransitionInformation &tm,
                               BaseFloat scale,
                               const Matrix<BaseFloat> *likes):
       trans_model_(tm), likes_(likes),
+      tid_to_pdf_(trans_model_.TransitionIdToPdfArray()),
       scale_(scale), delete_likes_(true) {
     if (likes->NumCols() != tm.NumPdfs())
       KALDI_ERR << "DecodableMatrixScaledMapped: mismatch, matrix has "
@@ -66,7 +68,7 @@ class DecodableMatrixScaledMapped: public DecodableInterface {
 
   // Note, frames are numbered from zero.
   virtual BaseFloat LogLikelihood(int32 frame, int32 tid) {
-    return scale_ * (*likes_)(frame, trans_model_.TransitionIdToPdfFast(tid));
+    return scale_ * (*likes_)(frame, tid_to_pdf_[tid]);
   }
 
   // Indices are one-based!  This is for compatibility with OpenFst.
@@ -76,8 +78,9 @@ class DecodableMatrixScaledMapped: public DecodableInterface {
     if (delete_likes_) delete likes_;
   }
  private:
-  const TransitionModel &trans_model_;  // for tid to pdf mapping
+  const TransitionInformation &trans_model_;  // for tid to pdf mapping
   const Matrix<BaseFloat> *likes_;
+  const std::vector<int32> &tid_to_pdf_;
   BaseFloat scale_;
   bool delete_likes_;
   KALDI_DISALLOW_COPY_AND_ASSIGN(DecodableMatrixScaledMapped);
@@ -100,13 +103,13 @@ class DecodableMatrixMapped: public DecodableInterface {
   // This constructor creates an object that will not delete "likes" when done.
   // the frame_offset is the frame the row 0 of 'likes' corresponds to, would be
   // greater than one if this is not the first chunk of likelihoods.
-  DecodableMatrixMapped(const TransitionModel &tm,
+  DecodableMatrixMapped(const TransitionInformation &tm,
                         const MatrixBase<BaseFloat> &likes,
                         int32 frame_offset = 0);
 
   // This constructor creates an object that will delete "likes"
   // when done.
-  DecodableMatrixMapped(const TransitionModel &tm,
+  DecodableMatrixMapped(const TransitionInformation &tm,
                         const Matrix<BaseFloat> *likes,
                         int32 frame_offset = 0);
 
@@ -122,7 +125,8 @@ class DecodableMatrixMapped: public DecodableInterface {
   virtual ~DecodableMatrixMapped();
 
  private:
-  const TransitionModel &trans_model_;  // for tid to pdf mapping
+  const TransitionInformation &trans_model_;  // for tid to pdf mapping
+  const std::vector<int32>& tid_to_pdf_;
   const MatrixBase<BaseFloat> *likes_;
   const Matrix<BaseFloat> *likes_to_delete_;
   int32 frame_offset_;
@@ -151,8 +155,9 @@ class DecodableMatrixMapped: public DecodableInterface {
 */
 class DecodableMatrixMappedOffset: public DecodableInterface {
  public:
-  DecodableMatrixMappedOffset(const TransitionModel &tm):
-      trans_model_(tm), frame_offset_(0), input_is_finished_(false) { }
+  DecodableMatrixMappedOffset(const TransitionInformation &tm):
+      trans_model_(tm), tid_to_pdf_(trans_model_.TransitionIdToPdfArray()),
+      frame_offset_(0), input_is_finished_(false) { }
 
   // this is not part of the generic Decodable interface.
   int32 FirstAvailableFrame() const { return frame_offset_; }
@@ -178,7 +183,7 @@ class DecodableMatrixMappedOffset: public DecodableInterface {
   }
 
   virtual BaseFloat LogLikelihood(int32 frame, int32 tid) {
-    int32 pdf_id = trans_model_.TransitionIdToPdfFast(tid);
+    int32 pdf_id = tid_to_pdf_[tid];
 #ifdef KALDI_PARANOID
     return loglikes_(frame - frame_offset_, pdf_id);
 #else
@@ -192,7 +197,8 @@ class DecodableMatrixMappedOffset: public DecodableInterface {
   // nothing special to do in destructor.
   virtual ~DecodableMatrixMappedOffset() { }
  private:
-  const TransitionModel &trans_model_;  // for tid to pdf mapping
+  const TransitionInformation &trans_model_;  // for tid to pdf mapping
+  const std::vector<int32>& tid_to_pdf_;
   Matrix<BaseFloat> loglikes_;
   int32 frame_offset_;
   bool input_is_finished_;

--- a/src/decoder/decodable-matrix.h
+++ b/src/decoder/decodable-matrix.h
@@ -68,6 +68,7 @@ class DecodableMatrixScaledMapped: public DecodableInterface {
 
   // Note, frames are numbered from zero.
   virtual BaseFloat LogLikelihood(int32 frame, int32 tid) {
+    KALDI_PARANOID_ASSERT(tid >= 1 && tid < tid_to_pdf_.size());
     return scale_ * (*likes_)(frame, tid_to_pdf_[tid]);
   }
 
@@ -183,6 +184,7 @@ class DecodableMatrixMappedOffset: public DecodableInterface {
   }
 
   virtual BaseFloat LogLikelihood(int32 frame, int32 tid) {
+    KALDI_PARANOID_ASSERT(tid >= 1 && tid < tid_to_pdf_.size());
     int32 pdf_id = tid_to_pdf_[tid];
 #ifdef KALDI_PARANOID
     return loglikes_(frame - frame_offset_, pdf_id);

--- a/src/decoder/decoder-wrappers.cc
+++ b/src/decoder/decoder-wrappers.cc
@@ -32,7 +32,7 @@ namespace kaldi {
 DecodeUtteranceLatticeFasterClass::DecodeUtteranceLatticeFasterClass(
     LatticeFasterDecoder *decoder,
     DecodableInterface *decodable,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     const std::string &utt,
     BaseFloat acoustic_scale,
@@ -199,7 +199,7 @@ template <typename FST>
 bool DecodeUtteranceLatticeIncremental(
     LatticeIncrementalDecoderTpl<FST> &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -287,7 +287,7 @@ template <typename FST>
 bool DecodeUtteranceLatticeFaster(
     LatticeFasterDecoderTpl<FST> &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -385,7 +385,7 @@ bool DecodeUtteranceLatticeFaster(
 template bool DecodeUtteranceLatticeIncremental(
     LatticeIncrementalDecoderTpl<fst::Fst<fst::StdArc> > &decoder,
     DecodableInterface &decodable,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -400,7 +400,7 @@ template bool DecodeUtteranceLatticeIncremental(
 template bool DecodeUtteranceLatticeIncremental(
     LatticeIncrementalDecoderTpl<fst::ConstGrammarFst > &decoder,
     DecodableInterface &decodable,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -415,7 +415,7 @@ template bool DecodeUtteranceLatticeIncremental(
 template bool DecodeUtteranceLatticeFaster(
     LatticeFasterDecoderTpl<fst::Fst<fst::StdArc> > &decoder,
     DecodableInterface &decodable,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -430,7 +430,7 @@ template bool DecodeUtteranceLatticeFaster(
 template bool DecodeUtteranceLatticeFaster(
     LatticeFasterDecoderTpl<fst::ConstGrammarFst > &decoder,
     DecodableInterface &decodable,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -447,7 +447,7 @@ template bool DecodeUtteranceLatticeFaster(
 bool DecodeUtteranceLatticeSimple(
     LatticeSimpleDecoder &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,

--- a/src/decoder/decoder-wrappers.h
+++ b/src/decoder/decoder-wrappers.h
@@ -94,7 +94,7 @@ template <typename FST>
 bool DecodeUtteranceLatticeIncremental(
     LatticeIncrementalDecoderTpl<FST> &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -121,7 +121,7 @@ template <typename FST>
 bool DecodeUtteranceLatticeFaster(
     LatticeFasterDecoderTpl<FST> &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,
@@ -147,7 +147,7 @@ class DecodeUtteranceLatticeFasterClass {
   DecodeUtteranceLatticeFasterClass(
       LatticeFasterDecoder *decoder,
       DecodableInterface *decodable,
-      const TransitionModel &trans_model,
+      const TransitionInformation &trans_model,
       const fst::SymbolTable *word_syms,
       const std::string &utt,
       BaseFloat acoustic_scale,
@@ -168,7 +168,7 @@ class DecodeUtteranceLatticeFasterClass {
   // The following variables correspond to inputs:
   LatticeFasterDecoder *decoder_;
   DecodableInterface *decodable_;
-  const TransitionModel *trans_model_;
+  const TransitionInformation *trans_model_;
   const fst::SymbolTable *word_syms_;
   std::string utt_;
   BaseFloat acoustic_scale_;
@@ -201,7 +201,7 @@ class DecodeUtteranceLatticeFasterClass {
 bool DecodeUtteranceLatticeSimple(
     LatticeSimpleDecoder &decoder, // not const but is really an input.
     DecodableInterface &decodable, // not const but is really an input.
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
     const fst::SymbolTable *word_syms,
     std::string utt,
     double acoustic_scale,

--- a/src/decoder/lattice-incremental-decoder.cc
+++ b/src/decoder/lattice-incremental-decoder.cc
@@ -26,7 +26,7 @@ namespace kaldi {
 // instantiate this class once for each thing you have to decode.
 template <typename FST, typename Token>
 LatticeIncrementalDecoderTpl<FST, Token>::LatticeIncrementalDecoderTpl(
-    const FST &fst, const TransitionModel &trans_model,
+    const FST &fst, const TransitionInformation &trans_model,
     const LatticeIncrementalDecoderConfig &config)
     : fst_(&fst),
       delete_fst_(false),
@@ -40,7 +40,7 @@ LatticeIncrementalDecoderTpl<FST, Token>::LatticeIncrementalDecoderTpl(
 template <typename FST, typename Token>
 LatticeIncrementalDecoderTpl<FST, Token>::LatticeIncrementalDecoderTpl(
     const LatticeIncrementalDecoderConfig &config, FST *fst,
-    const TransitionModel &trans_model)
+    const TransitionInformation &trans_model)
     : fst_(fst),
       delete_fst_(true),
       num_toks_(0),

--- a/src/decoder/lattice-incremental-decoder.h
+++ b/src/decoder/lattice-incremental-decoder.h
@@ -202,7 +202,7 @@ class LatticeIncrementalDeterminizer {
                                                 specific type all the time but
                                                 just say 'Label' */
   LatticeIncrementalDeterminizer(
-      const TransitionModel &trans_model,
+      const TransitionInformation &trans_model,
       const LatticeIncrementalDecoderConfig &config):
       trans_model_(trans_model), config_(config) { }
 
@@ -390,7 +390,7 @@ class LatticeIncrementalDeterminizer {
 
   // trans_model_ is needed by DeterminizeLatticePhonePrunedWrapper() which this
   // class calls.
-  const TransitionModel &trans_model_;
+  const TransitionInformation &trans_model_;
   // config_ is needed by DeterminizeLatticePhonePrunedWrapper() which this
   // class calls.
   const LatticeIncrementalDecoderConfig &config_;
@@ -474,13 +474,13 @@ class LatticeIncrementalDecoderTpl {
   // Instantiate this class once for each thing you have to decode.
   // This version of the constructor does not take ownership of
   // 'fst'.
-  LatticeIncrementalDecoderTpl(const FST &fst, const TransitionModel &trans_model,
+  LatticeIncrementalDecoderTpl(const FST &fst, const TransitionInformation &trans_model,
                                const LatticeIncrementalDecoderConfig &config);
 
   // This version of the constructor takes ownership of the fst, and will delete
   // it when this object is destroyed.
   LatticeIncrementalDecoderTpl(const LatticeIncrementalDecoderConfig &config,
-                               FST *fst, const TransitionModel &trans_model);
+                               FST *fst, const TransitionInformation &trans_model);
 
   void SetOptions(const LatticeIncrementalDecoderConfig &config) { config_ = config; }
 

--- a/src/decoder/lattice-incremental-decoder.h
+++ b/src/decoder/lattice-incremental-decoder.h
@@ -27,6 +27,7 @@
 #include "fstext/fstext-lib.h"
 #include "lat/determinize-lattice-pruned.h"
 #include "lat/kaldi-lattice.h"
+#include "hmm/transition-model.h"
 #include "decoder/grammar-fst.h"
 #include "decoder/lattice-faster-decoder.h"
 

--- a/src/decoder/lattice-incremental-decoder.h
+++ b/src/decoder/lattice-incremental-decoder.h
@@ -27,7 +27,6 @@
 #include "fstext/fstext-lib.h"
 #include "lat/determinize-lattice-pruned.h"
 #include "lat/kaldi-lattice.h"
-#include "hmm/transition-model.h"
 #include "decoder/grammar-fst.h"
 #include "decoder/lattice-faster-decoder.h"
 

--- a/src/decoder/lattice-incremental-online-decoder.h
+++ b/src/decoder/lattice-incremental-online-decoder.h
@@ -62,7 +62,7 @@ class LatticeIncrementalOnlineDecoderTpl:
   // This version of the constructor does not take ownership of
   // 'fst'.
   LatticeIncrementalOnlineDecoderTpl(const FST &fst,
-    const TransitionModel &trans_model,
+    const TransitionInformation &trans_model,
                                 const LatticeIncrementalDecoderConfig &config):
       LatticeIncrementalDecoderTpl<FST, Token>(fst, trans_model, config) { }
 
@@ -70,7 +70,7 @@ class LatticeIncrementalOnlineDecoderTpl:
   // it when this object is destroyed.
   LatticeIncrementalOnlineDecoderTpl(const LatticeIncrementalDecoderConfig &config,
                                 FST *fst,
-    const TransitionModel &trans_model):
+    const TransitionInformation &trans_model):
       LatticeIncrementalDecoderTpl<FST, Token>(config, fst, trans_model) { }
 
 

--- a/src/hmm/transition-model.cc
+++ b/src/hmm/transition-model.cc
@@ -787,7 +787,7 @@ bool TransitionModel::TransitionIdsEquivalent(int32_t trans_id1,
     TransitionIdToTransitionState(trans_id2);
 }
 
-bool TransitionModel::TransitionIdIsStartOfToken(int32_t trans_id) const {
+bool TransitionModel::TransitionIdIsStartOfPhone(int32_t trans_id) const {
   return TransitionIdToHmmState(trans_id) == 0;
 }
 

--- a/src/hmm/transition-model.cc
+++ b/src/hmm/transition-model.cc
@@ -781,6 +781,9 @@ void TransitionModel::MapUpdateShared(const Vector<double> &stats,
   ComputeDerivedOfProbs();
 }
 
+const std::vector<int32>& TransitionModel::TransitionIdToPdfArray() const {
+  return id2pdf_id_;
+}
 
 int32 TransitionModel::TransitionIdToPhone(int32 trans_id) const {
   KALDI_ASSERT(trans_id != 0 && static_cast<size_t>(trans_id) < id2state_.size());

--- a/src/hmm/transition-model.cc
+++ b/src/hmm/transition-model.cc
@@ -781,6 +781,16 @@ void TransitionModel::MapUpdateShared(const Vector<double> &stats,
   ComputeDerivedOfProbs();
 }
 
+bool TransitionModel::TransitionIdsEquivalent(int32_t trans_id1,
+                                              int32_t trans_id2) const {
+  return TransitionIdToTransitionState(trans_id1) ==
+    TransitionIdToTransitionState(trans_id2);
+}
+
+bool TransitionModel::TransitionIdIsStartOfToken(int32_t trans_id) const {
+  return TransitionIdToHmmState(trans_id) == 0;
+}
+
 const std::vector<int32>& TransitionModel::TransitionIdToPdfArray() const {
   return id2pdf_id_;
 }

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -157,11 +157,11 @@ class TransitionModel: public TransitionInformation {
   int32 SelfLoopOf(int32 trans_state) const;  // returns the self-loop transition-id, or zero if
   // this state doesn't have a self-loop.
 
-  inline int32 TransitionIdToPdf(int32 trans_id) const;
+  inline int32 TransitionIdToPdf(int32 trans_id) const final override;
   // TransitionIdToPdfFast is as TransitionIdToPdf but skips an assertion
   // (unless we're in paranoid mode).
   inline int32 TransitionIdToPdfFast(int32 trans_id) const;
-  const std::vector<int32>& TransitionIdToPdfArray() const override;
+  const std::vector<int32>& TransitionIdToPdfArray() const final override;
 
   int32 TransitionIdToPhone(int32 trans_id) const;
   int32 TransitionIdToPdfClass(int32 trans_id) const;
@@ -172,9 +172,6 @@ class TransitionModel: public TransitionInformation {
   bool IsFinal(int32 trans_id) const;  // returns true if this trans_id goes to the final state
   // (which is bound to be nonemitting).
   bool IsSelfLoop(int32 trans_id) const;  // return true if this trans_id corresponds to a self-loop.
-
-  /// Returns the total number of transition-ids (note, these are one-based).
-  inline int32 NumTransitionIds() const { return id2state_.size()-1; }
 
   /// Returns the number of transition-indices for a particular transition-state.
   /// Note: "Indices" is the plural of "index".   Index is not the same as "id",

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -157,11 +157,11 @@ class TransitionModel: public TransitionInformation {
   int32 SelfLoopOf(int32 trans_state) const;  // returns the self-loop transition-id, or zero if
   // this state doesn't have a self-loop.
 
-  inline int32 TransitionIdToPdf(int32 trans_id) const final override;
+  inline int32 TransitionIdToPdf(int32 trans_id) const final;
   // TransitionIdToPdfFast is as TransitionIdToPdf but skips an assertion
   // (unless we're in paranoid mode).
   inline int32 TransitionIdToPdfFast(int32 trans_id) const;
-  const std::vector<int32>& TransitionIdToPdfArray() const final override;
+  const std::vector<int32>& TransitionIdToPdfArray() const final;
 
   int32 TransitionIdToPhone(int32 trans_id) const;
   int32 TransitionIdToPdfClass(int32 trans_id) const;

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -161,6 +161,7 @@ class TransitionModel: public TransitionInformation {
   // TransitionIdToPdfFast is as TransitionIdToPdf but skips an assertion
   // (unless we're in paranoid mode).
   inline int32 TransitionIdToPdfFast(int32 trans_id) const;
+  const std::vector<int32>& TransitionIdToPdfArray() const override;
 
   int32 TransitionIdToPhone(int32 trans_id) const;
   int32 TransitionIdToPdfClass(int32 trans_id) const;

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -158,7 +158,7 @@ class TransitionModel: public TransitionInformation {
   // this state doesn't have a self-loop.
 
   bool TransitionIdsEquivalent(int32_t trans_id1, int32_t trans_id2) const final;
-  bool TransitionIdIsStartOfToken(int32_t trans_id) const final;
+  bool TransitionIdIsStartOfPhone(int32_t trans_id) const final;
 
   // TransitionIdToPdfFast is as TransitionIdToPdfArray()[trans_id] but skips an assertion
   // (unless we're in paranoid mode).

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -27,6 +27,7 @@
 #include "hmm/hmm-topology.h"
 #include "itf/options-itf.h"
 #include "itf/context-dep-itf.h"
+#include "itf/transition-information.h"
 #include "matrix/kaldi-vector.h"
 
 namespace kaldi {
@@ -120,7 +121,7 @@ struct MapTransitionUpdateConfig {
   }
 };
 
-class TransitionModel {
+class TransitionModel: public TransitionInformation {
 
  public:
   /// Initialize the object [e.g. at the start of training].

--- a/src/hmm/transition-model.h
+++ b/src/hmm/transition-model.h
@@ -157,8 +157,10 @@ class TransitionModel: public TransitionInformation {
   int32 SelfLoopOf(int32 trans_state) const;  // returns the self-loop transition-id, or zero if
   // this state doesn't have a self-loop.
 
-  inline int32 TransitionIdToPdf(int32 trans_id) const final;
-  // TransitionIdToPdfFast is as TransitionIdToPdf but skips an assertion
+  bool TransitionIdsEquivalent(int32_t trans_id1, int32_t trans_id2) const final;
+  bool TransitionIdIsStartOfToken(int32_t trans_id) const final;
+
+  // TransitionIdToPdfFast is as TransitionIdToPdfArray()[trans_id] but skips an assertion
   // (unless we're in paranoid mode).
   inline int32 TransitionIdToPdfFast(int32 trans_id) const;
   const std::vector<int32>& TransitionIdToPdfArray() const final;
@@ -322,13 +324,6 @@ class TransitionModel: public TransitionInformation {
 
   KALDI_DISALLOW_COPY_AND_ASSIGN(TransitionModel);
 };
-
-inline int32 TransitionModel::TransitionIdToPdf(int32 trans_id) const {
-  KALDI_ASSERT(
-      static_cast<size_t>(trans_id) < id2pdf_id_.size() &&
-      "Likely graph/model mismatch (graph built from wrong model?)");
-  return id2pdf_id_[trans_id];
-}
 
 inline int32 TransitionModel::TransitionIdToPdfFast(int32 trans_id) const {
   // Note: it's a little dangerous to assert this only in paranoid mode.

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -46,7 +46,11 @@ class TransitionInformation {
   virtual bool IsFinal(int32_t trans_id) const = 0;
   virtual bool IsSelfLoop(int32_t trans_id) const = 0;
   virtual int32_t TransitionIdToPdf(int32_t trans_id) const = 0;
+  // Ideally, this would return a std::span, but it doesn't because
+  // kaldi doesn't support C++20. Sorry.
+  virtual const std::vector<int32_t>& TransitionIdToPdfArray() const = 0;
   virtual int32_t NumTransitionIds() const = 0;
+  virtual int32 NumPdfs() const = 0;
   virtual int32_t TransitionIdToHmmState(int32_t trans_id) const = 0;
 };
 

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -21,6 +21,7 @@
 #define KALDI_ITF_TRANSITION_INFORMATION_H_
 
 #include <stdint.h>
+#include <vector>
 
 namespace kaldi {
 
@@ -99,7 +100,7 @@ class TransitionInformation {
    * TransitionIdToPdf(). Another way to look at this is as the number
    * of outputs over which your acoustic model does a softmax.
    */
-  virtual int32 NumPdfs() const = 0;
+  virtual int32_t NumPdfs() const = 0;
 };
 
 }  // namespace kaldi

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -55,14 +55,15 @@ class TransitionInformation {
    * Returns true if this trans_id corresponds to the start of a
    * phone.
    */
-  virtual bool TransitionIdIsStartOfToken(int32_t trans_id) const = 0;
+  virtual bool TransitionIdIsStartOfPhone(int32_t trans_id) const = 0;
   /**
-   * Phone is understood to correspond not only to linguistic phones,
-   * but also graphemes, word pieces, byte pieces, etc. A better word
-   * would be Token. We use the word Phone for backwards compatibility
-   * with TransitionModel, which was designed only with phones in
-   * mind. Since TransitionInformation was added to subsume
-   * TransitionModel, we did not want to change the call site of every
+   * Phone is a historical term, and should be understood in a wider
+   * sense that also includes graphemes, word pieces, etc.: any
+   * minimal entity in your problem domain which is represented by a
+   * sequence of transitions with a PDF assigned to each of them by
+   * the model. In this sense, Token is a better word. Since
+   * TransitionInformation was added to subsume TransitionModel, we
+   * did not want to change the call site of every
    * TransitionModel::TransitionIdToPhone to
    * TransitionInformation::TransitionIdToToken.
    */

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -103,4 +103,4 @@ class TransitionInformation {
 
 }  // namespace kaldi
 
-#endif // KALDI_HMM_TRANSITION_MODEL_H_
+#endif // KALDI_TRANSITION_INFORMATION_H_

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -31,17 +31,20 @@ namespace kaldi {
  * without a dependency on the hmm/ and tree/ directories. For
  * example, you can consider creating a subclass that implements these
  * via extracting information from Eesen's CTC T.fst object.
+ *
+ * TransitionId values must be contiguous, and starting from 1, rather
+ * than 0, since 0 corresponds to epsilon in OpenFST.
  */
 class TransitionInformation {
  public:
   virtual ~TransitionInformation() {};
   virtual int32_t TransitionIdToTransitionState(int32_t trans_id) const = 0;
-    /**
-     * Phone should really be Token here, where Token could be a word
-     * piece, phone, or character. However, because the original
-     * class, TransitionModel, used Phone, we retain it for the sake
-     * of not changing all the callers of this method.
-     */
+  /**
+   * Phone should really be Token here, where Token could be a word
+   * piece, phone, or character. However, because the original
+   * class, TransitionModel, used Phone, we retain it for the sake
+   * of not changing all the callers of this method.
+   */
   virtual int32_t TransitionIdToPhone(int32_t trans_id) const = 0;
   virtual bool IsFinal(int32_t trans_id) const = 0;
   virtual bool IsSelfLoop(int32_t trans_id) const = 0;
@@ -49,11 +52,13 @@ class TransitionInformation {
   // Ideally, this would return a std::span, but it doesn't because
   // kaldi doesn't support C++20. Sorry.
   virtual const std::vector<int32_t>& TransitionIdToPdfArray() const = 0;
-  virtual int32_t NumTransitionIds() const = 0;
+  int32_t NumTransitionIds() const {
+      return TransitionIdToPdfArray().size() - 1;
+  }
   virtual int32 NumPdfs() const = 0;
   virtual int32_t TransitionIdToHmmState(int32_t trans_id) const = 0;
 };
 
-}
+} // namespace kaldi
 
 #endif // KALDI_HMM_TRANSITION_MODEL_H_

--- a/src/itf/transition-information.h
+++ b/src/itf/transition-information.h
@@ -1,0 +1,55 @@
+// itf/transition-information.h
+
+// Copyright 2021 NVIDIA (author: Daniel Galvez)
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_ITF_TRANSITION_INFORMATION_H_
+#define KALDI_ITF_TRANSITION_INFORMATION_H_
+
+#include <stdint.h>
+
+namespace kaldi {
+
+/**
+ * Class that abstracts out TransitionModel's methods originally used
+ * in the lat/ directory. By instantiating a subclass of this abstract
+ * class other than TransitionModel, you can use kaldi's lattice tools
+ * without a dependency on the hmm/ and tree/ directories. For
+ * example, you can consider creating a subclass that implements these
+ * via extracting information from Eesen's CTC T.fst object.
+ */
+class TransitionInformation {
+ public:
+  virtual ~TransitionInformation() {};
+  virtual int32_t TransitionIdToTransitionState(int32_t trans_id) const = 0;
+    /**
+     * Phone should really be Token here, where Token could be a word
+     * piece, phone, or character. However, because the original
+     * class, TransitionModel, used Phone, we retain it for the sake
+     * of not changing all the callers of this method.
+     */
+  virtual int32_t TransitionIdToPhone(int32_t trans_id) const = 0;
+  virtual bool IsFinal(int32_t trans_id) const = 0;
+  virtual bool IsSelfLoop(int32_t trans_id) const = 0;
+  virtual int32_t TransitionIdToPdf(int32_t trans_id) const = 0;
+  virtual int32_t NumTransitionIds() const = 0;
+  virtual int32_t TransitionIdToHmmState(int32_t trans_id) const = 0;
+};
+
+}
+
+#endif // KALDI_HMM_TRANSITION_MODEL_H_

--- a/src/lat/Makefile
+++ b/src/lat/Makefile
@@ -8,7 +8,8 @@ EXTRA_CXXFLAGS += -Wno-sign-compare
 TESTFILES = kaldi-lattice-test push-lattice-test minimize-lattice-test \
       determinize-lattice-pruned-test word-align-lattice-lexicon-test
 
-OBJFILES = kaldi-lattice.o lattice-functions.o word-align-lattice.o \
+OBJFILES = kaldi-lattice.o lattice-functions.o \
+       lattice-functions-transition-model.o word-align-lattice.o \
 	   phone-align-lattice.o word-align-lattice-lexicon.o sausages.o \
        push-lattice.o minimize-lattice.o determinize-lattice-pruned.o \
        confidence.o compose-lattice-pruned.o

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -1294,7 +1294,7 @@ bool DeterminizeLatticePruned(const ExpandedFst<ArcTpl<Weight> > &ifst,
 
 template<class Weight>
 typename ArcTpl<Weight>::Label DeterminizeLatticeInsertPhones(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<ArcTpl<Weight> > *fst) {
   // Define some types.
   typedef ArcTpl<Weight> Arc;
@@ -1391,7 +1391,7 @@ void DeterminizeLatticeDeletePhones(
 */
 template<class Weight, class IntType>
 bool DeterminizeLatticePhonePrunedFirstPass(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     double beam,
     MutableFst<ArcTpl<Weight> > *fst,
     const DeterminizeLatticePrunedOptions &opts) {
@@ -1414,7 +1414,7 @@ bool DeterminizeLatticePhonePrunedFirstPass(
 // lattice might be modified.
 template<class Weight, class IntType>
 bool DeterminizeLatticePhonePruned(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<ArcTpl<Weight> > *ifst,
     double beam,
     MutableFst<ArcTpl<CompactLatticeWeightTpl<Weight, IntType> > > *ofst,
@@ -1475,7 +1475,7 @@ bool DeterminizeLatticePhonePruned(
 // will be kept as unchanged.
 template<class Weight, class IntType>
 bool DeterminizeLatticePhonePruned(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     const ExpandedFst<ArcTpl<Weight> > &ifst,
     double beam,
     MutableFst<ArcTpl<CompactLatticeWeightTpl<Weight, IntType> > > *ofst,
@@ -1486,7 +1486,7 @@ bool DeterminizeLatticePhonePruned(
 }
 
 bool DeterminizeLatticePhonePrunedWrapper(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<kaldi::LatticeArc> *ifst,
     double beam,
     MutableFst<kaldi::CompactLatticeArc> *ofst,
@@ -1528,7 +1528,7 @@ bool DeterminizeLatticePruned<kaldi::LatticeWeight>(
 
 template
 bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     const ExpandedFst<kaldi::LatticeArc> &ifst,
     double prune,
     MutableFst<kaldi::CompactLatticeArc> *ofst,
@@ -1536,7 +1536,7 @@ bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
 
 template
 bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<kaldi::LatticeArc> *ifst,
     double prune,
     MutableFst<kaldi::CompactLatticeArc> *ofst,

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -1319,7 +1319,7 @@ typename ArcTpl<Weight>::Label DeterminizeLatticeInsertPhones(
       // Note: the words are on the input symbol side and transition-id's are on
       // the output symbol side.
       if ((arc.olabel != 0)
-          && (trans_model.TransitionIdToHmmState(arc.olabel) == 0)
+          && (trans_model.TransitionIdIsStartOfToken(arc.olabel))
           && (!trans_model.IsSelfLoop(arc.olabel))) {
         Label phone =
             static_cast<Label>(trans_model.TransitionIdToPhone(arc.olabel));

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -1319,7 +1319,7 @@ typename ArcTpl<Weight>::Label DeterminizeLatticeInsertPhones(
       // Note: the words are on the input symbol side and transition-id's are on
       // the output symbol side.
       if ((arc.olabel != 0)
-          && (trans_model.TransitionIdIsStartOfToken(arc.olabel))
+          && (trans_model.TransitionIdIsStartOfPhone(arc.olabel))
           && (!trans_model.IsSelfLoop(arc.olabel))) {
         Label phone =
             static_cast<Label>(trans_model.TransitionIdToPhone(arc.olabel));

--- a/src/lat/determinize-lattice-pruned.h
+++ b/src/lat/determinize-lattice-pruned.h
@@ -28,7 +28,7 @@
 #include <set>
 #include <vector>
 #include "fstext/lattice-weight.h"
-#include "hmm/transition-model.h"
+#include "itf/transition-information.h"
 #include "itf/options-itf.h"
 #include "lat/kaldi-lattice.h"
 
@@ -222,7 +222,7 @@ bool DeterminizeLatticePruned(
 */
 template<class Weight>
 typename ArcTpl<Weight>::Label DeterminizeLatticeInsertPhones(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<ArcTpl<Weight> > *fst);
 
 /** This function takes in lattices and deletes "phones" from them. The "phones"
@@ -253,7 +253,7 @@ void DeterminizeLatticeDeletePhones(
 */
 template<class Weight, class IntType>
 bool DeterminizeLatticePhonePruned(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     const ExpandedFst<ArcTpl<Weight> > &ifst,
     double prune,
     MutableFst<ArcTpl<CompactLatticeWeightTpl<Weight, IntType> > > *ofst,
@@ -265,7 +265,7 @@ bool DeterminizeLatticePhonePruned(
 */
 template<class Weight, class IntType>
 bool DeterminizeLatticePhonePruned(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<ArcTpl<Weight> > *ifst,
     double prune,
     MutableFst<ArcTpl<CompactLatticeWeightTpl<Weight, IntType> > > *ofst,
@@ -282,7 +282,7 @@ bool DeterminizeLatticePhonePruned(
     code.
 */
 bool DeterminizeLatticePhonePrunedWrapper(
-    const kaldi::TransitionModel &trans_model,
+    const kaldi::TransitionInformation &trans_model,
     MutableFst<kaldi::LatticeArc> *ifst,
     double prune,
     MutableFst<kaldi::CompactLatticeArc> *ofst,

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -1,0 +1,138 @@
+// lat/lattice-functions-transition-model.cc
+
+// Copyright 2009-2011  Saarland University (Author: Arnab Ghoshal)
+//           2012-2013  Johns Hopkins University (Author: Daniel Povey);  Chao Weng;
+//                      Bagher BabaAli
+//                2013  Cisco Systems (author: Neha Agrawal) [code modified
+//                      from original code in ../gmmbin/gmm-rescore-lattice.cc]
+//                2014  Guoguo Chen
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lat/lattice-functions-transition-model.h"
+#include "hmm/transition-model.h"
+#include "hmm/hmm-utils.h"
+
+namespace kaldi {
+
+BaseFloat LatticeForwardBackwardMmi(
+    const TransitionModel &tmodel,
+    const Lattice &lat,
+    const std::vector<int32> &num_ali,
+    bool drop_frames,
+    bool convert_to_pdf_ids,
+    bool cancel,
+    Posterior *post) {
+  // First compute the MMI posteriors.
+
+  Posterior den_post;
+  BaseFloat ans = LatticeForwardBackward(lat,
+                                         &den_post,
+                                         NULL);
+
+  Posterior num_post;
+  AlignmentToPosterior(num_ali, &num_post);
+
+  // Now negate the MMI posteriors and add the numerator
+  // posteriors.
+  ScalePosterior(-1.0, &den_post);
+
+  if (convert_to_pdf_ids) {
+    Posterior num_tmp;
+    ConvertPosteriorToPdfs(tmodel, num_post, &num_tmp);
+    num_tmp.swap(num_post);
+    Posterior den_tmp;
+    ConvertPosteriorToPdfs(tmodel, den_post, &den_tmp);
+    den_tmp.swap(den_post);
+  }
+
+  MergePosteriors(num_post, den_post,
+                  cancel, drop_frames, post);
+
+  return ans;
+}
+
+
+bool CompactLatticeToWordProns(
+    const TransitionModel &tmodel,
+    const CompactLattice &clat,
+    std::vector<int32> *words,
+    std::vector<int32> *begin_times,
+    std::vector<int32> *lengths,
+    std::vector<std::vector<int32> > *prons,
+    std::vector<std::vector<int32> > *phone_lengths) {
+  words->clear();
+  begin_times->clear();
+  lengths->clear();
+  prons->clear();
+  phone_lengths->clear();
+  typedef CompactLattice::Arc Arc;
+  typedef Arc::Label Label;
+  typedef CompactLattice::StateId StateId;
+  typedef CompactLattice::Weight Weight;
+  using namespace fst;
+  StateId state = clat.Start();
+  int32 cur_time = 0;
+  if (state == kNoStateId) {
+    KALDI_WARN << "Empty lattice.";
+    return false;
+  }
+  while (1) {
+    Weight final = clat.Final(state);
+    size_t num_arcs = clat.NumArcs(state);
+    if (final != Weight::Zero()) {
+      if (num_arcs != 0) {
+        KALDI_WARN << "Lattice is not linear.";
+        return false;
+      }
+      if (! final.String().empty()) {
+        KALDI_WARN << "Lattice has alignments on final-weight: probably "
+            "was not word-aligned (alignments will be approximate)";
+      }
+      return true;
+    } else {
+      if (num_arcs != 1) {
+        KALDI_WARN << "Lattice is not linear: num-arcs = " << num_arcs;
+        return false;
+      }
+      fst::ArcIterator<CompactLattice> aiter(clat, state);
+      const Arc &arc = aiter.Value();
+      Label word_id = arc.ilabel; // Note: ilabel==olabel, since acceptor.
+      // Also note: word_id may be zero; we output it anyway.
+      int32 length = arc.weight.String().size();
+      words->push_back(word_id);
+      begin_times->push_back(cur_time);
+      lengths->push_back(length);
+      const std::vector<int32> &arc_alignment = arc.weight.String();
+      std::vector<std::vector<int32> > split_alignment;
+      SplitToPhones(tmodel, arc_alignment, &split_alignment);
+      std::vector<int32> phones(split_alignment.size());
+      std::vector<int32> plengths(split_alignment.size());
+      for (size_t i = 0; i < split_alignment.size(); i++) {
+        KALDI_ASSERT(!split_alignment[i].empty());
+        phones[i] = tmodel.TransitionIdToPhone(split_alignment[i][0]);
+        plengths[i] = split_alignment[i].size();
+      }
+      prons->push_back(phones);
+      phone_lengths->push_back(plengths);
+
+      cur_time += length;
+      state = arc.nextstate;
+    }
+  }
+}
+
+} // end namespace kaldi

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -136,4 +136,4 @@ bool CompactLatticeToWordProns(
   }
 }
 
-} // namespace kaldi
+}  // namespace kaldi

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -23,6 +23,7 @@
 // limitations under the License.
 
 #include "lat/lattice-functions-transition-model.h"
+#include "lat/lattice-functions.h"
 #include "hmm/transition-model.h"
 #include "hmm/hmm-utils.h"
 

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -136,4 +136,4 @@ bool CompactLatticeToWordProns(
   }
 }
 
-} // end namespace kaldi
+} // namespace kaldi

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -136,4 +136,126 @@ bool CompactLatticeToWordProns(
   }
 }
 
+// Returns true if this vector of transition-ids could be a valid
+// word.  Note: for testing, we assume that the lexicon always
+// has the same input-word and output-word.  The other case is complex
+// to test.
+static bool IsPlausibleWord(const WordAlignLatticeLexiconInfo &lexicon_info,
+                            const TransitionModel &tmodel,
+                            int32 word_id,
+                            const std::vector<int32> &transition_ids) {
+
+  std::vector<std::vector<int32> > split_alignment; // Split into phones.
+  if (!SplitToPhones(tmodel, transition_ids, &split_alignment)) {
+    KALDI_WARN << "Could not split word into phones correctly (forced-out?)";
+  }
+  std::vector<int32> phones(split_alignment.size());
+  for (size_t i = 0; i < split_alignment.size(); i++) {
+    KALDI_ASSERT(!split_alignment[i].empty());
+    phones[i] = tmodel.TransitionIdToPhone(split_alignment[i][0]);
+  }
+  std::vector<int32> lexicon_entry;
+  lexicon_entry.push_back(word_id);
+  lexicon_entry.insert(lexicon_entry.end(), phones.begin(), phones.end());
+
+  if (!lexicon_info.IsValidEntry(lexicon_entry)) {
+    std::ostringstream ostr;
+    for (size_t i = 0; i < lexicon_entry.size(); i++)
+      ostr << lexicon_entry[i] << ' ';
+    KALDI_WARN << "Invalid arc in aligned lattice (code error?) lexicon-entry is " << ostr.str();
+    return false;
+  } else {
+    return true;
+  }
+}
+
+/// Testing code; map word symbols in the lattice "lat" using the equivalence-classes
+/// obtained from the lexicon, using the function EquivalenceClassOf in the lexicon_info
+/// object.
+static void MapSymbols(const WordAlignLatticeLexiconInfo &lexicon_info,
+                       CompactLattice *lat) {
+  typedef CompactLattice::StateId StateId;
+  for (StateId s = 0; s < lat->NumStates(); s++) {
+    for (fst::MutableArcIterator<CompactLattice> aiter(lat, s);
+         !aiter.Done(); aiter.Next()) {
+      CompactLatticeArc arc (aiter.Value());
+      KALDI_ASSERT(arc.ilabel == arc.olabel);
+      arc.ilabel = lexicon_info.EquivalenceClassOf(arc.ilabel);
+      arc.olabel = arc.ilabel;
+      aiter.SetValue(arc);
+    }
+  }
+}
+
+bool TestWordAlignedLattice(const WordAlignLatticeLexiconInfo &lexicon_info,
+                            const TransitionModel &tmodel,
+                            CompactLattice clat,
+                            CompactLattice aligned_clat,
+                            bool allow_duplicate_paths) {
+  int32 max_err = 5, num_err = 0;
+  { // We test whether the forward-backward likelihoods differ; this is intended
+    // to detect when we have duplicate paths in the aligned lattice, for some path
+    // in the input lattice (e.g. due to epsilon-sequencing problems).
+    Posterior post;
+    Lattice lat, aligned_lat;
+    ConvertLattice(clat, &lat);
+    ConvertLattice(aligned_clat, &aligned_lat);
+    TopSort(&lat);
+    TopSort(&aligned_lat);
+    BaseFloat like_before = LatticeForwardBackward(lat, &post),
+        like_after = LatticeForwardBackward(aligned_lat, &post);
+    if (fabs(like_before - like_after) >
+        1.0e-04 * (fabs(like_before) + fabs(like_after))) {
+      KALDI_WARN << "Forward-backward likelihoods differ in word-aligned lattice "
+                 << "testing, " << like_before << " != " << like_after;
+      if (!allow_duplicate_paths)
+        num_err++;
+    }
+  }
+
+  // Do a check on the arcs of the aligned lattice, that each arc corresponds
+  // to an entry in the lexicon.
+  for (CompactLattice::StateId s = 0; s < aligned_clat.NumStates(); s++) {
+    for (fst::ArcIterator<CompactLattice> aiter(aligned_clat, s);
+         !aiter.Done(); aiter.Next()) {
+      const CompactLatticeArc &arc (aiter.Value());
+      KALDI_ASSERT(arc.ilabel == arc.olabel);
+      int32 word_id = arc.ilabel;
+      const std::vector<int32> &tids = arc.weight.String();
+      if (word_id == 0 && tids.empty()) continue; // We allow epsilon arcs.
+
+      if (num_err < max_err)
+        if (!IsPlausibleWord(lexicon_info, tmodel, word_id, tids))
+          num_err++;
+      // Note: IsPlausibleWord will warn if there is an error.
+    }
+    if (!aligned_clat.Final(s).String().empty()) {
+      KALDI_WARN << "Aligned lattice has nonempty string on its final-prob.";
+      return false;
+    }
+  }
+
+  // Next we'll do an equivalence test.
+  // First map symbols into equivalence classes, so that we don't wrongly fail
+  // due to the capability of the framework to map words to other words.
+  // (e.g. mapping <eps> on silence arcs to SIL).
+
+  MapSymbols(lexicon_info, &clat);
+  MapSymbols(lexicon_info, &aligned_clat);
+
+  /// Check equivalence.
+  int32 num_paths = 5, seed = Rand(), max_path_length = -1;
+  BaseFloat delta = 0.2; // some lattices have large costs -> use large delta.
+
+  FLAGS_v = GetVerboseLevel(); // set the OpenFst verbose level to the Kaldi
+                               // verbose level.
+  if (!RandEquivalent(clat, aligned_clat, num_paths, delta, seed, max_path_length)) {
+    KALDI_WARN << "Equivalence test failed during lattice alignment.";
+    return false;
+  }
+  FLAGS_v = 0;
+
+  return (num_err == 0);
+}
+
 }  // namespace kaldi

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -23,9 +23,10 @@
 // limitations under the License.
 
 #include "lat/lattice-functions-transition-model.h"
-#include "lat/lattice-functions.h"
-#include "hmm/transition-model.h"
+
 #include "hmm/hmm-utils.h"
+#include "hmm/transition-model.h"
+#include "lat/lattice-functions.h"
 
 namespace kaldi {
 

--- a/src/lat/lattice-functions-transition-model.h
+++ b/src/lat/lattice-functions-transition-model.h
@@ -99,6 +99,6 @@ bool TestWordAlignedLattice(const WordAlignLatticeLexiconInfo &lexicon_info,
                             CompactLattice aligned_clat,
                             bool allow_duplicate_paths);
 
-} // end namespace kaldi
+}  // namespace kaldi
 
 #endif // KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_

--- a/src/lat/lattice-functions-transition-model.h
+++ b/src/lat/lattice-functions-transition-model.h
@@ -1,0 +1,96 @@
+// lat/lattice-functions-transition-model.h
+
+// Copyright 2009-2012   Saarland University (author: Arnab Ghoshal)
+//           2012-2013   Johns Hopkins University (Author: Daniel Povey);
+//                       Bagher BabaAli
+//                2014   Guoguo Chen
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_
+#define KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_
+
+#include <vector>
+#include <map>
+
+#include "base/kaldi-common.h"
+#include "fstext/fstext-lib.h"
+#include "lat/kaldi-lattice.h"
+#include "itf/decodable-itf.h"
+#include "hmm/transition-model.h"
+#include "hmm/hmm-utils.h"
+#include "hmm/posterior.h"
+
+namespace kaldi {
+
+/**
+   This function can be used to compute posteriors for MMI, with a positive contribution
+   for the numerator and a negative one for the denominator.  This function is not actually
+   used in our normal MMI training recipes, where it's instead done using various command
+   line programs that each do a part of the job.  This function was written for use in
+   neural-net MMI training.
+
+   @param [in] trans    The transition model. Used to map the
+                        transition-ids to phones or pdfs.
+   @param [in] lat      The denominator lattice
+   @param [in] num_ali  The numerator alignment
+   @param [in] drop_frames   If "drop_frames" is true, it will not compute any
+                        posteriors on frames where the num and den have disjoint
+                        pdf-ids.
+   @param [in] convert_to_pdf_ids   If "convert_to_pdfs_ids" is true, it will
+                        convert the output to be at the level of pdf-ids, not
+                        transition-ids.
+   @param [in] cancel   If "cancel" is true, it will cancel out any positive and
+                        negative parts from the same transition-id (or pdf-id,
+                        if convert_to_pdf_ids == true).
+   @param [out] arc_post   The output MMI posteriors of transition-ids (or
+                        pdf-ids if convert_to_pdf_ids == true) at each frame
+                        i.e. the difference between the numerator
+                        and denominator posteriors.
+
+   It returns the forward-backward likelihood of the lattice. */
+BaseFloat LatticeForwardBackwardMmi(
+    const TransitionModel &trans,
+    const Lattice &lat,
+    const std::vector<int32> &num_ali,
+    bool drop_frames,
+    bool convert_to_pdf_ids,
+    bool cancel,
+    Posterior *arc_post);
+
+/// This function takes a CompactLattice that should only contain a single
+/// linear sequence (e.g. derived from lattice-1best), and that should have been
+/// processed so that the arcs in the CompactLattice align correctly with the
+/// word boundaries (e.g. by lattice-align-words).  It outputs 4 vectors of the
+/// same size, which give, for each word in the lattice (in sequence), the word
+/// label, the begin time and length in frames, and the pronunciation (sequence
+/// of phones).  This is done even for zero words, corresponding to optional
+/// silences -- if you don't want them, just ignore them in the output.
+/// This function will print a warning and return false, if the lattice
+/// did not have the correct format (e.g. if it is empty or it is not
+/// linear).
+bool CompactLatticeToWordProns(
+    const TransitionModel &tmodel,
+    const CompactLattice &clat,
+    std::vector<int32> *words,
+    std::vector<int32> *begin_times,
+    std::vector<int32> *lengths,
+    std::vector<std::vector<int32> > *prons,
+    std::vector<std::vector<int32> > *phone_lengths);
+
+} // end namespace kaldi
+
+#endif // KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_

--- a/src/lat/lattice-functions-transition-model.h
+++ b/src/lat/lattice-functions-transition-model.h
@@ -33,6 +33,7 @@
 #include "hmm/posterior.h"
 #include "itf/decodable-itf.h"
 #include "lat/kaldi-lattice.h"
+#include "lat/word-align-lattice-lexicon.h"
 
 namespace kaldi {
 
@@ -90,6 +91,13 @@ bool CompactLatticeToWordProns(
     std::vector<int32> *lengths,
     std::vector<std::vector<int32> > *prons,
     std::vector<std::vector<int32> > *phone_lengths);
+
+
+bool TestWordAlignedLattice(const WordAlignLatticeLexiconInfo &lexicon_info,
+                            const TransitionModel &tmodel,
+                            CompactLattice clat,
+                            CompactLattice aligned_clat,
+                            bool allow_duplicate_paths);
 
 } // end namespace kaldi
 

--- a/src/lat/lattice-functions-transition-model.h
+++ b/src/lat/lattice-functions-transition-model.h
@@ -23,16 +23,16 @@
 #ifndef KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_
 #define KALDI_LAT_LATTICE_FUNCTIONS_TRANSITION_MODEL_H_
 
-#include <vector>
 #include <map>
+#include <vector>
 
 #include "base/kaldi-common.h"
 #include "fstext/fstext-lib.h"
-#include "lat/kaldi-lattice.h"
-#include "itf/decodable-itf.h"
 #include "hmm/transition-model.h"
 #include "hmm/hmm-utils.h"
 #include "hmm/posterior.h"
+#include "itf/decodable-itf.h"
+#include "lat/kaldi-lattice.h"
 
 namespace kaldi {
 

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -424,8 +424,6 @@ void LatticeActivePhones(const Lattice &lat, const TransitionInformation &trans,
   }  // end looping over states
 }
 
-#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
-
 void ConvertLatticeToPhones(const TransitionInformation &trans,
                             Lattice *lat) {
   typedef LatticeArc Arc;
@@ -445,8 +443,6 @@ void ConvertLatticeToPhones(const TransitionInformation &trans,
     }  // end looping over arcs
   }  // end looping over states
 }
-
-#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS
 
 
 static inline double LogAddOrMax(bool viterbi, double a, double b) {

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -434,7 +434,7 @@ void ConvertLatticeToPhones(const TransitionInformation &trans,
       Arc arc(aiter.Value());
       arc.olabel = 0; // remove any word.
       if ((arc.ilabel != 0) // has a transition-id on input..
-          && (trans.TransitionIdToHmmState(arc.ilabel) == 0)
+          && (trans.TransitionIdIsStartOfToken(arc.ilabel))
           && (!trans.IsSelfLoop(arc.ilabel))) {
          // && trans.IsFinal(arc.ilabel)) // there is one of these per phone...
         arc.olabel = trans.TransitionIdToPhone(arc.ilabel);

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -434,7 +434,7 @@ void ConvertLatticeToPhones(const TransitionInformation &trans,
       Arc arc(aiter.Value());
       arc.olabel = 0; // remove any word.
       if ((arc.ilabel != 0) // has a transition-id on input..
-          && (trans.TransitionIdIsStartOfToken(arc.ilabel))
+          && (trans.TransitionIdIsStartOfPhone(arc.ilabel))
           && (!trans.IsSelfLoop(arc.ilabel))) {
          // && trans.IsFinal(arc.ilabel)) // there is one of these per phone...
         arc.olabel = trans.TransitionIdToPhone(arc.ilabel);

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -428,7 +428,7 @@ void LatticeActivePhones(const Lattice &lat, const TransitionInformation &trans,
 
 #ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
 
-void ConvertLatticeToPhones(const TransitionModel &trans,
+void ConvertLatticeToPhones(const TransitionInformation &trans,
                             Lattice *lat) {
   typedef LatticeArc Arc;
   int32 num_states = lat->NumStates();

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -25,8 +25,6 @@
 
 #include "base/kaldi-math.h"
 #include "lat/lattice-functions.h"
-// TODO: Can I remove this?
-// #include "util/stl-utils.h"
 
 namespace kaldi {
 using std::map;
@@ -1884,7 +1882,3 @@ void ReplaceAcousticScoresFromMap(
 }
 
 }  // namespace kaldi
-
-#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
-#include "lattice-functions-transition-model.cc"
-#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS

--- a/src/lat/lattice-functions.cc
+++ b/src/lat/lattice-functions.cc
@@ -23,11 +23,10 @@
 // limitations under the License.
 
 
-#include "lat/lattice-functions.h"
-#include "hmm/transition-model.h"
-#include "util/stl-utils.h"
 #include "base/kaldi-math.h"
-#include "hmm/hmm-utils.h"
+#include "lat/lattice-functions.h"
+// TODO: Can I remove this?
+// #include "util/stl-utils.h"
 
 namespace kaldi {
 using std::map;
@@ -403,7 +402,7 @@ BaseFloat LatticeForwardBackward(const Lattice &lat, Posterior *post,
 }
 
 
-void LatticeActivePhones(const Lattice &lat, const TransitionModel &trans,
+void LatticeActivePhones(const Lattice &lat, const TransitionInformation &trans,
                          const vector<int32> &silence_phones,
                          vector< std::set<int32> > *active_phones) {
   KALDI_ASSERT(IsSortedAndUniq(silence_phones));
@@ -427,6 +426,8 @@ void LatticeActivePhones(const Lattice &lat, const TransitionModel &trans,
   }  // end looping over states
 }
 
+#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
+
 void ConvertLatticeToPhones(const TransitionModel &trans,
                             Lattice *lat) {
   typedef LatticeArc Arc;
@@ -446,6 +447,8 @@ void ConvertLatticeToPhones(const TransitionModel &trans,
     }  // end looping over arcs
   }  // end looping over states
 }
+
+#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS
 
 
 static inline double LogAddOrMax(bool viterbi, double a, double b) {
@@ -704,7 +707,7 @@ void CompactLatticeDepthPerFrame(const CompactLattice &clat,
 
 
 
-void ConvertCompactLatticeToPhones(const TransitionModel &trans,
+void ConvertCompactLatticeToPhones(const TransitionInformation &trans,
                                    CompactLattice *clat) {
   typedef CompactLatticeArc Arc;
   typedef Arc::Weight Weight;
@@ -739,7 +742,7 @@ void ConvertCompactLatticeToPhones(const TransitionModel &trans,
   }  // end looping over states
 }
 
-bool LatticeBoost(const TransitionModel &trans,
+bool LatticeBoost(const TransitionInformation &trans,
                   const std::vector<int32> &alignment,
                   const std::vector<int32> &silence_phones,
                   BaseFloat b,
@@ -799,7 +802,7 @@ bool LatticeBoost(const TransitionModel &trans,
 
 
 BaseFloat LatticeForwardBackwardMpeVariants(
-    const TransitionModel &trans,
+    const TransitionInformation &trans,
     const std::vector<int32> &silence_phones,
     const Lattice &lat,
     const std::vector<int32> &num_ali,
@@ -1028,77 +1031,6 @@ bool CompactLatticeToWordAlignment(const CompactLattice &clat,
     }
   }
 }
-
-
-bool CompactLatticeToWordProns(
-    const TransitionModel &tmodel,
-    const CompactLattice &clat,
-    std::vector<int32> *words,
-    std::vector<int32> *begin_times,
-    std::vector<int32> *lengths,
-    std::vector<std::vector<int32> > *prons,
-    std::vector<std::vector<int32> > *phone_lengths) {
-  words->clear();
-  begin_times->clear();
-  lengths->clear();
-  prons->clear();
-  phone_lengths->clear();
-  typedef CompactLattice::Arc Arc;
-  typedef Arc::Label Label;
-  typedef CompactLattice::StateId StateId;
-  typedef CompactLattice::Weight Weight;
-  using namespace fst;
-  StateId state = clat.Start();
-  int32 cur_time = 0;
-  if (state == kNoStateId) {
-    KALDI_WARN << "Empty lattice.";
-    return false;
-  }
-  while (1) {
-    Weight final = clat.Final(state);
-    size_t num_arcs = clat.NumArcs(state);
-    if (final != Weight::Zero()) {
-      if (num_arcs != 0) {
-        KALDI_WARN << "Lattice is not linear.";
-        return false;
-      }
-      if (! final.String().empty()) {
-        KALDI_WARN << "Lattice has alignments on final-weight: probably "
-            "was not word-aligned (alignments will be approximate)";
-      }
-      return true;
-    } else {
-      if (num_arcs != 1) {
-        KALDI_WARN << "Lattice is not linear: num-arcs = " << num_arcs;
-        return false;
-      }
-      fst::ArcIterator<CompactLattice> aiter(clat, state);
-      const Arc &arc = aiter.Value();
-      Label word_id = arc.ilabel; // Note: ilabel==olabel, since acceptor.
-      // Also note: word_id may be zero; we output it anyway.
-      int32 length = arc.weight.String().size();
-      words->push_back(word_id);
-      begin_times->push_back(cur_time);
-      lengths->push_back(length);
-      const std::vector<int32> &arc_alignment = arc.weight.String();
-      std::vector<std::vector<int32> > split_alignment;
-      SplitToPhones(tmodel, arc_alignment, &split_alignment);
-      std::vector<int32> phones(split_alignment.size());
-      std::vector<int32> plengths(split_alignment.size());
-      for (size_t i = 0; i < split_alignment.size(); i++) {
-        KALDI_ASSERT(!split_alignment[i].empty());
-        phones[i] = tmodel.TransitionIdToPhone(split_alignment[i][0]);
-        plengths[i] = split_alignment[i].size();
-      }
-      prons->push_back(phones);
-      phone_lengths->push_back(plengths);
-
-      cur_time += length;
-      state = arc.nextstate;
-    }
-  }
-}
-
 
 
 void CompactLatticeShortestPath(const CompactLattice &clat,
@@ -1449,7 +1381,7 @@ struct ClatRescoreTuple {
     RescoreCompactLattice, "tmodel" will be NULL and speedup_factor will be 1.0.
  */
 bool RescoreCompactLatticeInternal(
-    const TransitionModel *tmodel,
+    const TransitionInformation *tmodel,
     BaseFloat speedup_factor,
     DecodableInterface *decodable,
     CompactLattice *clat) {
@@ -1579,7 +1511,7 @@ bool RescoreCompactLatticeInternal(
 
 
 bool RescoreCompactLatticeSpeedup(
-    const TransitionModel &tmodel,
+    const TransitionInformation &tmodel,
     BaseFloat speedup_factor,
     DecodableInterface *decodable,
     CompactLattice *clat) {
@@ -1643,44 +1575,6 @@ bool RescoreLattice(DecodableInterface *decodable,
     }
   }
   return true;
-}
-
-
-BaseFloat LatticeForwardBackwardMmi(
-    const TransitionModel &tmodel,
-    const Lattice &lat,
-    const std::vector<int32> &num_ali,
-    bool drop_frames,
-    bool convert_to_pdf_ids,
-    bool cancel,
-    Posterior *post) {
-  // First compute the MMI posteriors.
-
-  Posterior den_post;
-  BaseFloat ans = LatticeForwardBackward(lat,
-                                         &den_post,
-                                         NULL);
-
-  Posterior num_post;
-  AlignmentToPosterior(num_ali, &num_post);
-
-  // Now negate the MMI posteriors and add the numerator
-  // posteriors.
-  ScalePosterior(-1.0, &den_post);
-
-  if (convert_to_pdf_ids) {
-    Posterior num_tmp;
-    ConvertPosteriorToPdfs(tmodel, num_post, &num_tmp);
-    num_tmp.swap(num_post);
-    Posterior den_tmp;
-    ConvertPosteriorToPdfs(tmodel, den_post, &den_tmp);
-    den_tmp.swap(den_post);
-  }
-
-  MergePosteriors(num_post, den_post,
-                  cancel, drop_frames, post);
-
-  return ans;
 }
 
 
@@ -1990,3 +1884,7 @@ void ReplaceAcousticScoresFromMap(
 }
 
 }  // namespace kaldi
+
+#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
+#include "lattice-functions-transition-model.cc"
+#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS

--- a/src/lat/lattice-functions.h
+++ b/src/lat/lattice-functions.h
@@ -32,18 +32,13 @@
 #include "lat/kaldi-lattice.h"
 #include "itf/decodable-itf.h"
 #include "itf/transition-information.h"
-#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
 #include "lat/lattice-functions-transition-model.h"
-#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS
 
 namespace kaldi {
 
-// Redundant with the typedef in hmm/posterior.h. Redeclaration of a
-// typedef is valid in C++, but not C. This is for the sake of users
-// who compile with the macro KALDI_MINIMAL_LATTICE_FUNCTIONS defined,
-// so that they compile the majority of the lattice functions (all but
-// those declared in lattice-functions-transition-model.h) without depending
-// upon the hmm/ or tree/ libraries.
+// Redundant with the typedef in hmm/posterior.h. We want functions
+// using the Posterior type to be usable without a dependency on the
+// hmm library.
 typedef std::vector<std::vector<std::pair<int32, BaseFloat> > > Posterior;
 
 /**

--- a/src/lat/lattice-functions.h
+++ b/src/lat/lattice-functions.h
@@ -29,10 +29,9 @@
 
 #include "base/kaldi-common.h"
 #include "fstext/fstext-lib.h"
-#include "lat/kaldi-lattice.h"
 #include "itf/decodable-itf.h"
 #include "itf/transition-information.h"
-#include "lat/lattice-functions-transition-model.h"
+#include "lat/kaldi-lattice.h"
 
 namespace kaldi {
 

--- a/src/lat/lattice-functions.h
+++ b/src/lat/lattice-functions.h
@@ -31,7 +31,10 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 #include "itf/decodable-itf.h"
+#include "itf/transition-information.h"
+#ifndef KALDI_MINIMAL_LATTICE_FUNCTIONS
 #include "lat/lattice-functions-transition-model.h"
+#endif // KALDI_MINIMAL_LATTICE_FUNCTIONS
 
 namespace kaldi {
 
@@ -158,7 +161,7 @@ void LatticeActivePhones(const Lattice &lat, const TransitionInformation &trans,
 /// transition-id in the phone if reordering is not done (but typically
 /// we do reorder).
 /// Also see PhoneAlignLattice, in phone-align-lattice.h.
-void ConvertLatticeToPhones(const TransitionModel &trans_model,
+void ConvertLatticeToPhones(const TransitionInformation &trans_model,
                             Lattice *lat);
 
 /// Prunes a lattice or compact lattice.  Returns true on success, false if

--- a/src/lat/lattice-functions.h
+++ b/src/lat/lattice-functions.h
@@ -28,13 +28,20 @@
 #include <map>
 
 #include "base/kaldi-common.h"
-#include "hmm/posterior.h"
 #include "fstext/fstext-lib.h"
-#include "hmm/transition-model.h"
 #include "lat/kaldi-lattice.h"
 #include "itf/decodable-itf.h"
+#include "lat/lattice-functions-transition-model.h"
 
 namespace kaldi {
+
+// Redundant with the typedef in hmm/posterior.h. Redeclaration of a
+// typedef is valid in C++, but not C. This is for the sake of users
+// who compile with the macro KALDI_MINIMAL_LATTICE_FUNCTIONS defined,
+// so that they compile the majority of the lattice functions (all but
+// those declared in lattice-functions-transition-model.h) without depending
+// upon the hmm/ or tree/ libraries.
+typedef std::vector<std::vector<std::pair<int32, BaseFloat> > > Posterior;
 
 /**
    This function extracts the per-frame log likelihoods from a linear
@@ -96,7 +103,7 @@ bool ComputeCompactLatticeBetas(const CompactLattice &lat,
 // Computes (normal or Viterbi) alphas and betas; returns (total-prob, or
 // best-path negated cost) Note: in either case, the alphas and betas are
 // negated costs.  Requires that lat be topologically sorted.  This code
-// will work for either CompactLattice or Latice.
+// will work for either CompactLattice or Lattice.
 template<typename LatticeType>
 double ComputeLatticeAlphasAndBetas(const LatticeType &lat,
                                     bool viterbi,
@@ -137,7 +144,7 @@ void CompactLatticeLimitDepth(int32 max_arcs_per_frame,
 /// outputs for each frame the set of phones active on that frame.  If
 /// sil_phones (which must be sorted and uniq) is nonempty, it excludes
 /// phones in this list.
-void LatticeActivePhones(const Lattice &lat, const TransitionModel &trans,
+void LatticeActivePhones(const Lattice &lat, const TransitionInformation &trans,
                          const std::vector<int32> &sil_phones,
                          std::vector<std::set<int32> > *active_phones);
 
@@ -164,7 +171,7 @@ bool PruneLattice(BaseFloat beam, LatticeType *lat);
 /// replace the sequences of transition-ids with sequences of phones.
 /// Note that this is different from ConvertLatticeToPhones, in that
 /// we replace the transition-ids not the words.
-void ConvertCompactLatticeToPhones(const TransitionModel &trans_model,
+void ConvertCompactLatticeToPhones(const TransitionInformation &trans_model,
                                    CompactLattice *clat);
 
 /// Boosts LM probabilities by b * [number of frame errors]; equivalently, adds
@@ -172,14 +179,14 @@ void ConvertCompactLatticeToPhones(const TransitionModel &trans_model,
 /// There is a frame error if a particular transition-id on a particular frame
 /// corresponds to a phone not matching transcription's alignment for that frame.
 /// This is used in "margin-inspired" discriminative training, esp. Boosted MMI.
-/// The TransitionModel is used to map transition-ids in the lattice
+/// The TransitionInformation is used to map transition-ids in the lattice
 /// input-side to phones; the phones appearing in
 /// "silence_phones" are treated specially in that we replace the frame error f
 /// (either zero or 1) for a frame, with the minimum of f or max_silence_error.
 /// For the normal recipe, max_silence_error would be zero.
 /// Returns true on success, false if there was some kind of mismatch.
 /// At input, silence_phones must be sorted and unique.
-bool LatticeBoost(const TransitionModel &trans,
+bool LatticeBoost(const TransitionInformation &trans,
                   const std::vector<int32> &alignment,
                   const std::vector<int32> &silence_phones,
                   BaseFloat b,
@@ -226,49 +233,13 @@ bool LatticeBoost(const TransitionModel &trans,
                         pseudo log-likelihoods of states at each frame.
 */
 BaseFloat LatticeForwardBackwardMpeVariants(
-    const TransitionModel &trans,
+    const TransitionInformation &trans,
     const std::vector<int32> &silence_phones,
     const Lattice &lat,
     const std::vector<int32> &num_ali,
     std::string criterion,
     bool one_silence_class,
     Posterior *post);
-
-/**
-   This function can be used to compute posteriors for MMI, with a positive contribution
-   for the numerator and a negative one for the denominator.  This function is not actually
-   used in our normal MMI training recipes, where it's instead done using various command
-   line programs that each do a part of the job.  This function was written for use in
-   neural-net MMI training.
-
-   @param [in] trans    The transition model. Used to map the
-                        transition-ids to phones or pdfs.
-   @param [in] lat      The denominator lattice
-   @param [in] num_ali  The numerator alignment
-   @param [in] drop_frames   If "drop_frames" is true, it will not compute any
-                        posteriors on frames where the num and den have disjoint
-                        pdf-ids.
-   @param [in] convert_to_pdf_ids   If "convert_to_pdfs_ids" is true, it will
-                        convert the output to be at the level of pdf-ids, not
-                        transition-ids.
-   @param [in] cancel   If "cancel" is true, it will cancel out any positive and
-                        negative parts from the same transition-id (or pdf-id,
-                        if convert_to_pdf_ids == true).
-   @param [out] arc_post   The output MMI posteriors of transition-ids (or
-                        pdf-ids if convert_to_pdf_ids == true) at each frame
-                        i.e. the difference between the numerator
-                        and denominator posteriors.
-
-   It returns the forward-backward likelihood of the lattice. */
-BaseFloat LatticeForwardBackwardMmi(
-    const TransitionModel &trans,
-    const Lattice &lat,
-    const std::vector<int32> &num_ali,
-    bool drop_frames,
-    bool convert_to_pdf_ids,
-    bool cancel,
-    Posterior *arc_post);
-
 
 /// This function takes a CompactLattice that should only contain a single
 /// linear sequence (e.g. derived from lattice-1best), and that should have been
@@ -285,27 +256,6 @@ bool CompactLatticeToWordAlignment(const CompactLattice &clat,
                                    std::vector<int32> *words,
                                    std::vector<int32> *begin_times,
                                    std::vector<int32> *lengths);
-
-/// This function takes a CompactLattice that should only contain a single
-/// linear sequence (e.g. derived from lattice-1best), and that should have been
-/// processed so that the arcs in the CompactLattice align correctly with the
-/// word boundaries (e.g. by lattice-align-words).  It outputs 4 vectors of the
-/// same size, which give, for each word in the lattice (in sequence), the word
-/// label, the begin time and length in frames, and the pronunciation (sequence
-/// of phones).  This is done even for zero words, corresponding to optional
-/// silences -- if you don't want them, just ignore them in the output.
-/// This function will print a warning and return false, if the lattice
-/// did not have the correct format (e.g. if it is empty or it is not
-/// linear).
-bool CompactLatticeToWordProns(
-    const TransitionModel &tmodel,
-    const CompactLattice &clat,
-    std::vector<int32> *words,
-    std::vector<int32> *begin_times,
-    std::vector<int32> *lengths,
-    std::vector<std::vector<int32> > *prons,
-    std::vector<std::vector<int32> > *phone_lengths);
-
 
 /// A form of the shortest-path/best-path algorithm that's specially coded for
 /// CompactLattice.  Requires that clat be acyclic.
@@ -379,7 +329,7 @@ int32 LongestSentenceLength(const CompactLattice &lat);
 /// speedup_factor; otherwise we set them to zero.  This gives the right
 /// expected probability so our corpus-level diagnostics will be about right.
 bool RescoreCompactLatticeSpeedup(
-    const TransitionModel &tmodel,
+    const TransitionInformation &tmodel,
     BaseFloat speedup_factor,
     DecodableInterface *decodable,
     CompactLattice *clat);

--- a/src/lat/minimize-lattice.cc
+++ b/src/lat/minimize-lattice.cc
@@ -22,7 +22,6 @@
 
 
 #include "lat/minimize-lattice.h"
-#include "hmm/transition-model.h"
 #include "util/stl-utils.h"
 
 namespace fst {

--- a/src/lat/phone-align-lattice.cc
+++ b/src/lat/phone-align-lattice.cc
@@ -20,7 +20,6 @@
 
 
 #include "lat/phone-align-lattice.h"
-#include "hmm/transition-model.h"
 #include "util/stl-utils.h"
 
 namespace kaldi {
@@ -58,7 +57,7 @@ class LatticePhoneAligner {
     /// wrong so don't trust the output too fully.
     /// Note: the "next_state" of the arc will not be set, you have to do that
     /// yourself.
-    bool OutputPhoneArc(const TransitionModel &tmodel,
+    bool OutputPhoneArc(const TransitionInformation &tmodel,
                         const PhoneAlignLatticeOptions &opts,
                         CompactLatticeArc *arc_out,
                         bool *error);
@@ -67,7 +66,7 @@ class LatticePhoneAligner {
     /// the arc won't have any transition-ids on it.  This is intended to fix
     /// a particular pathology where too many words were pending and we had
     /// blowup.
-    bool OutputWordArc(const TransitionModel &tmodel,
+    bool OutputWordArc(const TransitionInformation &tmodel,
                        const PhoneAlignLatticeOptions &opts,
                        CompactLatticeArc *arc_out,
                        bool *error);
@@ -91,7 +90,7 @@ class LatticePhoneAligner {
     /// will consist of partial words, and this will only
     /// happen for lattices that were somehow broken, i.e.
     /// had not reached the final state.
-    void OutputArcForce(const TransitionModel &tmodel,
+    void OutputArcForce(const TransitionInformation &tmodel,
                         const PhoneAlignLatticeOptions &opts,
                         CompactLatticeArc *arc_out,
                         bool *error);
@@ -245,7 +244,7 @@ class LatticePhoneAligner {
   }
 
   LatticePhoneAligner(const CompactLattice &lat,
-                      const TransitionModel &tmodel,
+                      const TransitionInformation &tmodel,
                       const PhoneAlignLatticeOptions &opts,
                      CompactLattice *lat_out):
       lat_(lat), tmodel_(tmodel), opts_(opts), lat_out_(lat_out),
@@ -283,7 +282,7 @@ class LatticePhoneAligner {
   }
 
   CompactLattice lat_;
-  const TransitionModel &tmodel_;
+  const TransitionInformation &tmodel_;
   const PhoneAlignLatticeOptions &opts_;
   CompactLattice *lat_out_;
 
@@ -293,7 +292,7 @@ class LatticePhoneAligner {
 };
 
 bool LatticePhoneAligner::ComputationState::OutputPhoneArc(
-    const TransitionModel &tmodel,
+    const TransitionInformation &tmodel,
     const PhoneAlignLatticeOptions &opts,
     CompactLatticeArc *arc_out,
     bool *error) {
@@ -343,7 +342,7 @@ bool LatticePhoneAligner::ComputationState::OutputPhoneArc(
 }
 
 bool LatticePhoneAligner::ComputationState::OutputWordArc(
-    const TransitionModel &tmodel,
+    const TransitionInformation &tmodel,
     const PhoneAlignLatticeOptions &opts,
     CompactLatticeArc *arc_out,
     bool *error) {
@@ -362,7 +361,7 @@ bool LatticePhoneAligner::ComputationState::OutputWordArc(
 
 
 void LatticePhoneAligner::ComputationState::OutputArcForce(
-    const TransitionModel &tmodel,
+    const TransitionInformation &tmodel,
     const PhoneAlignLatticeOptions &opts,
     CompactLatticeArc *arc_out,
     bool *error) {
@@ -411,7 +410,7 @@ void LatticePhoneAligner::ComputationState::OutputArcForce(
 }
 
 bool PhoneAlignLattice(const CompactLattice &lat,
-                       const TransitionModel &tmodel,
+                       const TransitionInformation &tmodel,
                        const PhoneAlignLatticeOptions &opts,
                        CompactLattice *lat_out) {
   LatticePhoneAligner aligner(lat, tmodel, opts, lat_out);

--- a/src/lat/phone-align-lattice.h
+++ b/src/lat/phone-align-lattice.h
@@ -25,7 +25,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "fstext/fstext-lib.h"
-#include "hmm/transition-model.h"
+#include "itf/transition-information.h"
 #include "lat/kaldi-lattice.h"
 
 namespace kaldi {
@@ -59,7 +59,7 @@ struct PhoneAlignLatticeOptions {
 /// everything was OK, false if some kind of error was detected (e.g. the
 /// "reorder" option was incorrectly specified.)
 bool PhoneAlignLattice(const CompactLattice &lat,
-                       const TransitionModel &tmodel,
+                       const TransitionInformation &tmodel,
                        const PhoneAlignLatticeOptions &opts,
                        CompactLattice *lat_out);
 

--- a/src/lat/push-lattice.cc
+++ b/src/lat/push-lattice.cc
@@ -22,7 +22,6 @@
 
 
 #include "lat/push-lattice.h"
-#include "hmm/transition-model.h"
 #include "util/stl-utils.h"
 
 namespace fst {

--- a/src/lat/word-align-lattice-lexicon-test.cc
+++ b/src/lat/word-align-lattice-lexicon-test.cc
@@ -22,6 +22,7 @@
 #include "fstext/fst-test-utils.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 #include "hmm/hmm-test-utils.h"
 #include "lat/word-align-lattice-lexicon.h"
 
@@ -203,13 +204,20 @@ void TestWordAlignLatticeLexicon() {
 
   WordAlignLatticeLexiconOpts opts;
   WordAlignLatticeLexiconInfo lexicon_info(lexicon);
-  opts.test = true;  // we rely on the self-test code that's activated when we
-                     // do this.
-  opts.allow_duplicate_paths = true;
   opts.reorder = reorder;
   CompactLattice aligned_clat;
+  bool allow_duplicate_paths = true;
   bool ans = WordAlignLatticeLexicon(clat, *trans_model, lexicon_info, opts,
                                      &aligned_clat);
+  if (ans) { // We only test if it succeeded.
+      if (!TestWordAlignedLattice(lexicon_info, *trans_model, clat, aligned_clat,
+                                  allow_duplicate_paths)) {
+          KALDI_WARN << "Lattice failed test (activated because --test=true). "
+                     << "Probable code error, please contact Kaldi maintainers.";
+          ans = false;
+      }
+  }
+
   KALDI_LOG << "Aligned clat is ";
   WriteCompactLattice(std::cerr, false, aligned_clat);
   KALDI_ASSERT(ans);

--- a/src/lat/word-align-lattice-lexicon.cc
+++ b/src/lat/word-align-lattice-lexicon.cc
@@ -737,41 +737,6 @@ bool LatticeLexiconWordAligner::ComputationState::TakeTransition(
   }
 }
 
-
-
-// Returns true if this vector of transition-ids could be a valid
-// word.  Note: for testing, we assume that the lexicon always
-// has the same input-word and output-word.  The other case is complex
-// to test.
-static bool IsPlausibleWord(const WordAlignLatticeLexiconInfo &lexicon_info,
-                            const TransitionModel &tmodel,
-                            int32 word_id,
-                            const std::vector<int32> &transition_ids) {
-
-  std::vector<std::vector<int32> > split_alignment; // Split into phones.
-  if (!SplitToPhones(tmodel, transition_ids, &split_alignment)) {
-    KALDI_WARN << "Could not split word into phones correctly (forced-out?)";
-  }
-  std::vector<int32> phones(split_alignment.size());
-  for (size_t i = 0; i < split_alignment.size(); i++) {
-    KALDI_ASSERT(!split_alignment[i].empty());
-    phones[i] = tmodel.TransitionIdToPhone(split_alignment[i][0]);
-  }
-  std::vector<int32> lexicon_entry;
-  lexicon_entry.push_back(word_id);
-  lexicon_entry.insert(lexicon_entry.end(), phones.begin(), phones.end());
-
-  if (!lexicon_info.IsValidEntry(lexicon_entry)) {
-    std::ostringstream ostr;
-    for (size_t i = 0; i < lexicon_entry.size(); i++)
-      ostr << lexicon_entry[i] << ' ';
-    KALDI_WARN << "Invalid arc in aligned lattice (code error?) lexicon-entry is " << ostr.str();
-    return false;
-  } else {
-    return true;
-  }
-}
-
 void WordAlignLatticeLexiconInfo::UpdateViabilityMap(
     const std::vector<int32> &lexicon_entry) {
   int32 word = lexicon_entry[0];  // note: word may be zero.
@@ -907,97 +872,6 @@ WordAlignLatticeLexiconInfo::WordAlignLatticeLexiconInfo(
   UpdateEquivalenceMap(lexicon);
 }
 
-/// Testing code; map word symbols in the lattice "lat" using the equivalence-classes
-/// obtained from the lexicon, using the function EquivalenceClassOf in the lexicon_info
-/// object.
-static void MapSymbols(const WordAlignLatticeLexiconInfo &lexicon_info,
-                       CompactLattice *lat) {
-  typedef CompactLattice::StateId StateId;
-  for (StateId s = 0; s < lat->NumStates(); s++) {
-    for (fst::MutableArcIterator<CompactLattice> aiter(lat, s);
-         !aiter.Done(); aiter.Next()) {
-      CompactLatticeArc arc (aiter.Value());
-      KALDI_ASSERT(arc.ilabel == arc.olabel);
-      arc.ilabel = lexicon_info.EquivalenceClassOf(arc.ilabel);
-      arc.olabel = arc.ilabel;
-      aiter.SetValue(arc);
-    }
-  }
-}
-
-static bool TestWordAlignedLattice(const WordAlignLatticeLexiconInfo &lexicon_info,
-                                   const TransitionModel &tmodel,
-                                   CompactLattice clat,
-                                   CompactLattice aligned_clat,
-                                   bool allow_duplicate_paths) {
-  int32 max_err = 5, num_err = 0;
-  { // We test whether the forward-backward likelihoods differ; this is intended
-    // to detect when we have duplicate paths in the aligned lattice, for some path
-    // in the input lattice (e.g. due to epsilon-sequencing problems).
-    Posterior post;
-    Lattice lat, aligned_lat;
-    ConvertLattice(clat, &lat);
-    ConvertLattice(aligned_clat, &aligned_lat);
-    TopSort(&lat);
-    TopSort(&aligned_lat);
-    BaseFloat like_before = LatticeForwardBackward(lat, &post),
-        like_after = LatticeForwardBackward(aligned_lat, &post);
-    if (fabs(like_before - like_after) >
-        1.0e-04 * (fabs(like_before) + fabs(like_after))) {
-      KALDI_WARN << "Forward-backward likelihoods differ in word-aligned lattice "
-                 << "testing, " << like_before << " != " << like_after;
-      if (!allow_duplicate_paths)
-        num_err++;
-    }
-  }
-
-  // Do a check on the arcs of the aligned lattice, that each arc corresponds
-  // to an entry in the lexicon.
-  for (CompactLattice::StateId s = 0; s < aligned_clat.NumStates(); s++) {
-    for (fst::ArcIterator<CompactLattice> aiter(aligned_clat, s);
-         !aiter.Done(); aiter.Next()) {
-      const CompactLatticeArc &arc (aiter.Value());
-      KALDI_ASSERT(arc.ilabel == arc.olabel);
-      int32 word_id = arc.ilabel;
-      const std::vector<int32> &tids = arc.weight.String();
-      if (word_id == 0 && tids.empty()) continue; // We allow epsilon arcs.
-
-      if (num_err < max_err)
-        if (!IsPlausibleWord(lexicon_info, tmodel, word_id, tids))
-          num_err++;
-      // Note: IsPlausibleWord will warn if there is an error.
-    }
-    if (!aligned_clat.Final(s).String().empty()) {
-      KALDI_WARN << "Aligned lattice has nonempty string on its final-prob.";
-      return false;
-    }
-  }
-
-  // Next we'll do an equivalence test.
-  // First map symbols into equivalence classes, so that we don't wrongly fail
-  // due to the capability of the framework to map words to other words.
-  // (e.g. mapping <eps> on silence arcs to SIL).
-
-  MapSymbols(lexicon_info, &clat);
-  MapSymbols(lexicon_info, &aligned_clat);
-
-  /// Check equivalence.
-  int32 num_paths = 5, seed = Rand(), max_path_length = -1;
-  BaseFloat delta = 0.2; // some lattices have large costs -> use large delta.
-
-  FLAGS_v = GetVerboseLevel(); // set the OpenFst verbose level to the Kaldi
-                               // verbose level.
-  if (!RandEquivalent(clat, aligned_clat, num_paths, delta, seed, max_path_length)) {
-    KALDI_WARN << "Equivalence test failed during lattice alignment.";
-    return false;
-  }
-  FLAGS_v = 0;
-
-  return (num_err == 0);
-}
-
-
-
 // This is the wrapper function for users to call.
 bool WordAlignLatticeLexicon(const CompactLattice &lat,
                              const TransitionInformation &tmodel,
@@ -1038,24 +912,6 @@ bool WordAlignLatticeLexicon(const CompactLattice &lat,
                                     max_states, opts.partial_word_label, lat_out);
   // We'll let the calling code warn if this is false; it will know the utterance-id.
   ans = aligner.AlignLattice() && ans;
-  if (ans && opts.test) { // We only test if it succeeded.
-    const TransitionModel* transition_model;
-    if ((transition_model = dynamic_cast<const TransitionModel*>(&tmodel)) == nullptr) {
-        KALDI_WARN << "Lattice test via TestWordAlignedLattice does not support "
-                   << "non-TransitionModel TransitionInformation instances. No "
-                   << "testing will be done.";
-    }
-    // this function brings in Posterior and TransitionModel from
-    // "hmm/transition-model.h" and "hmm/hmm-utils.h". It would be
-    // nice to be able to fully remove those dependencies from this
-    // function, given that it is only for sanity checking.
-    else if (!TestWordAlignedLattice(lexicon_info, *transition_model, lat, *lat_out,
-                                     opts.allow_duplicate_paths)) {
-      KALDI_WARN << "Lattice failed test (activated because --test=true). "
-                 << "Probable code error, please contact Kaldi maintainers.";
-      ans = false;
-    }
-  }
   return ans;
 }
 

--- a/src/lat/word-align-lattice-lexicon.cc
+++ b/src/lat/word-align-lattice-lexicon.cc
@@ -571,7 +571,8 @@ void LatticeLexiconWordAligner::ProcessFinalForceOut() {
 }
 
 void LatticeLexiconWordAligner::ComputationState::Advance(
-    const CompactLatticeArc &arc, const TransitionInformation &tmodel, LatticeWeight *weight) {
+    const CompactLatticeArc &arc, const TransitionInformation &tmodel,
+    LatticeWeight *weight) {
   const std::vector<int32> &tids = arc.weight.String();
   int32 phone;
   if (tids.empty()) phone = 0;

--- a/src/lat/word-align-lattice-lexicon.h
+++ b/src/lat/word-align-lattice-lexicon.h
@@ -161,7 +161,7 @@ struct WordAlignLatticeLexiconOpts {
 /// error including when the the lattice seems to have been "forced out"
 /// (did not reach end state, resulting in partial word at end).
 bool WordAlignLatticeLexicon(const CompactLattice &lat,
-                             const TransitionModel &tmodel,
+                             const TransitionInformation &tmodel,
                              const WordAlignLatticeLexiconInfo &lexicon_info,
                              const WordAlignLatticeLexiconOpts &opts,
                              CompactLattice *lat_out);
@@ -177,7 +177,7 @@ bool WordAlignLatticeLexicon(const CompactLattice &lat,
 ///   partial-word arcs, with the partial-word label.
 ///   silence arcs, with the silence label.
 void TestWordAlignedLatticeLexicon(const CompactLattice &lat,
-                                   const TransitionModel &tmodel,
+                                   const TransitionInformation &tmodel,
                                    const std::vector<std::vector<int32> > &lexicon,
                                    const CompactLattice &aligned_lat,
                                    bool allow_duplicate_paths);

--- a/src/lat/word-align-lattice-lexicon.h
+++ b/src/lat/word-align-lattice-lexicon.h
@@ -166,21 +166,5 @@ bool WordAlignLatticeLexicon(const CompactLattice &lat,
                              const WordAlignLatticeLexiconOpts &opts,
                              CompactLattice *lat_out);
 
-
-/// This function is designed to crash if something went wrong with the
-/// word-alignment of the lattice.  If was_ok==true (was_ok is the return status
-/// of WordAlignLattice), it tests that, after removing any silence and
-/// partial-word labels that may have been inserted by WordAlignLattice,
-/// the word-aligned lattice is equivalent to the input.  It also verifies
-/// that arcs are of 4 types:
-///   properly-aligned word arcs, with a word label.
-///   partial-word arcs, with the partial-word label.
-///   silence arcs, with the silence label.
-void TestWordAlignedLatticeLexicon(const CompactLattice &lat,
-                                   const TransitionInformation &tmodel,
-                                   const std::vector<std::vector<int32> > &lexicon,
-                                   const CompactLattice &aligned_lat,
-                                   bool allow_duplicate_paths);
-
-} // end namespace kaldi
+} // namespace kaldi
 #endif

--- a/src/lat/word-align-lattice-lexicon.h
+++ b/src/lat/word-align-lattice-lexicon.h
@@ -120,12 +120,9 @@ class WordAlignLatticeLexiconInfo {
 struct WordAlignLatticeLexiconOpts {
   int32 partial_word_label;
   bool reorder;
-  bool test;
-  bool allow_duplicate_paths;
   BaseFloat max_expand;
 
   WordAlignLatticeLexiconOpts(): partial_word_label(0), reorder(true),
-                                 test(false), allow_duplicate_paths(false),
                                  max_expand(-1.0) { }
 
   void Register(OptionsItf *opts) {
@@ -136,13 +133,6 @@ struct WordAlignLatticeLexiconOpts {
     opts->Register("reorder", &reorder, "True if the lattices were generated "
                    "from graphs that had the --reorder option true, relating to "
                    "reordering self-loops (typically true)");
-    opts->Register("test", &test, "If true, testing code will be activated "
-                   "(the purpose of this is to validate the algorithm).");
-    opts->Register("allow-duplicate-paths", &allow_duplicate_paths, "Only "
-                   "has an effect if --test=true.  If true, does not die "
-                   "(only prints warnings) if duplicate paths are found. "
-                   "This should only happen with very pathological lexicons, "
-                   "e.g. as encountered in testing code.");
     opts->Register("max-expand", &max_expand, "If >0.0, the maximum ratio "
                    "by which we allow the lattice-alignment code to increase the #states "
                    "in a lattice (vs. the phone-aligned lattice) before we fail and "

--- a/src/lat/word-align-lattice.cc
+++ b/src/lat/word-align-lattice.cc
@@ -786,8 +786,7 @@ class WordAlignedLatticeTester {
           // rest of the transition ids are the self-loop of that same
           // transition-state.
           for (size_t j = i+1; j < tids.size(); j++) {
-            if (!(tmodel_.TransitionIdToTransitionState(tids[j])
-                  == tmodel_.TransitionIdToTransitionState(tids[i]))) return false;
+              if (!tmodel_.TransitionIdsEquivalent(tids[j], tids[i])) return false;
           }
           return true;
         }
@@ -814,8 +813,7 @@ class WordAlignedLatticeTester {
           // rest of the transition ids are the self-loop of that same
           // transition-state.
           for (size_t j = i+1; j < tids.size(); j++) {
-            if (tmodel_.TransitionIdToTransitionState(tids[j])
-                != tmodel_.TransitionIdToTransitionState(tids[i])) return false;
+            if (!tmodel_.TransitionIdsEquivalent(tids[j], tids[i])) return false;
           }
           return true;
         }
@@ -864,9 +862,8 @@ class WordAlignedLatticeTester {
           // Make sure the only thing that follows this is self-loops
           // of the final transition-state.
           for (size_t k = j + 1; k < tids.size(); k++)
-            if (tmodel_.TransitionIdToTransitionState(tids[k])
-                != tmodel_.TransitionIdToTransitionState(tids[j])
-                || !tmodel_.IsSelfLoop(tids[k]))
+              if (!tmodel_.TransitionIdsEquivalent(tids[k], tids[j])
+                  || !tmodel_.IsSelfLoop(tids[k]))
               return false;
           return true;
         }

--- a/src/lat/word-align-lattice.cc
+++ b/src/lat/word-align-lattice.cc
@@ -19,7 +19,6 @@
 
 
 #include "lat/word-align-lattice.h"
-#include "hmm/transition-model.h"
 #include "util/stl-utils.h"
 
 namespace kaldi {

--- a/src/lat/word-align-lattice.cc
+++ b/src/lat/word-align-lattice.cc
@@ -57,7 +57,7 @@ class LatticeWordAligner {
     /// Note: the "next_state" of the arc will not be set, you have to do that
     /// yourself.
     bool OutputArc(const WordBoundaryInfo &info,
-                   const TransitionModel &tmodel,
+                   const TransitionInformation &tmodel,
                    CompactLatticeArc *arc_out,
                    bool *error) {
       // order of this ||-expression doesn't matter for
@@ -69,15 +69,15 @@ class LatticeWordAligner {
     }
 
     bool OutputSilenceArc(const WordBoundaryInfo &info,
-                          const TransitionModel &tmodel,
+                          const TransitionInformation &tmodel,
                           CompactLatticeArc *arc_out,
                           bool *error);
     bool OutputOnePhoneWordArc(const WordBoundaryInfo &info,
-                               const TransitionModel &tmodel,
+                               const TransitionInformation &tmodel,
                                CompactLatticeArc *arc_out,
                                bool *error);
     bool OutputNormalWordArc(const WordBoundaryInfo &info,
-                             const TransitionModel &tmodel,
+                             const TransitionInformation &tmodel,
                              CompactLatticeArc *arc_out,
                              bool *error);
 
@@ -101,7 +101,7 @@ class LatticeWordAligner {
     /// happen for lattices that were somehow broken, i.e.
     /// had not reached the final state.
     void OutputArcForce(const WordBoundaryInfo &info,
-                        const TransitionModel &tmodel,
+                        const TransitionInformation &tmodel,
                         CompactLatticeArc *arc_out,
                         bool *error);
 
@@ -250,7 +250,7 @@ class LatticeWordAligner {
   }
 
   LatticeWordAligner(const CompactLattice &lat,
-                     const TransitionModel &tmodel,
+                     const TransitionInformation &tmodel,
                      const WordBoundaryInfo &info,
                      int32 max_states,
                      CompactLattice *lat_out):
@@ -332,7 +332,7 @@ class LatticeWordAligner {
   }
 
   CompactLattice lat_;
-  const TransitionModel &tmodel_;
+  const TransitionInformation &tmodel_;
   const WordBoundaryInfo &info_in_;
   WordBoundaryInfo info_;
   int32 max_states_;
@@ -348,7 +348,7 @@ class LatticeWordAligner {
 };
 
 bool LatticeWordAligner::ComputationState::OutputSilenceArc(
-    const WordBoundaryInfo &info, const TransitionModel &tmodel,
+    const WordBoundaryInfo &info, const TransitionInformation &tmodel,
     CompactLatticeArc *arc_out,  bool *error) {
   if (transition_ids_.empty()) return false;
   int32 phone = tmodel.TransitionIdToPhone(transition_ids_[0]);
@@ -394,7 +394,7 @@ bool LatticeWordAligner::ComputationState::OutputSilenceArc(
 
 
 bool LatticeWordAligner::ComputationState::OutputOnePhoneWordArc(
-    const WordBoundaryInfo &info, const TransitionModel &tmodel,
+    const WordBoundaryInfo &info, const TransitionInformation &tmodel,
     CompactLatticeArc *arc_out,  bool *error) {
   if (transition_ids_.empty()) return false;
   if (word_labels_.empty()) return false;
@@ -448,7 +448,7 @@ bool LatticeWordAligner::ComputationState::OutputOnePhoneWordArc(
 /// This function tries to see if it can output a normal word arc--
 /// one with at least two phones in it.
 bool LatticeWordAligner::ComputationState::OutputNormalWordArc(
-    const WordBoundaryInfo &info, const TransitionModel &tmodel,
+    const WordBoundaryInfo &info, const TransitionInformation &tmodel,
     CompactLatticeArc *arc_out,  bool *error) {
   if (transition_ids_.empty()) return false;
   if (word_labels_.empty()) return false;
@@ -541,7 +541,7 @@ bool LatticeWordAligner::ComputationState::OutputNormalWordArc(
 // Returns true if this vector of transition-ids could be a valid
 // word.  Note: the checks are not 100% exhaustive.
 static bool IsPlausibleWord(const WordBoundaryInfo &info,
-                            const TransitionModel &tmodel,
+                            const TransitionInformation &tmodel,
                             const std::vector<int32> &transition_ids) {
   if (transition_ids.empty()) return false;
   int32 first_phone = tmodel.TransitionIdToPhone(transition_ids.front()),
@@ -563,7 +563,7 @@ static bool IsPlausibleWord(const WordBoundaryInfo &info,
 
 
 void LatticeWordAligner::ComputationState::OutputArcForce(
-    const WordBoundaryInfo &info, const TransitionModel &tmodel,
+    const WordBoundaryInfo &info, const TransitionInformation &tmodel,
     CompactLatticeArc *arc_out,  bool *error) {
 
   KALDI_ASSERT(!IsEmpty());
@@ -721,7 +721,7 @@ void WordBoundaryInfo::Init(std::istream &stream) {
 }
 
 bool WordAlignLattice(const CompactLattice &lat,
-                      const TransitionModel &tmodel,
+                      const TransitionInformation &tmodel,
                       const WordBoundaryInfo &info,
                       int32 max_states,
                       CompactLattice *lat_out) {
@@ -734,7 +734,7 @@ bool WordAlignLattice(const CompactLattice &lat,
 class WordAlignedLatticeTester {
  public:
   WordAlignedLatticeTester(const CompactLattice &lat,
-                           const TransitionModel &tmodel,
+                           const TransitionInformation &tmodel,
                            const WordBoundaryInfo &info,
                            const CompactLattice &aligned_lat):
       lat_(lat), tmodel_(tmodel), info_(info), aligned_lat_(aligned_lat) { }
@@ -904,7 +904,7 @@ class WordAlignedLatticeTester {
   }
 
   const CompactLattice &lat_;
-  const TransitionModel &tmodel_;
+  const TransitionInformation &tmodel_;
   const WordBoundaryInfo &info_;
   const CompactLattice &aligned_lat_;
 };
@@ -916,7 +916,7 @@ class WordAlignedLatticeTester {
 /// succeeded and it wasn't a forced-out lattice); otherwise the test will most
 /// likely fail.
 void TestWordAlignedLattice(const CompactLattice &lat,
-                            const TransitionModel &tmodel,
+                            const TransitionInformation &tmodel,
                             const WordBoundaryInfo &info,
                             const CompactLattice &aligned_lat) {
   WordAlignedLatticeTester t(lat, tmodel, info, aligned_lat);

--- a/src/lat/word-align-lattice.h
+++ b/src/lat/word-align-lattice.h
@@ -25,7 +25,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "fstext/fstext-lib.h"
-#include "hmm/transition-model.h"
+#include "itf/transition-information.h"
 #include "lat/kaldi-lattice.h"
 
 namespace kaldi {
@@ -189,7 +189,7 @@ struct WordBoundaryInfo {
 /// abort the computation, return false and produce an empty
 /// lattice out.
 bool WordAlignLattice(const CompactLattice &lat,
-                      const TransitionModel &tmodel,
+                      const TransitionInformation &tmodel,
                       const WordBoundaryInfo &info,
                       int32 max_states,
                       CompactLattice *lat_out);
@@ -203,7 +203,7 @@ bool WordAlignLattice(const CompactLattice &lat,
 ///   partial-word arcs, with the partial-word label.
 ///   silence arcs, with the silence label.
 void TestWordAlignedLattice(const CompactLattice &lat,
-                            const TransitionModel &tmodel,
+                            const TransitionInformation &tmodel,
                             const WordBoundaryInfo &info,
                             const CompactLattice &aligned_lat);
 

--- a/src/latbin/lattice-align-phones.cc
+++ b/src/latbin/lattice-align-phones.cc
@@ -19,10 +19,11 @@
 
 
 #include "base/kaldi-common.h"
-#include "util/common-utils.h"
+#include "hmm/transition-model.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/phone-align-lattice.h"
 #include "lat/lattice-functions.h"
+#include "util/common-utils.h"
 
 int main(int argc, char *argv[]) {
   try {

--- a/src/latbin/lattice-align-words-lexicon.cc
+++ b/src/latbin/lattice-align-words-lexicon.cc
@@ -25,8 +25,6 @@
 #include "lat/lattice-functions.h"
 #include "lat/lattice-functions-transition-model.h"
 
-using namespace kaldi;
-
 int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;

--- a/src/latbin/lattice-align-words-lexicon.cc
+++ b/src/latbin/lattice-align-words-lexicon.cc
@@ -23,6 +23,9 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/word-align-lattice-lexicon.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
+
+using namespace kaldi;
 
 int main(int argc, char *argv[]) {
   try {
@@ -47,11 +50,20 @@ int main(int argc, char *argv[]) {
     ParseOptions po(usage);
     bool output_if_error = true;
     bool output_if_empty = false;
+    bool test = false;
+    bool allow_duplicate_paths = false;
     
     po.Register("output-error-lats", &output_if_error, "Output lattices that aligned "
                 "with errors (e.g. due to force-out");
     po.Register("output-if-empty", &output_if_empty, "If true: if algorithm gives "
                 "error and produces empty output, pass the input through.");
+    po.Register("test", &test, "If true, testing code will be activated "
+                 "(the purpose of this is to validate the algorithm).");
+    po.Register("allow-duplicate-paths", &allow_duplicate_paths, "Only "
+                "has an effect if --test=true.  If true, does not die "
+                "(only prints warnings) if duplicate paths are found. "
+                "This should only happen with very pathological lexicons, "
+                "e.g. as encountered in testing code.");
     
     WordAlignLatticeLexiconOpts opts;
     opts.Register(&po);
@@ -100,7 +112,16 @@ int main(int argc, char *argv[]) {
       
       bool ok = WordAlignLatticeLexicon(clat, tmodel, lexicon_info, opts,
                                         &aligned_clat);
-      
+
+      if (ok && test) { // We only test if it succeeded.
+        if (!TestWordAlignedLattice(lexicon_info, tmodel, clat, aligned_clat,
+                                    allow_duplicate_paths)) {
+          KALDI_WARN << "Lattice failed test (activated because --test=true). "
+                     << "Probable code error, please contact Kaldi maintainers.";
+          ok = false;
+        }
+      }
+
       if (!ok) {
         num_err++;
         if (output_if_empty && aligned_clat.NumStates() == 0 &&

--- a/src/latbin/lattice-align-words.cc
+++ b/src/latbin/lattice-align-words.cc
@@ -23,6 +23,7 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/word-align-lattice.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 
 int main(int argc, char *argv[]) {
   try {

--- a/src/latbin/lattice-arc-post.cc
+++ b/src/latbin/lattice-arc-post.cc
@@ -20,6 +20,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "fstext/fstext-lib.h"
+#include "hmm/transition-model.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 

--- a/src/latbin/lattice-boost-ali.cc
+++ b/src/latbin/lattice-boost-ali.cc
@@ -22,6 +22,7 @@
 #include "fstext/fstext-lib.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 
 int main(int argc, char *argv[]) {
   try {

--- a/src/latbin/lattice-to-mpe-post.cc
+++ b/src/latbin/lattice-to-mpe-post.cc
@@ -24,6 +24,7 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 #include "gmm/am-diag-gmm.h"
+#include "hmm/posterior.h"
 #include "hmm/transition-model.h"
 
 int main(int argc, char *argv[]) {

--- a/src/latbin/lattice-to-post.cc
+++ b/src/latbin/lattice-to-post.cc
@@ -21,6 +21,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "fstext/fstext-lib.h"
+#include "hmm/posterior.h"
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 

--- a/src/latbin/lattice-to-smbr-post.cc
+++ b/src/latbin/lattice-to-smbr-post.cc
@@ -24,6 +24,7 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 #include "gmm/am-diag-gmm.h"
+#include "hmm/posterior.h"
 #include "hmm/transition-model.h"
 
 int main(int argc, char *argv[]) {

--- a/src/latbin/nbest-to-prons.cc
+++ b/src/latbin/nbest-to-prons.cc
@@ -19,8 +19,10 @@
 
 
 #include "base/kaldi-common.h"
-#include "util/common-utils.h"
+#include "hmm/transition-model.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
+#include "util/common-utils.h"
 
 int main(int argc, char *argv[]) {
   try {

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -907,8 +907,8 @@ void MatrixBase<float>::CopyFromSp(const SpMatrix<float> & M) {
   const float *Mdata = M.Data();
   float *row_data = data_, *col_data = data_;
   for (MatrixIndexT i = 0; i < num_rows; i++) {
-    cblas_scopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
-    cblas_scopy(i, Mdata, 1, col_data, stride); // copy to the column.
+    cblas_Xcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
+    cblas_Xcopy(i, Mdata, 1, col_data, stride); // copy to the column.
     Mdata += i+1;
     row_data += stride;
     col_data += 1;
@@ -924,8 +924,8 @@ void MatrixBase<double>::CopyFromSp(const SpMatrix<double> & M) {
   const double *Mdata = M.Data();
   double *row_data = data_, *col_data = data_;
   for (MatrixIndexT i = 0; i < num_rows; i++) {
-    cblas_dcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
-    cblas_dcopy(i, Mdata, 1, col_data, stride); // copy to the column.
+    cblas_Xcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
+    cblas_Xcopy(i, Mdata, 1, col_data, stride); // copy to the column.
     Mdata += i+1;
     row_data += stride;
     col_data += 1;

--- a/src/nnet2/nnet-compute-discriminative.cc
+++ b/src/nnet2/nnet-compute-discriminative.cc
@@ -20,6 +20,7 @@
 #include "nnet2/nnet-compute-discriminative.h"
 #include "hmm/posterior.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 
 namespace kaldi {
 namespace nnet2 {

--- a/src/nnet2/nnet-example-functions.cc
+++ b/src/nnet2/nnet-example-functions.cc
@@ -19,6 +19,7 @@
 
 #include "nnet2/nnet-example-functions.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 
 namespace kaldi {
 namespace nnet2 {

--- a/src/nnet3/discriminative-training.cc
+++ b/src/nnet3/discriminative-training.cc
@@ -20,6 +20,7 @@
 
 #include "nnet3/discriminative-training.h"
 #include "lat/lattice-functions.h"
+#include "lat/lattice-functions-transition-model.h"
 #include "cudamatrix/cu-matrix.h"
 
 namespace kaldi {


### PR DESCRIPTION
Various lattice tools depend upon the (rather large) TransitionModel
interface to discover extra information, like phone boundaries, and so
on. Fortunately, none depends upon anything HMM-specific other than
LatticeForwardBackwardMmi and CompactLatticeToWordProns. Therefore, I
created an interface called TransitionInformation to capture the extra
information required by the functions in lat/. I prototyped a
CtcTransitionInformation subclass that allows us to use these
functions on the output of CTC acoustic model decoding, but I don't
provide that in this PR because it sits in an external repo.

The functions that require a larger interface than
TransitionInformation (i.e.,LatticeForwardBackwardMmi and CompactLatticeToWordProns) can be excluded by defining the macro "KALDI_MINIMAL_LATTICE_FUNCTIONS". This is primarily intended
to be used by people integrating kaldi into their larger C++
codebases with their own build systems.

In bazel, someone could do this:
```
cc_library(kaldi,
...
defines=[""],
...)
```
In cmake, someone could do this:
```
target_compile_definitions(kaldi PUBLIC
KALDI_MINIMAL_LATTICE_FUNCTIONS)
```