### PR TITLE
egs/chime6/s5c_track2/local/ts-vad/diarize_TS-VAD_itX.sh: use python3

### DIFF
--- a/egs/chime6/s5c_track2/local/ts-vad/diarize_TS-VAD_it1.sh
+++ b/egs/chime6/s5c_track2/local/ts-vad/diarize_TS-VAD_it1.sh
@@ -140,7 +140,7 @@ scoring=$out/scoring
 hyp_rttm=$scoring/rttm
 if [ ! -f $scoring/.done ]; then
   if [ ! -f $hyp_rttm ]; then 
-    python local/ts-vad/convert_prob_to_rttm.py --threshold $thr --window $window --min_silence $min_silence --min_speech $min_speech ark:"sort $out/weights.ark |" $hyp_rttm || exit 1;
+    python3 local/ts-vad/convert_prob_to_rttm.py --threshold $thr --window $window --min_silence $min_silence --min_speech $min_speech ark:"sort $out/weights.ark |" $hyp_rttm || exit 1;
   fi
   echo "Diarization results for $test"
   [ ! -f $ref_rttm.scoring ] && sed 's/_U0[1-6]\.ENH//g' $ref_rttm > $ref_rttm.scoring
@@ -148,7 +148,7 @@ if [ ! -f $scoring/.done ]; then
   ref_rttm_path=$(readlink -f ${ref_rttm}.scoring)
   hyp_rttm_path=$(readlink -f ${hyp_rttm}.scoring)
   [ ! -f ./local/uem_file.scoring ] && cat ./local/uem_file | grep 'U06' | sed 's/_U0[1-6]//g' > ./local/uem_file.scoring
-  cd dscore && python score.py -u ../local/uem_file.scoring -r $ref_rttm_path \
+  cd dscore && python3 score.py -u ../local/uem_file.scoring -r $ref_rttm_path \
     -s $hyp_rttm_path 2>&1 | tee -a ../$scoring/DER && cd .. || exit 1;
   touch $scoring/.done
 fi

--- a/egs/chime6/s5c_track2/local/ts-vad/diarize_TS-VAD_it2.sh
+++ b/egs/chime6/s5c_track2/local/ts-vad/diarize_TS-VAD_it2.sh
@@ -74,7 +74,7 @@ test="$(cut -d'_' -f1 <<<"$initname")"
 weights=$initdir/weights.ark
 weights_mod=$initdir/weights_t${t}_mt${mt}.ark
 if [ ! -f ${weights_mod}.gz ]; then
-  python local/ts-vad/vad_prob_mod.py --threshold $t --multispk_threshold $mt ark:$weights ark,t:${weights_mod}
+  python3 local/ts-vad/vad_prob_mod.py --threshold $t --multispk_threshold $mt ark:$weights ark,t:${weights_mod}
   cat ${weights_mod} | sed s/_U06.ENH// | sort | gzip -c > ${weights_mod}.gz
   rm $weights_mod
 fi
@@ -194,7 +194,7 @@ scoring=$out/scoring
 hyp_rttm=$scoring/rttm
 if [ ! -f $scoring/.done ]; then
   if [ ! -f $hyp_rttm ]; then 
-    python local/ts-vad/convert_prob_to_rttm.py --threshold $thr --window $window --min_silence $min_silence --min_speech $min_speech ark:"sort $out/weights.ark |" $hyp_rttm || exit 1;
+    python3 local/ts-vad/convert_prob_to_rttm.py --threshold $thr --window $window --min_silence $min_silence --min_speech $min_speech ark:"sort $out/weights.ark |" $hyp_rttm || exit 1;
   fi
   echo "Diarization results for $test"
   [ ! -f $ref_rttm.scoring ] && sed 's/_U0[1-6]\.ENH//g' $ref_rttm > $ref_rttm.scoring
@@ -202,7 +202,7 @@ if [ ! -f $scoring/.done ]; then
   ref_rttm_path=$(readlink -f ${ref_rttm}.scoring)
   hyp_rttm_path=$(readlink -f ${hyp_rttm}.scoring)
   [ ! -f ./local/uem_file.scoring ] && cat ./local/uem_file | grep 'U06' | sed 's/_U0[1-6]//g' > ./local/uem_file.scoring
-  cd dscore && python score.py -u ../local/uem_file.scoring -r $ref_rttm_path \
+  cd dscore && python3 score.py -u ../local/uem_file.scoring -r $ref_rttm_path \
     -s $hyp_rttm_path 2>&1 | tee -a ../$scoring/DER && cd .. || exit 1;
   touch $scoring/.done
 fi


### PR DESCRIPTION
I got the error
```
Traceback (most recent call last):
  File "local/ts-vad/convert_prob_to_rttm.py", line 32, in <module>
    import regex as re
ImportError: No module named regex
```
for the CHiME-6 recipe and I had issues to figure out, why I get this error, because the
first line of that script says it runs with python3
(I installed in every python3 env regex, but it didn't helped).

So I printed the python version, and it said, it's python2.
Then I tried to install regex in python2, but there I got errors like:

```
$ python2 -m pip install regex
...
regex_3/_regex.c:755:15: error: ‘Py_UCS1’ undeclared (first use in this function); did you mean ‘Py_UCS4’?
...
regex_3/_regex.c:26218:5: error: ‘PyModuleDef_HEAD_INIT’ undeclared here (not in a function)
...
```
I think it is easier to change to python3, especially since eol was 2020 for python2.

This PR changes all python calls in diarize_TS-VAD_itX.sh to use python3, as indicated in the first line of the script.
