### PR TITLE
Fix typo in gen_cmake_skeleton

### DIFF
--- a/cmake/gen_cmake_skeleton.py
+++ b/cmake/gen_cmake_skeleton.py
@@ -147,7 +147,7 @@ def get_exe_additional_depends(t):
     for pattern in additional.keys():
         if fnmatch.fnmatch(t, pattern):
             libs.extend(list(map(lambda name: lib_dir_name_to_lib_target(name), additional[pattern])))
-    return sorted(list(set(l)))
+    return sorted(list(set(libs)))
 
 def disable_for_win32(t):
     disabled = [


### PR DESCRIPTION
@jtrmal There was a typo in gen_cmake_skeletons.py, but with it fixed, all platforms are building: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=552548&view=results