### PR TITLE
segments related bug fix

### DIFF
--- a/egs/wsj/s5/utils/fix_data_dir.sh
+++ b/egs/wsj/s5/utils/fix_data_dir.sh
@@ -97,10 +97,9 @@ function filter_recordings {
     utils/filter_scp.pl $data/wav.scp $tmpdir/recordings > $tmpdir/recordings.tmp
     mv $tmpdir/recordings.tmp $tmpdir/recordings
 
-
-    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4}' <$data/segments.tmp >$data/segments
+    cp $data/segments{,.tmp}; awk '{out=""; for(i=3;i<=NF;i++){out=out" "$i}; print $2, $1, out}' <$data/segments.tmp >$data/segments
     filter_file $tmpdir/recordings $data/segments
-    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4}' <$data/segments.tmp >$data/segments
+    cp $data/segments{,.tmp}; awk '{out=""; for(i=3;i<=NF;i++){out=out" "$i}; print $2, $1, out}' <$data/segments.tmp >$data/segments
     rm $data/segments.tmp
 
     filter_file $tmpdir/recordings $data/wav.scp

--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -184,7 +184,7 @@ if [ -f $data/wav.scp ]; then
     check_sorted_and_uniq $data/segments
     # We have a segments file -> interpret wav file as "recording-ids" not utterance-ids.
     ! cat $data/segments | \
-      awk '{if (NF != 4 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
+      awk '{if (NF < 4 || NF > 5 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
       echo "$0: badly formatted segments file" && exit 1;
 
     segments_len=`cat $data/segments | wc -l`


### PR DESCRIPTION
Please check it
I followed the description here:
>          "Extract segments from a large audio file in WAV format.\n"
>          "Usage:  extract-segments [options] <wav-rspecifier> <segments-file> <wav-wspecifier>\n"
>          "e.g. extract-segments scp:wav.scp segments ark:- | <some-other-program>\n"
>          " segments-file format: each line is either\n"
>          "<segment-id> <recording-id> <start-time> <end-time>\n"
>          "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5\n"
>          "or (less frequently, and not supported in scripts):\n"
>          "<segment-id> <wav-file-name> <start-time> <end-time> <channel>\n"
>          "where <channel> will normally be 0 (left) or 1 (right)\n"
>          "e.g. call-861225-A-0050-0065 call-861225 5.0 6.5 1\n"
>          "And <end-time> of -1 means the segment runs till the end of the WAV file\n"
>          "See also: extract-feature-segments, wav-copy, wav-to-duration\n";

https://kaldi-asr.org/doc/extract-segments_8cc.html