### PR TITLE
Prevent dangling symlink creation

### DIFF
--- a/egs/wsj/s5/utils/subset_data_dir.sh
+++ b/egs/wsj/s5/utils/subset_data_dir.sh
@@ -116,7 +116,7 @@ else
     # Select $numutt shortest utterances.
     . ./path.sh
     if [ -f $srcdir/utt2num_frames ]; then
-      ln -sf $srcdir/utt2num_frames $destdir/tmp.len
+      ln -sf $(utils/make_absolute.sh $srcdir)/utt2num_frames $destdir/tmp.len
     else
       feat-to-len scp:$srcdir/feats.scp ark,t:$destdir/tmp.len || exit 1;
     fi


### PR DESCRIPTION
When `$srcdir` is a relative path, the path written by `ln` is invalid w.r.t. the symlink directory. Use an absolute path instead.