### PR TITLE
WSL PATH fixes

### DIFF
--- a/egs/wsj/s5/path.sh
+++ b/egs/wsj/s5/path.sh
@@ -1,6 +1,6 @@
 export KALDI_ROOT=`pwd`/../../..
 [ -f $KALDI_ROOT/tools/env.sh ] && . $KALDI_ROOT/tools/env.sh
-export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$PWD:$PATH
+export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$PWD:"$PATH"
 [ ! -f $KALDI_ROOT/tools/config/common_path.sh ] && echo >&2 "The standard file $KALDI_ROOT/tools/config/common_path.sh is not present -> Exit!" && exit 1
 . $KALDI_ROOT/tools/config/common_path.sh
 export LC_ALL=C

--- a/tools/config/common_path.sh
+++ b/tools/config/common_path.sh
@@ -24,4 +24,4 @@ ${KALDI_ROOT}/src/sgmmbin:\
 ${KALDI_ROOT}/src/tfrnnlmbin:\
 ${KALDI_ROOT}/src/cudadecoderbin:\
 ${KALDI_ROOT}/src/cudafeatbin:\
-$PATH
+"$PATH"

--- a/tools/extras/check_dependencies.sh
+++ b/tools/extras/check_dependencies.sh
@@ -113,7 +113,7 @@ if $pythonok && ! have python2; then
   echo "$0: python2.7 is installed, but the python2 binary does not exist." \
        "Creating a symlink and adding this to tools/env.sh"
   ln -s $(command -v python2.7) $PWD/python/python2
-  echo "export PATH=$PWD/python:\${PATH}" >> env.sh
+  echo "export PATH=$PWD/python:\"\${PATH}\"" >> env.sh
 fi
 
 if [[ -f $PWD/python/.use_default_python && -f $PWD/python/python ]]; then
@@ -129,7 +129,7 @@ if $pythonok && have python && [[ ! -f $PWD/python/.use_default_python ]]; then
          "empty file $PWD/python/.use_default_python and run this script again."
     mkdir -p $PWD/python
     ln -s $(command -v python2.7) $PWD/python/python
-    echo "export PATH=$PWD/python:\${PATH}" >> env.sh
+    echo "export PATH=$PWD/python:\"\${PATH}\"" >> env.sh
   fi
 fi
 )


### PR DESCRIPTION
for solving the "bad variable name" error which occurs in WSL.
The error is due to the WSL automatically appends the Windows path to the WSL/Linux path, and the Windows path includes space such as "Program file".
![image](https://user-images.githubusercontent.com/18275400/216757643-08924ddd-d226-453c-9f21-69aa0bc27486.png)
