### PR TITLE
[egs] If utt2num_frames already exists, don't run feat-to-len.

### DIFF
--- a/egs/wsj/s5/utils/subset_data_dir.sh
+++ b/egs/wsj/s5/utils/subset_data_dir.sh
@@ -115,7 +115,11 @@ else
   if $shortest; then
     # Select $numutt shortest utterances.
     . ./path.sh
-    feat-to-len scp:$srcdir/feats.scp ark,t:$destdir/tmp.len || exit 1;
+    if [ -f $srcdir/utt2num_frames ]; then
+      ln -sf $srcdir/utt2num_frames $destdir/tmp.len
+    else
+      feat-to-len scp:$srcdir/feats.scp ark,t:$destdir/tmp.len || exit 1;
+    fi
     sort -n -k2 $destdir/tmp.len |
       awk '{print $1}' |
       head -$numutt >$destdir/tmp.uttlist


### PR DESCRIPTION
There are presumably places other than utils/subset_data_dir.sh that
can use this.

utt2num_frames can be produced by passing --write_utt2num_frames=true
to steps/make_mfcc.sh. This is much faster than running feat-to-len
after the fact.