### PR TITLE
Support for both OpenFST 1.7.3 and 1.8.2

### DIFF
--- a/src/base/kaldi-error-test.cc
+++ b/src/base/kaldi-error-test.cc
@@ -76,7 +76,7 @@ int main() {
     kaldi::UnitTestError();
     KALDI_ASSERT(0); // should not happen.
     exit(1);
-  } catch (kaldi::KaldiFatalError &e) {
+  } catch (const kaldi::KaldiFatalError &e) {
     std::cout << "The error we generated was: '" << e.KaldiMessage() << "'\n";
   }
 }

--- a/src/base/kaldi-types.h
+++ b/src/base/kaldi-types.h
@@ -39,37 +39,16 @@ typedef float   BaseFloat;
 // we find in the future lacks stdint.h
 #include <stdint.h>
 
-// for discussion on what to do if you need compile kaldi
-// without OpenFST, see the bottom of this this file
-#include <fst/types.h>
+typedef int8_t   int8;
+typedef int16_t  int16;
+typedef int32_t  int32;
+typedef int64_t  int64;
 
-namespace kaldi {
-  using ::int16;
-  using ::int32;
-  using ::int64;
-  using ::uint16;
-  using ::uint32;
-  using ::uint64;
-  typedef float   float32;
-  typedef double double64;
-}  // end namespace kaldi
-
-// In a theoretical case you decide compile Kaldi without the OpenFST
-// comment the previous namespace statement and uncomment the following
-/*
-namespace kaldi {
-  typedef int8_t   int8;
-  typedef int16_t  int16;
-  typedef int32_t  int32;
-  typedef int64_t  int64;
-
-  typedef uint8_t  uint8;
-  typedef uint16_t uint16;
-  typedef uint32_t uint32;
-  typedef uint64_t uint64;
-  typedef float    float32;
-  typedef double   double64;
-}  // end namespace kaldi
-*/
+typedef uint8_t  uint8;
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef uint64_t uint64;
+typedef float    float32;
+typedef double   double64;
 
 #endif  // KALDI_BASE_KALDI_TYPES_H_

--- a/src/base/kaldi-types.h
+++ b/src/base/kaldi-types.h
@@ -39,6 +39,7 @@ typedef float   BaseFloat;
 // we find in the future lacks stdint.h
 #include <stdint.h>
 
+#if OPENFST_VER >= 10800
 typedef int8_t   int8;
 typedef int16_t  int16;
 typedef int32_t  int32;
@@ -50,5 +51,18 @@ typedef uint32_t uint32;
 typedef uint64_t uint64;
 typedef float    float32;
 typedef double   double64;
+#else
+#include <fst/types.h>
+#endif
 
+namespace kaldi {
+  using ::int16;
+  using ::int32;
+  using ::int64;
+  using ::uint16;
+  using ::uint32;
+  using ::uint64;
+  typedef float   float32;
+  typedef double double64;
+}  // end namespace kaldi
 #endif  // KALDI_BASE_KALDI_TYPES_H_

