### PR TITLE
Change build path to be user-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ then build the package as follows:
 
 ```
 cmake -S ./ -Bbuild/Release -DFETCHCONTENT_FULLY_DISCONNECTED=ON -DBuildForFedora=ON
-cmake --build /home/gerhard/workspace/kaldi/build/Release
+cmake --build ./build/Release
 ```
 
 


### PR DESCRIPTION
Updated the CMake build path to use a relative directory instead of a specific user's home directory.