### PR TITLE
[egs] Improve steps/align_si.sh commentary

### DIFF
--- a/egs/wsj/s5/steps/align_si.sh
+++ b/egs/wsj/s5/steps/align_si.sh
@@ -2,7 +2,8 @@
 # Copyright 2012  Johns Hopkins University (Author: Daniel Povey)
 # Apache 2.0
 
-# Computes training alignments using a model with delta or delta+delta-delta features.
+# Compute training alignments using a model with delta or
+# delta + delta-delta features.
 
 # If you supply the "--use-graphs true" option, it will use the training
 # graphs from the source directory (where the model is).  In this

--- a/egs/wsj/s5/steps/align_si.sh
+++ b/egs/wsj/s5/steps/align_si.sh
@@ -2,8 +2,7 @@
 # Copyright 2012  Johns Hopkins University (Author: Daniel Povey)
 # Apache 2.0
 
-# Computes training alignments using a model with delta or
-# LDA+MLLT features.
+# Computes training alignments using a model with delta or delta+delta-delta features.
 
 # If you supply the "--use-graphs true" option, it will use the training
 # graphs from the source directory (where the model is).  In this


### PR DESCRIPTION
Since align_si.sh could be used to align monophone, it could deal with delta features.
Since align_si.sh could also be used to align triphone trained by "train_deltas.sh", it could deal with delta+ delta-delta features.

For LDA+MLLT features, I think "align_fmmlr.sh" could help deal with them.