### PR TITLE
Fix vector casts by using explicit namespace

### DIFF
--- a/src/onlinebin/online-audio-server-decode-faster.cc
+++ b/src/onlinebin/online-audio-server-decode-faster.cc
@@ -308,9 +308,9 @@ int32 main(int argc, char *argv[]) {
         } else {
           std::vector<int32> word_ids;
           if (decoder.PartialTraceback(&out_fst)) {
-            GetLinearSymbolSequence(out_fst, static_cast<vector<int32> *>(0),
+            GetLinearSymbolSequence(out_fst, static_cast<std::vector<int32> *>(nullptr),
                                     &word_ids,
-                                    static_cast<LatticeArc::Weight*>(0));
+                                    static_cast<LatticeArc::Weight*>(nullptr));
             for (size_t i = 0; i < word_ids.size(); i++) {
               if (word_ids[i] != 0) {
                 WriteLine(client_socket,

--- a/src/onlinebin/online-gmm-decode-faster.cc
+++ b/src/onlinebin/online-gmm-decode-faster.cc
@@ -166,9 +166,9 @@ int main(int argc, char *argv[]) {
         std::vector<int32> word_ids;
         decoder.FinishTraceBack(&out_fst);
         fst::GetLinearSymbolSequence(out_fst,
-                                     static_cast<vector<int32> *>(0),
+                                     static_cast<std::vector<int32> *>(nullptr),
                                      &word_ids,
-                                     static_cast<LatticeArc::Weight*>(0));
+                                     static_cast<LatticeArc::Weight*>(nullptr));
         PrintPartialResult(word_ids, word_syms, partial_res || word_ids.size());
         partial_res = false;
         if (dstate == decoder.kEndFeats) {
@@ -181,9 +181,9 @@ int main(int argc, char *argv[]) {
         std::vector<int32> word_ids;
         if (decoder.PartialTraceback(&out_fst)) {
           fst::GetLinearSymbolSequence(out_fst,
-                                       static_cast<vector<int32> *>(0),
+                                       static_cast<std::vector<int32> *>(nullptr),
                                        &word_ids,
-                                       static_cast<LatticeArc::Weight*>(0));
+                                       static_cast<LatticeArc::Weight*>(nullptr));
           PrintPartialResult(word_ids, word_syms, false);
           if (!partial_res)
             partial_res = (word_ids.size() > 0);

--- a/src/onlinebin/online-server-gmm-decode-faster.cc
+++ b/src/onlinebin/online-server-gmm-decode-faster.cc
@@ -179,18 +179,18 @@ int main(int argc, char *argv[]) {
       if (dstate & (decoder.kEndFeats | decoder.kEndUtt)) {
         decoder.FinishTraceBack(&out_fst);
         fst::GetLinearSymbolSequence(out_fst,
-                                     static_cast<vector<int32> *>(0),
+                                     static_cast<std::vector<int32> *>(nullptr),
                                      &word_ids,
-                                     static_cast<LatticeArc::Weight*>(0));
+                                     static_cast<LatticeArc::Weight*>(nullptr));
         SendPartialResult(word_ids, word_syms, partial_res || word_ids.size(),
                           udp_input.descriptor(), udp_input.client_addr());
         partial_res = false;
       } else {
         if (decoder.PartialTraceback(&out_fst)) {
           fst::GetLinearSymbolSequence(out_fst,
-                                       static_cast<vector<int32> *>(0),
+                                       static_cast<std::vector<int32> *>(nullptr),
                                        &word_ids,
-                                       static_cast<LatticeArc::Weight*>(0));
+                                       static_cast<LatticeArc::Weight*>(nullptr));
           SendPartialResult(word_ids, word_syms, false,
                             udp_input.descriptor(), udp_input.client_addr());
           if (!partial_res)

--- a/src/onlinebin/online-wav-gmm-decode-faster.cc
+++ b/src/onlinebin/online-wav-gmm-decode-faster.cc
@@ -196,9 +196,9 @@ int main(int argc, char *argv[]) {
           std::vector<int32> word_ids;
           decoder.FinishTraceBack(&out_fst);
           fst::GetLinearSymbolSequence(out_fst,
-                                       static_cast<vector<int32> *>(0),
+                                       static_cast<std::vector<int32> *>(nullptr),
                                        &word_ids,
-                                       static_cast<LatticeArc::Weight*>(0));
+                                       static_cast<LatticeArc::Weight*>(nullptr));
           PrintPartialResult(word_ids, word_syms, partial_res || word_ids.size());
           partial_res = false;
 
@@ -207,7 +207,7 @@ int main(int argc, char *argv[]) {
           fst::GetLinearSymbolSequence(out_fst,
                                        &tids,
                                        &word_ids,
-                                       static_cast<LatticeArc::Weight*>(0));
+                                       static_cast<LatticeArc::Weight*>(nullptr));
           std::stringstream res_key;
           res_key << wav_key << '_' << start_frame << '-' << decoder.frame();
           if (!word_ids.empty())
@@ -220,9 +220,9 @@ int main(int argc, char *argv[]) {
           std::vector<int32> word_ids;
           if (decoder.PartialTraceback(&out_fst)) {
             fst::GetLinearSymbolSequence(out_fst,
-                                        static_cast<vector<int32> *>(0),
+                                        static_cast<std::vector<int32> *>(nullptr),
                                         &word_ids,
-                                        static_cast<LatticeArc::Weight*>(0));
+                                        static_cast<LatticeArc::Weight*>(nullptr));
             PrintPartialResult(word_ids, word_syms, false);
             if (!partial_res)
               partial_res = (word_ids.size() > 0);


### PR DESCRIPTION
This code caused build-time errors due to lacking namespace imports or prefixes when I tried to build `kaldi`. This pull request fixes that.

The errors looked something like: `error: 'vector' does not name a type`