### PR TITLE
fix DecodeSymbol function left context phone decoding bug

### DIFF
--- a/src/decoder/grammar-fst.cc
+++ b/src/decoder/grammar-fst.cc
@@ -79,7 +79,7 @@ void GrammarFstTpl<FST>::DecodeSymbol(Label label,
   KALDI_ASSERT(big_number % static_cast<int32>(kNontermMediumNumber) == 0);
 
   *nonterminal_symbol = (label - big_number) / encoding_multiple;
-  *left_context_phone = label % encoding_multiple;
+  *left_context_phone = (label - big_number) % encoding_multiple;
   if (*nonterminal_symbol <= nonterm_phones_offset ||
       *left_context_phone == 0 || *left_context_phone >
       nonterm_phones_offset + static_cast<int32>(kNontermBos))


### PR DESCRIPTION


encoding function: 

```
int32 encoded_symbol = big_number + nonterminal * encoding_multiple +left_context_phone
```

decoding function:

 ```  
*nonterminal_symbol = (label - big_number) / encoding_multiple;
  *left_context_phone = label % encoding_multiple;
```

decoded left_context_phone is not same when kNontermBigNumber is not be divisible by `encoding_multiple`