### PR TITLE
minor fix in calculating per catetory stats

### DIFF
--- a/egs/babel/s5d/local/search/per_category_stats.pl
+++ b/egs/babel/s5d/local/search/per_category_stats.pl
@@ -161,7 +161,7 @@ while (my $line=<STDIN>) {
     $score = 1.0 if $score > 1.0;
     my $q = int($score/$step_size) + 1;
     for (my $i = 0; $i < $q ; $i += 1) {
-      if ($ref_time) {
+      if ($ref_time ne "") {
         $STATS{$termid}->{corr_sweep}->[$i]  += 1;
       } else {
         $STATS{$termid}->{fa_sweep}->[$i]  += 1;


### PR DESCRIPTION
Hi Yenda, here is the fix. @jtrmal 

To explain more, without this fix, we could not distinguish `ref_time=0` or `ref_time=`. Thus the counting in the following `corr_sweep` and `fa_sweep` may be wrong.