### PR TITLE
Fix an error in expressing column ranges in the I/O doc.

### DIFF
--- a/src/doc/io.dox
+++ b/src/doc/io.dox
@@ -313,7 +313,7 @@ namespace kaldi {
  \endverbatim
  and if you just want to express a column range, you can leave the row-range blank, as follows:
  \verbatim
-  utt_id_01002 foo.ark:89142[,89:100]
+  utt_id_01002 foo.ark:89142[:,89:100]
  \endverbatim
 
  \subsection io_sec_scp_details  How Kaldi processes lines of scp files


### PR DESCRIPTION
From the comments in the code
https://github.com/kaldi-asr/kaldi/blob/d7877b8688b1041b3e9c529f03519c4e5d1a742d/src/util/kaldi-holder.cc#L32

You cannot leave the row range empty when you want to select all rows.

---

Also, the following code checks that if `,` is present, then there has to be something before the comma
https://github.com/kaldi-asr/kaldi/blob/d7877b8688b1041b3e9c529f03519c4e5d1a742d/src/util/kaldi-holder.cc#L41-L47