### PR TITLE
Patch sctk for macOS picky compiler

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -121,6 +121,8 @@ sclite sctk_made: sctk/.compiled
 
 sctk/.compiled: sctk
 	rm -f sctk/.compiled
+	sed -i -e '2s/^/#include <unistd.h>\n/' sctk/src/sclite/align.c
+	sed -i -e '99s/^/int TEXT_set_lang_prof(char *lprof);\n/' sctk/src/sclite/text.h
 	$(SCTK_MKENV) $(MAKE) -C sctk config
 	$(SCTK_MKENV) $(MAKE) -C sctk all doc
 	$(MAKE) -C sctk install


### PR DESCRIPTION
sctk has two minor issues that compilers on recent versions of macOS choke on.

1. It lacks an include to unistd.h to use unlink and getpid
2. it doesn't define the prototype for TEXT_set_lang_prof

This fix patches sctk before it is compiled.
Tested on ubuntu 20.04, ubuntu 22.04, macOS 12, macOS 13 and macOS 14 (using GitHub actions)