### PR TITLE
Fix 'make valgrind'

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ SUBDIRS := base bin chain chainbin cudamatrix decoder		\
 # (default 'true' if CUDA is used, else 'false')
 CUDADECODER = cudafeat cudafeatbin cudadecoder cudadecoderbin
 
-MEMTESTDIRS = $(filter-out chainbin cudamatrix rnnlmbin $(SUBDIRS))
+MEMTESTDIRS = $(filter-out chainbin cudamatrix rnnlmbin, $(SUBDIRS))
 CUDAMEMTESTDIR = cudamatrix
 
 # Optional subdirectories


### PR DESCRIPTION
Fix the 'make valgrind' command so that it will work instead of giving something like:
Makefile:22: *** insufficient number of arguments (1) to function 'filter-out'.  Stop.