### PR TITLE
Expose API to wait for separate streams

### DIFF
--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.cc
@@ -181,7 +181,7 @@ void CudaOnlinePipelineDynamicBatcher::WaitForCompletion() {
   cuda_pipeline_.WaitForLatticeCallbacks();
 }
 
-int CudaOnlinePipelineDynamicBatcher::GetPendingChunks(CorrelationID corr_id) {
+int CudaOnlinePipelineDynamicBatcher::GetNumPendingChunks(CorrelationID corr_id) {
   std::lock_guard<std::mutex> lk(next_batch_and_backlog_m_);
   if (n_chunks_per_corr_.find(corr_id) == n_chunks_per_corr_.end())
     return 0;

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -52,6 +52,7 @@ class CudaOnlinePipelineDynamicBatcher {
   void Push(CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
             const SubVector<BaseFloat> &wave_samples);
   void WaitForCompletion();
+  int GetPendingChunks(CorrelationID corr_id);
 
  private:
   // Batches created by this Batcher
@@ -126,6 +127,7 @@ class CudaOnlinePipelineDynamicBatcher {
   std::vector<const std::string *> partial_hypotheses_;
   std::vector<bool> end_points_;
   std::atomic<std::uint32_t> n_chunks_not_done_;
+  std::map<CorrelationID, int> n_chunks_per_corr_;
 
   int max_batch_size_;
   int num_channels_;

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -51,7 +51,10 @@ class CudaOnlinePipelineDynamicBatcher {
   // return
   void Push(CorrelationID corr_id, bool is_first_chunk, bool is_last_chunk,
             const SubVector<BaseFloat> &wave_samples);
+
+  // Wait for completion of the submitted chunks
   void WaitForCompletion();
+  // Get the number of unprocessed chunks for poll-like processing
   int GetPendingChunks(CorrelationID corr_id);
 
  private:
@@ -126,8 +129,9 @@ class CudaOnlinePipelineDynamicBatcher {
 
   std::vector<const std::string *> partial_hypotheses_;
   std::vector<bool> end_points_;
+
   std::atomic<std::uint32_t> n_chunks_not_done_;
-  std::map<CorrelationID, int> n_chunks_per_corr_;
+  std::unordered_map<CorrelationID, int> n_chunks_per_corr_;
 
   int max_batch_size_;
   int num_channels_;

--- a/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
+++ b/src/cudadecoder/cuda-online-pipeline-dynamic-batcher.h
@@ -55,7 +55,7 @@ class CudaOnlinePipelineDynamicBatcher {
   // Wait for completion of the submitted chunks
   void WaitForCompletion();
   // Get the number of unprocessed chunks for poll-like processing
-  int GetPendingChunks(CorrelationID corr_id);
+  int GetNumPendingChunks(CorrelationID corr_id);
 
  private:
   // Batches created by this Batcher


### PR DESCRIPTION
If data from streams comes in irregular intervals it becomes important to understand how much data per-stream is processed. This API allows decoder to wait for particular stream results instead of waiting for the whole pack.
