### PR TITLE
[src] Optimize lattice-faster-decoder to use memory pools for tokens and links

### DIFF
--- a/src/decoder/lattice-faster-decoder.cc
+++ b/src/decoder/lattice-faster-decoder.cc
@@ -33,8 +33,8 @@ LatticeFasterDecoderTpl<FST, Token>::LatticeFasterDecoderTpl(
       delete_fst_(false),
       config_(config),
       num_toks_(0),
-      token_pool_(config.memory_pool_size),
-      forward_link_pool_(config.memory_pool_size) {
+      token_pool_(config.memory_pool_tokens_block_size),
+      forward_link_pool_(config.memory_pool_links_block_size) {
   config.Check();
   toks_.SetSize(1000);  // just so on the first frame we do something reasonable.
 }
@@ -46,8 +46,8 @@ LatticeFasterDecoderTpl<FST, Token>::LatticeFasterDecoderTpl(
       delete_fst_(true),
       config_(config),
       num_toks_(0),
-      token_pool_(config.memory_pool_size),
-      forward_link_pool_(config.memory_pool_size) {
+      token_pool_(config.memory_pool_tokens_block_size),
+      forward_link_pool_(config.memory_pool_links_block_size) {
   config.Check();
   toks_.SetSize(1000);  // just so on the first frame we do something reasonable.
 }


### PR DESCRIPTION
Hi, this is a follow up optimization from EasyPerf contest https://easyperf.net/blog/2021/07/16/Performance-analysis-and-tuning-contest-5

I managed to optimize the performance by 13.5% in benchmark provided in
the contest.

We presented the (not so many) solutions in https://www.youtube.com/watch?v=jQG3QnhunZg.

I have couple of more things to optimize, for example, changing
nth_element to a little faster algorithm and prefetching opportunity in
ProcessEmitting. However, they totally do optimize at most 0.5% and
memory allocator is the most elegant, easy to understand approach to
save some cycles. But please do let me know if you want to see them.

In contest I used my implementation of memory allocator, however, I
found that openfst has its own which perfectly fits so that we can
use it in this decoder.

If you know other places where I should replace raw news and deletes
with the memory pool, let me also know.