### PR TITLE
Introduce determinize_max_active option to control determinization delay

### DIFF
--- a/src/decoder/lattice-incremental-decoder.cc
+++ b/src/decoder/lattice-incremental-decoder.cc
@@ -108,6 +108,11 @@ void LatticeIncrementalDecoderTpl<FST, Token>::UpdateLatticeDeterminization() {
       best_frame = t;
     }
   }
+  /* Skip this update if we have too many tokens, determinization will take too long,
+     postpone it to the next update */
+  if (fewest_tokens > config_.determinize_max_active)
+      return;
+
   /* OK, determinize the chunk that spans from num_frames_in_lattice_ to
      best_frame. */
   bool use_final_probs = false;


### PR DESCRIPTION
In times of uncertainty determinization takes too much time. We try to skip update step if there are too many tokens. Relevant discussion on kaldi-help is https://groups.google.com/g/kaldi-help/c/JtMJ8-XGjGs 