### PR TITLE
Make logits in cudadecoder const.

### DIFF
--- a/src/cudadecoder/batched-static-nnet3.cc
+++ b/src/cudadecoder/batched-static-nnet3.cc
@@ -298,7 +298,7 @@ void BatchedStaticNnet3::RunBatch(
     const std::vector<bool> &is_first_chunk,
     const std::vector<bool> &is_last_chunk,
     CuMatrix<BaseFloat> *d_all_log_posteriors,
-    std::vector<std::vector<std::pair<int, BaseFloat *>>>
+    std::vector<std::vector<std::pair<int, const BaseFloat *>>>
         *all_frames_log_posteriors_ptrs) {
   // Using >= to avoid having to recompute d_features
   // In some cases the ptrs in d_features and d_ivectors are always the same,
@@ -366,7 +366,7 @@ void BatchedStaticNnet3::RunBatch(
 
 void BatchedStaticNnet3::FormatOutputPtrs(
     const std::vector<int> &channels, CuMatrix<BaseFloat> *d_all_log_posteriors,
-    std::vector<std::vector<std::pair<int, BaseFloat *>>>
+    std::vector<std::vector<std::pair<int, const BaseFloat *>>>
         *all_frames_log_posteriors_ptrs,
     const std::vector<int> &n_output_frames_valid,
     const std::vector<int> *n_output_frames_valid_offset) {
@@ -380,7 +380,7 @@ void BatchedStaticNnet3::FormatOutputPtrs(
     if (all_frames_log_posteriors_ptrs->size() < total_output_nframes)
       all_frames_log_posteriors_ptrs->resize(total_output_nframes);
     for (int iframe = offset; iframe < total_output_nframes; ++iframe) {
-      std::vector<std::pair<int, BaseFloat *>> &this_frame =
+      std::vector<std::pair<int, const BaseFloat *>> &this_frame =
           (*all_frames_log_posteriors_ptrs)[iframe];
       int local_iframe = iframe - offset;
       CuSubVector<BaseFloat> out = d_all_log_posteriors->Row(

--- a/src/cudadecoder/batched-static-nnet3.h
+++ b/src/cudadecoder/batched-static-nnet3.h
@@ -119,7 +119,7 @@ class BatchedStaticNnet3 {
                 const std::vector<bool> &is_first_chunk,
                 const std::vector<bool> &is_last_chunk,
                 CuMatrix<BaseFloat> *d_all_log_posteriors,
-                std::vector<std::vector<std::pair<int, BaseFloat *>>>
+                std::vector<std::vector<std::pair<int, const BaseFloat *>>>
                     *all_frames_log_posteriors);
 
   // Nnet3 puts the output frames in the matrix all_frames_log_posteriors_ptrs
@@ -130,7 +130,7 @@ class BatchedStaticNnet3 {
   void FormatOutputPtrs(
       const std::vector<int> &channels,
       CuMatrix<BaseFloat> *d_all_log_posteriors,
-      std::vector<std::vector<std::pair<int, BaseFloat *>>>
+      std::vector<std::vector<std::pair<int, const BaseFloat *>>>
           *all_frames_log_posteriors_ptrs,
       const std::vector<int> &n_output_frames_valid,
       const std::vector<int> *n_output_frames_valid_offset = NULL);

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.h
@@ -356,7 +356,7 @@ class BatchedThreadedNnet3CudaOnlinePipeline {
 
   std::vector<int> n_samples_valid_, n_input_frames_valid_;
 
-  std::vector<std::vector<std::pair<int, BaseFloat *>>>
+  std::vector<std::vector<std::pair<int, const BaseFloat *>>>
       all_frames_log_posteriors_;
 
   // Channels done after current batch. We've just received

--- a/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-pipeline.h
@@ -29,6 +29,7 @@
 #include "feat/wave-reader.h"
 #include "lat/determinize-lattice-pruned.h"
 #include "nnet3/nnet-batch-compute.h"
+#include "nnet3/decodable-simple-looped.h"
 #include "online2/online-nnet2-feature-pipeline.h"
 
 // This pipeline is deprecated and will be removed. Please switch to

--- a/src/cudadecoder/cuda-decoder-common.h
+++ b/src/cudadecoder/cuda-decoder-common.h
@@ -404,7 +404,7 @@ struct LaneCounters {
   // hannel that this lane will compute for the current frame
   ChannelId channel_to_compute;
   // Pointer to the loglikelihoods array for this channel and current frame
-  BaseFloat *loglikelihoods;
+  const BaseFloat *loglikelihoods;
   // Contains both main_q_end and narcs
   // End index of the main queue
   // only tokens at index i with i < main_q_end

--- a/src/cudadecoder/cuda-decoder.cc
+++ b/src/cudadecoder/cuda-decoder.cc
@@ -808,21 +808,21 @@ void CudaDecoder::AdvanceDecoding(
   if (max_num_frames >= 0)
     nframes_to_decode = std::min(nframes_to_decode, max_num_frames);
 
-  std::vector<std::pair<ChannelId, BaseFloat *>> lanes_assignements;
+  std::vector<std::pair<ChannelId, const BaseFloat *>> lanes_assignments;
   for (int f = 0; f < nframes_to_decode; ++f) {
-    lanes_assignements.clear();
+    lanes_assignments.clear();
     for (int32 ilane = 0; ilane < channels.size(); ++ilane) {
       const ChannelId ichannel = channels[ilane];
       int32 iframe = num_frames_decoded_[ichannel];
-      BaseFloat *ptr = decodables[ilane]->GetLogLikelihoodsCudaPointer(iframe);
-      lanes_assignements.push_back({ichannel, ptr});
+      const BaseFloat *ptr = decodables[ilane]->GetLogLikelihoodsCudaPointer(iframe);
+      lanes_assignments.push_back({ichannel, ptr});
     }
-    AdvanceDecoding(lanes_assignements);
+    AdvanceDecoding(lanes_assignments);
   }
 }
 
 void CudaDecoder::AdvanceDecoding(
-    const std::vector<std::pair<ChannelId, BaseFloat *>> &lanes_assignements) {
+    const std::vector<std::pair<ChannelId, const BaseFloat *>> &lanes_assignements) {
   if (lanes_assignements.size() == 0) return;  // nothing to do
   // Context switch : Loading the channels state in lanes
 

--- a/src/cudadecoder/cuda-decoder.h
+++ b/src/cudadecoder/cuda-decoder.h
@@ -257,7 +257,7 @@ class CudaDecoder {
   // If max_num_frames is >= 0 it will decode no more than
   // that many frames.
   void AdvanceDecoding(
-      const std::vector<std::pair<ChannelId, BaseFloat *>> &lanes_assignements);
+      const std::vector<std::pair<ChannelId, const BaseFloat *>> &lanes_assignements);
 
   // Version with deprecated API - will be removed at some point
   void AdvanceDecoding(const std::vector<ChannelId> &channels,


### PR DESCRIPTION
There is no reason why they couldn't be const. It was just an
oversight in the interface.