### PR TITLE
Remove `-lcblas` and `-llapack` from `gen_cmake_skeleton.py`

### DIFF
--- a/cmake/gen_cmake_skeleton.py
+++ b/cmake/gen_cmake_skeleton.py
@@ -269,7 +269,7 @@ class CMakeListsLibrary(object):
 
         if len(self.depends) > 0:
             ret.append("target_link_libraries(" + self.target_name + " PUBLIC")
-            for d in self.depends + ['-lcblas', '-llapack']:
+            for d in self.depends:
                 ret.append("    " + d)
             ret.append(")\n")
 


### PR DESCRIPTION
They are already specified for all targets via `target_link_libraries()` in main `CMakeLists.txt`. The current setup is especially problematic on systems where cblas is part of blas and therefore has to be linked via `-lblas`. The logic in the main `CMakeLists.txt` file should already handle this correctly.