### PR TITLE
Fix SCTK compilation for Mac M1

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -103,7 +103,7 @@ openfst_cleaned:
 
 #== SCTK =======================================================================
 
-SCTK_CXFLAGS = -w -march=native
+SCTK_CXFLAGS = -w
 SCTK_MKENV = CFLAGS="$(CFLAGS) $(SCTK_CXFLAGS)" \
              CXXFLAGS="$(CXXFLAGS) -std=c++11 $(SCTK_CXFLAGS)" \
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -103,7 +103,13 @@ openfst_cleaned:
 
 #== SCTK =======================================================================
 
+# We don't set -march=native on MacOS because it breaks the compilation on M1 CPUs.
+OS := $(shell uname -s)
 SCTK_CXFLAGS = -w
+ifneq ($(OS), Darwin)
+SCTK_CXFLAGS += -march=native
+endif
+
 SCTK_MKENV = CFLAGS="$(CFLAGS) $(SCTK_CXFLAGS)" \
              CXXFLAGS="$(CXXFLAGS) -std=c++11 $(SCTK_CXFLAGS)" \
 


### PR DESCRIPTION
I doubt the `-march=native` flag in SCTK compilation has any observable effect for Kaldi users, but it breaks the compilation on M1 Macs where clang apparently doesn't have a registered tuning configuration for `native`.