### PR TITLE
Fix LatticeSimpleDecoder

### DIFF
--- a/src/decoder/lattice-simple-decoder.cc
+++ b/src/decoder/lattice-simple-decoder.cc
@@ -571,7 +571,7 @@ void LatticeSimpleDecoder::ProcessNonemitting() {
   }
   if (queue.empty()) {
     if (!warned_) {
-      KALDI_ERR << "Error in ProcessEmitting: no surviving tokens: frame is "
+      KALDI_LOG << "Error in ProcessNonEmitting: no surviving tokens: frame is "
                 << frame;
       warned_ = true;
     }

--- a/src/gmm/mle-diag-gmm.h
+++ b/src/gmm/mle-diag-gmm.h
@@ -93,7 +93,7 @@ struct MapDiagGmmOptions {
   void Register(OptionsItf *opts) {
     opts->Register("mean-tau", &mean_tau,
                    "Tau value for updating means.");
-    opts->Register("variance-tau", &mean_tau,
+    opts->Register("variance-tau", &variance_tau,
                    "Tau value for updating variances (note: only relevant if "
                    "update-flags contains \"v\".");
     opts->Register("weight-tau", &weight_tau,


### PR DESCRIPTION
Closes #4870 

It should not be a fatal error if the start state's number of input epsilons is 0.

For instance, for CTC decoding with an H, there are no epsilon transitions at all.