### PR TITLE
[egs] train_lda_mllt.sh: Fix out-of-memory errors when training on large datasets.

### DIFF
--- a/egs/wsj/s5/steps/train_lda_mllt.sh
+++ b/egs/wsj/s5/steps/train_lda_mllt.sh
@@ -196,7 +196,7 @@ while [ $x -lt $num_iters ]; do
       $cmd JOB=1:$nj $dir/log/macc.$x.JOB.log \
         ali-to-post "ark:gunzip -c $dir/ali.JOB.gz|" ark:- \| \
         weight-silence-post 0.0 $silphonelist $dir/$x.mdl ark:- ark:- \| \
-        gmm-acc-mllt --rand-prune=$randprune  $dir/$x.mdl "$feats" ark:- $dir/$x.JOB.macc \
+        gmm-acc-mllt --rand-prune=$randprune  $dir/$x.mdl "$feats" ark,s,o,cs:- $dir/$x.JOB.macc \
         || exit 1;
       est-mllt $dir/$x.mat.new $dir/$x.*.macc 2> $dir/log/mupdate.$x.log || exit 1;
       gmm-transform-means  $dir/$x.mat.new $dir/$x.mdl $dir/$x.mdl \


### PR DESCRIPTION
Previously, gmm-acc-mllt would load the entirety of the alignments
into memory. When training on very large datasets like The People's
Speech (>20,000 hours), this can result in each process (I was using 16) loading ~18 GiB into
memory. However, both the features and the alignments are in sorted
order (because they are derived from wav.scp and text, which start
sorted). Therefore, I add annotations to the alignments archive
specifier to ensure that values are discarded aftering being read ("o"
is unnecessary here for reducing memory usage but I add it anyway
because it's true).