### PR TITLE
[src] remove duplicate cleaning up operations of LatticeDeterminization

### DIFF
--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -223,10 +223,6 @@ template<class Weight, class IntType> class LatticeDeterminizerPruned {
          iter != initial_hash_.end(); ++iter)
       delete iter->first;
     { InitialSubsetHash tmp; tmp.swap(initial_hash_); }
-    for (size_t i = 0; i < output_states_.size(); i++) {
-      vector<Element> tmp;
-      tmp.swap(output_states_[i]->minimal_subset);
-    }
     { vector<char> tmp;  tmp.swap(isymbol_or_final_); }
     { // Free up the queue.  I'm not sure how to make sure all
       // the memory is really freed (no swap() function)... doesn't really


### PR DESCRIPTION
The "minimal_subset" of each "output_states_[i]" has been cleaned up in line 217-220. Remove the duplicate operations.