### PR TITLE
SRLIM file download process

### DIFF
--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -20,7 +20,7 @@ if [ $# -ne 3 ]; then
     exit 1
 fi
 
-curl -d "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -X POST http://www.speech.sri.com/projects/srilm/srilm_download.php > ./srilm.tar.gz
+wget --post-data "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -O ./srilm.tar.gz http://www.speech.sri.com/projects/srilm/srilm_download.php
 
 ! which gawk 2>/dev/null && \
    echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -20,7 +20,14 @@ if [ $# -ne 3 ]; then
     exit 1
 fi
 
-wget --post-data "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -O ./srilm.tar.gz http://www.speech.sri.com/projects/srilm/srilm_download.php
+srilm_url="http://www.speech.sri.com/projects/srilm/srilm_download.php"
+post_data="WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3"
+
+if ! wget --post-data "$post_data" -O ./srilm.tar.gz "$srilm_url"; then
+    echo 'There was a problem downloading the file.'
+    echo 'Check you internet connection and try again.'
+    exit 1
+fi
 
 ! which gawk 2>/dev/null && \
    echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -13,7 +13,7 @@ if [ ! -d liblbfgs-1.10 ]; then
     bash extras/install_liblbfgs.sh || exit 1
 fi
 
-! which gawk 2>/dev/null && \
+! command -v gawk > /dev/null && \
    echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;
 
 if [ $# -ne 3 ]; then

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -42,9 +42,9 @@ elif [  -f ../srilm.tar.gz ]; then
     tar -xvzf ../srilm.tar.gz # Changed format type from tgz to tar.gz
 fi
 
-major=`awk -F. '{ print $1 }' RELEASE`
-minor=`awk -F. '{ print $2 }' RELEASE`
-micro=`awk -F. '{ print $3 }' RELEASE`
+major=`gawk -F. '{ print $1 }' RELEASE`
+minor=`gawk -F. '{ print $2 }' RELEASE`
+micro=`gawk -F. '{ print $3 }' RELEASE`
 
 if [ $major -le 1 ] && [ $minor -le 7 ] && [ $micro -le 1 ]; then
   echo "Detected version 1.7.1 or earlier. Applying patch."
@@ -54,7 +54,7 @@ fi
 # set the SRILM variable in the top-level Makefile to this directory.
 cp Makefile tmpf
 
-cat tmpf | awk -v pwd=`pwd` '/SRILM =/{printf("SRILM = %s\n", pwd); next;} {print;}' \
+cat tmpf | gawk -v pwd=`pwd` '/SRILM =/{printf("SRILM = %s\n", pwd); next;} {print;}' \
   > Makefile || exit 1
 rm tmpf
 

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -14,7 +14,7 @@ if [ ! -d liblbfgs-1.10 ]; then
 fi
 
 if [ $# -ne 3 ]; then
-    echo "The download require some information about you"
+    echo "SRILM download requires some information about you"
     echo
     echo "Usage: $0 <name> <organization> <email>"
     exit 1

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -13,15 +13,14 @@ if [ ! -d liblbfgs-1.10 ]; then
     bash extras/install_liblbfgs.sh || exit 1
 fi
 
-# http://www.speech.sri.com/projects/srilm/download.html
-if [ ! -f srilm.tgz ] && [ ! -f srilm.tar.gz ]; then  # Changed format type from tgz to tar.gz as the srilm v1.7.3 downloads as tar.gz
-  echo This script cannot install SRILM in a completely automatic
-  echo way because you need to put your address in a download form.
-  echo Please download SRILM from http://www.speech.sri.com/projects/srilm/download.html
-  echo put it in ./srilm.tar.gz , then run this script.
-  echo Note: You may have to rename the downloaded file to remove version name from filename eg: mv srilm-1.7.3.tar.gz srilm.tar.gz
-  exit 1
+if [ $# -ne 3 ]; then
+    echo "The download require some information about you"
+    echo
+    echo "Usage: $0 <name> <organization> <email>"
+    exit 1
 fi
+
+curl -d "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -X POST http://www.speech.sri.com/projects/srilm/srilm_download.php > ./srlim.tar.gz
 
 ! which gawk 2>/dev/null && \
    echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -20,7 +20,7 @@ if [ $# -ne 3 ]; then
     exit 1
 fi
 
-curl -d "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -X POST http://www.speech.sri.com/projects/srilm/srilm_download.php > ./srlim.tar.gz
+curl -d "WWW_file=srilm-1.7.3.tar.gz&WWW_name=$1&WWW_org=$2&WWW_email=$3" -X POST http://www.speech.sri.com/projects/srilm/srilm_download.php > ./srilm.tar.gz
 
 ! which gawk 2>/dev/null && \
    echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;

--- a/tools/extras/install_srilm.sh
+++ b/tools/extras/install_srilm.sh
@@ -13,6 +13,9 @@ if [ ! -d liblbfgs-1.10 ]; then
     bash extras/install_liblbfgs.sh || exit 1
 fi
 
+! which gawk 2>/dev/null && \
+   echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;
+
 if [ $# -ne 3 ]; then
     echo "SRILM download requires some information about you"
     echo
@@ -28,9 +31,6 @@ if ! wget --post-data "$post_data" -O ./srilm.tar.gz "$srilm_url"; then
     echo 'Check you internet connection and try again.'
     exit 1
 fi
-
-! which gawk 2>/dev/null && \
-   echo "GNU awk is not installed so SRILM will probably not work correctly: refusing to install" && exit 1;
 
 mkdir -p srilm
 cd srilm


### PR DESCRIPTION
running the `install_srlim.sh` does not longer needs to download manually the file and rename it. Provide your data as you do in the web and the file will be downloaded on current folder with the format required.

This helps users with no access to a web browser when working on the installation.