### PR TITLE
Fix missing separator in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,7 @@ ifneq ($(KALDILIBDIR), )
 	-rmdir 2>/dev/null $(KALDILIBDIR); true
 else
 # KALDILIBDIR might have been unset because of reconfigure. Do a best guess.
- 	@echo "Something seems wrong. Please re-run configure."
+	@echo "Something seems wrong. Please re-run configure."
 	@echo "I will continue but the cleanup might not be complete."
 endif
 


### PR DESCRIPTION
Hi @jtrmal. Recent change commit 528595e89816c8aefa2a9c609e132c94a7c0e5bd introduced Makefile problem:

`Makefile:64: *** missing separator. Stop.`

due to tiny space