### PR TITLE
kaldi-cuda-fixes and target platform parameterization

### DIFF
--- a/src/cudadecoder/cuda-decoder-kernels.cu
+++ b/src/cudadecoder/cuda-decoder-kernels.cu
@@ -26,6 +26,10 @@
 #include "cuda-decoder-kernels.h"
 #include "cuda-decoder-kernels-utils.h"
 
+#ifndef FLT_MAX
+#define FLT_MAX 340282346638528859811704183484516925440.0f
+#endif
+
 namespace kaldi {
 namespace cuda_decoder {
 

--- a/tools/extras/install_openblas.sh
+++ b/tools/extras/install_openblas.sh
@@ -32,7 +32,7 @@ fi
 tar xzf $tarball
 mv OpenMathLib-OpenBLAS-* OpenBLAS
 
-make PREFIX=$(pwd)/OpenBLAS/install USE_LOCKING=1 USE_THREAD=0 -C OpenBLAS all install
+make TARGET=$TARGET PREFIX=$(pwd)/OpenBLAS/install USE_LOCKING=1 USE_THREAD=0 -C OpenBLAS all install 
 if [ $? -eq 0 ]; then
    echo "OpenBLAS is installed successfully."
    rm $tarball


### PR DESCRIPTION
### What

- `FLT_MAX` for CUDA build;
- OpenBLAS CPU target platform;