### PR TITLE
Add scripts support for channel in segments file

### DIFF
--- a/egs/wsj/s5/utils/fix_data_dir.sh
+++ b/egs/wsj/s5/utils/fix_data_dir.sh
@@ -98,9 +98,9 @@ function filter_recordings {
     mv $tmpdir/recordings.tmp $tmpdir/recordings
 
 
-    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4}' <$data/segments.tmp >$data/segments
+    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4, $5}' <$data/segments.tmp >$data/segments
     filter_file $tmpdir/recordings $data/segments
-    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4}' <$data/segments.tmp >$data/segments
+    cp $data/segments{,.tmp}; awk '{print $2, $1, $3, $4, $5}' <$data/segments.tmp >$data/segments
     rm $data/segments.tmp
 
     filter_file $tmpdir/recordings $data/wav.scp

--- a/egs/wsj/s5/utils/validate_data_dir.sh
+++ b/egs/wsj/s5/utils/validate_data_dir.sh
@@ -184,7 +184,7 @@ if [ -f $data/wav.scp ]; then
     check_sorted_and_uniq $data/segments
     # We have a segments file -> interpret wav file as "recording-ids" not utterance-ids.
     ! cat $data/segments | \
-      awk '{if (NF != 4 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
+      awk '{if (NF < 4 || NF > 5 || $4 <= $3) { print "Bad line in segments file", $0; exit(1); }}' && \
       echo "$0: badly formatted segments file" && exit 1;
 
     segments_len=`cat $data/segments | wc -l`


### PR DESCRIPTION
The channel column is supported by `extract-segments` binary but not in the scripts. This PR adds support in the scripts.