### PR TITLE
fix: update fstproject flag syntax

### DIFF
--- a/egs/wsj/s5/utils/lang/make_unk_lm.sh
+++ b/egs/wsj/s5/utils/lang/make_unk_lm.sh
@@ -304,7 +304,7 @@ fstcompile $sym_opts <$dir/unk_fst_orig.txt >$dir/unk_orig.fst
 # a lot of final-states that have no transitions out of them.
 fstproject $dir/unk_orig.fst | \
   fstcompose - $dir/constraint.fst | \
-  fstproject --project_output=true | \
+  fstproject --project_type=output | \
   fstpushspecial | \
   fstminimizeencoded | \
   fstrmsymbols --remove-from-output=true <(echo $phone_disambig_int) >$dir/unk.fst


### PR DESCRIPTION
```bash
root@2bd4628ac8ba:/opt/kaldi/egs/wsj/s5/utils/lang# /opt/kaldi/tools/openfst-1.8.3/bin/fstproject --help
Projects a transduction onto its input or output language.

  Usage: /opt/kaldi/tools/openfst-1.8.3/bin/fstproject [in.fst [out.fst]]

PROGRAM FLAGS:

  --project_type: type = std::string, default = "input"
  Side to project from, one of: "input", "output"
  ```
  
  https://www.openfst.org/doxygen/fst/html/fstproject_8cc.html
  
  I think there is a deprecated flag being used.
  
  It seems that in some places it is up to date(on master it should be 139):
  
<img width="346" alt="image" src="https://github.com/user-attachments/assets/2aef1bc5-5b77-4924-8755-f76598e8b069">


But there are 2300 with old syntax:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/04422f66-3c8b-4638-b360-a6a6cfb230f4">
