### PR TITLE
chime6: missing --cmd argument

### DIFF
--- a/egs/chime6/s5c_track2/local/decode_ts-vad.sh
+++ b/egs/chime6/s5c_track2/local/decode_ts-vad.sh
@@ -154,7 +154,8 @@ if [ $stage -le 3 ]; then
       exit 0
     fi
     # Perform segmentation
-    local/segmentation/detect_speech_activity.sh --nj $nj --stage $sad_stage \
+    local/segmentation/detect_speech_activity.sh --nj $nj \
+      --cmd "$train_cmd" --stage $sad_stage \
       $test_set $sad_nnet_dir mfcc $sad_work_dir \
       data/${datadir} || exit 1
 


### PR DESCRIPTION
In `egs/chime6/s5c_track2/local/decode_ts-vad.sh` the script `local/segmentation/detect_speech_activity.sh` is called
without the --cmd arguments, so it uses by always the default queue.pl and not what the user specified.
