### PR TITLE
[src] cublasGetStatusString overloaded

### DIFF
--- a/src/cudamatrix/cu-common.cc
+++ b/src/cudamatrix/cu-common.cc
@@ -85,7 +85,7 @@ void GetBlockSizesForSimpleMatrixOperation(int32 num_rows,
   dimGrid->z = 1;
 }
 
-const char* cublasGetStatusString(cublasStatus_t status) {
+const char* cublasGetStatusStringK(cublasStatus_t status) {
   // Defined in CUDA include file: cublas.h or cublas_api.h
   switch(status) {
     case CUBLAS_STATUS_SUCCESS:           return "CUBLAS_STATUS_SUCCESS";

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -57,7 +57,7 @@
 { \
   int32 ret; \
   if ((ret = (fun)) != 0) { \
-    KALDI_ERR << "cublasStatus_t " << ret << " : \"" << cublasGetStatusString((cublasStatus_t)ret) << "\" returned from '" << #fun << "'"; \
+    KALDI_ERR << "cublasStatus_t " << ret << " : \"" << cublasGetStatusStringK((cublasStatus_t)ret) << "\" returned from '" << #fun << "'"; \
   } \
 }
 
@@ -130,7 +130,7 @@ void GetBlockSizesForSimpleMatrixOperation(int32 num_rows,
                                            dim3 *dimBlock);
 
 /** This is analogous to the CUDA function cudaGetErrorString(). **/
-const char* cublasGetStatusString(cublasStatus_t status);
+const char* cublasGetStatusStringK(cublasStatus_t status);
 
 /** This is analogous to the CUDA function cudaGetErrorString(). **/
 const char* cusparseGetStatusString(cusparseStatus_t status);


### PR DESCRIPTION
cublasGetStatusString will be declared in cublas headers in future cuda revisions. Renaming the Kaldi version to avoid collision (we need to keep it around for older cuda versions)