### PR TITLE
Ignore the second registration in ParseOptions

### DIFF
--- a/src/util/parse-options-test.cc
+++ b/src/util/parse-options-test.cc
@@ -293,6 +293,20 @@ void UnitTestParseOptions() {
   po6.Read(argc6, argv6);
   KALDI_ASSERT(po6.NumArgs() == 1);
   KALDI_ASSERT(po6.GetArg(1) == "--foo=8");
+
+  // test that a second registration is ignored
+  int argc7 = 2;
+  const char *const argv7[] = {"program_name", "--i=8"};
+  ParseOptions po7("my usage msg");
+
+  int i7 = 10, k7 = 20;
+  po7.Register("i", &i7, "My int32 variable");
+  po7.Register("i", &k7, "My int32 variable");
+
+  po7.Read(argc7, argv7);
+
+  KALDI_ASSERT(i7 == 8);
+  KALDI_ASSERT(k7 == 20);
 }
 
 
@@ -303,5 +317,3 @@ int main() {
   UnitTestParseOptions();
   return 0;
 }
-
-

--- a/src/util/parse-options.cc
+++ b/src/util/parse-options.cc
@@ -106,7 +106,8 @@ void ParseOptions::RegisterCommon(const std::string &name, T *ptr,
   NormalizeArgName(&idx);
   if (doc_map_.find(idx) != doc_map_.end())
     KALDI_WARN << "Registering option twice, ignoring second time: " << name;
-  this->RegisterSpecific(name, idx, ptr, doc, is_standard);
+  else
+    this->RegisterSpecific(name, idx, ptr, doc, is_standard);
 }
 
 // used to register standard parameters (those that are present in all of the


### PR DESCRIPTION
https://github.com/kaldi-asr/kaldi/blob/d673298886e8d62d4c890e5e3eac8491df0b7e12/src/util/parse-options.cc#L107-L109

This PR fixes the code to match the warning messages.