### PR TITLE
Fix Windows build - Add cctype import to kaldi-utils.cc, remove mkl_intel_c.lib

### DIFF
--- a/src/base/kaldi-utils.cc
+++ b/src/base/kaldi-utils.cc
@@ -22,7 +22,6 @@
 #include <chrono>
 #include <cstdio>
 #include <thread>
-#include <cctype>
 
 
 namespace kaldi {

--- a/src/base/kaldi-utils.cc
+++ b/src/base/kaldi-utils.cc
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <cstdio>
 #include <thread>
+#include <cctype>
 
 
 namespace kaldi {

--- a/src/matrix/Matrix.vcxproj
+++ b/src/matrix/Matrix.vcxproj
@@ -53,7 +53,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>c:\Program Files\Intel\MKL\10.2.5.035\ia32\lib;</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libguide.lib;libguide40.lib;libiomp5md.lib;libiomp5mt.lib;mkl_blacs_intelmpi.lib;mkl_blacs_mpich2.lib;mkl_blas95.lib;mkl_cdft_core.lib;mkl_core.lib;mkl_intel_c.lib;mkl_intel_s.lib;mkl_intel_thread.lib;mkl_lapack95.lib;mkl_pgi_thread.lib;mkl_scalapack_core.lib;mkl_sequential.lib;mkl_solver.lib;mkl_solver_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;libguide.lib;libguide40.lib;libiomp5md.lib;libiomp5mt.lib;mkl_blacs_intelmpi.lib;mkl_blacs_mpich2.lib;mkl_blas95.lib;mkl_cdft_core.lib;mkl_core.lib;mkl_intel_s.lib;mkl_intel_thread.lib;mkl_lapack95.lib;mkl_pgi_thread.lib;mkl_scalapack_core.lib;mkl_sequential.lib;mkl_solver.lib;mkl_solver_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/windows/kaldiwin_win32.props
+++ b/windows/kaldiwin_win32.props
@@ -13,7 +13,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(MKLDIR)\lib\ia32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>mkl_rt.lib;mkl_intel_thread.lib;mkl_core.lib;mkl_intel_c.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mkl_rt.lib;mkl_intel_thread.lib;mkl_core.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Hello again!
I was able to get a successful build in VS2019, and online-gmm-decode-faster.exe running in Powershell successfully. Not too much to report, mkl_intel_c.lib is no longer a thing.
Let me know if I need to do an IFDEF and check for Win32 on the cctype import.
Thanks!