### PR TITLE
Update install_mkl.sh

### DIFF
--- a/tools/extras/install_mkl.sh
+++ b/tools/extras/install_mkl.sh
@@ -16,7 +16,7 @@ default_package=intel-mkl-64bit-2020.0-088
 
 yum_repo='https://yum.repos.intel.com/mkl/setup/intel-mkl.repo'
 apt_repo='https://apt.repos.intel.com/mkl'
-intel_key_url='https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'
+intel_key_url='https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB'
 
 Usage () {
   cat >&2 <<EOF


### PR DESCRIPTION
Update Intel APT key in install_mkl.sh

Old APT key has expired a few weeks ago and the script now does not operate properly on Debian-based OSes.
See the issues related to this apt error ([one](https://community.intel.com/t5/oneAPI-Registration-Download/The-GPG-PUB-KEY-INTEL-SW-PRODUCTS-PUB-expired/m-p/1529230), [two](https://community.intel.com/t5/Intel-Edge-Software-Hub/Suddenly-has-occured-error-with-PUBKEY/m-p/1531342))

The fix is easy: just update the key.