### PR TITLE
No need for atomicAdd for float2, conflicts with CUDA 12.1

### DIFF
--- a/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-cmvn-cuda-kernels.cu
@@ -24,16 +24,12 @@ __host__ __device__ inline float2 operator-(const float2 &a, const float2 &b) {
   retval.y = a.y - b.y;
   return retval;
 }
+
 __host__ __device__ inline float2 operator+(const float2 &a, const float2 &b) {
   float2 retval;
   retval.x = a.x + b.x;
   retval.y = a.y + b.y;
   return retval;
-}
-
-__device__ inline void atomicAdd(float2 *addr, float2 val) {
-  atomicAdd(reinterpret_cast<float *>(addr), val.x);
-  atomicAdd(reinterpret_cast<float *>(addr) + 1, val.y);
 }
 
 __device__ inline void operator+=(float2 &a, float2 &b) {


### PR DESCRIPTION
Since 12.1 CUDA added float2 version of atomicAdd

https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd

which causes build error:

```
#7 392.3 feature-online-batched-cmvn-cuda-kernels.cu(34): error: cannot overload functions distinguished by return type alone
#7 392.3   __attribute__((device)) inline void atomicAdd(float2 *addr, float2 val) {
```

as far as I see currently this function is not used, we can remove it safely

