### PR TITLE
use last segment of the CXX as the ccbin compiler for cuda

### DIFF
--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -9,7 +9,7 @@ CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include -fPIC -pthread -isystem $(OPENFST
 
 CUDA_INCLUDE= -I$(CUDATKDIR)/include -I$(CUBROOT) -I.. -isystem $(OPENFSTINC)
 CUDA_FLAGS = --compiler-options -fPIC --machine 64 -DHAVE_CUDA \
-             -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
+             -ccbin $(lastword $(CXX)) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
              -std=c++14 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -lineinfo \
              --verbose -Wno-deprecated-gpu-targets
 


### PR DESCRIPTION
This is a minor change to help in situation where the CXX variable is set to e.g. `ccache g++` 
The nvcc will fail to parse this correctly both in cases where the name is escaped and when it's not escaped, i.e.
both
```
-ccbin ccache g++ 
```
and 
```
-ccbin "ccache g++"
```
will fail, causing compilation failure. This solves the issue.
