### PR TITLE
Remove sgmm2 from gmm-est-fmllr-gpost dependencies

### DIFF
--- a/cmake/gen_cmake_skeleton.py
+++ b/cmake/gen_cmake_skeleton.py
@@ -92,7 +92,7 @@ def get_exe_additional_depends(t):
         "gmm-decode-*": ["decoder"],
         "gmm-align": ["decoder"],
         "gmm-align-compiled": ["decoder"],
-        "gmm-est-fmllr-gpost": ["sgmm2", "hmm"],
+        "gmm-est-fmllr-gpost": ["hmm"],
         "gmm-rescore-lattice": ["hmm", "lat"],
 
         # solve fgmmbin


### PR DESCRIPTION
Small fix from the CMake change, sgmm2 was still listed as a dependency of gmm-est-fmllr-gpost, despite not being used, so removing sgmm2 from being built caused linker errors.