### PR TITLE
fix: Fix creation of vocab_autogen_our.{1} when using 1 job

### DIFF
--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -76,7 +76,7 @@ if [ $stage -le 1 ]; then
     then
       auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}") #Create the list of files to split  
     else
-      auto_vocab_splits="$g2p_dir/vocab_autogen.1" #If nj is 1, use vocab_autogen.1 instead of .{1}
+      auto_vocab_splits="${auto_vocab_prefix}.1"  #If nj is 1, use vocab_autogen.1 instead of .{1}
     fi
   awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab  |\
   sort | tee $g2p_dir/vocab_autogen.full |\

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -72,12 +72,11 @@ if [ $stage -le 1 ]; then
   auto_lexicon_prefix="$g2p_dir/lexicon_autogen"
 
   mkdir -p $g2p_dir/log
-  if [ ! $nj -eq 1 ];
-    then
-      auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}") #Create the list of files to split  
-    else
-      auto_vocab_splits="${auto_vocab_prefix}.1"  #If nj is 1, use vocab_autogen.1 instead of .{1}
-    fi
+  if [ $nj -eq 1 ]; then
+    auto_vocab_splits="${auto_vocab_prefix}.1"  #If nj is 1, use vocab_autogen.1 instead of .{1}
+  else
+    auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}") #Create the list of files to split
+  fi
   awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab  |\
   sort | tee $g2p_dir/vocab_autogen.full |\
   utils/split_scp.pl /dev/stdin $auto_vocab_splits || exit 1

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -77,7 +77,7 @@ if [ $stage -le 1 ]; then
   else
     auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}") #Create the list of files to split
   fi
-  awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab  |\
+  awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab |\
     sort | tee $g2p_dir/vocab_autogen.full |\
     utils/split_scp.pl /dev/stdin $auto_vocab_splits || exit 1
   echo "Autogenerating pronunciations for the words in $auto_vocab_prefix.* ..."

--- a/egs/librispeech/s5/local/prepare_dict.sh
+++ b/egs/librispeech/s5/local/prepare_dict.sh
@@ -78,8 +78,8 @@ if [ $stage -le 1 ]; then
     auto_vocab_splits=$(eval "echo $auto_vocab_prefix.{$(seq -s',' $nj | sed 's/,$//')}") #Create the list of files to split
   fi
   awk 'NR==FNR{a[$1] = 1; next} !($1 in a)' $cmudict_plain $vocab  |\
-  sort | tee $g2p_dir/vocab_autogen.full |\
-  utils/split_scp.pl /dev/stdin $auto_vocab_splits || exit 1
+    sort | tee $g2p_dir/vocab_autogen.full |\
+    utils/split_scp.pl /dev/stdin $auto_vocab_splits || exit 1
   echo "Autogenerating pronunciations for the words in $auto_vocab_prefix.* ..."
   $cmd JOB=1:$nj $g2p_dir/log/g2p.JOB.log \
     local/g2p.sh  $auto_vocab_prefix.JOB $g2p_model_dir $auto_lexicon_prefix.JOB || exit 1


### PR DESCRIPTION
When creating the lexicon using prepare_dict.sh when my `njobs=1` , the auto_vocab_splits @ Line 75 causes it to be named as
`$g2p_dir/"vocab_autogen_our.{1}` when we want it to be named as `vocab_autogen_our.1`