### PR TITLE
[tools] Replace uses of Python distutils for 3.12 compatibility

### DIFF
--- a/tools/extras/install_cffi.sh
+++ b/tools/extras/install_cffi.sh
@@ -35,7 +35,7 @@ echo "**** Installing Cffi and dependencies"
 
 echo "Checking for Python-Dev"
 # copied from https://stackoverflow.com/questions/4848566/check-for-existence-of-python-dev-files-from-bash-script
-if [ ! -e $(python -c 'from distutils.sysconfig import get_makefile_filename as m; print m()') ]; then
+if [ ! -e $(python -c 'from sysconfig import get_makefile_filename as m; print m()') ]; then
     echo "On Debian/Ubuntu like system install by 'sudo apt-get python-dev' package."
     echo "On Fedora by 'yum install python-devel'"
     echo "On Mac OS X by 'brew install python'"

--- a/tools/extras/install_mmseg.sh
+++ b/tools/extras/install_mmseg.sh
@@ -16,13 +16,13 @@ fi
 
 
 # Install python-devel package if not already available
-# first, makes sure distutils.sysconfig usable
-if ! $(python -c "import distutils.sysconfig" &> /dev/null); then
-    echo "$0: WARNING: python library distutils.sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
+# first, makes sure sysconfig is usable
+if ! $(python -c "import sysconfig" &> /dev/null); then
+    echo "$0: WARNING: python library sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
     echo "Proceeding with installation." >&2
 else
   # get include path for this python version
-  INCLUDE_PY=$(python -c "from distutils import sysconfig as s; print(s.get_python_inc())")
+  INCLUDE_PY=$(python -c "import sysconfig as s; print(s.get_path('include'))")
   if [ ! -f "${INCLUDE_PY}/Python.h" ]; then
       echo "$0 : ERROR: python-devel/python-dev not installed" >&2
       if which yum >&/dev/null; then

--- a/tools/extras/install_phonetisaurus.sh
+++ b/tools/extras/install_phonetisaurus.sh
@@ -15,16 +15,16 @@ fi
   echo "You must call this script from the tools/ directory" && exit 1;
 
 # Install python-devel package if not already available
-# first, makes sure distutils.sysconfig usable
+# first, makes sure sysconfig is usable
 # We are not currently compiling the bindings by default, but it seems
 # worth it to keep this section as we do have them and they will
 # probably be used.
-if ! $(python -c "import distutils.sysconfig" &> /dev/null); then
-    echo "$0: WARNING: python library distutils.sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
+if ! $(python -c "import sysconfig" &> /dev/null); then
+    echo "$0: WARNING: python library sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
     echo "Proceeding with installation." >&2
 else
   # get include path for this python version
-  INCLUDE_PY=$(python -c "from distutils import sysconfig as s; print(s.get_python_inc())")
+  INCLUDE_PY=$(python -c "import sysconfig as s; print(s.get_path('include'))")
   if [ ! -f "${INCLUDE_PY}/Python.h" ]; then
       echo "$0 : ERROR: python-devel/python-dev not installed" >&2
       if which yum >&/dev/null; then

--- a/tools/extras/install_sequitur.sh
+++ b/tools/extras/install_sequitur.sh
@@ -15,13 +15,13 @@ fi
   echo "You must call this script from the tools/ directory" && exit 1;
 
 # Install python-devel package if not already available
-# first, makes sure distutils.sysconfig usable
-if ! $(python -c "import distutils.sysconfig" &> /dev/null); then
-    echo "$0: WARNING: python library distutils.sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
+# first, makes sure sysconfig is usable
+if ! $(python -c "import sysconfig" &> /dev/null); then
+    echo "$0: WARNING: python library sysconfig not usable, this is necessary to figure out the path of Python.h." >&2
     echo "Proceeding with installation." >&2
 else
   # get include path for this python version
-  INCLUDE_PY=$(python -c "from distutils import sysconfig as s; print(s.get_python_inc())")
+  INCLUDE_PY=$(python -c "import sysconfig as s; print(s.get_path('include'))")
   if [ ! -f "${INCLUDE_PY}/Python.h" ]; then
       echo "$0 : ERROR: python-devel/python-dev not installed" >&2
       if which yum >&/dev/null; then


### PR DESCRIPTION
The `distutils` packages has been removed in Python 3.12: https://docs.python.org/3.11/distutils/index.html

The `sysconfig` package is available since Python 3.2 and provides the necessary replacement functionality:
https://docs.python.org/3/library/sysconfig.html

Note, there is one remaining `distutils` usage in https://github.com/kaldi-asr/kaldi/blob/a670447e047331150753fb42cc926a6d4faa2606/egs/aspire/s5/local/multi_condition/check_version.sh#L22 but afaict there is no suitable replacement for this in the standard library.