### PR TITLE
Allow override cxx/ar/ranlib when host is set

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -586,12 +586,6 @@ OPENBLASROOT=
 # libraries will run. It is set by the configure script when cross compiling.
 HOST=
 
-# These environment variables can be used to override the default toolchain.
-CXX=${CXX:-g++}
-AR=${AR:-ar}
-AS=${AS:-as}
-RANLIB=${RANLIB:-ranlib}
-
 # These environment variables can be used to provide additional flags to the
 # compiler/linker. We want these flags to override the flags determined by the
 # configure script, so we append them to the appropriate variables (CXXFLAGS,
@@ -795,11 +789,6 @@ if is_set $HOST; then
   IFS='-' read -ra PARTS <<< "$HOST"
 
   if [[ "$HOST" != WASM ]]; then
-    CXX="$HOST-$CXX"
-    AR="$HOST-$AR"
-    AS="$HOST-$AS"
-    RANLIB="$HOST-$RANLIB"
-
     # The first field in the PARTS list is the target architecture.
     TARGET_ARCH="$PARTS"
     if [[ "$TARGET_ARCH" != aarch64* && "$TARGET_ARCH" != arm* && "$TARGET_ARCH" != ppc64le && \
@@ -812,9 +801,24 @@ if is_set $HOST; then
   else
     TARGET_ARCH="$HOST"
   fi
+
+  HOST_CXX="$HOST-c++"
+  HOST_AR="$HOST-ar"
+  HOST_AS="$HOST-as"
+  HOST_RANLIB="$HOST-ranlib"
 else
   TARGET_ARCH="`uname -m`"
+  HOST_CXX=c++
+  HOST_AR=ar
+  HOST_AS=as
+  HOST_RANLIB=ranlib
 fi
+
+# These environment variables can be used to override the default toolchain.
+CXX=${CXX:-$HOST_CXX}
+AR=${AR:-$HOST_AR}
+AS=${AS:-$HOST_AS}
+RANLIB=${RANLIB:-$HOST_RANLIB}
 
 #------------------------------------------------------------------------------
 # Matrix algebra library selection and validation.


### PR DESCRIPTION
Currently when HOST environment is set, CXX, AR and RANLIB are hardcoded. This change allows to redefine them with environment variables which follows default automake practice.