### PR TITLE
At the end of Finalize，When setting LatticeCallback, clean up the mapping of corr_id to channel in corr_id2 channel_

### DIFF
--- a/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
+++ b/src/cudadecoder/batched-threaded-nnet3-cuda-online-pipeline.cc
@@ -479,9 +479,9 @@ void BatchedThreadedNnet3CudaOnlinePipeline::RunCallbacksAndFinalize(
         } else {
           // All done with this corr_ids. Cleaning up
           available_channels_.push_back(ichannel);
-          int32 ndeleted = corr_id2channel_.erase(corr_id);
-          KALDI_ASSERT(ndeleted == 1);
         }
+        int32 ndeleted = corr_id2channel_.erase(corr_id);
+        KALDI_ASSERT(ndeleted == 1);
 
         if (!config_.use_gpu_feature_extraction) {
           // Done with this CPU FE pipeline


### PR DESCRIPTION
if set LatticeCallback, at the end of Finalize, it is also necessary to clean up the corr_id to channel mapping in corr_id2 channel_. Otherwise, when TryInitCorrID is called again, no new channel will be allocated