### PR TITLE
avoid build error on Windows

### DIFF
--- a/src/base/kaldi-utils.cc
+++ b/src/base/kaldi-utils.cc
@@ -18,6 +18,7 @@
 
 #include "base/kaldi-utils.h"
 
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <thread>


### PR DESCRIPTION
Hi maintainers.

I have tried to build this toolkit on Windows along with [this instruction](https://github.com/kaldi-asr/kaldi/blob/master/windows/INSTALL.md), but failed to compile `src/base/kaldi-utils.cc`. According to the error message, the compiler failed to find `std::isprint()` function [here](https://github.com/kaldi-asr/kaldi/blob/ac29a6ff09823d1cbb4814da60360c966f33cd0d/src/base/kaldi-utils.cc#L30). This function is defined in `ctype.h`, so adding `#include <cctype>` can avoid this error.