### PR TITLE
Copy utt2lang when using utils/copy_data_dir.sh

### DIFF
--- a/egs/wsj/s5/utils/copy_data_dir.sh
+++ b/egs/wsj/s5/utils/copy_data_dir.sh
@@ -84,6 +84,10 @@ if [ -f $srcdir/vad.scp ]; then
   utils/apply_map.pl -f 1 $destdir/utt_map <$srcdir/vad.scp >$destdir/vad.scp
 fi
 
+if [ -f $srcdir/utt2lang ]; then
+  utils/apply_map.pl -f 1 $destdir/utt_map <$srcdir/utt2lang >$destdir/utt2lang
+fi
+
 if [ -f $srcdir/segments ]; then
   utils/apply_map.pl -f 1 $destdir/utt_map <$srcdir/segments >$destdir/segments
   cp $srcdir/wav.scp $destdir


### PR DESCRIPTION
Currently `utils/copy_data_dir.sh` does not copy `utt2lang` to destination directory. However, `utils/subset_data_dir.sh` does as follows:
https://github.com/kaldi-asr/kaldi/blob/0fb502d10047ab702c664db4d7e175d282762539/egs/wsj/s5/utils/subset_data_dir.sh#L141-L142

Because I encountered this issue when making multi-language and multi-speaker TTS model, I wrote this PR.