### PR TITLE
Updata train_mono.sh annotation

### DIFF
--- a/egs/wsj/s5/steps/train_mono.sh
+++ b/egs/wsj/s5/steps/train_mono.sh
@@ -5,7 +5,7 @@
 
 
 # To be run from ..
-# Flat start and monophone training, with delta-delta features.
+# Flat start and monophone training, with delta features.
 # This script applies cepstral mean normalization (per speaker).
 
 # Begin configuration section.


### PR DESCRIPTION
As it says in line 73 "# Note: JOB=1 just uses the 1st part of the features-- we only need a subset anyway."

I think it would be better to say that monophone is trained with delta features.