--- a/src/bin/phones-to-prons.cc
+++ b/src/bin/phones-to-prons.cc
@@ -172,7 +172,8 @@ int main(int argc, char *argv[]) {
         if (g_kaldi_verbose_level >= 2) {
           KALDI_LOG << "phn2word FST is below:";
           fst::FstPrinter<StdArc> fstprinter(phn2word, NULL, NULL, NULL, false, true, "\t");
-          fstprinter.Print(&std::cerr, "standard error");
+          printer_print(std::cerr, fstprinter, "standard error");
+          //fstprinter.Print(&std::cerr, "standard error");
           KALDI_LOG << "phone sequence is: ";
           for (size_t i = 0; i < phones.size(); i++)
             std::cerr << phones[i] << ' ';

--- a/src/chain/chain-supervision.cc
+++ b/src/chain/chain-supervision.cc
@@ -571,9 +571,8 @@ void Supervision::Write(std::ostream &os, bool binary) const {
       // Write using StdAcceptorCompactFst, making use of the fact that it's an
       // acceptor.
       fst::FstWriteOptions write_options("<unknown>");
-      fst::StdCompactAcceptorFst::WriteFst(
-          fst, fst::AcceptorCompactor<fst::StdArc>(), os,
-          write_options);
+      fst::StdCompactAcceptorFst cfst(fst);
+      cfst.Write(os, write_options);
     }
   } else {
     KALDI_ASSERT(e2e_fsts.size() == num_sequences);
@@ -586,9 +585,8 @@ void Supervision::Write(std::ostream &os, bool binary) const {
         // Write using StdAcceptorCompactFst, making use of the fact that it's an
         // acceptor.
         fst::FstWriteOptions write_options("<unknown>");
-        fst::StdCompactAcceptorFst::WriteFst(
-            e2e_fsts[i], fst::AcceptorCompactor<fst::StdArc>(), os,
-            write_options);
+        fst::StdCompactAcceptorFst cfst(e2e_fsts[i]);
+        cfst.Write(os, write_options);
       }
     }
     WriteToken(os, binary, "</Fsts>");

--- a/src/configure
+++ b/src/configure
@@ -39,7 +39,7 @@
 
 # This should be incremented after any significant change to the configure
 # script, i.e. any change affecting kaldi.mk or the build system as a whole.
-CONFIGURE_VERSION=14
+CONFIGURE_VERSION=15
 
 # We support bash version 3.2 (Macs still ship with this version as of 2019)
 # and above.
@@ -1024,6 +1024,14 @@ OPENFST_VER_NUM=$(echo $OPENFST_VER | sed 's/\./ /g' | xargs printf "%d%02d%02d"
 if [ $OPENFST_VER_NUM -lt 10600 ]; then
   failure "OpenFst-$OPENFST_VER is not supported. You need OpenFst >= 1.6.0.)"
 fi
+
+if [ $OPENFST_VER_NUM -lt 10800 ]; then
+  echo "CXXLANGVERSION = c++14"
+else
+  echo "CXXLANGVERSION = c++17"
+fi >> kaldi.mk
+
+echo "OPENFSTVER = $OPENFST_VER_NUM" >> kaldi.mk
 echo "OPENFSTINC = $FSTROOT/include" >> kaldi.mk
 if $static_fst ; then
   OPENFSTLIBS="$FSTROOT/lib/libfst.a"

--- a/src/fstext/context-fst-test.cc
+++ b/src/fstext/context-fst-test.cc
@@ -23,6 +23,8 @@
 #include "util/kaldi-io.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst
 {
 using std::vector;
@@ -196,7 +198,7 @@ static void TestContextFst(bool verbose, bool use_matcher) {
       std::cout << "Sequence FST is:\n";
       {  // Try to print the fst.
         FstPrinter<Arc> fstprinter(*f, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
     }
 
@@ -224,7 +226,7 @@ static void TestContextFst(bool verbose, bool use_matcher) {
       std::cout << "Composed FST is:\n";
       {  // Try to print the fst.
         FstPrinter<Arc> fstprinter(fst_composed, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
     }
 

--- a/src/fstext/determinize-lattice-test.cc
+++ b/src/fstext/determinize-lattice-test.cc
@@ -22,6 +22,8 @@
 #include "fstext/fst-test-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst {
 using std::vector;
 using std::cout;
@@ -94,7 +96,7 @@ template<class Arc> void TestDeterminizeLattice() {
     std::cout << "FST before lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> det_fst;
     try {
@@ -106,7 +108,7 @@ template<class Arc> void TestDeterminizeLattice() {
       std::cout << "FST after lattice-determinizing is:\n";
       {
         FstPrinter<Arc> fstprinter(det_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       assert(det_fst.Properties(kIDeterministic, true) & kIDeterministic);
       // OK, now determinize it a different way and check equivalence.
@@ -117,7 +119,7 @@ template<class Arc> void TestDeterminizeLattice() {
       std::cout << "Compact FST is:\n";
       {
         FstPrinter<CompactArc> fstprinter(compact_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       if (kaldi::Rand() % 2 == 1)
         ConvertLattice<Weight, Int>(det_fst, &compact_det_fst, false);
@@ -128,7 +130,7 @@ template<class Arc> void TestDeterminizeLattice() {
       std::cout << "Compact version of determinized FST is:\n";
       {
         FstPrinter<CompactArc> fstprinter(compact_det_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
       assert(RandEquivalent(compact_det_fst, compact_fst, 5/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 100/*path length, max*/));
@@ -149,14 +151,14 @@ template<class Arc> void TestDeterminizeLattice2() {
     std::cout << "FST before lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> ofst;
     DeterminizeLattice<TropicalWeight, int32>(*fst, &ofst);
     std::cout << "FST after lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(ofst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     delete fst;
   }

--- a/src/fstext/determinize-star-test.cc
+++ b/src/fstext/determinize-star-test.cc
@@ -24,6 +24,7 @@
 #include "fstext/trivial-factor-weight.h"
 #include "fstext/fst-test-utils.h"
 
+#include "fstext/openfst_compat.h"
 
 namespace fst
 {
@@ -38,7 +39,7 @@ template<class Arc> void TestDeterminizeGeneral() {
     std::cout << "FST before determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> ofst;
     try {
@@ -46,7 +47,7 @@ template<class Arc> void TestDeterminizeGeneral() {
       std::cout << "FST after determinizing is:\n";
       {
         FstPrinter<Arc> fstprinter(ofst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       assert(RandEquivalent(*fst, ofst, 5/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 100/*path length, max*/));
     } catch (...) {
@@ -101,7 +102,7 @@ template<class Arc>  void TestDeterminize() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -109,7 +110,7 @@ template<class Arc>  void TestDeterminize() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
@@ -122,7 +123,7 @@ template<class Arc>  void TestDeterminize() {
   std::cout <<" printing after predeterminization\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -138,7 +139,7 @@ template<class Arc>  void TestDeterminize() {
   std::cout <<" printing after epsilon removal\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   VectorFst<Arc> ofst_orig;
   VectorFst<Arc> ofst_star;
@@ -157,14 +158,14 @@ template<class Arc>  void TestDeterminize() {
   {
     std::cout <<" printing after determinization [baseline]\n";
     FstPrinter<Arc> fstprinter(ofst_orig, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
     assert(ofst_orig.Properties(kIDeterministic, true) == kIDeterministic);
   }
 
   {
     std::cout <<" printing after determinization [star]\n";
     FstPrinter<Arc> fstprinter(ofst_star, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
     assert(ofst_star.Properties(kIDeterministic, true) == kIDeterministic);
   }
 
@@ -174,7 +175,7 @@ template<class Arc>  void TestDeterminize() {
   std::cout <<" printing after removing "<<num_removed<<" instances of extra symbols\n";
   {
     FstPrinter<Arc> fstprinter(ofst_star, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   std::cout <<" Checking equivalent to original FST.\n";
@@ -242,7 +243,7 @@ template<class Arc>  void TestPush() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -250,7 +251,7 @@ template<class Arc>  void TestPush() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
@@ -267,7 +268,7 @@ template<class Arc>  void TestPush() {
   std::cout <<" printing after pushing\n";
   {
     FstPrinter<Arc> fstprinter(fst_pushed, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   assert(RandEquivalent(*fst, fst_pushed, 5/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 100/*path length-- max?*/));
@@ -320,7 +321,7 @@ template<class Arc>  void TestMinimize() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -328,7 +329,7 @@ template<class Arc>  void TestMinimize() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
@@ -341,7 +342,7 @@ template<class Arc>  void TestMinimize() {
   std::cout <<" printing after predeterminization\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -357,7 +358,7 @@ template<class Arc>  void TestMinimize() {
   std::cout <<" printing after epsilon removal\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   VectorFst<Arc> ofst_orig;
   VectorFst<Arc> ofst_star;
@@ -370,7 +371,7 @@ template<class Arc>  void TestMinimize() {
   {
     std::cout <<" printing after determinization [baseline]\n";
     FstPrinter<Arc> fstprinter(ofst_orig, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -382,7 +383,7 @@ template<class Arc>  void TestMinimize() {
     {
       std::cout <<" printing after determinization by DeterminizeStar [in gallic]\n";
       FstPrinter<GallicArc< Arc> > fstprinter(gallic_fst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
 
@@ -392,7 +393,7 @@ template<class Arc>  void TestMinimize() {
     {
       std::cout <<" printing after pushing weights [in gallic]\n";
       FstPrinter<GallicArc< Arc> > fstprinter(gallic_fst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
 
@@ -401,7 +402,7 @@ template<class Arc>  void TestMinimize() {
     {
       std::cout <<" printing after  minimization [in gallic]\n";
       FstPrinter<GallicArc< Arc> > fstprinter(gallic_fst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
     printf("Converting gallic back to regular [my approach]\n");
@@ -410,7 +411,7 @@ template<class Arc>  void TestMinimize() {
     {
       std::cout <<" printing factor-weight FST\n";
       FstPrinter<GallicArc< Arc> > fstprinter(fwfst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
     Map(fwfst, &ofst_star, FromGallicMapper<Arc, GALLIC_LEFT>());
@@ -418,7 +419,7 @@ template<class Arc>  void TestMinimize() {
     {
       std::cout <<" printing after converting back to regular FST\n";
       FstPrinter<Arc> fstprinter(ofst_star, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
   }
@@ -431,7 +432,7 @@ template<class Arc>  void TestMinimize() {
   std::cout <<" printing after removing "<<num_removed<<" instances of extra symbols\n";
   {
     FstPrinter<Arc> fstprinter(ofst_star, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   std::cout <<" Checking equivalent to original FST.\n";

--- a/src/fstext/factor-test.cc
+++ b/src/fstext/factor-test.cc
@@ -23,6 +23,7 @@
 #include "fstext/fst-test-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
 
 namespace fst
 {
@@ -79,7 +80,7 @@ template<class Arc> static void TestFactor() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(&fst);
@@ -87,7 +88,7 @@ template<class Arc> static void TestFactor() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   if (fst.Start() == kNoStateId) return;  // "Connect" made it empty.

--- a/src/fstext/fstext-lib.h
+++ b/src/fstext/fstext-lib.h
@@ -20,6 +20,9 @@
 #ifndef KALDI_FSTEXT_FSTEXT_LIB_H_
 #define KALDI_FSTEXT_FSTEXT_LIB_H_
 #include "fst/fstlib.h"
+
+#include "fstext/openfst_compat.h"
+
 #include "fstext/context-fst.h"
 #include "fstext/determinize-star.h"
 #include "fstext/factor.h"

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -374,12 +374,12 @@ void GetSymbols(const SymbolTable &symtab,
                 std::vector<I> *syms_out) {
   KALDI_ASSERT(syms_out != NULL);
   syms_out->clear();
-  for (SymbolTableIterator iter(symtab);
-      !iter.Done();
-      iter.Next()) {
-    if (include_eps || iter.Value() != 0) {
-      syms_out->push_back(iter.Value());
-      KALDI_ASSERT(syms_out->back() == iter.Value());  // an integer-range thing.
+  for (SymbolTable::iterator iter = symtab.begin();
+      iter != symtab.end();
+      ++iter) {
+    if (include_eps || iter->Label() != 0) {
+      syms_out->push_back(iter->Label());
+      KALDI_ASSERT(syms_out->back() == iter->Label());  // an integer-range thing.
     }
   }
 }

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -374,6 +374,7 @@ void GetSymbols(const SymbolTable &symtab,
                 std::vector<I> *syms_out) {
   KALDI_ASSERT(syms_out != NULL);
   syms_out->clear();
+#if OPENFST_VER >= 10800
   for (SymbolTable::iterator iter = symtab.begin();
       iter != symtab.end();
       ++iter) {
@@ -382,6 +383,16 @@ void GetSymbols(const SymbolTable &symtab,
       KALDI_ASSERT(syms_out->back() == iter->Label());  // an integer-range thing.
     }
   }
+#else
+  for (SymbolTableIterator iter(symtab);
+      !iter.Done();
+      iter.Next()) {
+    if (include_eps || iter.Value() != 0) {
+      syms_out->push_back(iter.Value());
+      KALDI_ASSERT(syms_out->back() == iter.Value());  // an integer-range thing.
+    }
+  }
+#endif
 }
 
 template<class Arc>

--- a/src/fstext/fstext-utils-inl.h
+++ b/src/fstext/fstext-utils-inl.h
@@ -163,7 +163,7 @@ void RemoveSomeInputSymbols(const std::vector<I> &to_remove,
                             MutableFst<Arc> *fst) {
   KALDI_ASSERT_IS_INTEGER_TYPE(I);
   RemoveSomeInputSymbolsMapper<Arc, I> mapper(to_remove);
-  Map(fst, mapper);
+  ArcMap(fst, mapper);
 }
 
 template<class Arc, class I>

--- a/src/fstext/fstext-utils-test.cc
+++ b/src/fstext/fstext-utils-test.cc
@@ -23,6 +23,8 @@
 #include "util/stl-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst
 {
 using std::vector;
@@ -140,7 +142,7 @@ template<class Arc>  void TestSafeDeterminizeWrapper() {  // also tests SafeDete
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -148,7 +150,7 @@ template<class Arc>  void TestSafeDeterminizeWrapper() {  // also tests SafeDete
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
@@ -362,7 +364,7 @@ void TestEqualAlign() {
 template<class Arc> void Print(const Fst<Arc> &fst, std::string message) {
   std::cout << message << "\n";
   FstPrinter<Arc> fstprinter(fst, NULL, NULL, NULL, false, true, "\t");
-  fstprinter.Print(&std::cout, "standard output");
+  printer_print(std::cout, fstprinter, "standard output");
 }
 
 

--- a/src/fstext/fstext-utils.h
+++ b/src/fstext/fstext-utils.h
@@ -113,7 +113,7 @@ void PushInLog(VectorFst<StdArc> *fst, uint32 ptype, float delta = kDelta) {
 template<class Arc>
 void MinimizeEncoded(VectorFst<Arc> *fst, float delta = kDelta) {
 
-  Map(fst, QuantizeMapper<Arc>(delta));
+  ArcMap(fst, QuantizeMapper<Arc>(delta));
   EncodeMapper<Arc> encoder(kEncodeLabels | kEncodeWeights, ENCODE);
   Encode(fst, &encoder);
   internal::AcceptorMinimize(fst);

--- a/src/fstext/kaldi-fst-io-inl.h
+++ b/src/fstext/kaldi-fst-io-inl.h
@@ -44,7 +44,7 @@ void WriteFstKaldi(std::ostream &os, bool binary,
     bool acceptor = false, write_one = false;
     FstPrinter<Arc> printer(t, t.InputSymbols(), t.OutputSymbols(),
                             NULL, acceptor, write_one, "\t");
-    printer.Print(&os, "<unknown>");
+    printer.Print(os, "<unknown>");
     if (os.fail())
       KALDI_ERR << "Stream failure detected writing FST to stream";
     // Write another newline as a terminating character.  The read routine will

--- a/src/fstext/kaldi-fst-io-inl.h
+++ b/src/fstext/kaldi-fst-io-inl.h
@@ -24,6 +24,8 @@
 
 #include "util/text-utils.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst {
 
 
@@ -44,7 +46,8 @@ void WriteFstKaldi(std::ostream &os, bool binary,
     bool acceptor = false, write_one = false;
     FstPrinter<Arc> printer(t, t.InputSymbols(), t.OutputSymbols(),
                             NULL, acceptor, write_one, "\t");
-    printer.Print(os, "<unknown>");
+    //printer.Print(&os, "<unknown>");
+    printer_print(os, printer, "<unknown>");
     if (os.fail())
       KALDI_ERR << "Stream failure detected writing FST to stream";
     // Write another newline as a terminating character.  The read routine will

--- a/src/fstext/kaldi-fst-io-inl.h
+++ b/src/fstext/kaldi-fst-io-inl.h
@@ -99,7 +99,7 @@ void ReadFstKaldi(std::istream &is, bool binary,
     fst->DeleteStates();
     string line;
     size_t nline = 0;
-    string separator = FLAGS_fst_field_separator + "\r\n";
+    string separator = FST_FLAGS_fst_field_separator + "\r\n";
     while (std::getline(is, line)) {
       nline++;
       vector<string> col;

--- a/src/fstext/kaldi-fst-io.h
+++ b/src/fstext/kaldi-fst-io.h
@@ -26,6 +26,7 @@
 #include <fst/fst-decl.h>
 #include <fst/script/print-impl.h>
 #include "base/kaldi-common.h"
+#include "fstext/openfst_compat.h"
 
 // Some functions for writing Fsts.
 // I/O for FSTs is a bit of a mess, and not very well integrated with Kaldi's

--- a/src/fstext/lattice-utils-inl.h
+++ b/src/fstext/lattice-utils-inl.h
@@ -270,7 +270,7 @@ void ConvertFstToLattice(
   fst::CacheOptions cache_opts(true, num_states_cache);
   fst::ArcMapFstOptions mapfst_opts(cache_opts);
   StdToLatticeMapper<Real> mapper;
-  MapFst<StdArc, ArcTpl<LatticeWeightTpl<Real> >,
+  ArcMapFst<StdArc, ArcTpl<LatticeWeightTpl<Real> >,
          StdToLatticeMapper<Real> > map_fst(ifst, mapper, mapfst_opts);
   *ofst = map_fst;
 }

--- a/src/fstext/lattice-utils-inl.h
+++ b/src/fstext/lattice-utils-inl.h
@@ -268,7 +268,7 @@ void ConvertFstToLattice(
     MutableFst<ArcTpl<LatticeWeightTpl<Real> > > *ofst) {
   int32 num_states_cache = 50000;
   fst::CacheOptions cache_opts(true, num_states_cache);
-  fst::MapFstOptions mapfst_opts(cache_opts);
+  fst::ArcMapFstOptions mapfst_opts(cache_opts);
   StdToLatticeMapper<Real> mapper;
   MapFst<StdArc, ArcTpl<LatticeWeightTpl<Real> >,
          StdToLatticeMapper<Real> > map_fst(ifst, mapper, mapfst_opts);

--- a/src/fstext/lattice-utils-test.cc
+++ b/src/fstext/lattice-utils-test.cc
@@ -21,6 +21,8 @@
 #include "fstext/fst-test-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst {
 
 template<class Weight, class Int> void TestConvert(bool invert) {
@@ -31,7 +33,7 @@ template<class Weight, class Int> void TestConvert(bool invert) {
     std::cout << "FST before converting to compact-arc is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<CompactArc> ofst;
     ConvertLattice<Weight, Int>(*fst, &ofst, invert);
@@ -39,14 +41,14 @@ template<class Weight, class Int> void TestConvert(bool invert) {
     std::cout << "FST after converting is:\n";
     {
       FstPrinter<CompactArc> fstprinter(ofst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> origfst;
     ConvertLattice<Weight, Int>(ofst, &origfst, invert);
     std::cout << "FST after back conversion is:\n";
     {
       FstPrinter<Arc> fstprinter(origfst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
     assert(RandEquivalent(*fst, origfst, 5/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 100/*path length-- max?*/));
@@ -67,7 +69,7 @@ template<class Weight, class Int> void TestShortestPath() {
       std::cout << "FST before converting to compact-arc is:\n";
       {
         FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       VectorFst<CompactArc> cfst;
       ConvertLattice<Weight, Int>(*fst, &cfst, false); // invert == false
@@ -205,7 +207,7 @@ template<class Weight, class Int> void TestConvertPair(bool invert) {
     /*std::cout << "FST before converting to compact-arc is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
     VectorFst<CompactArc> ofst;
     ConvertLattice<Weight, Int>(*fst, &ofst, invert);
@@ -213,14 +215,14 @@ template<class Weight, class Int> void TestConvertPair(bool invert) {
     /*std::cout << "FST after converting is:\n";
     {
       FstPrinter<CompactArc> fstprinter(ofst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
     VectorFst<Arc> origfst;
     ConvertLattice<Weight, Int>(ofst, &origfst, invert);
     /*std::cout << "FST after back conversion is:\n";
     {
       FstPrinter<Arc> fstprinter(origfst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
 
     assert(RandEquivalent(*fst, origfst, 5/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 100/*path length-- max?*/));
@@ -260,7 +262,7 @@ template<class Weight, class Int> void TestScalePair(bool invert) {
     /*std::cout << "FST before converting to compact-arc is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
     VectorFst<CompactArc> ofst;
     ConvertLattice<Weight, Int>(*fst, &ofst, invert);
@@ -268,7 +270,7 @@ template<class Weight, class Int> void TestScalePair(bool invert) {
     /*std::cout << "FST after converting and scaling is:\n";
     {
       FstPrinter<CompactArc> fstprinter(ofst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
     VectorFst<Arc> origfst;
     ConvertLattice<Weight, Int>(ofst, &origfst, invert);
@@ -276,7 +278,7 @@ template<class Weight, class Int> void TestScalePair(bool invert) {
     /*std::cout << "FST after back conversion and scaling is:\n";
     {
       FstPrinter<Arc> fstprinter(origfst, NULL, NULL, NULL, false, true);
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
       }*/
     // If RandEquivalent doesn't work, it could be due to a nasty issue related to the use
     // of exact floating-point comparisons in the Plus function of LatticeWeight.

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -396,8 +396,8 @@ inline bool ApproxEqual(const LatticeWeightTpl<FloatType> &w1,
 template <class FloatType>
 inline std::ostream &operator <<(std::ostream &strm, const LatticeWeightTpl<FloatType> &w) {
   LatticeWeightTpl<FloatType>::WriteFloatType(strm, w.Value1());
-  CHECK(FLAGS_fst_weight_separator.size() == 1);
-  strm << FLAGS_fst_weight_separator[0]; // comma by default;
+  CHECK(FST_FLAGS_fst_weight_separator.size() == 1);
+  strm << FST_FLAGS_fst_weight_separator[0]; // comma by default;
   // may or may not be settable from Kaldi programs.
   LatticeWeightTpl<FloatType>::WriteFloatType(strm, w.Value2());
   return strm;
@@ -405,9 +405,9 @@ inline std::ostream &operator <<(std::ostream &strm, const LatticeWeightTpl<Floa
 
 template <class FloatType>
 inline std::istream &operator >>(std::istream &strm, LatticeWeightTpl<FloatType> &w1) {
-  CHECK(FLAGS_fst_weight_separator.size() == 1);
+  CHECK(FST_FLAGS_fst_weight_separator.size() == 1);
   // separator defaults to ','
-  return w1.ReadNoParen(strm, FLAGS_fst_weight_separator[0]);
+  return w1.ReadNoParen(strm, FST_FLAGS_fst_weight_separator[0]);
 }
 
 
@@ -726,8 +726,8 @@ inline CompactLatticeWeightTpl<WeightType, IntType> Divide(const CompactLatticeW
 template <class WeightType, class IntType>
 inline std::ostream &operator <<(std::ostream &strm, const CompactLatticeWeightTpl<WeightType, IntType> &w) {
   strm << w.Weight();
-  CHECK(FLAGS_fst_weight_separator.size() == 1);
-  strm << FLAGS_fst_weight_separator[0]; // comma by default.
+  CHECK(FST_FLAGS_fst_weight_separator.size() == 1);
+  strm << FST_FLAGS_fst_weight_separator[0]; // comma by default.
   for(size_t i = 0; i < w.String().size(); i++) {
     strm << w.String()[i];
     if (i+1 < w.String().size())
@@ -743,8 +743,8 @@ inline std::istream &operator >>(std::istream &strm, CompactLatticeWeightTpl<Wei
   if (strm.fail()) {
     return strm;
   }
-  CHECK(FLAGS_fst_weight_separator.size() == 1);
-  size_t pos = s.find_last_of(FLAGS_fst_weight_separator); // normally ","
+  CHECK(FST_FLAGS_fst_weight_separator.size() == 1);
+  size_t pos = s.find_last_of(FST_FLAGS_fst_weight_separator); // normally ","
   if (pos == std::string::npos) {
     strm.clear(std::ios::badbit);
     return strm;

--- a/src/fstext/lattice-weight.h
+++ b/src/fstext/lattice-weight.h
@@ -23,6 +23,7 @@
 
 #include "fst/fstlib.h"
 #include "base/kaldi-common.h"
+#include "fstext/openfst_compat.h"
 
 namespace fst {
 

--- a/src/fstext/openfst_compat.h
+++ b/src/fstext/openfst_compat.h
@@ -1,0 +1,42 @@
+#ifndef KALDI_FSTEXT_OPENFST_COMPAT_H
+#define KALDI_FSTEXT_OPENFST_COMPAT_H
+
+
+#if OPENFST_VER < 10800
+#define FST_FLAGS_fst_weight_separator FLAGS_fst_weight_separator
+#define FST_FLAGS_fst_field_separator FLAGS_fst_field_separator
+#define FST_FLAGS_v FLAGS_v
+
+#endif
+
+namespace fst {
+#if OPENFST_VER >= 10800
+
+
+template <typename... Args>
+auto Map(Args&&... args) -> decltype(ArcMap(std::forward<Args>(args)...)) {
+  return ArcMap(std::forward<Args>(args)...);
+}
+
+using MapFstOptions=ArcMapFstOptions;
+
+template <class A, class B, class C>
+using MapFst = ArcMapFst<A, B, C>;
+
+template<typename Printer, typename Stream>
+void printer_print(Stream &os, Printer &printer, const std::string &s) {
+  printer.Print(os, s);
+}
+
+#else
+
+template<typename Printer, typename Stream>
+void printer_print(Stream &os, Printer &printer, const std::string &s) {
+  printer.Print(&os, s);
+}
+
+#endif
+
+}  // namespace fst
+
+#endif  //KALDI_FSTEXT_OPENFST_COMPAT_H

--- a/src/fstext/pre-determinize-inl.h
+++ b/src/fstext/pre-determinize-inl.h
@@ -235,8 +235,8 @@ inline bool HasBannedPrefixPlusDigits(SymbolTable *symTable, std::string prefix,
   assert(symTable != NULL);
   const char *prefix_ptr = prefix.c_str();
   size_t prefix_len = strlen(prefix_ptr);  // allowed to be zero but not encouraged.
-  for (SymbolTableIterator siter(*symTable); !siter.Done(); siter.Next()) {
-    const std::string &sym = siter.Symbol();
+  for (SymbolTable::iterator siter = symTable->begin(); siter != symTable->end(); ++siter) {
+    const std::string &sym = siter->Symbol();
     if (!strncmp(prefix_ptr, sym.c_str(), prefix_len)) {  // has prefix.
       if (isdigit(sym[prefix_len])) {  // we don't allow prefix followed by a digit, as a symbol.
         // Has at least one digit.

--- a/src/fstext/pre-determinize-inl.h
+++ b/src/fstext/pre-determinize-inl.h
@@ -235,8 +235,13 @@ inline bool HasBannedPrefixPlusDigits(SymbolTable *symTable, std::string prefix,
   assert(symTable != NULL);
   const char *prefix_ptr = prefix.c_str();
   size_t prefix_len = strlen(prefix_ptr);  // allowed to be zero but not encouraged.
+#if OPENFST_VER >= 10800
   for (SymbolTable::iterator siter = symTable->begin(); siter != symTable->end(); ++siter) {
     const std::string &sym = siter->Symbol();
+#else
+  for (SymbolTableIterator siter(*symTable); !siter.Done(); siter.Next()) {
+    const std::string &sym = siter.Symbol();
+#endif
     if (!strncmp(prefix_ptr, sym.c_str(), prefix_len)) {  // has prefix.
       if (isdigit(sym[prefix_len])) {  // we don't allow prefix followed by a digit, as a symbol.
         // Has at least one digit.

--- a/src/fstext/pre-determinize-test.cc
+++ b/src/fstext/pre-determinize-test.cc
@@ -22,8 +22,7 @@
 #include "fstext/fst-test-utils.h"
 #include "fstext/fstext-utils.h"
 
-// Just check that it compiles, for now.
-
+#include "fstext/openfst_compat.h"
 namespace fst
 {
   using std::vector;
@@ -73,7 +72,7 @@ template<class Arc>  void TestPreDeterminize() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -81,7 +80,7 @@ template<class Arc>  void TestPreDeterminize() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> *fst_copy_orig = new VectorFst<Arc>(*fst);
@@ -95,7 +94,7 @@ template<class Arc>  void TestPreDeterminize() {
   std::cout <<" printing after predeterminization\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -111,7 +110,7 @@ template<class Arc>  void TestPreDeterminize() {
   std::cout <<" printing after epsilon removal\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -121,14 +120,14 @@ template<class Arc>  void TestPreDeterminize() {
   std::cout <<" printing after determinization\n";
   {
     FstPrinter<Arc> fstprinter(ofst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   int64 num_removed = DeleteISymbols(&ofst, extra_syms);
   std::cout <<" printing after removing "<<num_removed<<" instances of extra symbols\n";
   {
     FstPrinter<Arc> fstprinter(ofst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   std::cout <<" Checking equivalent to original FST.\n";
@@ -180,7 +179,7 @@ template<class Arc>  void TestAddSelfLoops() {
   std::cout <<" printing before adding self-loops\n";
   {
     FstPrinter<Arc> fstprinter(*fst, ilabels, olabels, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -199,7 +198,7 @@ template<class Arc>  void TestAddSelfLoops() {
   std::cout <<" printing after adding self-loops\n";
   {
     FstPrinter<Arc> fstprinter(*fst, ilabels, olabels, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   delete fst;

--- a/src/fstext/prune-special-test.cc
+++ b/src/fstext/prune-special-test.cc
@@ -22,6 +22,8 @@
 #include "fstext/rand-fst.h"
 #include "fstext/fstext-utils.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst {
 
 static void TestPruneSpecial() {
@@ -38,7 +40,7 @@ static void TestPruneSpecial() {
 
   {
     FstPrinter<Arc> fstprinter(*ifst, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
     std::cout << std::endl;
   }
 
@@ -47,7 +49,7 @@ static void TestPruneSpecial() {
   PruneSpecial<StdArc>(*ifst, &ofst1, beam);
   {
     FstPrinter<Arc> fstprinter(ofst1, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
     std::cout << std::endl;
   }
 
@@ -56,7 +58,7 @@ static void TestPruneSpecial() {
   Prune(*ifst, &ofst2, beam);
   {
     FstPrinter<Arc> fstprinter(ofst2, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
     std::cout << std::endl;
   }
 

--- a/src/fstext/push-special-test.cc
+++ b/src/fstext/push-special-test.cc
@@ -23,6 +23,8 @@
 #include "fstext/fstext-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst
 {
 
@@ -38,7 +40,7 @@ static void TestPushSpecial() {
 
   {
     FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> fst_copy(*fst);
@@ -56,7 +58,7 @@ static void TestPushSpecial() {
 
   {
     FstPrinter<Arc> fstprinter(fst_copy, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   KALDI_LOG << "Min value is " << min.Value() << ", max value is " << max.Value();
 

--- a/src/fstext/remove-eps-local-test.cc
+++ b/src/fstext/remove-eps-local-test.cc
@@ -23,6 +23,7 @@
 #include "fstext/fst-test-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
 
 namespace fst
 {
@@ -83,7 +84,7 @@ template<class Arc> static void TestRemoveEpsLocal() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<Arc> fst_copy1(fst);
@@ -96,7 +97,7 @@ template<class Arc> static void TestRemoveEpsLocal() {
   {
     std::cout << "copy1 = \n";
     FstPrinter<Arc> fstprinter(fst_copy1, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -141,7 +142,7 @@ static void TestRemoveEpsLocalSpecial() {
   {
     std::cout << "logfst = \n";
     FstPrinter<LogArc> fstprinter(*logfst, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   VectorFst<StdArc> fst;
@@ -156,7 +157,7 @@ static void TestRemoveEpsLocalSpecial() {
   {
     std::cout << "logfst2 = \n";
     FstPrinter<LogArc> fstprinter(logfst2, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   if (ApproxEqual(ShortestDistance(*logfst), ShortestDistance(logfst2))) {
     // make sure we preserved stochasticity in cases where doing so was

--- a/src/fstext/table-matcher-test.cc
+++ b/src/fstext/table-matcher-test.cc
@@ -21,6 +21,8 @@
 #include "fstext/fst-test-utils.h"
 #include "base/kaldi-math.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst{
 
 
@@ -64,13 +66,13 @@ template<class Arc>  void TestTableMatcher(bool connect, bool left) {
   std::cout <<"Table-Composed FST\n";
   {
     FstPrinter<Arc> fstprinter(composed, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   std::cout <<" Baseline-Composed FST\n";
   {
     FstPrinter<Arc> fstprinter(composed_baseline, NULL, NULL, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   if ( !RandEquivalent(composed, composed_baseline, 3/*paths*/, 0.01/*delta*/, kaldi::Rand()/*seed*/, 20/*path length-- max?*/)) {
@@ -79,7 +81,7 @@ template<class Arc>  void TestTableMatcher(bool connect, bool left) {
     std::cout <<" Diff1 (composed - baseline) \n";
     {
       FstPrinter<Arc> fstprinter(diff1, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
 
@@ -88,7 +90,7 @@ template<class Arc>  void TestTableMatcher(bool connect, bool left) {
     std::cout <<" Diff2 (baseline - composed) \n";
     {
       FstPrinter<Arc> fstprinter(diff2, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
     assert(0);
@@ -149,7 +151,7 @@ template<class Arc>  void TestTableMatcherCacheLeft(bool connect) {
       std::cout <<" Diff1 (composed - baseline) \n";
       {
         FstPrinter<Arc> fstprinter(diff1, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
 
@@ -158,7 +160,7 @@ template<class Arc>  void TestTableMatcherCacheLeft(bool connect) {
       std::cout <<" Diff2 (baseline - composed) \n";
       {
         FstPrinter<Arc> fstprinter(diff2, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
       assert(0);
@@ -219,7 +221,7 @@ template<class Arc>  void TestTableMatcherCacheRight(bool connect) {
       std::cout <<" Diff1 (composed - baseline) \n";
       {
         FstPrinter<Arc> fstprinter(diff1, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
 
@@ -228,7 +230,7 @@ template<class Arc>  void TestTableMatcherCacheRight(bool connect) {
       std::cout <<" Diff2 (baseline - composed) \n";
       {
         FstPrinter<Arc> fstprinter(diff2, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
       assert(0);

--- a/src/fstext/table-matcher.h
+++ b/src/fstext/table-matcher.h
@@ -22,7 +22,7 @@
 #include <fst/fstlib.h>
 #include <fst/fst-decl.h>
 
-
+#include "base/kaldi-types.h"
 
 namespace fst {
 

--- a/src/fstext/trivial-factor-weight-test.cc
+++ b/src/fstext/trivial-factor-weight-test.cc
@@ -22,7 +22,8 @@
 #include "fstext/determinize-star.h"
 #include "fstext/trivial-factor-weight.h"
 #include "fstext/fst-test-utils.h"
-// Just check that it compiles, for now.
+
+#include "fstext/openfst_compat.h"
 
 namespace fst
 {
@@ -73,7 +74,7 @@ template<class Arc>  void TestFactor() {
   std::cout <<" printing before trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   // Trim resulting FST.
   Connect(fst);
@@ -81,7 +82,7 @@ template<class Arc>  void TestFactor() {
   std::cout <<" printing after trimming\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
   vector<Label> extra_syms;
@@ -92,7 +93,7 @@ template<class Arc>  void TestFactor() {
   std::cout <<" printing after predeterminization\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
 
 
@@ -108,7 +109,7 @@ template<class Arc>  void TestFactor() {
   std::cout <<" printing after double-epsilon removal\n";
   {
     FstPrinter<Arc> fstprinter(*fst, sptr, sptr, NULL, false, true, "\t");
-    fstprinter.Print(&std::cout, "standard output");
+    printer_print(std::cout, fstprinter, "standard output");
   }
   VectorFst<Arc> ofst_star;
 
@@ -127,7 +128,7 @@ template<class Arc>  void TestFactor() {
     {
       std::cout <<" printing gallic FST\n";
       FstPrinter<GallicArc<Arc> >  fstprinter(gallic_fst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
 
@@ -139,7 +140,7 @@ template<class Arc>  void TestFactor() {
     {
       std::cout <<" printing factor-weight FST\n";
       FstPrinter<GallicArc<Arc> >  fstprinter(fwfst, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
     Map(fwfst, &ofst_star, FromGallicMapper<Arc, GALLIC_LEFT>());
@@ -147,7 +148,7 @@ template<class Arc>  void TestFactor() {
     {
       std::cout <<" printing after converting back to regular FST\n";
       FstPrinter<Arc> fstprinter(ofst_star, sptr, sptr, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
 
 

--- a/src/fstext/trivial-factor-weight.h
+++ b/src/fstext/trivial-factor-weight.h
@@ -390,7 +390,11 @@ class ArcIterator< TrivialFactorWeightFst<A, F> >
 template <class A, class F>
 inline void TrivialFactorWeightFst<A, F>::InitStateIterator(
     StateIteratorData<A> *data) const {
+#if OPENFST_VER >= 10803
+  data->base.reset(new StateIterator< TrivialFactorWeightFst<A, F> >(*this));
+#else
   data->base = new StateIterator< TrivialFactorWeightFst<A, F> >(*this);
+#endif
 }
 
 

--- a/src/kws/kws-functions.cc
+++ b/src/kws/kws-functions.cc
@@ -175,7 +175,7 @@ bool CreateFactorTransducer(const CompactLattice &clat,
 
   // Now we map the CompactLattice to VectorFst<KwsProductArc>. We drop the
   // alignment information and only keep the negated log-probs
-  Map(clat, factor_transducer, CompactLatticeToKwsProductFstMapper());
+  ArcMap(clat, factor_transducer, CompactLatticeToKwsProductFstMapper());
 
   // Now do the weight pushing manually on the CompactLattice format. Note that
   // the alphas and betas in Kaldi are stored as the log-probs, not the negated
@@ -366,7 +366,7 @@ void MaybeDoSanityCheck(const KwsProductFst &product_transducer) {
   if (GetVerboseLevel() < 2) return;
   KwsLexicographicFst index_transducer;
 
-  Map(product_transducer,
+  ArcMap(product_transducer,
       &index_transducer,
       KwsProductFstToKwsLexicographicFstMapper());
 

--- a/src/kws/kws-functions.cc
+++ b/src/kws/kws-functions.cc
@@ -75,7 +75,7 @@ bool ClusterLattice(CompactLattice *clat,
   unordered_map<StateId, std::vector<Interval> >::iterator iter;
   for (iter = head.begin(); iter != head.end(); ++iter) {
     // For this ilabel, sort all the arcs on time, from first to last.
-    sort(iter->second.begin(), iter->second.end(), CompareInterval);
+    std::sort(iter->second.begin(), iter->second.end(), CompareInterval);
     std::vector<Interval> tmp;
     tmp.push_back(iter->second[0]);
     for (int32 i = 1; i < iter->second.size(); i++) {

--- a/src/kws/kws-functions2.cc
+++ b/src/kws/kws-functions2.cc
@@ -92,7 +92,7 @@ void DoFactorMerging(KwsProductFst *factor_transducer,
 
   Decode(&dest_transducer, encoder);
 
-  Map(dest_transducer, index_transducer, KwsProductFstToKwsLexicographicFstMapper());
+  ArcMap(dest_transducer, index_transducer, KwsProductFstToKwsLexicographicFstMapper());
 }
 
 void DoFactorDisambiguation(KwsLexicographicFst *index_transducer) {

--- a/src/kwsbin/kws-search.cc
+++ b/src/kwsbin/kws-search.cc
@@ -25,6 +25,8 @@
 #include "fstext/kaldi-fst-io.h"
 #include "kws/kaldi-kws.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace kaldi {
 
 typedef KwsLexicographicArc Arc;

--- a/src/lat/arctic-weight.h
+++ b/src/lat/arctic-weight.h
@@ -50,7 +50,7 @@ class ArcticWeightTpl : public FloatWeightTpl<T> {
 
   static const std::string &Type() {
     static const std::string type = std::string("arctic") +
-        FloatWeightTpl<T>::GetPrecisionString();
+        std::string(FloatWeightTpl<T>::GetPrecisionString());
     return type;
   }
 

--- a/src/lat/determinize-lattice-pruned-test.cc
+++ b/src/lat/determinize-lattice-pruned-test.cc
@@ -24,6 +24,8 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace fst {
 // Caution: these tests are not as generic as you might think from all the
 // templates in the code.  They are basically only valid for LatticeArc.
@@ -63,7 +65,7 @@ template<class Arc> void TestDeterminizeLatticePruned() {
     std::cout << "FST before lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> det_fst;
     try {
@@ -76,7 +78,7 @@ template<class Arc> void TestDeterminizeLatticePruned() {
       std::cout << "FST after lattice-determinizing is:\n";
       {
         FstPrinter<Arc> fstprinter(det_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       KALDI_ASSERT(det_fst.Properties(kIDeterministic, true) & kIDeterministic);
       // OK, now determinize it a different way and check equivalence.
@@ -93,14 +95,14 @@ template<class Arc> void TestDeterminizeLatticePruned() {
       std::cout << "Compact pruned FST is:\n";
       {
         FstPrinter<CompactArc> fstprinter(compact_pruned_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
       ConvertLattice<Weight, Int>(det_fst, &compact_pruned_det_fst, false);
 
       std::cout << "Compact version of determinized FST is:\n";
       {
         FstPrinter<CompactArc> fstprinter(compact_pruned_det_fst, NULL, NULL, NULL, false, true, "\t");
-        fstprinter.Print(&std::cout, "standard output");
+        printer_print(std::cout, fstprinter, "standard output");
       }
 
       if (ans)
@@ -123,14 +125,14 @@ template<class Arc> void TestDeterminizeLatticePruned2() {
     std::cout << "FST before lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(*fst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     VectorFst<Arc> ofst;
     DeterminizeLatticePruned<Weight>(*fst, 10.0, &ofst);
     std::cout << "FST after lattice-determinizing is:\n";
     {
       FstPrinter<Arc> fstprinter(ofst, NULL, NULL, NULL, false, true, "\t");
-      fstprinter.Print(&std::cout, "standard output");
+      printer_print(std::cout, fstprinter, "standard output");
     }
     delete fst;
   }

--- a/src/lat/determinize-lattice-pruned.cc
+++ b/src/lat/determinize-lattice-pruned.cc
@@ -1499,7 +1499,7 @@ bool DeterminizeLatticePhonePrunedWrapper(
   }
   ILabelCompare<kaldi::LatticeArc> ilabel_comp;
   ArcSort(ifst, ilabel_comp);
-  ans = DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
+  ans = DeterminizeLatticePhonePruned<kaldi::LatticeWeight, int32>(
       trans_model, ifst, beam, ofst, opts);
   Connect(ofst);
   return ans;
@@ -1523,7 +1523,7 @@ bool DeterminizeLatticePruned<kaldi::LatticeWeight>(
     DeterminizeLatticePrunedOptions opts);
 
 template
-bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
+bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, int32>(
     const kaldi::TransitionInformation &trans_model,
     const ExpandedFst<kaldi::LatticeArc> &ifst,
     double prune,
@@ -1531,7 +1531,7 @@ bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
     DeterminizeLatticePhonePrunedOptions opts);
 
 template
-bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, kaldi::int32>(
+bool DeterminizeLatticePhonePruned<kaldi::LatticeWeight, int32>(
     const kaldi::TransitionInformation &trans_model,
     MutableFst<kaldi::LatticeArc> *ifst,
     double prune,

--- a/src/lat/kaldi-lattice.cc
+++ b/src/lat/kaldi-lattice.cc
@@ -78,7 +78,7 @@ bool WriteCompactLattice(std::ostream &os, bool binary,
     fst::FstPrinter<CompactLatticeArc> printer(t, t.InputSymbols(),
                                                t.OutputSymbols(),
                                                NULL, acceptor, write_one, "\t");
-    printer.Print(&os, "<unknown>");
+    printer.Print(os, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will
@@ -403,7 +403,7 @@ bool WriteLattice(std::ostream &os, bool binary, const Lattice &t) {
     fst::FstPrinter<LatticeArc> printer(t, t.InputSymbols(),
                                         t.OutputSymbols(),
                                         NULL, acceptor, write_one, "\t");
-    printer.Print(&os, "<unknown>");
+    printer.Print(os, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will

--- a/src/lat/kaldi-lattice.cc
+++ b/src/lat/kaldi-lattice.cc
@@ -22,7 +22,10 @@
 #include "lat/kaldi-lattice.h"
 #include "fst/script/print-impl.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace kaldi {
+
 
 /// Converts lattice types if necessary, deleting its input.
 template<class OrigWeightType>
@@ -78,7 +81,8 @@ bool WriteCompactLattice(std::ostream &os, bool binary,
     fst::FstPrinter<CompactLatticeArc> printer(t, t.InputSymbols(),
                                                t.OutputSymbols(),
                                                NULL, acceptor, write_one, "\t");
-    printer.Print(os, "<unknown>");
+    //printer.Print(&os, "<unknown>");
+    printer_print(os, printer, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will
@@ -403,7 +407,8 @@ bool WriteLattice(std::ostream &os, bool binary, const Lattice &t) {
     fst::FstPrinter<LatticeArc> printer(t, t.InputSymbols(),
                                         t.OutputSymbols(),
                                         NULL, acceptor, write_one, "\t");
-    printer.Print(os, "<unknown>");
+    //printer.Print(&os, "<unknown>");
+    printer_print(os, printer, "<unknown>");
     if (os.fail())
       KALDI_WARN << "Stream failure detected.";
     // Write another newline as a terminating character.  The read routine will

--- a/src/lat/kaldi-lattice.cc
+++ b/src/lat/kaldi-lattice.cc
@@ -114,7 +114,7 @@ class LatticeReader {
     CompactLattice *cfst = new CompactLattice();
     string line;
     size_t nline = 0;
-    string separator = FLAGS_fst_field_separator + "\r\n";
+    string separator = FST_FLAGS_fst_field_separator + "\r\n";
     while (std::getline(is, line)) {
       nline++;
       vector<string> col;

--- a/src/lat/lattice-functions-transition-model.cc
+++ b/src/lat/lattice-functions-transition-model.cc
@@ -248,13 +248,13 @@ bool TestWordAlignedLattice(const WordAlignLatticeLexiconInfo &lexicon_info,
   int32 num_paths = 5, seed = Rand(), max_path_length = -1;
   BaseFloat delta = 0.2; // some lattices have large costs -> use large delta.
 
-  FLAGS_v = GetVerboseLevel(); // set the OpenFst verbose level to the Kaldi
+  FST_FLAGS_v = GetVerboseLevel(); // set the OpenFst verbose level to the Kaldi
                                // verbose level.
   if (!RandEquivalent(clat, aligned_clat, num_paths, delta, seed, max_path_length)) {
     KALDI_WARN << "Equivalence test failed during lattice alignment.";
     return false;
   }
-  FLAGS_v = 0;
+  FST_FLAGS_v = 0;
 
   return (num_err == 0);
 }

--- a/src/lat/minimize-lattice.cc
+++ b/src/lat/minimize-lattice.cc
@@ -279,7 +279,7 @@ bool MinimizeCompactLattice(
 
 // Instantiate for CompactLattice type.
 template
-bool MinimizeCompactLattice<kaldi::LatticeWeight, kaldi::int32>(
+bool MinimizeCompactLattice<kaldi::LatticeWeight, int32>(
     MutableFst<kaldi::CompactLatticeArc> *clat, float delta);
   
 

--- a/src/lat/push-lattice-test.cc
+++ b/src/lat/push-lattice-test.cc
@@ -22,6 +22,8 @@
 #include "lat/push-lattice.h"
 #include "fstext/rand-fst.h"
 
+#include "fstext/openfst_compat.h"
+
 
 namespace kaldi {
 using namespace fst;
@@ -92,12 +94,12 @@ void TestPushCompactLatticeWeights() {
       {
         fst::FstPrinter<CompactLatticeArc> printer(clat2, NULL, NULL,
                                                    NULL, true, true, "\t");
-        printer.Print(&std::cerr, "<unknown>");
+        printer_print(std::cerr, printer, "<unknown>");
       }
       {
         fst::FstPrinter<CompactLatticeArc> printer(*clat, NULL, NULL,
                                                    NULL, true, true, "\t");
-        printer.Print(&std::cerr, "<unknown>");
+        printer_print(std::cerr, printer, "<unknown>");
       }
       KALDI_ERR << "Bad lattice being pushed.";
     }

--- a/src/lat/push-lattice.cc
+++ b/src/lat/push-lattice.cc
@@ -280,11 +280,11 @@ bool PushCompactLatticeWeights(
 
 // Instantiate for CompactLattice.
 template
-bool PushCompactLatticeStrings<kaldi::LatticeWeight, kaldi::int32>(
+bool PushCompactLatticeStrings<kaldi::LatticeWeight, int32>(
    MutableFst<kaldi::CompactLatticeArc> *clat);
 
 template
-bool PushCompactLatticeWeights<kaldi::LatticeWeight, kaldi::int32>(
+bool PushCompactLatticeWeights<kaldi::LatticeWeight, int32>(
    MutableFst<kaldi::CompactLatticeArc> *clat);
 
 }  // namespace fst

--- a/src/lat/sausages.cc
+++ b/src/lat/sausages.cc
@@ -325,7 +325,7 @@ void MinimumBayesRisk::PrepareLatticeAndInitStats(CompactLattice *clat) {
   // paper (i.e. just one final state).
 
   // Topologically sort the lattice, if not already sorted.
-  kaldi::uint64 props = clat->Properties(fst::kFstProperties, false);
+  uint64 props = clat->Properties(fst::kFstProperties, false);
   if (!(props & fst::kTopSorted)) {
     if (fst::TopSort(clat) == false)
       KALDI_ERR << "Cycles detected in lattice.";

--- a/src/latbin/lattice-oracle.cc
+++ b/src/latbin/lattice-oracle.cc
@@ -25,6 +25,8 @@
 #include "lat/kaldi-lattice.h"
 #include "lat/lattice-functions.h"
 
+#include "fstext/openfst_compat.h"
+
 namespace kaldi {
 
  using std::string;

--- a/src/makefiles/android_openblas.mk
+++ b/src/makefiles/android_openblas.mk
@@ -25,9 +25,10 @@ $(error Android build does not support compiling with $(CXX).
         Supported compilers: clang++)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self -Wno-mismatched-tags \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_CXXABI_H -DHAVE_OPENBLAS -DANDROID_BUILD \
            -I$(OPENBLASINC) -I$(ANDROIDINC) -ftree-vectorize -mfloat-abi=softfp \

--- a/src/makefiles/cygwin.mk
+++ b/src/makefiles/cygwin.mk
@@ -10,9 +10,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -U__STRICT_ANSI__ -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -U__STRICT_ANSI__ -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_CLAPACK -I../../tools/CLAPACK/ \
            -msse -msse2 -O -Wa,-mbig-obj \

--- a/src/makefiles/darwin.mk
+++ b/src/makefiles/darwin.mk
@@ -10,9 +10,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK \
            -msse -msse2 -pthread \

--- a/src/makefiles/darwin_arm64.mk
+++ b/src/makefiles/darwin_arm64.mk
@@ -10,9 +10,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK \
            -pthread \

--- a/src/makefiles/darwin_clapack.mk
+++ b/src/makefiles/darwin_clapack.mk
@@ -17,9 +17,10 @@ CLAPACKLIBS = $(CLAPACKROOT)/CLAPACK-3.2.1/lapack.a $(CLAPACKROOT)/CLAPACK-3.2.1
 	      $(CLAPACKROOT)/CBLAS/lib/cblas.a \
 	      $(CLAPACKROOT)/f2c_BLAS-3.8.0/blas.a $(CLAPACKROOT)/libf2c/libf2c.a
 
-CXXFLAGS = -std=c++14 -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -I$(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK -I../../tools/CLAPACK \
            -msse -msse2 \

--- a/src/makefiles/linux_atlas.mk
+++ b/src/makefiles/linux_atlas.mk
@@ -19,9 +19,10 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_ATLAS -I$(ATLASINC) \
            -msse -msse2 -pthread \

--- a/src/makefiles/linux_atlas_arm.mk
+++ b/src/makefiles/linux_atlas_arm.mk
@@ -16,9 +16,10 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_ATLAS -I$(ATLASINC) \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \

--- a/src/makefiles/linux_atlas_ppc64le.mk
+++ b/src/makefiles/linux_atlas_ppc64le.mk
@@ -19,9 +19,10 @@ ifndef ATLASLIBS
 $(error ATLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_ATLAS -I$(ATLASINC) \
            -m64 -maltivec -mcpu=power8 -mtune=power8 -mpower8-vector -mvsx \

--- a/src/makefiles/linux_clapack.mk
+++ b/src/makefiles/linux_clapack.mk
@@ -17,9 +17,10 @@ CLAPACKLIBS = $(CLAPACKROOT)/CLAPACK-3.2.1/lapack.a $(CLAPACKROOT)/CLAPACK-3.2.1
 	      $(CLAPACKROOT)/CBLAS/lib/cblas.a \
 	      $(CLAPACKROOT)/f2c_BLAS-3.8.0/blas.a $(CLAPACKROOT)/libf2c/libf2c.a
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK -I../../tools/CLAPACK \
            -msse -msse2 \

--- a/src/makefiles/linux_clapack_arm.mk
+++ b/src/makefiles/linux_clapack_arm.mk
@@ -13,9 +13,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_CLAPACK -I../../tools/CLAPACK \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -19,9 +19,10 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -I$(OPENBLASINC) \
            -msse -msse2 -pthread \

--- a/src/makefiles/linux_openblas_aarch64.mk
+++ b/src/makefiles/linux_openblas_aarch64.mk
@@ -19,9 +19,10 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -I$(OPENBLASINC) \
            -ftree-vectorize -pthread \

--- a/src/makefiles/linux_openblas_arm.mk
+++ b/src/makefiles/linux_openblas_arm.mk
@@ -19,9 +19,10 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -I$(OPENBLASINC) \
            -ftree-vectorize -mfloat-abi=hard -mfpu=neon -pthread \

--- a/src/makefiles/linux_openblas_ppc64le.mk
+++ b/src/makefiles/linux_openblas_ppc64le.mk
@@ -19,9 +19,10 @@ ifndef OPENBLASLIBS
 $(error OPENBLASLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 $(EXTRA_CXXFLAGS) \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -I$(OPENBLASINC) \
            -m64 -maltivec -mcpu=power8 -mtune=power8 -mpower8-vector -mvsx \

--- a/src/makefiles/linux_x86_64_mkl.mk
+++ b/src/makefiles/linux_x86_64_mkl.mk
@@ -17,9 +17,10 @@ ifndef OPENFSTLIBS
 $(error OPENFSTLIBS not defined.)
 endif
 
-CXXFLAGS = -std=c++14 -I.. -isystem $(OPENFSTINC) -O1 \
+CXXFLAGS = -std=$(CXXLANGVERSION) -I.. -isystem $(OPENFSTINC) -O1 \
            -Wall -Wno-sign-compare -Wno-unused-local-typedefs \
            -Wno-deprecated-declarations -Winit-self \
+           -DOPENFST_VER=$(OPENFSTVER) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_MKL $(MKL_CXXFLAGS) \
            -m64 -msse -msse2 -pthread -g

--- a/src/nnet3/nnet-batch-compute.cc
+++ b/src/nnet3/nnet-batch-compute.cc
@@ -1503,7 +1503,7 @@ NnetBatchDecoder::~NnetBatchDecoder() {
   }
   // Print diagnostics.
 
-  kaldi::int64 input_frame_count =
+  int64 input_frame_count =
       frame_count_ * computer_->GetOptions().frame_subsampling_factor;
   int32 num_threads = static_cast<int32>(decode_threads_.size());
 

--- a/src/online/online-tcp-source.cc
+++ b/src/online/online-tcp-source.cc
@@ -24,7 +24,7 @@
 
 namespace kaldi {
 
-typedef kaldi::int32 int32;
+typedef int32 int32;
 
 OnlineTcpVectorSource::OnlineTcpVectorSource(int32 socket)
     : socket_desc(socket),

--- a/src/rnnlm/rnnlm-test-utils.cc
+++ b/src/rnnlm/rnnlm-test-utils.cc
@@ -78,7 +78,7 @@ void ConvertToInteger(
   for (int i = 0; i < string_sentences.size(); i++) {
     (*int_sentences)[i].resize(string_sentences[i].size());
     for (int j = 0; j < string_sentences[i].size(); j++) {
-      kaldi::int64 key = symbol_table.Find(string_sentences[i][j]);
+      int64 key = symbol_table.Find(string_sentences[i][j]);
       KALDI_ASSERT(key != -1); // fst::kNoSymbol
       (*int_sentences)[i][j] = static_cast<int32>(key);
     }

--- a/src/tree/tree-renderer.cc
+++ b/src/tree/tree-renderer.cc
@@ -67,7 +67,7 @@ TreeRenderer::MakeEdgeLabel(const EventKeyType &key,
       oss << ", ";
     if (key != kPdfClass) {
       std::string phone =
-          phone_syms_.Find(static_cast<kaldi::int64>(*child));
+          phone_syms_.Find(static_cast<int64>(*child));
       if (phone.empty())
         KALDI_ERR << "No phone found for Phone ID " << *child;
       oss << phone;
@@ -137,7 +137,7 @@ void TreeRenderer::RenderTable(const EventType *query, int32 id) {
         ExpectToken(is_, binary_, "NULL"); // consume the invalid/NULL entry
         continue;
       }
-      std::string phone = phone_syms_.Find(static_cast<kaldi::int64>(t));
+      std::string phone = phone_syms_.Find(static_cast<int64>(t));
       if (phone.empty())
           KALDI_ERR << "Phone ID found in a TableEventMap, but not in the "
                     << "phone symbol table! ID: " << t;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,7 +7,7 @@ CC ?= gcc        # used for sph2pipe
 
 WGET ?= wget
 
-OPENFST_VERSION ?= 1.7.2
+OPENFST_VERSION ?= 1.8.3
 CUB_VERSION ?= 1.8.0
 # No '?=', since there exists only one version of sph2pipe.
 SPH2PIPE_VERSION = 2.5


### PR DESCRIPTION
I added a thin compatibility layer (and a few ifdefs)
By default the build infrastructure uses OpenFST-1.7.2 and there should be no change compared to current pipelines.
It is however switch the openFst version while making `/tools` like so:
```
make clean && make -j 18 OPENFST_VERSION=1.8.3
```
and after that the version should be picked up by  `configure` (also to be re-run) and flags will be appropriately defined. Will be grateful for reviews/testing --so far I tested only on Apple M3

For 1.8.3, not all tests will compile. There are two outstanding tests failing to compile with this error:
```
In file included from trivial-factor-weight-test.cc:23:
../fstext/trivial-factor-weight.h:393:14: error: no viable overloaded '='
  data->base = new StateIterator< TrivialFactorWeightFst<A, F> >(*this);
  ~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
trivial-factor-weight-test.cc:139:46: note: in instantiation of member function 'fst::TrivialFactorWeightFst<fst::GallicArc<fst::ArcTpl<fst::TropicalWeightTpl<float>>>, fst::GallicFactor<int, fst::TropicalWeightTpl<float>>>::InitStateIterator' requested here
        typename Arc::Weight, GALLIC_LEFT> > fwfst(gallic_fst);
                                             ^
trivial-factor-weight-test.cc:213:10: note: in instantiation of function template specialization 'fst::TestFactor<fst::ArcTpl<fst::TropicalWeightTpl<float>>>' requested here
    fst::TestFactor<fst::StdArc>();
         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:233:71: note: candidate function not viable: no known conversion from 'StateIterator<TrivialFactorWeightFst<GallicArc<ArcTpl<TropicalWeightTpl<float>, int, int>, fst::GALLIC_LEFT>, GallicFactor<int, TropicalWeightTpl<float>, fst::GALLIC_LEFT>>> *' to 'unique_ptr<StateIteratorBase<GallicArc<ArcTpl<TropicalWeightTpl<float>>>>>' for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
                                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:243:71: note: candidate template ignored: could not match 'unique_ptr<_Up, _Ep>' against 'StateIterator<TrivialFactorWeightFst<GallicArc<ArcTpl<TropicalWeightTpl<float>, int, int>, fst::GALLIC_LEFT>, GallicFactor<int, TropicalWeightTpl<float>, fst::GALLIC_LEFT>>> *'
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
                                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:268:71: note: candidate function not viable: no known conversion from 'StateIterator<TrivialFactorWeightFst<GallicArc<ArcTpl<TropicalWeightTpl<float>, int, int>, fst::GALLIC_LEFT>, GallicFactor<int, TropicalWeightTpl<float>, fst::GALLIC_LEFT>>> *' to 'nullptr_t' (aka 'std::nullptr_t') for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(nullptr_t) _NOEXCEPT {
                                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:127:59: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'StateIterator<TrivialFactorWeightFst<GallicArc<ArcTpl<TropicalWeightTpl<float>, int, int>, fst::GALLIC_LEFT>, GallicFactor<int, TropicalWeightTpl<float>, fst::GALLIC_LEFT>>> *' to 'const std::unique_ptr<fst::StateIteratorBase<fst::GallicArc<fst::ArcTpl<fst::TropicalWeightTpl<float>>>>>' for 1st argument
class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS unique_ptr {
                                                          ^
1 error generated.
make[1]: *** [trivial-factor-weight-test.o] Error 1

```
if anyone can help me figure out the issue, I will be grateful

cc: @georgthegreat  @mmcauliffe 