### PR TITLE
Add missing line to mgb2_arabic data prep script

### DIFF
--- a/egs/mgb2_arabic/s5/local/mgb_data_prep.sh
+++ b/egs/mgb2_arabic/s5/local/mgb_data_prep.sh
@@ -11,6 +11,7 @@ fi
 
 db_dir=$1
 mer=$2
+process_xml=$3
 
 train_dir=data/train_mer$mer
 dev_dir=data/dev


### PR DESCRIPTION
Add missing line "process_xml=$3" to accept process_xml as a third command-line argument.