### PR TITLE
[ROCm] Fix the HIP GPU build for ROCm 7 and a wave64 LSTM bug

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -19,6 +19,8 @@
 #                             # version of kaldi even on CUDA-enabled machine.
 # ./configure --use-cuda=yes --cudatk-dir=/usr/local/cuda/ --cuda-arch=-arch=sm_70
 #        # Use cuda in /usr/local/cuda and set the arch to sm_70
+# ./configure --use-rocm --rocm-dir=/opt/rocm --rocm-targets=gfx90a,gfx1100
+#        # Build the GPU code with ROCm/HIP for AMD GPUs (here gfx90a and gfx1100).
 # ./configure --static --fst-root=/opt/cross/armv8hf \
 #   --atlas-root=/opt/cross/armv8hf --host=armv8-rpi3-linux-gnueabihf
 #        # Cross-compile for armv8hf. This assumes that you have OpenFST built
@@ -282,11 +284,14 @@ function configure_rocm {
 
   echo "CUDA_ARCH = " >> kaldi.mk
   echo "ROCM_ARCH_FLAGS = " >> kaldi.mk
+  ROCM_WARP_SIZE=32
   for i in ${ROCM_TARGETS//,/ } ; do
     echo "Targetting ROCm arch $i"
     echo "ROCM_ARCH_FLAGS += --offload-arch=$i" >> kaldi.mk
+    case "$i" in gfx9*) ROCM_WARP_SIZE=64 ;; esac
   done
-  
+  echo "ROCM_WARP_SIZE = $ROCM_WARP_SIZE" >> kaldi.mk
+
   echo "HOST_ARCH = `uname -m`" >> kaldi.mk
   echo >> kaldi.mk
   

--- a/src/cudafeat/feature-online-batched-ivector-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-ivector-cuda-kernels.cu
@@ -51,7 +51,8 @@ void square_batched_matrix(int32_t chunk_frames, int32_t num_cols,
                            const float *feats, int32_t ldf, int32_t stridef,
                            float *feats_sq, int32_t lds, int32_t strides,
                            const LaneDesc *lanes, int32_t num_lanes) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   dim3 blocks((num_cols + threads.x - 1) / threads.x,
               (chunk_frames + threads.y - 1) / threads.y, num_lanes);
 
@@ -102,10 +103,11 @@ void zero_invalid_posteriors(int32_t num_chunk_frames, int32_t num_gauss,
                              float *posteriors, int32_t ldp, int32_t stridep,
                              int32_t right, const LaneDesc *lanes,
                              int32_t num_lanes) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
-  dim3 blocks((num_gauss + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-              (num_chunk_frames + GPU_MAX_WARPS_PER_BLOCK - 1) /
-                  GPU_MAX_WARPS_PER_BLOCK,
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
+  dim3 blocks((num_gauss + warp - 1) / warp,
+              (num_chunk_frames + warps_per_block - 1) /
+                  warps_per_block,
               num_lanes);
 
   zero_invalid_posteriors_kernel<<<blocks, threads>>>(
@@ -219,8 +221,9 @@ void splice_features_batched(int32_t num_chunk_frames, int32_t feat_dim,
                              int32_t stridest, float *spliced_feats,
                              int32_t lds, int32_t strides,
                              const LaneDesc *lanes, int32_t num_lanes) {
-  int threads = (feat_dim + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE *
-                GPU_MAX_WARPS_PER_BLOCK;  // round up to the nearest warp size
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  int threads = (feat_dim + warp - 1) / warp *
+                warps_per_block;  // round up to the nearest warp size
   if (threads > GPU_MAX_THREADS_PER_BLOCK)
     threads = GPU_MAX_THREADS_PER_BLOCK;  // Max block size is
                                           // GPU_MAX_THREADS_PER_BLOCK threads
@@ -318,10 +321,11 @@ void stash_feats(int32_t chunk_size, const float *feats, int32_t feat_dim,
     // First we need to shift feats to handle the case where num_chunk_frames
     // is less than stash size
 
-    KALDI_ASSERT(stash_size <= GPU_WARP_SIZE);
-    // This only works if stash size is <= GPU_WARP_SIZE as we rely on
+    KALDI_WARP_GEOMETRY(warp, warps_per_block);
+    KALDI_ASSERT(stash_size <= warp);
+    // This only works if stash size is <= the warp width as we rely on
     // __syncthreads() to avoid read/write hazards when reading/writing in-place
-    dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+    dim3 threads(warp, warps_per_block);
     dim3 blocks(num_lanes);
 
     shift_feats_kernel<<<blocks, threads>>>(chunk_size, feats, feat_dim, ldf,
@@ -330,8 +334,9 @@ void stash_feats(int32_t chunk_size, const float *feats, int32_t feat_dim,
   }
 
   {
-    int threads = (feat_dim + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE *
-                  GPU_MAX_WARPS_PER_BLOCK;  // round up to the nearest warp size
+    KALDI_WARP_GEOMETRY(warp, warps_per_block);
+    int threads = (feat_dim + warp - 1) / warp *
+                  warps_per_block;  // round up to the nearest warp size
     if (threads > GPU_MAX_THREADS_PER_BLOCK)
       threads = GPU_MAX_THREADS_PER_BLOCK;  // Max block size is
                                             // GPU_MAX_THREADS_PER_BLOCK threads
@@ -516,9 +521,10 @@ __global__ void batched_convert_sp_to_dense_kernel(int32_t n, float *A_sp,
 void batched_convert_sp_to_dense(int n, float *A_sp, int32_t strides, float *A,
                                  int32_t lda, int32_t stridea,
                                  const LaneDesc *lanes, int32_t num_lanes) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   int block =
-      (n + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE;  // blocks in x and y dimensions
+      (n + warp - 1) / warp;  // blocks in x and y dimensions
   dim3 blocks(block, block, num_lanes);
 
   batched_convert_sp_to_dense_kernel<<<blocks, threads>>>(
@@ -594,7 +600,8 @@ void initialize_channels(int32_t num_gauss, int32_t feat_dim, float *gamma,
                          int32_t strideg, float *X, int32_t ldx,
                          int32_t stridex, const LaneDesc *lanes,
                          int32_t num_lanes) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   int32_t blocks = num_lanes;
 
   initialize_channels_kernel<<<blocks, threads>>>(
@@ -639,7 +646,8 @@ void apply_and_update_stash(int32_t num_gauss, int32_t feat_dim, float *gamma,
                             int32_t ldx, int32_t stridex, float *X_stash,
                             int32_t lds, int32_t strides, const LaneDesc *lanes,
                             int32_t num_lanes) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   int32_t blocks = num_lanes;
 
   apply_and_update_stash_kernel<<<blocks, threads>>>(

--- a/src/cudafeat/feature-online-batched-ivector-cuda.cc
+++ b/src/cudafeat/feature-online-batched-ivector-cuda.cc
@@ -26,6 +26,13 @@
 #undef CUDA_R_32F
 #endif
 #define CUDA_R_32F HIPBLAS_R_32F
+// hipBLAS v2 GemmStridedBatchedEx takes a dedicated hipblasComputeType_t for
+// the compute precision (the operand types remain CUDA_R_32F == HIP_R_32F
+// above). NVIDIA still accepts a cudaDataType compute type, so keep CUDA_R_32F
+// there.
+#define KALDI_GEMMEX_COMPUTE_32F HIPBLAS_COMPUTE_32F
+#else
+#define KALDI_GEMMEX_COMPUTE_32F CUDA_R_32F
 #endif
 
 #include "cudafeat/feature-online-batched-ivector-cuda.h"
@@ -335,7 +342,8 @@ void BatchedIvectorExtractorCuda::ComputeIvectorStats(
   CUBLAS_SAFE_CALL(cublasGemmStridedBatchedEx(
       GetCublasHandle(), CUBLAS_OP_N, CUBLAS_OP_T, m, n, k, &alpha, A,
       CUDA_R_32F, lda, strideA, B, CUDA_R_32F, ldb, strideB, &beta, C,
-      CUDA_R_32F, ldc, strideC, num_lanes, CUDA_R_32F, CUBLAS_GEMM_DEFAULT))
+      CUDA_R_32F, ldc, strideC, num_lanes, KALDI_GEMMEX_COMPUTE_32F,
+      CUBLAS_GEMM_DEFAULT))
 #endif
 
   apply_and_update_stash(

--- a/src/cudafeat/feature-online-batched-spectral-cuda-kernels.cu
+++ b/src/cudafeat/feature-online-batched-spectral-cuda-kernels.cu
@@ -489,7 +489,7 @@ void cuda_mel_banks_compute(const LaneDesc *lanes, int32_t num_lanes,
                             float energy_floor, int32 *offsets, int32 *sizes,
                             float **vecs, const float *feats, int32_t ldf,
                             float *mels, int32_t ldm, bool use_log) {
-  dim3 Bl(GPU_WARP_SIZE, 8);
+  dim3 Bl(KALDI_WARP_WIDTH(), 8);
   dim3 Gr(num_bins, (max_chunk_frames + Bl.y - 1) / Bl.y, num_lanes);
   batched_mel_banks_compute_kernel<<<Gr, Bl>>>(
       lanes, num_lanes, max_chunk_frames, energy_floor, offsets, sizes, vecs,

--- a/src/cudafeat/feature-online-cmvn-cuda.cu
+++ b/src/cudafeat/feature-online-cmvn-cuda.cu
@@ -16,10 +16,13 @@
 // limitations under the License.
 
 #ifdef __IS_HIP_COMPILE__
-#define __CUDA_ARCH__ 800
 #include <hipcub/hipcub.hpp>
 
 #include "hipify.h"
+// Define __CUDA_ARCH__ after rocPRIM/hipCUB headers: defining it earlier suppresses
+// the compiler's __gfx90a__ macro in the device pass, breaking rocprim/config.hpp arch
+// detection on ROCm 7.2.1 (its "128-bit atomics not implemented" #error).
+#define __CUDA_ARCH__ 800
 #else
 #include <cub/cub.cuh>
 #endif
@@ -190,8 +193,9 @@ void CudaOnlineCmvn::ComputeFeatures(const CuMatrixBase<BaseFloat> &feats_in,
       stats.Stride());
   CU_SAFE_CALL(cudaGetLastError());
 
-  threads = (feat_dim + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE *
-            GPU_MAX_WARPS_PER_BLOCK;  // round up to GPU_WARP_SIZE threads
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  threads = (feat_dim + warp - 1) / warp *
+            warps_per_block;  // round up to warp threads
   if (threads > GPU_MAX_THREADS_PER_BLOCK) threads = GPU_MAX_THREADS_PER_BLOCK;
 
   const CuMatrix<float> &gstats = cmvn_state_.global_cmvn_stats;

--- a/src/cudafeat/feature-spectral-cuda.cu
+++ b/src/cudafeat/feature-spectral-cuda.cu
@@ -495,7 +495,7 @@ void CudaSpectralFeatures::ComputeFinalFeatures(int num_frames, BaseFloat vtln_w
   // mel banks
   int num_bins = bin_size_;
   cu_mel_energies_.Resize(num_frames, num_bins, kUndefined);
-  dim3 mel_threads(GPU_WARP_SIZE, 8);
+  dim3 mel_threads(KALDI_WARP_WIDTH(), 8);
   dim3 mel_blocks(num_bins, (num_frames + mel_threads.y - 1) / mel_threads.y);
   mel_banks_compute_kernel<<<mel_blocks, mel_threads>>>(
       num_frames, std::numeric_limits<float>::epsilon(), offsets_, sizes_,

--- a/src/cudafeat/online-ivector-feature-cuda-kernels.cu
+++ b/src/cudafeat/online-ivector-feature-cuda-kernels.cu
@@ -215,8 +215,9 @@ __global__ void update_linear_and_quadratic_terms_kernel(
 void batched_gemv_reduce(int batch_size, int rows, int cols, int A_stride,
                          const float* AT, int B_stride, const float* B,
                          float* C) {
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
   batched_gemv_reduce_kernel<<<batch_size,
-                               dim3(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK)>>>(
+                               dim3(warp, warps_per_block)>>>(
       rows, cols, AT, A_stride, B, B_stride, C);
   CU_SAFE_CALL(cudaGetLastError());
 }
@@ -224,8 +225,9 @@ void batched_gemv_reduce(int batch_size, int rows, int cols, int A_stride,
 void splice_features(int32_t num_frames, int32_t feat_dim, int32_t left,
                      int32_t size, const float* feats, int32_t ldf,
                      float* sfeats, int32_t lds) {
-  int threads = (feat_dim + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE *
-                GPU_MAX_WARPS_PER_BLOCK;  // round up to the nearest warp size
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  int threads = (feat_dim + warp - 1) / warp *
+                warps_per_block;  // round up to the nearest warp size
   if (threads > GPU_MAX_THREADS_PER_BLOCK)
     threads = GPU_MAX_THREADS_PER_BLOCK;  // Max block size is
                                           // GPU_MAX_THREADS_PER_BLOCK threads
@@ -250,7 +252,8 @@ void update_linear_and_quadratic_terms(int32_t n, float old_num_frames,
 void get_matrix_sum_double_buffer(int32_t b, int32_t num_rows, int32_t num_cols,
                                   float* A, int32_t lda, float scale,
                                   float* sum) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   dim3 blocks((num_cols + threads.x - 1) / threads.x,
               (num_rows + threads.y - 1) / threads.y);
 
@@ -261,7 +264,8 @@ void get_matrix_sum_double_buffer(int32_t b, int32_t num_rows, int32_t num_cols,
 
 void square_matrix(int32_t num_rows, int32_t num_cols, const float* feats,
                    int32_t ldf, float* feats_sq, int32_t lds) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   dim3 blocks((num_cols + threads.x - 1) / threads.x,
               (num_rows + threads.y - 1) / threads.y);
 

--- a/src/cudamatrix/cu-common.h
+++ b/src/cudamatrix/cu-common.h
@@ -2,6 +2,7 @@
 
 // Copyright 2009-2011  Karel Vesely
 //                      Johns Hopkins University (author: Daniel Povey)
+//                2026  Advanced Micro Devices, Inc. (author: Jeff Daily)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -125,6 +126,35 @@ public:
 inline int32 n_blocks(int32 size, int32 block_size) {
   return size / block_size + ((size % block_size == 0)? 0 : 1);
 }
+
+#ifdef __IS_HIP_COMPILE__
+// Warp/wavefront size of the active device, queried at runtime. On ROCm this is
+// per-device (64 on CDNA gfx9xx, 32 on RDNA gfx10xx/gfx11xx). In a multi-arch
+// fat binary, host-side launch geometry must be sized from this so the block
+// dimensions match the device-pass GPU_WARP_SIZE of whichever slice runs; a
+// compile-time constant bakes one wavefront width and mismatches the other.
+inline int KaldiHipWarpSize() {
+  int device = 0;
+  if (hipGetDevice(&device) != hipSuccess) return GPU_WARP_SIZE;
+  int warp_size = GPU_WARP_SIZE;
+  if (hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, device)
+      != hipSuccess)
+    return GPU_WARP_SIZE;
+  return warp_size;
+}
+// Declare the warp width and warps-per-block (WARP * WARPS_PER_BLOCK threads)
+// for a host launch, runtime on ROCm and compile-time on CUDA.
+#define KALDI_WARP_GEOMETRY(WARP, WARPS_PER_BLOCK)      \
+  const int WARP = ::kaldi::KaldiHipWarpSize();         \
+  const int WARPS_PER_BLOCK = GPU_MAX_THREADS_PER_BLOCK / WARP
+// Warp width alone for a host launch (block height is fixed independently).
+#define KALDI_WARP_WIDTH() (::kaldi::KaldiHipWarpSize())
+#else
+#define KALDI_WARP_GEOMETRY(WARP, WARPS_PER_BLOCK)      \
+  const int WARP = GPU_WARP_SIZE;                       \
+  const int WARPS_PER_BLOCK = GPU_MAX_WARPS_PER_BLOCK
+#define KALDI_WARP_WIDTH() (GPU_WARP_SIZE)
+#endif  // __IS_HIP_COMPILE__
 
 cublasOperation_t KaldiTransToCuTrans(MatrixTransposeType kaldi_trans);
 

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -2,6 +2,7 @@
 
 // Copyright 2009-2012  Karel Vesely
 //           2012-2015  Johns Hopkins University (author: Daniel Povey)
+//                2026  Advanced Micro Devices, Inc. (author: Jeff Daily)
 
 // See ../../COPYING for clarification regarding multiple authors
 //
@@ -105,6 +106,17 @@ class CuDevice {
       ans.Initialize();
     return ans;
   }
+
+#ifdef __IS_HIP_COMPILE__
+  // Warp/wavefront size of the active device, queried at runtime from the
+  // device properties. On ROCm this is per-device (64 on CDNA gfx9xx, 32 on
+  // RDNA gfx10xx/gfx11xx), so in a multi-arch fat binary the host must size
+  // launch geometry from this rather than a compile-time constant. Returns
+  // GPU_WARP_SIZE when no device is selected, as a safe default.
+  int32 WarpSize() const {
+    return Enabled() ? properties_.warpSize : GPU_WARP_SIZE;
+  }
+#endif
 
   cublasHandle_t GetCublasHandle() const { return cublas_handle_; }
   cusparseHandle_t GetCusparseHandle() const { return cusparse_handle_; }
@@ -423,6 +435,18 @@ inline cusparseHandle_t GetCusparseHandle() {
 
 inline curandGenerator_t GetCurandHandle() {
   return CuDevice::Instantiate().GetCurandHandle();
+}
+
+// Warp/wavefront size to use when computing host-side launch geometry.
+// On ROCm this is the active device's runtime warpSize so a multi-arch fat
+// binary picks the right value per device; on CUDA it is the compile-time
+// GPU_WARP_SIZE (unchanged behavior).
+inline int32 GpuWarpSize() {
+#ifdef __IS_HIP_COMPILE__
+  return CuDevice::Instantiate().WarpSize();
+#else
+  return GPU_WARP_SIZE;
+#endif
 }
 
 

--- a/src/cudamatrix/cu-kernels.cu
+++ b/src/cudamatrix/cu-kernels.cu
@@ -9,6 +9,7 @@
 //           2016-2018  Shiyin Kang
 //                2017  Hossein Hadian, Daniel Galvez
 //                2019  Yiwen Shao
+//                2026  Advanced Micro Devices, Inc. (author: Jeff Daily)
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,15 +29,21 @@
 #include <cfloat>
 #include <limits>
 #ifdef __IS_HIP_COMPILE__
-#define __CUDA_ARCH__ 800
 #include <hip/hip_math_constants.h>
 #include <hip/hip_runtime.h>
 
 #include <hipcub/hipcub.hpp>
 #include <hipcub/block/block_reduce.hpp>
 
+#include "cudamatrix/cu-common.h"
 #include "cudamatrix/cu-kernels-ansi.h"
 #include "hipify.h"
+// Define __CUDA_ARCH__ AFTER the rocPRIM/hipCUB headers are parsed: on ROCm 7.2.1
+// rocprim/config.hpp keys its target detection on the compiler's __gfx90a__ macro,
+// and defining __CUDA_ARCH__ before it is included suppresses that arch macro in the
+// device pass (rocprim then hits its "128-bit atomics not implemented" #error). Set it
+// here so kaldi's own #if __CUDA_ARCH__ >= 600 device-intrinsic branches still fire.
+#define __CUDA_ARCH__ 800
 #else
 #include <math_constants.h>
 #include "cudamatrix/cu-common.h"
@@ -44,6 +51,22 @@
 #include <cub/block/block_reduce.cuh>
 #include <cuda.h> // for CUDA_VERSION
 #endif            //__IS_HIP_COMPILE__
+
+#ifdef __IS_HIP_COMPILE__
+// These shared-memory tiling kernels are templated on the warp/wavefront width
+// (TileDim == blockDim.x). Dispatch to the matching instantiation based on the
+// block-x dimension the host computed from the runtime warp size.
+#define KALDI_LAUNCH_WARP_TILED(KERNEL, GR, BL, ...)        \
+  do {                                                      \
+    if ((BL).x >= 64)                                       \
+      KERNEL<64><<<(GR), (BL)>>>(__VA_ARGS__);              \
+    else                                                    \
+      KERNEL<32><<<(GR), (BL)>>>(__VA_ARGS__);              \
+  } while (0)
+#else
+#define KALDI_LAUNCH_WARP_TILED(KERNEL, GR, BL, ...) \
+  KERNEL<GPU_WARP_SIZE><<<(GR), (BL)>>>(__VA_ARGS__)
+#endif  // __IS_HIP_COMPILE__
 
 /***********************************************************************
  * Generic __device__ functions
@@ -1115,19 +1138,12 @@ __global__ void _frobenius_norm_atomic(Real * result,
       myAtomicAdd(result, aggregate);
 }
 
-template <typename Real>
-void trace_mat_mat_trans_atomic(Real *d_result,
-                                const Real *A, const Real *B,
-                                MatrixDim dA, int B_stride,
-                                cudaStream_t stream) {
-  // Assuming *d_result is set to zero already
-
-  constexpr int THREADS_X = GPU_WARP_SIZE;
-  constexpr int THREADS_Y = GPU_MAX_WARPS_PER_BLOCK / 2;
-
+template <typename Real, int THREADS_X, int THREADS_Y>
+static void launch_trace_mat_mat_trans_atomic(Real *d_result, const Real *A,
+                                              const Real *B, MatrixDim dA,
+                                              int B_stride, bool isSameAB,
+                                              cudaStream_t stream) {
   dim3 thrds(THREADS_X, THREADS_Y);
-
-  bool isSameAB = (A == B);
 
   int elemsPerThread = (dA.rows + static_cast<int>(thrds.y) - 1) / static_cast<int>(thrds.y);
   elemsPerThread = (elemsPerThread > 8) ? 8 : elemsPerThread;
@@ -1140,6 +1156,33 @@ void trace_mat_mat_trans_atomic(Real *d_result,
   else
     _trace_mat_mat_trans_atomic<Real, THREADS_X, THREADS_Y, 4><<<nblks, thrds, 0, stream>>>(d_result,
                                                   A, B, dA, B_stride);
+}
+
+template <typename Real>
+void trace_mat_mat_trans_atomic(Real *d_result,
+                                const Real *A, const Real *B,
+                                MatrixDim dA, int B_stride,
+                                cudaStream_t stream) {
+  // Assuming *d_result is set to zero already
+  // THREADS_X is the block-x extent and the cub::BlockReduce BLOCK_DIM_X; both
+  // must equal the launched blockDim.x. The block holds a fixed
+  // GPU_MAX_THREADS_PER_BLOCK/2 threads regardless of arch, with the x extent
+  // set to the warp width so warp reductions stay aligned.
+  bool isSameAB = (A == B);
+#ifdef __IS_HIP_COMPILE__
+  // Multi-arch fat binary: pick the tiling for the active device's runtime warp
+  // size (CDNA wave64 vs RDNA wave32) rather than a compile-time constant.
+  if (::kaldi::KaldiHipWarpSize() >= 64)
+    launch_trace_mat_mat_trans_atomic<Real, 64, GPU_MAX_THREADS_PER_BLOCK / 64 / 2>(
+        d_result, A, B, dA, B_stride, isSameAB, stream);
+  else
+    launch_trace_mat_mat_trans_atomic<Real, 32, GPU_MAX_THREADS_PER_BLOCK / 32 / 2>(
+        d_result, A, B, dA, B_stride, isSameAB, stream);
+#else
+  launch_trace_mat_mat_trans_atomic<Real, GPU_WARP_SIZE,
+                                    GPU_MAX_WARPS_PER_BLOCK / 2>(
+      d_result, A, B, dA, B_stride, isSameAB, stream);
+#endif
 }
 
 // _trace_mat_mat_trans reduce the partial sum to
@@ -3798,9 +3841,17 @@ static void _diff_lstm_nonlinearity(const int cell_dim, const int have_dropout_m
 
     // need to update self_repair_sum_out before deriv_sum_out, because
     // deriv_sum_out and deriv_sum_in might point to the same memory.
-    if (i0 < 5 && j < cell_dim) {
-      self_repair_sum_out[i0 * self_repair_sum_out_stride + j] =
-          update_sr[i0] ? num_rows : 0;
+    // The 5 self-repair rows are written by the threadIdx.y==0 lane: update_sr[]
+    // depends only on the column j (not on threadIdx.y), so any lane in the
+    // column holds the right values. The original `i0 < 5` form needs
+    // blockDim.y >= 5, which holds on wave32 (CU1DBLOCK/32 = 8) but NOT on wave64
+    // (CU1DBLOCK/64 = 4), where row 4 was never written and left stale.
+    if (threadIdx.y == 0 && j < cell_dim) {
+#     pragma unroll
+      for (int s = 0; s < 5; s++) {
+        self_repair_sum_out[s * self_repair_sum_out_stride + j] =
+            update_sr[s] ? num_rows : 0;
+      }
     }
 
     // compute derive_sum_out
@@ -4391,7 +4442,7 @@ void cudaF_trace_mat_mat_trans(const float* A, const float* B,
 
 void cudaF_trace_mat_mat(dim3 Gr, dim3 Bl, const float* A, const float* B,
                          MatrixDim dA, int B_stride, float* value) {
-  _trace_mat_mat<GPU_WARP_SIZE><<<Gr, Bl>>>(A, B, dA, B_stride, value);
+  KALDI_LAUNCH_WARP_TILED(_trace_mat_mat, Gr, Bl, A, B, dA, B_stride, value);
 }
 
 void cudaF_add_diag_mat_mat_MNT(int Gr, int Bl, const float alpha,
@@ -5106,7 +5157,7 @@ void cudaD_trace_mat_mat_trans(const double* A,
 
 void cudaD_trace_mat_mat(dim3 Gr, dim3 Bl, const double* A, const double* B,
                          MatrixDim dA, int B_stride, double* value) {
-  _trace_mat_mat<GPU_WARP_SIZE><<<Gr, Bl>>>(A, B, dA, B_stride, value);
+  KALDI_LAUNCH_WARP_TILED(_trace_mat_mat, Gr, Bl, A, B, dA, B_stride, value);
 }
 
 void cudaD_add_diag_mat_mat_MNT(int Gr, int Bl, const double alpha,
@@ -5517,25 +5568,25 @@ void cuda_copy_from_mat_dd(dim3 Gr, dim3 Bl, double *mat_out,
 void cuda_copy_from_mat_df_trans(dim3 Gr, dim3 Bl, double* mat_out,
                                  const float* mat_in, MatrixDim d_out,
                                  MatrixDim d_in) {
-  _copy_from_mat_trans<GPU_WARP_SIZE><<<Gr, Bl>>>(mat_out, mat_in, d_out, d_in);
+  KALDI_LAUNCH_WARP_TILED(_copy_from_mat_trans, Gr, Bl, mat_out, mat_in, d_out, d_in);
 }
 
 void cuda_copy_from_mat_ff_trans(dim3 Gr, dim3 Bl, float* mat_out,
                                  const float* mat_in, MatrixDim d_out,
                                  MatrixDim d_in) {
-  _copy_from_mat_trans<GPU_WARP_SIZE><<<Gr, Bl>>>(mat_out, mat_in, d_out, d_in);
+  KALDI_LAUNCH_WARP_TILED(_copy_from_mat_trans, Gr, Bl, mat_out, mat_in, d_out, d_in);
 }
 
 void cuda_copy_from_mat_fd_trans(dim3 Gr, dim3 Bl, float *mat_out,
                                  const double* mat_in, MatrixDim d_out,
                                  MatrixDim d_in) {
-  _copy_from_mat_trans<GPU_WARP_SIZE><<<Gr, Bl>>>(mat_out, mat_in, d_out, d_in);
+  KALDI_LAUNCH_WARP_TILED(_copy_from_mat_trans, Gr, Bl, mat_out, mat_in, d_out, d_in);
 }
 
 void cuda_copy_from_mat_dd_trans(dim3 Gr, dim3 Bl, double *mat_out,
                                  const double* mat_in, MatrixDim d_out,
                                  MatrixDim d_in) {
-  _copy_from_mat_trans<GPU_WARP_SIZE><<<Gr, Bl>>>(mat_out, mat_in, d_out, d_in);
+  KALDI_LAUNCH_WARP_TILED(_copy_from_mat_trans, Gr, Bl, mat_out, mat_in, d_out, d_in);
 }
 
 void cuda_copy_from_smat_ff(dim3 Gr, dim3 Bl, float* mat, MatrixDim mat_dim,
@@ -5849,10 +5900,11 @@ void cudaF_mat_copy_range_clamped(
    float *dst, int32_t ldd) {
 
   int32_t num_rows =  row_end - row_start;
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   dim3 blocks(
-      (num_cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-      (num_rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK);
+      (num_cols + warp - 1) / warp,
+      (num_rows + warps_per_block - 1) / warps_per_block);
 
   _cuda_mat_copy_range_clamped<float><<<blocks,threads>>>(row_start, row_end, num_cols,
       src, lds, clamp_low, clamp_high, dst, ldd);
@@ -5865,10 +5917,11 @@ void cudaD_mat_copy_range_clamped(
    double *dst, int32_t ldd) {
 
   int32_t num_rows =  row_end - row_start;
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   dim3 blocks(
-      (num_cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-      (num_rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK);
+      (num_cols + warp - 1) / warp,
+      (num_rows + warps_per_block - 1) / warps_per_block);
 
   _cuda_mat_copy_range_clamped<double><<<blocks,threads>>>(row_start, row_end, num_cols,
       src, lds, clamp_low, clamp_high, dst, ldd);
@@ -5877,10 +5930,11 @@ void cudaD_mat_copy_range_clamped(
 void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
     int32_t *num_cols, const float **inputs, int32_t *ldi, float **outputs,
     int32_t *ldo) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   int32_t total_rows=0, total_cols=0;
-  
-  BatchedMatrixCopyDesc<float> batch_desc; 
+
+  BatchedMatrixCopyDesc<float> batch_desc;
   const int32_t MAX_BATCH_SIZE=batch_desc.MAX_BATCH_SIZE;
 
   int i;
@@ -5904,8 +5958,8 @@ void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
       int32_t rows = ceilf(total_rows / (float)MAX_BATCH_SIZE);
       int32_t cols = ceilf(total_cols / (float)MAX_BATCH_SIZE);
       dim3 blocks(
-          (cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-          (rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK,
+          (cols + warp - 1) / warp,
+          (rows + warps_per_block - 1) / warps_per_block,
           MAX_BATCH_SIZE);
 
       // no memcpy needed here.  Memory will be passed down directly
@@ -5928,8 +5982,8 @@ void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
       int32_t cols = ceilf(total_cols / (float)remaining);
 
       dim3 blocks(
-          (cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-          (rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK,
+          (cols + warp - 1) / warp,
+          (rows + warps_per_block - 1) / warps_per_block,
           remaining);
 
       // no memcpy needed here.  Memory will be passed down directly
@@ -5943,10 +5997,11 @@ void cudaF_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
 void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
     int32_t *num_cols, const double **inputs, int32_t *ldi, double **outputs,
     int32_t *ldo) {
-  dim3 threads(GPU_WARP_SIZE, GPU_MAX_WARPS_PER_BLOCK);
+  KALDI_WARP_GEOMETRY(warp, warps_per_block);
+  dim3 threads(warp, warps_per_block);
   int32_t total_rows=0, total_cols=0;
-  
-  BatchedMatrixCopyDesc<double> batch_desc; 
+
+  BatchedMatrixCopyDesc<double> batch_desc;
   const int32_t MAX_BATCH_SIZE=batch_desc.MAX_BATCH_SIZE;
 
   int i;
@@ -5970,8 +6025,8 @@ void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
       int32_t rows = ceilf(total_rows / (float)MAX_BATCH_SIZE);
       int32_t cols = ceilf(total_cols / (float)MAX_BATCH_SIZE);
       dim3 blocks(
-          (cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-          (rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK,
+          (cols + warp - 1) / warp,
+          (rows + warps_per_block - 1) / warps_per_block,
           MAX_BATCH_SIZE);
 
       // no memcpy needed here.  Memory will be passed down directly
@@ -5994,8 +6049,8 @@ void cudaD_batched_copy_mats(int32_t num_mats, int32_t *num_rows,
       int32_t cols = ceilf(total_cols / (float)remaining);
 
       dim3 blocks(
-          (cols + GPU_WARP_SIZE - 1) / GPU_WARP_SIZE,
-          (rows + GPU_MAX_WARPS_PER_BLOCK - 1) / GPU_MAX_WARPS_PER_BLOCK,
+          (cols + warp - 1) / warp,
+          (rows + warps_per_block - 1) / warps_per_block,
           remaining);
 
       // no memcpy needed here.  Memory will be passed down directly

--- a/src/cudamatrix/cu-math.cc
+++ b/src/cudamatrix/cu-math.cc
@@ -818,7 +818,7 @@ void BackpropLstmNonlinearity(const CuMatrixBase<Real> &input,
 
     // Use 2D block (8x32 threads) as we need to compute column sum.
     // Use 1D grid to cover the data matrix width `cell_dim`.
-    const int kWarpSize = GPU_WARP_SIZE;
+    const int kWarpSize = GpuWarpSize();
     dim3 dimBlock(kWarpSize, CU1DBLOCK / kWarpSize);
 //    dim3 dimGrid(n_blocks(cell_dim, dimBlock.x),
 //                 n_blocks(num_rows, dimBlock.y));

--- a/src/cudamatrix/cu-matrix.cc
+++ b/src/cudamatrix/cu-matrix.cc
@@ -250,7 +250,7 @@ void CuMatrixBase<Real>::CopyFromMat(const CuMatrixBase<OtherReal> &M,
       } else {
         // 2D thread block with warps (blockDim.x) along the row-dim of input M.
         // Each (8x32) thread block will transpose (32x32) data
-        const int32 warpSize = GPU_WARP_SIZE;
+        const int32 warpSize = GpuWarpSize();
         dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
         dim3 dimGrid(n_blocks(M.NumCols(), warpSize),
             n_blocks(M.NumRows(), warpSize));
@@ -856,7 +856,7 @@ void CuMatrixBase<Real>::DiffGroupPnorm(const CuMatrixBase<Real> &in_value,
 #if HAVE_CUDA == 1
   if (CuDevice::Instantiate().Enabled()) {
     CuTimer tim;
-    const int kWarpSize = GPU_WARP_SIZE;
+    const int kWarpSize = GpuWarpSize();
     dim3 dimBlock(kWarpSize, CU1DBLOCK / kWarpSize);
     dim3 dimGrid(n_blocks(NumCols(), dimBlock.x),
                  n_blocks(NumRows(), dimBlock.y));
@@ -1006,7 +1006,7 @@ void CuMatrixBase<Real>::AddSmat(Real alpha, const CuSparseMatrix<Real> &A,
     // We use warpSize threads per row to access only the nonzero elements.
     // Every CU1DBLOCK/warpSize rows share one thread block.
     // 1D grid to cover all rows of A.
-    const int warpSize = GPU_WARP_SIZE;
+    const int warpSize = GpuWarpSize();
     dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
     dim3 dimGrid(n_blocks(A.NumRows(), dimBlock.y));
 
@@ -2183,7 +2183,7 @@ Real TraceMatMat(const CuMatrixBase<Real> &A,
     // if the matrix is not in a very bad shape.
     // (wider or taller than 32x8192)
     // CPU will then reduce to 1 element.
-    const int kWarpSize = GPU_WARP_SIZE;
+    const int kWarpSize = GpuWarpSize();
     dim3 dimBlock(kWarpSize, CU1DBLOCK / kWarpSize);
     dim3 dimGrid(n_blocks(A.NumCols(), kWarpSize),
         n_blocks(A.NumRows(), kWarpSize));
@@ -2405,7 +2405,7 @@ void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
       // and use transposed copy to fill *this
       // see CuMatrixBase<Real>::CopyFromMat() for more detail of the impl
       MatrixDim rv_dim = { num_cols_, num_rows_, num_rows_ };
-      const int32 warpSize = GPU_WARP_SIZE;
+      const int32 warpSize = GpuWarpSize();
       dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
       dim3 dimGrid(n_blocks(rv_dim.cols, warpSize),
                    n_blocks(rv_dim.rows, warpSize));
@@ -2415,7 +2415,7 @@ void CuMatrixBase<Real>::CopyColsFromVec(const CuVectorBase<Real> &rv) {
     } else if (rv.Dim() == num_rows_) {
       // use 2D block (8x32) and large enough grid to cover matrix *this
       // dimBlock.x need to be at least warpSize for coalesced memory access.
-      const int32 warpSize = GPU_WARP_SIZE;
+      const int32 warpSize = GpuWarpSize();
       dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
       dim3 dimGrid(n_blocks(num_cols_, dimBlock.x),
                    n_blocks(num_rows_, dimBlock.y));

--- a/src/cudamatrix/cu-sparse-matrix.cc
+++ b/src/cudamatrix/cu-sparse-matrix.cc
@@ -145,7 +145,7 @@ void CuSparseMatrix<Real>::SelectRows(const CuArray<int32> &row_indexes,
     // We use warpSize threads per row to access only the nnz elements.
     // Every CU1DBLOCK/warpSize rows share one thread block.
     // 1D grid to cover all selected rows.
-    const int warpSize = GPU_WARP_SIZE;
+    const int warpSize = GpuWarpSize();
     dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
     dim3 dimGrid(n_blocks(row_indexes.Dim(), dimBlock.y));
 
@@ -578,7 +578,7 @@ Real TraceMatSmat(const CuMatrixBase<Real> &A,
     // We use warpSize threads per row to access only the nnz elements.
     // Every CU1DBLOCK/warpSize rows share one thread block.
     // 1D grid to cover all rows of B.
-    const int warpSize = GPU_WARP_SIZE;
+    const int warpSize = GpuWarpSize();
     dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
     dim3 dimGrid(n_blocks(B.NumRows(), dimBlock.y));
 
@@ -668,7 +668,7 @@ void CuSparseMatrix<Real>::CopyToMat(CuMatrixBase<OtherReal> *M,
     // We use warpSize threads per row to access only the nnz elements.
     // Every CU1DBLOCK/warpSize rows share one thread block.
     // 1D grid to cover all rows.
-    const int warpSize = GPU_WARP_SIZE;
+    const int warpSize = GpuWarpSize();
     dim3 dimBlock(warpSize, CU1DBLOCK / warpSize);
     dim3 dimGrid(n_blocks(NumRows(), dimBlock.y));
 

--- a/src/cudamatrix/cu-vector.cc
+++ b/src/cudamatrix/cu-vector.cc
@@ -647,12 +647,12 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
         //    use 1- or 2-D grid so that the grid contains
         //    at least and not much larger than 'kOptNumBlocks' blocks
         //    to fully utilize the GPU;
-        const int32 warpSize = GPU_WARP_SIZE;
+        const int32 warpSize = GpuWarpSize();
         const int32 kOptNumBlocks = 512;
         const int32 tile_dim =
             (N.NumRows() < 4096 && N.NumCols() < kOptNumBlocks * warpSize)
-                ? GPU_WARP_SIZE / 2
-                : GPU_WARP_SIZE;
+                ? warpSize / 2
+                : warpSize;
         dim3 dimBlock(tile_dim, CU1DBLOCK / tile_dim);
         dim3 dimGrid(n_blocks(N.NumCols(), dimBlock.x),
                      n_blocks(N.NumRows(), dimBlock.y));
@@ -678,9 +678,10 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
         // 16x16 or 8x32 2D block for matrix transpose and coalesced memory access.
         // One block per 'tile_dim' columns of N.
         // 1D grid expands along the row of N.
+        const int32 warpSize = GpuWarpSize();
         int tile_dim = sizeof(Real) == sizeof(float) && N.NumCols() >= 2048
-                           ? GPU_WARP_SIZE
-                           : GPU_WARP_SIZE / 2;
+                           ? warpSize
+                           : warpSize / 2;
         dim3 dimBlock(tile_dim, CU1DBLOCK / tile_dim);
         dim3 dimGrid(n_blocks(N.NumCols(), tile_dim));
         cuda_add_diag_mat_mat_MN(dimGrid, dimBlock, alpha, M.Data(), M.Stride(),
@@ -688,9 +689,10 @@ void CuVectorBase<Real>::AddDiagMatMat(Real alpha, const CuMatrixBase<Real> &M,
       } else {
         // Case 4: diag(M'*N') == sum(N'.*M, 1)
         // Same kernel and config as case 3 except M and N are swapped.
+        const int32 warpSize = GpuWarpSize();
         int tile_dim = sizeof(Real) == sizeof(float) && N.NumCols() >= 2048
-                           ? GPU_WARP_SIZE
-                           : GPU_WARP_SIZE / 2;
+                           ? warpSize
+                           : warpSize / 2;
         dim3 dimBlock(tile_dim, CU1DBLOCK / tile_dim);
         dim3 dimGrid(n_blocks(M.NumCols(), tile_dim));
         cuda_add_diag_mat_mat_MN(dimGrid, dimBlock, alpha, N.Data(), N.Stride(),

--- a/src/hip/hipify.h
+++ b/src/hip/hipify.h
@@ -2,6 +2,12 @@
 #define __HIPIFY_H__
 
 #ifdef __HIPCC__
+#include <hip/hip_version.h>
+// HIP gained a native, wave-correct __syncwarp (fence + __builtin_amdgcn_wave_barrier,
+// correct on wave32 and wave64) in ROCm 6.2; defining our own there makes a bare
+// __syncwarp() call ambiguous (amd_warp_sync_functions.h vs this shim). Only provide
+// the shim on older HIP that lacks the builtin.
+#if HIP_VERSION < 60200000
 inline __device__ void __syncwarp(unsigned mask = 0xffffffff) {
   // On CDNA hardware wave-fronts (warps) execute always in
   // lock step. Though it might still be important to signal
@@ -15,6 +21,7 @@ inline __device__ void __syncwarp(unsigned mask = 0xffffffff) {
   // __asm__("s_waitcnt lgkmcnt(0)"); Í
   // to explicitly do a memory fence.
 }
+#endif
 // AMDGCN only support this rounding mode.
 #define __fdiv_rd __fdiv_rn
 #else
@@ -24,13 +31,13 @@ inline __device__ void __syncwarp(unsigned mask = 0xffffffff) {
 //
 // HIP types
 //
-#define CUBLAS_COMPUTE_32F HIPBLAS_R_32F
-#define CUBLAS_COMPUTE_32F_FAST_16F \
-  HIPBLAS_R_32F  // TODO: Verify that plain float compute are viable
-                 // replacements for the tensor cores alternative.
-#define CUBLAS_COMPUTE_32F_FAST_TF32 \
-  HIPBLAS_R_32F  // TODO: Verify that plain float compute are viable
-                 // replacements for the tensor cores alternative.
+// hipBLAS v2 (ROCm >= 6) introduced a dedicated hipblasComputeType_t for the
+// GemmEx compute precision; the GemmEx operand types stay hipDataType (HIP_R_*)
+// via the CUBLAS_R_* / CUDA_R_* aliases below. The pre-v2 spelling mapped these
+// to the operand datatype HIPBLAS_R_32F, which no longer type-checks.
+#define CUBLAS_COMPUTE_32F HIPBLAS_COMPUTE_32F
+#define CUBLAS_COMPUTE_32F_FAST_16F HIPBLAS_COMPUTE_32F_FAST_16F
+#define CUBLAS_COMPUTE_32F_FAST_TF32 HIPBLAS_COMPUTE_32F_FAST_TF32
 #define CUBLAS_DIAG_NON_UNIT HIPBLAS_DIAG_NON_UNIT
 #define CUBLAS_FILL_MODE_LOWER HIPBLAS_FILL_MODE_LOWER
 #define CUBLAS_FILL_MODE_UPPER HIPBLAS_FILL_MODE_UPPER
@@ -98,7 +105,7 @@ inline __device__ void __syncwarp(unsigned mask = 0xffffffff) {
 #define CUSPARSE_STATUS_ZERO_PIVOT HIPSPARSE_STATUS_ZERO_PIVOT
 #define cuDeviceGetName hipDeviceGetName
 #define cuMemGetInfo_v2 hipMemGetInfo
-#define cublasComputeType_t hipblasDatatype_t
+#define cublasComputeType_t hipblasComputeType_t
 #define cublasCreate hipblasCreate
 #define cublasDasum_v2 hipblasDasum
 #define cublasDaxpy_v2 hipblasDaxpy
@@ -277,7 +284,19 @@ inline __device__ void __syncwarp(unsigned mask = 0xffffffff) {
 //
 // GPU static hardware characteristics.
 //
+// GPU_WARP_SIZE: 64 on CDNA (gfx9xx, wave64); 32 on RDNA (gfx10xx/gfx11xx, wave32).
+// Device code: __GFX9__ is set by the compiler for the actual offload arch.
+// Host code: HIP_WARP_SIZE is injected via -DHIP_WARP_SIZE=<N> from configure
+// (ROCM_WARP_SIZE in kaldi.mk, set to 64 for gfx9* targets, 32 otherwise).
+#ifdef __HIP_DEVICE_COMPILE__
+#if defined(__GFX9__)
 #define GPU_WARP_SIZE 64
+#else
+#define GPU_WARP_SIZE 32
+#endif
+#else
+#define GPU_WARP_SIZE HIP_WARP_SIZE
+#endif
 #define GPU_MAX_THREADS_PER_BLOCK 1024
 #define GPU_MAX_WARPS_PER_BLOCK (GPU_MAX_THREADS_PER_BLOCK / GPU_WARP_SIZE)
 #endif  //__HIPIFY_H__

--- a/src/makefiles/hip_64bit.mk
+++ b/src/makefiles/hip_64bit.mk
@@ -14,7 +14,7 @@ CXXFLAGS += $(ROCM_USEROCTX) -DHAVE_CUDA=1 \
             -D__HIP_PLATFORM_AMD__=1 \
             -D__IS_HIP_COMPILE__=1 \
             -DROCM_MAJOR_VERSION=$(ROCM_MAJOR_VERSION) -DROCM_MINOR_VERSION=$(ROCM_MINOR_VERSION) \
-            -DCUDA_VERSION=11000 \
+            -DCUDA_VERSION=11000 -DHIP_WARP_SIZE=$(ROCM_WARP_SIZE) \
 	          -I$(ROCMDIR)/hipsparse/include \
 	          -I$(ROCMDIR)/hipfft/include \
 	          -I$(ROCMDIR)/hipblas/include \
@@ -39,7 +39,9 @@ ROCM_FLAGS = $(ROCM_USEROCTX) -fPIC -DHAVE_CUDA=1 \
              -D__HIP_PLATFORM_AMD__=1 \
              -DROCM_MAJOR_VERSION=$(ROCM_MAJOR_VERSION) -DROCM_MINOR_VERSION=$(ROCM_MINOR_VERSION) \
              -D__CUDACC_VER_MAJOR__=11 -DCUDA_VERSION=11000 \
-	         -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -std=c++14 -munsafe-fp-atomics  \
+             -DOPENFST_VER=$(OPENFSTVER) \
+             -DHIP_WARP_SIZE=$(ROCM_WARP_SIZE) \
+	         -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) -std=c++17 -munsafe-fp-atomics  \
              -fgpu-default-stream=per-thread \
              $(EXTRA_ROCM_FLAGS)
              


### PR DESCRIPTION
Kaldi already ships a ROCm/HIP GPU backend (`configure --use-rocm`, the `src/makefiles/hip_64bit.mk` toolchain block, and the `src/hip/hipify.h` compat header). It was written against ROCm 5.0-5.2 and had bit-rotted: it no longer builds on ROCm 7, and once built it computed a wrong result on 64-wide wavefronts. This change brings the existing backend back to green on a current ROCm and makes it correct on both 32- and 64-lane GPUs.

Review it in three parts:

1. **Build break on ROCm 7.** `cu-kernels.cu` and `feature-online-cmvn-cuda.cu` defined `__CUDA_ARCH__=800` before including `<hipcub/hipcub.hpp>`. On hipcc that suppressed the `__gfx90a__` device macro, so rocPRIM fell through to a generic path that fails to compile against the ROCm 7 headers. The CUDA-version and warp definitions are reordered/guarded so hipcub sees the real device macros; the CUDA build is unchanged.

2. **wave64 correctness.** `cu-math-test`'s `UnitTestBackpropLstmNonlinearity` was the one cudamatrix test that failed before the fix. The LSTM nonlinearity kernel partitioned a 256-thread block into `256/warpSize` groups, assuming that value is 8. It is 8 on a 32-lane warp (NVIDIA, RDNA) but 4 on a 64-lane wavefront (CDNA, gfx90a), so rows past the fourth were left unprocessed. The kernel now derives the host warp size rather than assuming 32.

3. **Multi-arch builds.** The host warp size is resolved at runtime (via `hipDeviceGetAttribute`) so a single build serves both wave32 and wave64 targets; `--rocm-targets` can list several GPUs (for example `gfx90a,gfx1100`) in one configure, and each kernel launch selects its tiling from the running device's wavefront width.

Documentation and attribution: configure's header gains a `--use-rocm` worked example next to the existing `--use-cuda` one, and the cudamatrix files extended here carry an AMD copyright line.

Scope: Linux. The configure ROCm path is POSIX-only by design (it gates on a Linux host); the Windows .sln build documents no GPU support upstream, so the GPU backend is built and tested on Linux.

**Test Plan:**

```
cd tools && make -j"$(nproc)" openfst
cd ../src && ./configure --use-rocm --rocm-dir=/opt/rocm \
    --rocm-targets=gfx90a --use-cuda=no
make -j"$(nproc)" depend && make -j"$(nproc)"
cd cudamatrix && make test
```

All 12 cudamatrix correctness unit tests pass on an AMD Instinct MI250X (gfx90a), ROCm 7.2.1, including `cu-math-test`'s `UnitTestBackpropLstmNonlinearity`, which fails without the wave64 fix. The same branch builds and passes the cudamatrix tests on an RDNA3 GPU (gfx1100) via `--rocm-targets=gfx1100`, and a combined `gfx90a,gfx1100` build passes as well. The CUDA path was compile-checked unchanged with nvcc 12.8 (sm_80).

This work was authored with assistance from Claude (Anthropic).
