### PR TITLE
Fix CuMemoryAllocator bug.

### DIFF
--- a/src/cudamatrix/cu-allocator.cc
+++ b/src/cudamatrix/cu-allocator.cc
@@ -251,7 +251,7 @@ start:
       end = largest_free_block_.end();
   size_t subregion_index = 0;
   for (; iter != end; ++iter, ++subregion_index) {
-    if (*iter > size) {
+    if (*iter >= size) {
       return MallocFromSubregion(subregions_[subregion_index], size);
     }
   }


### PR DESCRIPTION
In `CuMemoryAllocator::MallocInternal`, the memory allocator cannot allocate memory when requested size and largest subregion size are same. It makes 'out of memory`.

```
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:10275M, used:903M, total:11178M, free/total:0.919215
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:9757M, used:1421M, total:11178M, free/total:0.872876
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:9239M, used:1939M, total:11178M, free/total:0.826537
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:8721M, used:2457M, total:11178M, free/total:0.780199
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:8203M, used:2975M, total:11178M, free/total:0.73386
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:7685M, used:3493M, total:11178M, free/total:0.687521
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:7167M, used:4011M, total:11178M, free/total:0.641183
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:6649M, used:4529M, total:11178M, free/total:0.594844
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:6131M, used:5047M, total:11178M, free/total:0.548505
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:5613M, used:5565M, total:11178M, free/total:0.502167
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:5095M, used:6083M, total:11178M, free/total:0.455828
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:4577M, used:6601M, total:11178M, free/total:0.409489
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:4059M, used:7119M, total:11178M, free/total:0.36315
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:3541M, used:7637M, total:11178M, free/total:0.316812
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:3023M, used:8155M, total:11178M, free/total:0.270473
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:2505M, used:8673M, total:11178M, free/total:0.224134
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:1987M, used:9191M, total:11178M, free/total:0.177796
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:1469M, used:9709M, total:11178M, free/total:0.131457
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:951M, used:10227M, total:11178M, free/total:0.0851183
LOG (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:478) About to allocate new memory region of 542113792 bytes; current memory info is: free:433M, used:10745M, total:11178M, free/total:0.0387796
LOG (cuda-decoder-worker[5.5.0~1-3f40]:PrintMemoryUsage():cu-allocator.cc:340) Memory usage: 389804032/10867441664 bytes currently allocated/total-held; 372/21 blocks currently allocated/free; largest free/allocated block sizes are 43253760/542113792; time taken total/cudaMalloc is 0.0011723/0.0106711, synchronized the GPU 0 times out of 4 frees; device memory info: free:433M, used:10745M, total:11178M, free/total:0.0387796maximum allocated: 389804032current allocated: 389804032
ERROR (cuda-decoder-worker[5.5.0~1-3f40]:AllocateNewRegion():cu-allocator.cc:499) Failed to allocate a memory region of 542113792 bytes.  Possibly smaller minibatch size would help.  Memory info: free:433M, used:10745M, total:11178M, free/total:0.0387796 CUDA error: 'out of memory'
```