### PR TITLE
Fix missing FLT_MAX in some CUDA installation scenarios.

### DIFF
--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -26,6 +26,10 @@
 #include "cuda-decoder-kernels.h"
 #include "cuda-decoder-kernels-utils.h"
 
+#ifndef FLT_MAX
+#define FLT_MAX 340282346638528859811704183484516925440.0f
+#endif
+
 namespace kaldi {
 namespace cuda_decoder {
 


### PR DESCRIPTION
Refers to issue #4914 

This shouldn't affect situations where FLT_MAX is defined and for others it uses the value of FLT_MAX commonly present in 64-bit machines.