### PR TITLE
Development container for VS code.

### DIFF
--- a/docker/devcontainer/.devcontainer/Dockerfile
+++ b/docker/devcontainer/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"
+
+RUN apt-get -qq update && \
+    apt-get install -y -q \
+    build-essential \
+    curl \
+    git \
+    pkg-config \
+    # Libs below are used to install tools
+    libssl-dev \
+    zlib1g-dev \
+    automake \
+    autoconf \
+    unzip \
+    wget \
+    # used during mkl installation
+    sox \
+    gfortran \
+    python2.7 \
+    # Needed to kill the server on debug mode.
+    lsof \
+    libzmq3-dev 
+
+# RUN ln -s /usr/bin/python2.7 /usr/bin/python

--- a/docker/devcontainer/.devcontainer/Dockerfile
+++ b/docker/devcontainer/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 # RUN su node -c "npm install -g <your-package-list-here>"
 
 RUN apt-get -qq update && \
-    apt-get install -y -q \
+    apt-get install -y -q --no-install-recommends \
     build-essential \
     curl \
     git \
@@ -34,6 +34,8 @@ RUN apt-get -qq update && \
     python2.7 \
     # Needed to kill the server on debug mode.
     lsof \
-    libzmq3-dev 
+    libzmq3-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # RUN ln -s /usr/bin/python2.7 /usr/bin/python

--- a/docker/devcontainer/.devcontainer/devcontainer.json
+++ b/docker/devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node
+{
+	"name": "Node.js",
+	"dockerComposeFile": ["docker-compose.yml"],
+	"service": "kaldi-dev",
+	"shutdownAction": "stopCompose",
+	"workspaceFolder": "/workspaces/kaldi/",
+	// "workspaceFolder": "/opt/kaldi/",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"ms-vscode.cpptools"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/docker/devcontainer/.devcontainer/docker-compose.yml
+++ b/docker/devcontainer/.devcontainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  kaldi-dev:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      args:
+        - name=value
+    volumes:
+      - ../../../:/workspaces/kaldi/
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
This will enable Windows users to run kaldi in a Linux environment by [developing inside a container](https://code.visualstudio.com/docs/remote/containers).

Basically you choose to open kaldi/docker/devcontainer in Visual studio code. It will build a linux image with the requirements for building kaldi.

It is also possible to specify other volumes in `docker-compose.yml` to share models, datasets, etc.

